### PR TITLE
Fix Langmuir turbulence example

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -263,6 +263,7 @@ function nice_divergent_levels(c, clim)
 
     return levels
 end
+nothing # hide
 
 # Finally, we're ready to animate.
 


### PR DESCRIPTION
The Langmuir turbulence example requires JLD2.jl. This PR adds JLD2 in `docs/Project.toml`.

This PR closes #791.