### PR TITLE
Bump v0.30.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.29.0"
+version = "0.30.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Just bumping version to 0.30.0 now that you need to use SeawaterPolynomials.jl to access `TEOS10` (a breaking change).