### PR TITLE
Bump v0.31.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.30.0"
+version = "0.31.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
We should merge this after PR #805.

# Release notes

This release fixes a major bug where you couldn't run GPU models so if you're using GPUs you should upgrade to this version.  **Oceananigans.jl now requires Julia 1.4+.**

Major changes:
* Updated the backend to use [KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl) instead of [GPUifyLoops.jl](https://github.com/vchuravy/GPUifyLoops.jl).
* Updated to using [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl) instead of CuArrays.jl, CUDAnative.jl, and CUDAdrv.jl.
* Updated and slightly expanded the model setup documentation.
* Added a bibliography and citations to the documentation.
* Generalized `ConstantIsotropicDiffusivity` and `ConstantAnisotropicDiffusivity` to accept functions of `x, y, z, t` as well as constants. These types are called `IsotropicDiffusivity` and `AnisotropicDiffusivity`; `ConstantIsotropicDiffusivity` and `ConstantAnisotropicDiffusivity` aliases are provided for backwards compatibility.
* Lots of new convergence tests confirming the accuracy of the model!
