### PR TITLE
Fix deploying docs to OceananigansDocumentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -155,7 +155,7 @@ makedocs(
      ]
 )
 
-withenv("GITHUB_REPOSITORY" => "CliMA/OceananigansDocumentation") do
+withenv("TRAVIS_REPO_SLUG" => "CliMA/OceananigansDocumentation") do
   deploydocs(        repo = "github.com/CliMA/OceananigansDocumentation.git",
                 versions = ["stable" => "v^", "v#.#.#"],
             push_preview = true


### PR DESCRIPTION
The `GITHUB_REPOSITORY` environment variable is used by GitHub actions. We deploy from Travis so the right environment variable is `TRAVIS_REPO_SLUG`.