### PR TITLE
Allows field-dependent SimpleForcing. Updates plankton growth example.

### DIFF
--- a/examples/ocean_convection_with_plankton.jl
+++ b/examples/ocean_convection_with_plankton.jl
@@ -50,8 +50,8 @@ nothing # hide
 # ## Define a forcing function
 #
 # Our forcing function roughly corresponds to the growth of phytoplankton in light
-# (with a penetration depth of 16 meters here), and death due to grazing
-# at a rate of 1 phytoplankton unit per second.
+# (with a penetration depth of 16 meters here), and death due to viruses and grazing
+# by zooplankton at a rate of 1 phytoplankton unit per second (which is shockingly fast).
 
 growth_and_decay = SimpleForcing((x, y, z, t) -> exp(z/16) - 1)
 

--- a/examples/ocean_convection_with_plankton.jl
+++ b/examples/ocean_convection_with_plankton.jl
@@ -50,10 +50,10 @@ nothing # hide
 # ## Define a forcing function
 #
 # Our forcing function roughly corresponds to the growth of phytoplankton in light
-# (with a penetration depth of 16 meters here), and death due to natural mortality
+# (with a penetration depth of 16 meters here), and death due to grazing
 # at a rate of 1 phytoplankton unit per second.
 
-growth_and_decay = SimpleForcing((x, y, z, t) -> exp(z/16))
+growth_and_decay = SimpleForcing((x, y, z, t) -> exp(z/16) - 1)
 
 ## Instantiate the model
 model = IncompressibleModel(

--- a/src/Forcing/Forcing.jl
+++ b/src/Forcing/Forcing.jl
@@ -4,8 +4,6 @@ export ModelForcing, SimpleForcing, ParameterizedForcing
 
 using Oceananigans.Fields
 
-zeroforcing(args...) = 0
-
 include("simple_forcing.jl")
 include("model_forcing.jl")
 include("parameterized_forcing.jl")

--- a/src/Forcing/model_forcing.jl
+++ b/src/Forcing/model_forcing.jl
@@ -40,7 +40,7 @@ function for_field_name(field_name, f::SimpleForcing)
     X, Y, Z = field_name ∈ (:u, :v, :w) ? assumed_field_locations[field_name] :
                                           assumed_field_locations[:tracer]
 
-    return SimpleForcing{X, Y, Z}(field_name, f.forcing, f.parameters, f.multiplicative)
+    return SimpleForcing{X, Y, Z}(field_name, f.forcing, f.parameters, f.field_in_signature)
 end
 
 default_tracer_forcing(args...) = zeroforcing

--- a/src/Forcing/model_forcing.jl
+++ b/src/Forcing/model_forcing.jl
@@ -1,6 +1,13 @@
 using Oceananigans.Utils: with_tracers
 using Oceananigans.TurbulenceClosures: with_tracers
 
+@inline zeroforcing(args...) = 0
+
+const assumed_field_locations = Dict(:tracer => (Cell, Cell, Cell),
+                                          :u => (Face, Cell, Cell),
+                                          :v => (Cell, Face, Cell),
+                                          :w => (Face, Cell, Face))
+
 """
     ModelForcing(; u=zeroforcing, v=zeroforcing, w=zeroforcing, tracer_forcings...)
 
@@ -14,17 +21,29 @@ julia> u_forcing = SimpleForcing((x, y, z, t) -> exp(z) * cos(t))
 julia> model = IncompressibleModel(forcing=ModelForcing(u=u_forcing))
 """
 function ModelForcing(; u=zeroforcing, v=zeroforcing, w=zeroforcing, tracer_forcings...)
-    u = at_location((Face, Cell, Cell), u)
-    v = at_location((Cell, Face, Cell), v)
-    w = at_location((Cell, Cell, Face), w)
+    u = for_field_name(:u, u)
+    v = for_field_name(:v, v)
+    w = for_field_name(:w, w)
+
+    # The SimpleForcing API currently assumes the field is a tracer. Therefore,
+    # no action is requried to adapt SimpleForcing to work for tracers.
 
     return merge((u=u, v=v, w=w), tracer_forcings)
 end
 
-at_location(location, u) = u # Fallback
-at_location(location, u::SimpleForcing) =
-    SimpleForcing{location[1], location[2], location[3]}(u.func, u.parameters)
+for_field_name(field_name, forcing_function) = forcing_function # Fallback for ordinary functions
+
+""" Returns a SimpleForcing object at `field_name`'s assumed location. """
+function for_field_name(field_name, f::SimpleForcing)
+
+    # Deduce the location of `field_name`.
+    X, Y, Z = field_name ∈ (:u, :v, :w) ? assumed_field_locations[field_name] :
+                                          assumed_field_locations[:tracer]
+
+    return SimpleForcing{X, Y, Z}(field_name, f.forcing, f.parameters, f.multiplicative)
+end
 
 default_tracer_forcing(args...) = zeroforcing
+
 ModelForcing(tracers, proposal_forcing) = with_tracers(tracers, proposal_forcing, default_tracer_forcing,
                                                        with_velocities=true)

--- a/src/Forcing/simple_forcing.jl
+++ b/src/Forcing/simple_forcing.jl
@@ -4,11 +4,9 @@
 A callable object that implements a 'simple' forcing function
 on a field at the location `X, Y, Z`.
 """
-struct SimpleForcing{X, Y, Z, M, P, F}
+struct SimpleForcing{X, Y, Z, M, N, C, P, F}
             forcing :: F
          parameters :: P
-         field_name :: Symbol
-    field_container :: Symbol
      multiplicative :: Bool
 
     function SimpleForcing{X, Y, Z}(field_name, forcing, parameters, multiplicative) where {X, Y, Z}
@@ -17,8 +15,8 @@ struct SimpleForcing{X, Y, Z, M, P, F}
         # if multiplicative=true.
         field_container = field_name ∈ (:u, :v, :w) ? :velocities : :tracers
 
-        return new{X, Y, Z, multiplicative, typeof(parameters),
-                   typeof(forcing)}(forcing, parameters, field_name, field_container, multiplicative)
+        return new{X, Y, Z, multiplicative, typeof(parameters), field_name, field_container,
+                   typeof(forcing)}(forcing, parameters, multiplicative)
     end
 end
 
@@ -117,9 +115,9 @@ end
 end
 
 # Simple multiplicative forcing without parameters
-@inline function (f::SimpleForcing{X, Y, Z, true, <:Nothing})(i, j, k, grid, clock, state) where {X, Y, Z}
-    container = getproperty(state, f.field_container)
-    field = getproperty(container, f.field_name)
+@inline function (f::SimpleForcing{X, Y, Z, true, <:Nothing, N, C})(i, j, k, grid, clock, state) where {X, Y, Z, N, C}
+    container = getproperty(state, C)
+    field = getproperty(container, N)
 
     return @inbounds f.forcing(xnode(X, i, grid),
                                ynode(Y, j, grid),
@@ -129,9 +127,9 @@ end
 end
 
 # Simple multiplicative forcing with parameters
-@inline function (f::SimpleForcing{X, Y, Z, true})(i, j, k, grid, clock, state) where {X, Y, Z}
-    container = getproperty(state, f.field_container)
-    field = getproperty(container, f.field_name)
+@inline function (f::SimpleForcing{X, Y, Z, true, P, N, C})(i, j, k, grid, clock, state) where {X, Y, Z, P, N, C}
+    container = getproperty(state, C)
+    field = getproperty(container, N)
 
     return @inbounds f.forcing(xnode(X, i, grid),
                                ynode(Y, j, grid),

--- a/src/Forcing/simple_forcing.jl
+++ b/src/Forcing/simple_forcing.jl
@@ -1,52 +1,144 @@
 """
-    SimpleForcing{X, Y, Z, F, P}
+    struct SimpleForcing{X, Y, Z, M, F, P}
 
-Callable object for specifying 'simple' forcings of `x, y, z, t` and optionally
-`parameters` of type `P` at location `X, Y, Z`.
+A callable object that implements a 'simple' forcing function
+on a field at the location `X, Y, Z`.
 """
-struct SimpleForcing{X, Y, Z, F, P}
-          func :: F
-    parameters :: P
-    function SimpleForcing{X, Y, Z}(func, parameters) where {X, Y, Z}
-        return new{X, Y, Z, typeof(func), typeof(parameters)}(func, parameters)
+struct SimpleForcing{X, Y, Z, M, P, F}
+            forcing :: F
+         parameters :: P
+         field_name :: Symbol
+    field_container :: Symbol
+     multiplicative :: Bool
+
+    function SimpleForcing{X, Y, Z}(field_name, forcing, parameters, multiplicative) where {X, Y, Z}
+
+        # Deduce the container that `field_name` is found. This is only needed
+        # if multiplicative=true.
+        field_container = field_name ∈ (:u, :v, :w) ? :velocities : :tracers
+
+        return new{X, Y, Z, multiplicative, typeof(parameters),
+                   typeof(forcing)}(forcing, parameters, field_name, field_container, multiplicative)
     end
 end
 
 """
-    SimpleForcing([location=(Cell, Cell, Cell),] forcing; parameters=nothing)
+    SimpleForcing(forcing; parameters=nothing, multiplicative=false)
 
-Construct forcing for a field at `location` using `forcing::Function`, and optionally
-with `parameters`. If `parameters=nothing`, `forcing` must have the signature
+Construct forcing for a field named `field_name` based on a `forcing` function,
+with optional parameters. The keyword `multiplicative` specifies whether the `forcing`
+"multiplies" the field, in which case it requires a reference to the field at `x, y, z, t`.
 
-    `forcing(x, y, z, t)`;
+The expected function signature of `forcing` depends on the keyword arguments
+`parameters` and `multiplicative`. The four possible cases are
 
-otherwise it must have the signature
+* `parameters=nothing, multiplicative=false`:
 
-    `forcing(x, y, z, t, parameters)`.
+    `forcing(x, y, z, t)`
+
+This is the function signature for default choices of `parameters` and `multiplicative`.
+
+* `multiplicative=false`, specified parameters:
+
+    `forcing(x, y, z, t, parameters)`,
+
+where `parameters` is the object passed as keyword argument. To compile on the GPU
+this must be a simple object; typically, a `NamedTuple` of floats and other constants.
+
+* `parameters=nothing, multiplicative=true`:
+
+    `forcing(x, y, z, t, field)`
+
+where `field` is the value of the field the forcing is applied to at `x, y, z`.
+
+* `multiplicative=true`, specified parameters:
+
+    `forcing(x, y, z, t, field, parameters)`
 
 Examples
 ========
+
+* The simplest case: no parameters, additive forcing:
+
 ```julia
 julia> const a = 2.1
 
 julia> fun_forcing(x, y, z, t) = a * exp(z) * cos(t)
 
 julia> u_forcing = SimpleForcing(fun_forcing)
+```
 
-julia> parameterized_forcing(x, y, z, t, p) = p.μ * exp(z/p.λ) * cos(p.ω*t)
+* Parameterized, additive forcing:
 
-julia> v_forcing = SimpleForcing(parameterized_forcing, parameters=(μ=42, λ=0.1, ω=π))
+```julia
+julia> parameterized_forcing(x, y, z, t, p) = p.μ * exp(z / p.λ) * cos(p.ω * t)
+
+julia> v_forcing = SimpleForcing(parameterized_forcing, parameters = (μ=42, λ=0.1, ω=π))
+```
+
+* Multplicative forcing with no parameters:
+
+```julia
+julia> tracer_damping(x, y, z, t, c) = exp(z) * c
+
+julia> c_forcing = SimpleForcing(tracer_damping, multiplicative=true)
+```
+
+* Multiplicative forcing with parameters. This example relaxes a tracer to some reference
+    linear profile.
+
+```julia
+julia> tracer_relaxation(x, y, z, t, c, p) = p.μ * exp((z + p.H) / p.λ) * (p.dCdz * z - c) 
+
+julia> c_forcing = SimpleForcing(tracer_relaxation, parameters=(μ=1/60, λ=10, H=1000, dCdz=1), 
+                                 multiplicative=true)
 ```
 """
-SimpleForcing(location::Tuple, func::Function; parameters=nothing) =
-    SimpleForcing{location[1], location[2], location[3]}(func, parameters)
+SimpleForcing(forcing; parameters=nothing, multiplicative=false) =
+    SimpleForcing{Cell, Cell, Cell}(:tracer, forcing, parameters, multiplicative)
 
-SimpleForcing(func::Function; kwargs...) = SimpleForcing((Cell, Cell, Cell), func; kwargs...)
+# Simple additive forcing without parameters
+@inline function (f::SimpleForcing{X, Y, Z, false, <:Nothing})(i, j, k, grid, clock, state) where {X, Y, Z}
 
-SimpleForcing(location::Tuple, forcing::SimpleForcing) = SimpleForcing(location, forcing.func)
+    return @inbounds f.forcing(xnode(X, i, grid),
+                               ynode(Y, j, grid),
+                               znode(Z, k, grid),
+                               clock.time)
+end
+        
+# Simple additive forcing with parameters
+@inline function (f::SimpleForcing{X, Y, Z, false})(i, j, k, grid, clock, state) where {X, Y, Z}
 
-@inline (f::SimpleForcing{X, Y, Z})(i, j, k, grid, clock, state) where {X, Y, Z} =
-    @inbounds f.func(xnode(X, i, grid), ynode(Y, j, grid), znode(Z, k, grid), clock.time, f.parameters)
+    return @inbounds f.forcing(xnode(X, i, grid),
+                               ynode(Y, j, grid),
+                               znode(Z, k, grid),
+                               clock.time,
+                               f.parameters)
+end
 
-@inline (f::SimpleForcing{X, Y, Z, F, <:Nothing})(i, j, k, grid, clock, state) where {X, Y, Z, F} =
-    @inbounds f.func(xnode(X, i, grid), ynode(Y, j, grid), znode(Z, k, grid), clock.time)
+# Simple multiplicative forcing without parameters
+@inline function (f::SimpleForcing{X, Y, Z, true, <:Nothing})(i, j, k, grid, clock, state) where {X, Y, Z}
+    container = getproperty(state, f.field_container)
+    field = getproperty(container, f.field_name)
+
+    return @inbounds f.forcing(xnode(X, i, grid),
+                               ynode(Y, j, grid),
+                               znode(Z, k, grid),
+                               field[i, j, k],
+                               clock.time)
+end
+
+# Simple multiplicative forcing with parameters
+@inline function (f::SimpleForcing{X, Y, Z, true})(i, j, k, grid, clock, state) where {X, Y, Z}
+    container = getproperty(state, f.field_container)
+    field = getproperty(container, f.field_name)
+
+    return @inbounds f.forcing(xnode(X, i, grid),
+                               ynode(Y, j, grid),
+                               znode(Z, k, grid),
+                               clock.time,
+                               field[i, j, k],
+                               f.parameters)
+end
+
+

--- a/src/Forcing/simple_forcing.jl
+++ b/src/Forcing/simple_forcing.jl
@@ -1,5 +1,5 @@
 """
-    struct SimpleForcing{X, Y, Z, M, F, P}
+    SimpleForcing{X, Y, Z, M, F, P}
 
 A callable object that implements a 'simple' forcing function
 on a field at the location `X, Y, Z`.

--- a/src/Forcing/simple_forcing.jl
+++ b/src/Forcing/simple_forcing.jl
@@ -4,7 +4,7 @@
 A callable object that implements a 'simple' forcing function
 on a field at the location `X, Y, Z`.
 """
-struct SimpleForcing{X, Y, Z, M, N, C, P, F}
+struct SimpleForcing{X, Y, Z, M, P, N, C, F}
             forcing :: F
          parameters :: P
      multiplicative :: Bool

--- a/src/Forcing/simple_forcing.jl
+++ b/src/Forcing/simple_forcing.jl
@@ -13,7 +13,7 @@ struct SimpleForcing{X, Y, Z, M, P, F}
 
     function SimpleForcing{X, Y, Z}(field_name, forcing, parameters, multiplicative) where {X, Y, Z}
 
-        # Deduce the container that `field_name` is found. This is only needed
+        # Deduce the container where `field_name` is found. This is only needed
         # if multiplicative=true.
         field_container = field_name ∈ (:u, :v, :w) ? :velocities : :tracers
 

--- a/src/Forcing/simple_forcing.jl
+++ b/src/Forcing/simple_forcing.jl
@@ -79,9 +79,9 @@ julia> v_forcing = SimpleForcing(parameterized_forcing, parameters = (μ=42, λ=
 * Multplicative forcing with no parameters:
 
 ```julia
-julia> tracer_damping(x, y, z, t, c) = exp(z) * c
+julia> growth_in_sunlight(x, y, z, t, P) = exp(z) * P
 
-julia> c_forcing = SimpleForcing(tracer_damping, multiplicative=true)
+julia> plankton_forcing = SimpleForcing(growth_in_sunlight, multiplicative=true)
 ```
 
 * Multiplicative forcing with parameters. This example relaxes a tracer to some reference

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -75,8 +75,8 @@ function time_step_with_simple_forcing_parameters(arch)
 end
 
 """ Take one time step with a SimpleForcing forcing function with parameters. """
-function time_step_with_simple_multiplicative_forcing(arch)
-    u_forcing = SimpleForcing((x, y, z, t, u) -> -u, multiplicative=true)
+function time_step_with_simple_field_dependent_forcing(arch)
+    u_forcing = SimpleForcing((x, y, z, t, u) -> -u, field_in_signature=true)
     grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, euler=true)
@@ -84,8 +84,8 @@ function time_step_with_simple_multiplicative_forcing(arch)
 end
 
 """ Take one time step with a SimpleForcing forcing function with parameters. """
-function time_step_with_simple_multiplicative_forcing_parameters(arch)
-    u_forcing = SimpleForcing((x, y, z, t, u, p) -> sin(p.ω * x) * u, parameters=(ω=π,), multiplicative=true)
+function time_step_with_simple_field_dependent_forcing_parameters(arch)
+    u_forcing = SimpleForcing((x, y, z, t, u, p) -> sin(p.ω * x) * u, parameters=(ω=π,), field_in_signature=true)
     grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, euler=true)
@@ -110,8 +110,8 @@ end
             @test time_step_with_forcing_functions_sin_exp(arch)
             @test time_step_with_simple_forcing(arch)
             @test time_step_with_simple_forcing_parameters(arch)
-            @test time_step_with_simple_multiplicative_forcing(arch)
-            @test time_step_with_simple_multiplicative_forcing_parameters(arch)
+            @test time_step_with_simple_field_dependent_forcing(arch)
+            @test time_step_with_simple_field_dependent_forcing_parameters(arch)
         end
     end
 end

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -74,6 +74,24 @@ function time_step_with_simple_forcing_parameters(arch)
     return true
 end
 
+""" Take one time step with a SimpleForcing forcing function with parameters. """
+function time_step_with_simple_multiplicative_forcing(arch)
+    u_forcing = SimpleForcing((x, y, z, t, u) -> -u, multiplicative=true)
+    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
+    time_step!(model, 1, euler=true)
+    return true
+end
+
+""" Take one time step with a SimpleForcing forcing function with parameters. """
+function time_step_with_simple_multiplicative_forcing_parameters(arch)
+    u_forcing = SimpleForcing((x, y, z, t, u, p) -> sin(p.ω * x) * u, parameters=(ω=π,), multiplicative=true)
+    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
+    time_step!(model, 1, euler=true)
+    return true
+end
+
 @testset "Forcing" begin
     @info "Testing forcings..."
 
@@ -92,6 +110,8 @@ end
             @test time_step_with_forcing_functions_sin_exp(arch)
             @test time_step_with_simple_forcing(arch)
             @test time_step_with_simple_forcing_parameters(arch)
+            @test time_step_with_simple_multiplicative_forcing(arch)
+            @test time_step_with_simple_multiplicative_forcing_parameters(arch)
         end
     end
 end


### PR DESCRIPTION
A 'field-dependent' forcing is a user-specified forcing term that depends on `x, y, z, t, u`, where `u` is the field being forced, and optionally parameters.