### PR TITLE
fix doc links (clima org) and examples (extent keyword)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
   <a href="https://github.com/climate-machine/Oceananigans.jl/issues/new">
     <img alt="Ask us anything" src="https://img.shields.io/badge/Ask%20us-anything-1abc9c.svg?style=flat-square">
   </a>
-  <a href="https://climate-machine.github.io/Oceananigans.jl/stable/">
+  <a href="https://clima.github.io/Oceananigans.jl/stable/">
     <img alt="Stable documentation" src="https://img.shields.io/badge/docs-stable-blue.svg?style=flat-square">
   </a>
-  <a href="https://climate-machine.github.io/Oceananigans.jl/latest">
+  <a href="https://clima.github.io/Oceananigans.jl/latest">
     <img alt="Latest documentation" src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square">
   </a>
 </p>
@@ -85,7 +85,7 @@ At this time, updating should be done with care, as Oceananigans is under rapid 
 Let's initialize a 3D horizontally periodic model with 100×100×50 grid points on a 2×2×1 km domain and simulate it for 1 hour using a constant time step of 60 seconds.
 ```julia
 using Oceananigans
-grid = RegularCartesianGrid(size=(100, 100, 50), length=(2000, 2000, 1000))
+grid = RegularCartesianGrid(size=(100, 100, 50), extent=(2000, 2000, 1000))
 model = IncompressibleModel(grid=grid)
 simulation = Simulation(model, Δt=60, stop_time=3600)
 run!(simulation)
@@ -103,7 +103,7 @@ topology = (Periodic, Periodic, Bounded)
 
 model = IncompressibleModel(
     architecture = CPU(),
-            grid = RegularCartesianGrid(topology=topology, size=(N, N, N), length=(L, L, L)),
+            grid = RegularCartesianGrid(topology=topology, size=(N, N, N), extent=(L, L, L)),
          closure = ConstantIsotropicDiffusivity(ν=4e-2, κ=4e-2)
 )
 

--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -101,7 +101,7 @@ To, for example, create a set of horizontally periodic field boundary conditions
 ```@example
 using Oceananigans # hide
 topology = (Periodic, Periodic, Bounded)
-grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1), topology=topology)
+grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1), topology=topology)
 T_bcs = TracerBoundaryConditions(grid,    top = ValueBoundaryCondition(20),
                                        bottom = GradientBoundaryCondition(0.01))
 ```
@@ -114,7 +114,7 @@ conditions on all fields. To, for example, impose non-default boundary condition
 ```@example
 using Oceananigans # hide
 topology = (Periodic, Periodic, Bounded)
-grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1), topology=topology)
+grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1), topology=topology)
 
 u_bcs = UVelocityBoundaryConditions(grid,   top = ValueBoundaryCondition(+0.1),
                                          bottom = ValueBoundaryCondition(-0.1))

--- a/docs/src/model_setup/checkpointing.md
+++ b/docs/src/model_setup/checkpointing.md
@@ -6,7 +6,7 @@ cluster time limits, but also if you'd like to restore from a checkpoint and try
 For example, to periodically checkpoint the model state to disk every 1,000,000 seconds of simulation time to files of
 the form `model_checkpoint_iteration12500.jld2` where `12500` is the iteration number (automatically filled in)
 ```@example
-model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
+model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1)))
 model.output_writers[:checkpointer] = Checkpointer(model; interval=1e6, prefix="model_checkpoint")
 ```
 

--- a/docs/src/model_setup/diagnostics.md
+++ b/docs/src/model_setup/diagnostics.md
@@ -17,7 +17,7 @@ as [`TimeSeries`](@ref), [`FieldMaximum`](@ref), [`CFL`](@ref), and [`NaNChecker
 ## Horizontal averages
 You can create a `HorizontalAverage` diagnostic by passing a field to the constructor, e.g.
 ```@example
-model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
+model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1)))
 simulation = Simulation(model, Δt=6, stop_iteration=10)
 T_avg = HorizontalAverage(model.tracers.T)
 push!(simulation.diagnostics, T_avg)
@@ -26,7 +26,7 @@ which can then be called on-demand via `T_avg(model)` to return the horizontally
 the GPU you may want it to return an `Array` instead of a `CuArray` in case you want to save the horizontal average to
 disk in which case you'd want to construct it like
 ```@example
-model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
+model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1)))
 simulation = Simulation(model, Δt=6, stop_iteration=10)
 T_avg = HorizontalAverage(model.tracers.T, return_type=Array)
 push!(simulation.diagnostics, T_avg)
@@ -35,7 +35,7 @@ push!(simulation.diagnostics, T_avg)
 You can also use pass an abstract operator to take the horizontal average of any diagnosed quantity. For example, to
 compute the horizontal average of the vertical component of vorticity:
 ```@example
-model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
+model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1)))
 simulation = Simulation(model, Δt=6, stop_iteration=10)
 u, v, w = model.velocities
 ζ = ∂x(v) - ∂y(u)

