### PR TITLE
Bump v0.32.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.31.0"
+version = "0.32.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Release notes:

**Everyone should stop using Oceananigans v0.31.0 and upgrade to this version. Oceananigans now requires Julia 1.4 or later.**

This release fixes a major bug concerning a race condition making GPU simulation, especially large models, explode into NaNs in v0.31.0.

It also restores the "Examples" section in the documentation and adds experimental support for higher order advection schemes.