### PR TITLE
Fix existing identifer conflicts

### DIFF
--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -1,5 +1,5 @@
 using CUDA
-using KernelAbstractions
+using KernelAbstractions: @kernel, @index, CUDADevice
 using Oceananigans.Architectures: device
 using Oceananigans.Utils: work_layout
 

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -60,7 +60,7 @@ function launch!(arch, grid, dims, kernel!, args...; dependencies=nothing, kwarg
 
     workgroup, worksize = work_layout(grid, dims)
 
-    loop! = kernel!(Oceananigans.Architectures.device(arch), workgroup, worksize)
+    loop! = kernel!(Architectures.device(arch), workgroup, worksize)
 
     @debug "worksize and kernel:" worksize kernel!
 

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -2,9 +2,9 @@
 ##### Utilities for launching kernels
 #####
 
-using Oceananigans.Architectures: device
 using CUDA
 using KernelAbstractions
+using Oceananigans.Architectures
 
 const MAX_THREADS_PER_BLOCK = 256
 
@@ -19,24 +19,24 @@ For more information, see: https://github.com/climate-machine/Oceananigans.jl/pu
 """
 function work_layout(grid, dims)
 
-    workgroup = grid.Nx == 1 && grid.Ny == 1 ? 
+    workgroup = grid.Nx == 1 && grid.Ny == 1 ?
 
                     # One-dimensional column models:
-                    (1, 1) : 
+                    (1, 1) :
 
-                grid.Nx == 1 ? 
+                grid.Nx == 1 ?
 
                     # Two-dimensional y-z slice models:
                     (1, min(MAX_THREADS_PER_BLOCK, grid.Ny)) :
 
-                grid.Ny == 1 ? 
+                grid.Ny == 1 ?
 
                     # Two-dimensional x-z slice models:
-                    (1, min(MAX_THREADS_PER_BLOCK, grid.Nx)) : 
+                    (1, min(MAX_THREADS_PER_BLOCK, grid.Nx)) :
 
                     # Three-dimensional models use the default (16, 16)
                     (Int(√(MAX_THREADS_PER_BLOCK)), Int(√(MAX_THREADS_PER_BLOCK)))
-    
+
     worksize = dims == :xyz ? (grid.Nx, grid.Ny, grid.Nz) :
                dims == :xy  ? (grid.Nx, grid.Ny) :
                dims == :xz  ? (grid.Nx, grid.Nz) :
@@ -60,7 +60,7 @@ function launch!(arch, grid, dims, kernel!, args...; dependencies=nothing, kwarg
 
     workgroup, worksize = work_layout(grid, dims)
 
-    loop! = kernel!(device(arch), workgroup, worksize)
+    loop! = kernel!(Oceananigans.Architectures.device(arch), workgroup, worksize)
 
     @debug "worksize and kernel:" worksize kernel!
 


### PR DESCRIPTION
These things:
```
WARNING: using CUDA.device in module Utils conflicts with an existing identifier.
WARNING: using KernelAbstractions.CPU in module Fields conflicts with an existing identifier.
WARNING: using KernelAbstractions.GPU in module Fields conflicts with an existing identifier.
```