### PR TITLE
Only run GPU tests on GPU CI builds

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,7 +102,7 @@ end
 float_types = (Float32, Float64)
 
          archs = (CPU(),)
-@hascuda archs = (CPU(), GPU())
+@hascuda archs = (GPU(),)
 
 closures = (
     :ConstantIsotropicDiffusivity,


### PR DESCRIPTION
Should speed up GitLab CI builds. CPU is already well-tested on Travis CI and Appveyor.