### PR TITLE
Fixes strange error in ocean wind mixing and convection examples

### DIFF
--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -171,8 +171,8 @@ anim = @animate for i in 1:100
 
     ## Plot the slices.
     w_plot = heatmap(xC, zF, w', xlabel="x (m)", ylabel="z (m)", color=:balance, clims=(-3e-2, 3e-2))
-    T_plot = heatmap(xC, zC, T', xlabel="x (m)", ylabel="z (m)", color=:thermal, clims=(19.75, 20))
-    S_plot = heatmap(xC, zC, S', xlabel="x (m)", ylabel="z (m)", color=:haline, clims=(34.99, 35.01))
+    T_plot = heatmap(xC, zC, T', xlabel="x (m)", ylabel="z (m)", color=:thermal, clims=(19.75, 20.0))
+    S_plot = heatmap(xC, zC, S', xlabel="x (m)", ylabel="z (m)", color=:haline,  clims=(34.99, 35.01))
 
     ## Arrange the plots side-by-side.
     plot(w_plot, T_plot, S_plot, layout=(1, 3), size=(1600, 400),

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -33,8 +33,6 @@ function run_example(replace_strings, example_name, module_suffix="")
 
         @printf("% 3d end # module", number+2)
 
-        @show read(test_script_filepath)
-
         # Delete the test script
         rm(test_script_filepath)
 

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -20,7 +20,11 @@ function run_example(replace_strings, example_name, module_suffix="")
         include(test_script_filepath)
     catch err
         @error sprint(showerror, err)
+
+        @show read(test_script_filepath)
+
         rm(test_script_filepath)
+
         return false
     end
 
@@ -59,11 +63,11 @@ end
     end
 
     for arch in archs
-        @testset "Wind and convection mixing example [$(typeof(arch))]" begin
-            @info "  Testing wind and convection-driving mixing example [$(typeof(arch))]"
+        @testset "Wind and convection-driven mixing example [$(typeof(arch))]" begin
+            @info "  Testing wind and convection-driven mixing example [$(typeof(arch))]"
 
             replace_strings = [
-                ("Nz = 48", "Nz = 16"),
+                ("Nz = 32", "Nz = 16"),
                 ("progress_frequency=10", "progress_frequency=1"),
                 ("for i in 1:100", "for i in 1:1"),
                 ("stop_iteration += 10", "stop_iteration += 1"),

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -27,7 +27,7 @@ function run_example(replace_strings, example_name, module_suffix="")
 
         @printf "% 3d module Test_%s_%s\n" 1 example_name module_suffix
 
-        for (line, number) in enumerate(delineated_file_content)
+        for (number, line) in enumerate(delineated_file_content)
             @printf "% 3d %s\n" number line
         end
 

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -27,7 +27,7 @@ function run_example(replace_strings, example_name, module_suffix="")
 
         @printf "% 3d module Test_%s_%s\n" 1 example_name module_suffix
 
-        for (line, number) in enumerate(delinated_file_content)
+        for (line, number) in enumerate(delineated_file_content)
             @printf "% 3d %s\n" number line
         end
 


### PR DESCRIPTION
Also:

* Changes test_examples.jl to spew example file into the build log on error.
* Makes a minor correction to the replace strings for the `ocean_wind_mixing_ and_convection.jl` example.