### PR TITLE
Bump v0.33.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.32.0"
+version = "0.33.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Release notes:

This release adds new features to the `NetCDFOutputWriter` and fixes some bugs.
* The date the file was generated, the Julia version, and the Oceananigans version used are always written as global attributes (metadata) to all NetCDF files.
* Added `with_halos` and `verbose` keyword arguments to `NetCDFOutputWriter`.
* Fixed bug in writing grid coordinates to NetCDF (they were previously offset).
* Fixed bug in printing of grid coordinate ranges for `Bounded` dimensions.