### PR TITLE
Removes push_preview

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -145,5 +145,4 @@ makedocs(
      ]
 )
 
-deploydocs(repo = "github.com/CliMA/Oceananigans.jl.git",
-           push_preview = true)
+deploydocs(repo = "github.com/CliMA/Oceananigans.jl.git")


### PR DESCRIPTION
In retrospect, this option adds more stuff in the gh-pages branch and it increases the size of the repository's history.