### PR TITLE
Adds a hook for constant targets in Relaxation

### DIFF
--- a/src/Forcing/relaxation.jl
+++ b/src/Forcing/relaxation.jl
@@ -16,6 +16,9 @@ end
 @inline (f::RelaxingFunction)(x, y, z, t, field) =
     f.rate * f.mask(x, y, z) * (f.target(x, y, z, t) - field)
 
+@inline (f::RelaxingFunction{R, M, <:Number})(x, y, z, t, field) where {R, M} =
+    f.rate * f.mask(x, y, z) * (f.target - field)
+
 #####
 ##### Relaxing forcing
 #####

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -111,7 +111,7 @@ function relaxed_time_stepping(arch)
                                       target = LinearTarget{:y}(intercept=π, gradient=ℯ))
 
     z_relax = Relaxation(rate = 1/60,   mask = GaussianMask{:z}(center=0.5, width=0.1),
-                                      target = LinearTarget{:z}(intercept=π, gradient=ℯ))
+                                      target = π)
 
     grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
 


### PR DESCRIPTION
This PR permits the syntax

```julia
u_forcing = Relaxation(; rate=1/60, target=0.1)
```

Previously we would have had to write

```julia
u_forcing = Relaxation(; rate=1/60, target=(x, y, z, t) -> 0.1)
```

since `target` was expected to be a function of `x, y, z, t`.

Might help with #789 