--- a/docs/src/model_setup/forcing_functions.md
+++ b/docs/src/model_setup/forcing_functions.md
@@ -19,7 +19,7 @@ e-folding length scale of 1% of the domain height.
 ```@example
 using Oceananigans # hide
 N, L = 16, 100
-grid = RegularCartesianGrid(size=(N, N, N), length=(L, L, L))
+grid = RegularCartesianGrid(size=(N, N, N), extent=(L, L, L))
 
 const τ⁻¹ = 1 / 60  # Damping/relaxation time scale [s⁻¹].
 const Δμ = 0.01L    # Sponge layer width [m] set to 1% of the domain height.
@@ -39,7 +39,7 @@ nothing # hide
 using Oceananigans # hide
 Nx = Ny = Nz = 16
 Lx = Ly = Lz = 1000
-grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
+grid = RegularCartesianGrid(size=(Nx, Ny, Nz), extent=(Lx, Ly, Lz))
 
 λ = 1/(1minute)  # Relaxation timescale [s⁻¹].
 
@@ -76,7 +76,7 @@ v_forcing = SimpleForcing(parameterized_forcing, parameters=(μ=42, λ=0.1, ω=�
 
 forcing = ModelForcing(u=u_forcing, v=v_forcing)
 
-grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
+grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
 model = Model(grid=grid, forcing=forcing)
 nothing # hide
 ```

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -9,7 +9,7 @@ A regular Cartesian grid with $N_x \times N_y \times N_z = 64 \times 32 \times 1
 $L_x = 200$ meters, $L_y = 100$ meters, and $L_z = 100$ meters is constructed using
 ```@example
 using Oceananigans # hide
-grid = RegularCartesianGrid(size=(64, 32, 16), length=(200, 100, 100))
+grid = RegularCartesianGrid(size=(64, 32, 16), extent=(200, 100, 100))
 ```
 
 !!! info "Default domain"
@@ -38,7 +38,7 @@ Two-dimensional grids can be constructed by setting the number of grid points al
 two-dimensional grid in the $xz$-plane can be constructed using
 ```@example
 using Oceananigans # hide
-grid = RegularCartesianGrid(size=(64, 1, 16), length=(200, 1, 100), topology=(Periodic, Flat, Bounded))
+grid = RegularCartesianGrid(size=(64, 1, 16), extent=(200, 1, 100), topology=(Periodic, Flat, Bounded))
 ```
 
 In this case the length of the $y$ dimension must be specified but does not matter so we just set it to 1.
@@ -50,7 +50,7 @@ One-dimensional grids can be constructed in a similar manner, most commonly used
 example, to set up a 1D model with $N_z$ grid points
 ```@example
 using Oceananigans # hide
-grid = RegularCartesianGrid(size=(1, 1, 90), length=(1, 1, 1000), topology=(Flat, Flat, Bounded))
+grid = RegularCartesianGrid(size=(1, 1, 90), extent=(1, 1, 1000), topology=(Flat, Flat, Bounded))
 ```
 The length of the $x$ and $y$ dimensions must be specified but do not matter.
 

--- a/docs/src/model_setup/number_type.md
+++ b/docs/src/model_setup/number_type.md
@@ -5,7 +5,7 @@ with 64-bit or 32-bit floating point precision.
 !!! note "Avoiding mixed-precision operations"
     When not using `Float64` be careful to not mix different precisions as it could introduce implicit type conversions
     which can negatively effect performance. You can pass the number type desires to many constructors to enforce
-    the type you want: e.g. `RegularCartesianGrid(Float32; size=(16, 16, 16), length=(1, 1, 1))` and
+    the type you want: e.g. `RegularCartesianGrid(Float32; size=(16, 16, 16), extent=(1, 1, 1))` and
     `ConstantIsotropicDiffusivity(Float16; κ=1//7, ν=2//7)`.
 
 !!! warning "Effect of floating point precision on simulation accuracy"

--- a/docs/src/model_setup/output_writers.md
+++ b/docs/src/model_setup/output_writers.md
@@ -15,7 +15,7 @@ The following example shows how to construct NetCDF output writers for two diffe
 slices) along with output attributes
 ```@example
 Nx = Ny = Nz = 16
-model = Model(grid=RegularCartesianGrid(size=(Nx, Ny, Nz), length=(1, 1, 1)))
+model = Model(grid=RegularCartesianGrid(size=(Nx, Ny, Nz), extent=(1, 1, 1)))
 simulation = Simulation(model, Δt=12, stop_time=3600)
 
 fields = Dict(
@@ -49,7 +49,7 @@ functions have a single input `model`. Whenever output needs to be written, the 
 of the function will be saved to the JLD2 file. For example, to write out 3D fields for w and T and a horizontal average
 of T every 1 hour of simulation time to a file called `some_data.jld2`
 ```@example
-model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
+model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1)))
 simulation = Simulation(model, Δt=12, stop_time=3600)
 
 function init_save_some_metadata(file, model)


### PR DESCRIPTION
Links to documentation probably broke upon changing the org name. Also, the keyword change from `length` to `extent` was apparently not fully propagated through README & doc. Not sure but figured that sending this as PR might be helpful. 
