### PR TITLE
`iteration_interval` and `time_interval`

### DIFF
--- a/docs/src/model_setup/checkpointing.md
+++ b/docs/src/model_setup/checkpointing.md
@@ -18,7 +18,7 @@ julia> using Oceananigans.OutputWriters;
 
 julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1)));
 
-julia> checkpointer = Checkpointer(model, interval=1000000, prefix="model_checkpoint")
+julia> checkpointer = Checkpointer(model, time_interval=1000000, prefix="model_checkpoint")
 Checkpointer{Nothing,Int64,Array{Symbol,1}}(nothing, 1000000, 0.0, ".", "model_checkpoint", [:architecture, :grid, :clock, :coriolis, :buoyancy, :closure, :velocities, :tracers, :timestepper], false, false)
 ```
 

--- a/docs/src/model_setup/diagnostics.md
+++ b/docs/src/model_setup/diagnostics.md
@@ -9,7 +9,7 @@ Diagnostics are stored as a list of diagnostics in `simulation.diagnostics`. Dia
 time or be specified at any later time and appended (or assigned with a key value pair) to `simulation.diagnostics`.
 
 Most diagnostics can be run at specified frequencies (e.g. every 25 time steps) or specified intervals (e.g. every
-15 minutes of simulation time). If you'd like to run a diagnostic on demand then do not specify a frequency or interval
+15 minutes of simulation time). If you'd like to run a diagnostic on demand then do not specify any intervals
 (and do not add it to `simulation.diagnostics`).
 
 We describe the `HorizontalAverage` diagnostic in detail below but see the API documentation for other diagnostics such

--- a/docs/src/model_setup/output_writers.md
+++ b/docs/src/model_setup/output_writers.md
@@ -28,10 +28,10 @@ simulation = Simulation(model, Δt=12, stop_time=3600);
 fields = Dict("u" => model.velocities.u, "T" => model.tracers.T);
 
 simulation.output_writers[:field_writer] =
-    NetCDFOutputWriter(model, fields, filename="output_fields.nc", interval=60)
+    NetCDFOutputWriter(model, fields, filename="output_fields.nc", time_interval=60)
 
 # output
-NetCDFOutputWriter (interval=60): output_fields.nc
+NetCDFOutputWriter (time_interval=60): output_fields.nc
 ├── dimensions: zC(16), zF(17), xC(16), yF(16), xF(16), yC(16), time(0)
 └── 2 outputs: ["T", "u"]
 ```
@@ -39,10 +39,10 @@ NetCDFOutputWriter (interval=60): output_fields.nc
 ```jldoctest netcdf1
 simulation.output_writers[:surface_slice_writer] =
     NetCDFOutputWriter(model, fields, filename="output_surface_xy_slice.nc",
-                       interval=60, zC=grid.Nz, zF=grid.Nz+1)
+                       time_interval=60, zC=grid.Nz, zF=grid.Nz+1)
 
 # output
-NetCDFOutputWriter (interval=60): output_surface_xy_slice.nc
+NetCDFOutputWriter (time_interval=60): output_surface_xy_slice.nc
 ├── dimensions: zC(1), zF(1), xC(16), yF(16), xF(16), yC(16), time(0)
 └── 2 outputs: ["T", "u"]
 ```
@@ -79,11 +79,11 @@ global_attributes = Dict("location" => "Bay of Fundy", "onions" => 7);
 
 simulation.output_writers[:stuff] =
     NetCDFOutputWriter(model, outputs,
-                       frequency=1, filename="stuff.nc", dimensions=dims, verbose=true,
+                       iteration_interval=1, filename="stuff.nc", dimensions=dims, verbose=true,
                        global_attributes=global_attributes, output_attributes=output_attributes)
 
 # output
-NetCDFOutputWriter (frequency=1): stuff.nc
+NetCDFOutputWriter (iteration_interval=1): stuff.nc
 ├── dimensions: zC(16), zF(17), xC(16), yF(16), xF(16), yC(16), time(0)
 └── 3 outputs: ["profile", "slice", "scalar"]
 ```

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -88,7 +88,7 @@ forcing_parameters = (α=α, f=f, H=Lz)
 #
 # is applied at location `(f, c, c)`.
 
-function Fu_eady_func(i, j, k, grid, clock, state, p) 
+function Fu_eady_func(i, j, k, grid, clock, state, p)
     return @inbounds (- p.α * ℑxzᶠᵃᶜ(i, j, k, grid, state.velocities.w)
                       - p.α * (grid.zC[k] + p.H) * ∂xᶠᵃᵃ(i, j, k, grid, ℑxᶜᵃᵃ, state.velocities.u))
 end
@@ -99,7 +99,7 @@ end
 #
 # is applied at location `(c, f, c)`.
 
-function Fv_eady_func(i, j, k, grid, clock, state, p) 
+function Fv_eady_func(i, j, k, grid, clock, state, p)
     return @inbounds -p.α * (grid.zC[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, state.velocities.v)
 end
 
@@ -109,7 +109,7 @@ end
 #
 # is applied at location `(c, c, f)`.
 
-function Fw_eady_func(i, j, k, grid, clock, state, p) 
+function Fw_eady_func(i, j, k, grid, clock, state, p)
     return @inbounds -p.α * (grid.zF[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, state.velocities.w)
 end
 
@@ -119,7 +119,7 @@ end
 #
 # is applied at location `(c, c, c)`.
 
-function Fb_eady_func(i, j, k, grid, clock, state, p) 
+function Fb_eady_func(i, j, k, grid, clock, state, p)
     return @inbounds (- p.α * (grid.zC[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, state.tracers.b)
                       + p.f * p.α * ℑyᵃᶜᵃ(i, j, k, grid, state.velocities.v))
 end
@@ -184,7 +184,7 @@ wmax = FieldMaximum(abs, model.velocities.w)
 # Set up output. Here we output the velocity and buoyancy fields at intervals of one day.
 fields_to_output = merge(model.velocities, (b=model.tracers.b,))
 output_writer = JLD2OutputWriter(model, FieldOutputs(fields_to_output);
-                                 interval=day, prefix=output_filename_prefix,
+                                 time_interval=day, prefix=output_filename_prefix,
                                  force=true, max_filesize=10GiB)
 
 # # The `TimeStepWizard`

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -85,12 +85,12 @@ set!(model, u=u₀, v=v₀, w=w₀, b=b₀)
 # Finally, we release the packet and watch it go!
 
 simulation = Simulation(model, Δt = 0.001 * 2π/ω, stop_iteration = 0,
-                        progress_frequency = 20)
+                        iteration_interval = 20)
 
 anim = @animate for i=0:100
     x, z = xnodes(Cell, model.grid)[:], znodes(Face, model.grid)[:]
     w = model.velocities.w
-    
+
     contourf(x, z, w.data[1:Nx, 1, 1:Nx+1]',
                    title = @sprintf("ωt = %.2f", ω * model.clock.time),
                   levels = range(-1e-8, stop=1e-8, length=10),
@@ -103,7 +103,7 @@ anim = @animate for i=0:100
                    color = :balance,
                   legend = false,
              aspectratio = :equal)
-            
+
     simulation.stop_iteration += 20
     run!(simulation)
 end

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -198,7 +198,7 @@ end
 
 using Oceananigans.Utils: hour # correpsonds to "1 hour", in units of seconds
 
-simulation = Simulation(model, progress_frequency = 100,
+simulation = Simulation(model, iteration_interval = 100,
                                                Δt = wizard,
                                         stop_time = 4hour,
                                          progress = print_progress)

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -1,13 +1,13 @@
 # # Langmuir turbulence example
 #
 # This example implements the Langmuir turbulence simulation reported in section
-# 4 of 
-# 
-# [McWilliams, J. C. et al., "Langmuir Turbulence in the ocean," Journal of Fluid Mechanics (1997)](https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/langmuir-turbulence-in-the-ocean/638FD0E368140E5972144348DB930A38). 
+# 4 of
+#
+# [McWilliams, J. C. et al., "Langmuir Turbulence in the ocean," Journal of Fluid Mechanics (1997)](https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/langmuir-turbulence-in-the-ocean/638FD0E368140E5972144348DB930A38).
 #
 # This example demonstrates:
 #
-#   * how to run large eddy simulations with surface wave effects 
+#   * how to run large eddy simulations with surface wave effects
 #     via the Craik-Leibovich approximation
 
 using Oceananigans
@@ -19,7 +19,7 @@ using Oceananigans
 #
 # ### Domain specification and Grid construction
 #
-# We create a grid with modest resolution. The grid extent is similar, but not 
+# We create a grid with modest resolution. The grid extent is similar, but not
 # exactly the same as that in McWilliams et al. (1997).
 
 using Oceananigans.Grids
@@ -65,7 +65,7 @@ nothing # hide
 ∂z_uˢ(z, t) = 2wavenumber * Uˢ * exp(2wavenumber * z)
 nothing # hide
 
-# Finally, we note that the time-derivative of the Stokes drift must be provided 
+# Finally, we note that the time-derivative of the Stokes drift must be provided
 # if the Stokes drift changes in time. In this example, the Stokes drift is constant
 # and thus the time-derivative of the Stokes drift is 0.
 
@@ -119,7 +119,7 @@ nothing # hide
 # model for large eddy simulation. Because our Stokes drift does not vary in $x, y$,
 # we use `UniformStokesDrift`, which expects Stokes drift functions of $z, t$ only.
 
-using Oceananigans.Buoyancy: BuoyancyTracer 
+using Oceananigans.Buoyancy: BuoyancyTracer
 using Oceananigans.SurfaceWaves: UniformStokesDrift
 
 model = IncompressibleModel(        architecture = CPU(),
@@ -129,13 +129,13 @@ model = IncompressibleModel(        architecture = CPU(),
                                         coriolis = FPlane(f=f),
                                          closure = AnisotropicMinimumDissipation(),
                                    surface_waves = UniformStokesDrift(∂z_uˢ=∂z_uˢ),
-                             boundary_conditions = (u=u_boundary_conditions, 
+                             boundary_conditions = (u=u_boundary_conditions,
                                                     b=b_boundary_conditions),
                             )
 
 # ## Initial conditions
 #
-# We make use of random noise concentrated in the upper 4 meters 
+# We make use of random noise concentrated in the upper 4 meters
 # for buoyancy and velocity initial conditions,
 
 Ξ(z) = randn() * exp(z / 4)
@@ -187,7 +187,7 @@ function print_progress(simulation)
                    prettytime(wizard.Δt),
                    umax(), vmax(), wmax(),
                    prettytime(1e-9 * (time_ns() - wall_clock))
-                  )       
+                  )
 
     @info msg
 
@@ -202,10 +202,10 @@ simulation = Simulation(model, iteration_interval = 100,
                                                Δt = wizard,
                                         stop_time = 4hour,
                                          progress = print_progress)
-                        
+
 # ## Output
 #
-# We set up an output writer for the simulation that saves all velocity fields, 
+# We set up an output writer for the simulation that saves all velocity fields,
 # tracer fields, and the subgrid turbulent diffusivity every 2 minutes.
 
 using Oceananigans.OutputWriters
@@ -213,10 +213,9 @@ using Oceananigans.Utils: minute
 
 field_outputs = FieldOutputs(merge(model.velocities, model.tracers, (νₑ=model.diffusivities.νₑ,)))
 
-simulation.output_writers[:fields] = JLD2OutputWriter(model, field_outputs,
-                                                      interval = 2minute,
-                                                        prefix = "langmuir_turbulence",
-                                                         force = true)
+simulation.output_writers[:fields] =
+    JLD2OutputWriter(model, field_outputs, time_interval = 2minute,
+                     prefix = "langmuir_turbulence", force = true)
 nothing # hide
 
 # ## Running the simulation
@@ -317,7 +316,7 @@ anim = @animate for (i, iter) in enumerate(iterations)
                               ylims = (-grid.Lz, 0),
                              xlabel = "x (m)",
                              ylabel = "z (m)")
-                        
+
     plot(wxy_plot, wxz_plot, uxz_plot, layout=(1, 3), size=(1000, 400),
          title = ["w(x, y, z=-8, t) (m/s)" "w(x, y=0, z, t) (m/s)" "u(x, y = 0, z, t) (m/s)"])
 

--- a/examples/netcdf_ouput_example.jl
+++ b/examples/netcdf_ouput_example.jl
@@ -42,14 +42,14 @@ globalattrib = Dict("f" => 1e-4, "name" => "Thermal bubble expt 1")
 # have xC as their dimension and at xF[6] for all fields that have xF
 # as their dimension. Ranges also can be specified (e.g. xC=2:10)
 subsetwriter = NetCDFOutputWriter(model, outputs;
-                                  interval=10, filename="dump_subset.nc",
+                                  time_interval=10, filename="dump_subset.nc",
                                   output_attributes=outputattrib,
                                   global_attributes=globalattrib,
                                   xC=5, xF=6)
 push!(model.output_writers, subsetwriter)
 
 # The following writer saves a data from the entire domain
-globalwriter = NetCDFOutputWriter(model, outputs, interval=10,
+globalwriter = NetCDFOutputWriter(model, outputs, time_interval=10,
                                   filename="dump_global.nc")
 push!(model.output_writers, globalwriter)
 

--- a/examples/ocean_convection_with_plankton.jl
+++ b/examples/ocean_convection_with_plankton.jl
@@ -77,7 +77,7 @@ wizard = TimeStepWizard(cfl=0.1, Δt=1.0, max_change=1.1, max_Δt=90.0)
 nothing # hide
 
 # Set up and run the simulation:
-simulation = Simulation(model, Δt=wizard, stop_iteration=0, progress_frequency=100)
+simulation = Simulation(model, Δt=wizard, stop_iteration=0, iteration_interval=100)
 
 anim = @animate for i = 1:100
     simulation.stop_iteration += 100

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -129,7 +129,7 @@ nothing # hide
 
 ## Instantiate a JLD2OutputWriter to write fields. We will add it to the simulation before
 ## running it.
-field_writer = JLD2OutputWriter(model, FieldOutputs(fields_to_output); interval=hour/4,
+field_writer = JLD2OutputWriter(model, FieldOutputs(fields_to_output); time_interval=hour/4,
                                 prefix="ocean_wind_mixing_and_convection", force=true)
 
 # ## Running the simulation

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -148,7 +148,7 @@ nothing # hide
 
 # Finally, we set up and run the the simulation.
 
-simulation = Simulation(model, Δt=wizard, stop_iteration=0, progress_frequency=10)
+simulation = Simulation(model, Δt=wizard, stop_iteration=0, iteration_interval=10)
 simulation.output_writers[:fields] = field_writer
 
 anim = @animate for i in 1:100

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -90,10 +90,8 @@ plot!(p, interior(T)[1, 1, :], z, linewidth=2, label=tracer_label(model.clock.ti
 using Oceananigans.OutputWriters: JLD2OutputWriter, FieldOutputs
 
 simulation.output_writers[:temperature] =
-    JLD2OutputWriter(model, FieldOutputs(model.tracers),
-                     frequency = 100,
-                        prefix = "one_dimensional_diffusion",
-                         force = true)
+    JLD2OutputWriter(model, FieldOutputs(model.tracers), prefix = "one_dimensional_diffusion",
+                     iteration_interval = 100, force = true)
 
 ## Run simulation for 10,000 more iterations
 simulation.stop_iteration += 10000
@@ -101,7 +99,7 @@ simulation.stop_iteration += 10000
 run!(simulation)
 nothing
 
-# Finally, we animate the results by opening the JLD2 file, extract the 
+# Finally, we animate the results by opening the JLD2 file, extract the
 # iterations we ended up saving at, and plot the evolution of the
 # temperature profile in a loop over the iterations.
 

--- a/src/Diagnostics/horizontal_average.jl
+++ b/src/Diagnostics/horizontal_average.jl
@@ -8,18 +8,18 @@ using Oceananigans.Grids: total_size
 
 A diagnostic for computing horizontal average of a field.
 """
-mutable struct HorizontalAverage{F, R, P, I, Ω, G} <: AbstractDiagnostic
-          field :: F
-         result :: P
-      frequency :: Ω
-       interval :: I
-       previous :: Float64
-    return_type :: R
-           grid :: G
+mutable struct HorizontalAverage{F, R, P, I, T, G} <: AbstractDiagnostic
+                   field :: F
+                  result :: P
+      iteration_interval :: I
+           time_interval :: T
+                previous :: Float64
+             return_type :: R
+                    grid :: G
 end
 
 """
-    HorizontalAverage(model, field; frequency=nothing, interval=nothing, return_type=Array)
+    HorizontalAverage(model, field; iteration_interval=nothing, time_interval=nothing, return_type=Array)
 
 Construct a `HorizontalAverage` of `field`.
 
@@ -28,18 +28,18 @@ After the horizontal average is computed it will be stored in the `result` prope
 The `HorizontalAverage` can be used as a callable object that computes and returns the
 horizontal average.
 
-A `frequency` or `interval` (or both) can be passed to indicate how often to run this
-diagnostic if it is part of `model.diagnostics`. `frequency` is a number of iterations
-while `interval` is a time interval in units of `model.clock.time`.
+An `iteration_interval` or `time_interval` (or both) can be passed to indicate how often
+to run this diagnostic if it is part of `simulation.diagnostics`. `iteration_interval` is
+a number of iterations while `time_interval` is in units of `model.clock.time`.
 
 A `return_type` can be used to specify the type returned when the `HorizontalAverage` is
 used as a callable object. The default `return_type=Array` is useful when running a GPU
 model and you want to save the output to disk by passing it to an output writer.
 """
-function HorizontalAverage(field; frequency=nothing, interval=nothing, return_type=Array)
+function HorizontalAverage(field; iteration_interval=nothing, time_interval=nothing, return_type=Array)
     arch = architecture(field)
     result = zeros(arch, field.grid, 1, 1, total_size(parent(field))[3])
-    return HorizontalAverage(field, result, frequency, interval, 0.0, return_type, field.grid)
+    return HorizontalAverage(field, result, iteration_interval, time_interval, 0.0, return_type, field.grid)
 end
 
 # Normalize a horizontal sum to get the horizontal average.

--- a/src/Diagnostics/nan_checker.jl
+++ b/src/Diagnostics/nan_checker.jl
@@ -4,19 +4,19 @@
 A diagnostic that checks for `NaN` values and aborts the simulation if any are found.
 """
 struct NaNChecker{F} <: AbstractDiagnostic
-    frequency :: Int
-       fields :: F
+    iteration_interval :: Int
+                fields :: F
 end
 
 """
-    NaNChecker(model; frequency, fields)
+    NaNChecker(model; iteration_interval, fields)
 
-Construct a `NaNChecker` for `model`. `fields` should be a `Dict{Symbol,Field}`. A
-`frequency` should be passed to indicate how often to check for NaNs (in number of
-iterations).
+Construct a `NaNChecker` for `model`. `fields` should be a `Dict{Symbol,Field}`. An
+`iteration_interval` should be passed to indicate how often to check for NaNs (in
+number of iterations).
 """
-function NaNChecker(model; frequency, fields)
-    return NaNChecker(frequency, fields)
+function NaNChecker(model; iteration_interval, fields)
+    return NaNChecker(iteration_interval, fields)
 end
 
 function run_diagnostic(model, nc::NaNChecker)

--- a/src/Diagnostics/time_series.jl
+++ b/src/Diagnostics/time_series.jl
@@ -19,7 +19,7 @@ A `TimeSeries` `Diagnostic` that records a time series of `diagnostic(model)`.
 Example
 =======
 
-```jldoctest
+```jldoctest timeseries1
 julia> using Oceananigans, Oceananigans.Diagnostics
 
 julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1)));
@@ -33,7 +33,10 @@ julia> max_u = TimeSeries(FieldMaximum(abs, model.velocities.u), model; iteratio
 julia> sim.diagnostics[:max_u] = max_u;
 
 julia> run!(sim);
+[ Info: Simulation is stopping. Model iteration 3 has hit or exceeded simulation stop iteration 3.
+```
 
+```jldoctest timeseries1
 julia> max_u.data
 4-element Array{Float64,1}:
  3.141592653589793
@@ -65,7 +68,7 @@ A `TimeSeries` `Diagnostic` that records a `NamedTuple` of time series of
 Example
 =======
 
-```jldoctest timeseries
+```jldoctest timeseries2
 julia> using Oceananigans, Oceananigans.Diagnostics
 
 julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1)));
@@ -79,12 +82,15 @@ julia> sim = Simulation(model, Δt=Δt, stop_iteration=3);
 julia> sim.diagnostics[:cfl] = cfl;
 
 julia> run!(sim);
+[ Info: Simulation is stopping. Model iteration 3 has hit or exceeded simulation stop iteration 3.
+```
 
+```jldoctest timeseries2
 julia> cfl.data
 (adv = [0.0, 0.0, 0.0, 0.0], diff = [0.0002688, 0.0002688, 0.0002688, 0.0002688])
 ```
 
-``` jldoctest timeseries
+``` jldoctest timeseries2
 julia> cfl.diff
 4-element Array{Float64,1}:
  0.0002688

--- a/src/Diagnostics/time_series.jl
+++ b/src/Diagnostics/time_series.jl
@@ -1,29 +1,30 @@
 """
-    TimeSeries{D, Ω, I, T, TT} <: AbstractDiagnostic
+    TimeSeries{D, II, TI, T, TT} <: AbstractDiagnostic
 
 A diagnostic for collecting and storing time series.
 """
-struct TimeSeries{D, Ω, I, T, TT} <: AbstractDiagnostic
-    diagnostic :: D
-     frequency :: Ω
-      interval :: I
-          data :: T
-          time :: Vector{TT}
+struct TimeSeries{D, II, TI, T, TT} <: AbstractDiagnostic
+            diagnostic :: D
+    iteration_interval :: II
+         time_interval :: TI
+                  data :: T
+                  time :: Vector{TT}
 end
 
 """
-    TimeSeries(diagnostic, model; frequency=nothing, interval=nothing)
+    TimeSeries(diagnostic, model; iteration_interval=nothing, time_interval=nothing)
 
 A `TimeSeries` `Diagnostic` that records a time series of `diagnostic(model)`.
 
 Example
 =======
-```julia
-julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)));
 
-julia> max_u = TimeSeries(FieldMaximum(abs, model.velocities.u), model; frequency=1)
+```jldoctest
+julia> using Oceananigans, Oceananigans.Diagnostics
 
-julia> model.diagnostics[:max_u] = max_u; data(model.velocities.u) .= π; time_step!(model, Nt=3, Δt=1e-16)
+julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1)));
+
+julia> max_u = TimeSeries(FieldMaximum(abs, model.velocities.u), model; iteration_interval=1)
 
 julia> max_u.data
 3-element Array{Float64,1}:
@@ -32,10 +33,10 @@ julia> max_u.data
  3.1415925323439517
 ```
 """
-function TimeSeries(diagnostic, model; frequency=nothing, interval=nothing)
+function TimeSeries(diagnostic, model; iteration_interval=nothing, time_interval=nothing)
     TD = typeof(diagnostic(model))
     TT = typeof(model.clock.time)
-    return TimeSeries(diagnostic, frequency, interval, TD[], TT[])
+    return TimeSeries(diagnostic, iteration_interval, time_interval, TD[], TT[])
 end
 
 @inline (time_series::TimeSeries)(model) = time_series.diagnostic(model)
@@ -47,17 +48,17 @@ function run_diagnostic(model, diag::TimeSeries)
 end
 
 """
-    TimeSeries(diagnostics::NamedTuple, model; frequency=nothing, interval=nothing)
+    TimeSeries(diagnostics::NamedTuple, model; iteration_interval=nothing, time_interval=nothing)
 
 A `TimeSeries` `Diagnostic` that records a `NamedTuple` of time series of
 `diag(model)` for each `diag` in `diagnostics`.
 
 Example
 =======
-```julia
+```jldoctest
 julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))); Δt = 1.0;
 
-julia> cfl = TimeSeries((adv=AdvectiveCFL(Δt), diff=DiffusiveCFL(Δt)), model; frequency=1);
+julia> cfl = TimeSeries((adv=AdvectiveCFL(Δt), diff=DiffusiveCFL(Δt)), model; iteration_interval=1);
 
 julia> model.diagnostics[:cfl] = cfl; time_step!(model, Nt=3, Δt=Δt)
 
@@ -72,11 +73,11 @@ julia> cfl.adv
  0.0
 ```
 """
-function TimeSeries(diagnostics::NamedTuple, model; frequency=nothing, interval=nothing)
+function TimeSeries(diagnostics::NamedTuple, model; iteration_interval=nothing, time_interval=nothing)
     TT = typeof(model.clock.time)
     TDs = Tuple(typeof(diag(model)) for diag in diagnostics)
     data = NamedTuple{propertynames(diagnostics)}(Tuple(T[] for T in TDs))
-    return TimeSeries(diagnostics, frequency, interval, data, TT[])
+    return TimeSeries(diagnostics, iteration_interval, time_interval, data, TT[])
 end
 
 function (time_series::TimeSeries{<:NamedTuple})(model)

--- a/src/Diagnostics/time_series.jl
+++ b/src/Diagnostics/time_series.jl
@@ -24,8 +24,6 @@ julia> using Oceananigans, Oceananigans.Diagnostics
 
 julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1)));
 
-julia> set!(model, u=π);
-
 julia> sim = Simulation(model, Δt=1, stop_iteration=3);
 
 julia> max_u = TimeSeries(FieldMaximum(abs, model.velocities.u), model; iteration_interval=1);
@@ -39,10 +37,10 @@ julia> run!(sim);
 ```jldoctest timeseries1
 julia> max_u.data
 4-element Array{Float64,1}:
- 3.141592653589793
- 3.141592653589793
- 3.141592653589793
- 3.141592653589793
+ 0.0
+ 0.0
+ 0.0
+ 0.0
 ```
 """
 function TimeSeries(diagnostic, model; iteration_interval=nothing, time_interval=nothing)

--- a/src/Diagnostics/time_series.jl
+++ b/src/Diagnostics/time_series.jl
@@ -91,12 +91,12 @@ julia> cfl.data
 ```
 
 ``` jldoctest timeseries2
-julia> cfl.diff
+julia> cfl.adv
 4-element Array{Float64,1}:
- 0.0002688
- 0.0002688
- 0.0002688
- 0.0002688
+ 0.0
+ 0.0
+ 0.0
+ 0.0
 ```
 """
 function TimeSeries(diagnostics::NamedTuple, model; iteration_interval=nothing, time_interval=nothing)

--- a/src/Grids/regular_cartesian_grid.jl
+++ b/src/Grids/regular_cartesian_grid.jl
@@ -90,22 +90,28 @@ Grid properties
 Examples
 ========
 
-```julia
+```jldoctest
+julia> using Oceananigans
+
 julia> grid = RegularCartesianGrid(size=(32, 32, 32), extent=(1, 2, 3))
-RegularCartesianGrid{Float64}
-domain: x ∈ [0.0, 1.0], y ∈ [0.0, 2.0], z ∈ [0.0, -3.0]
-  resolution (Nx, Ny, Nz) = (32, 32, 32)
-   halo size (Hx, Hy, Hz) = (1, 1, 1)
-grid spacing (Δx, Δy, Δz) = (0.03125, 0.0625, 0.09375)
+RegularCartesianGrid{Float64, Periodic, Periodic, Bounded}
+                   domain: x ∈ [0.0, 1.0], y ∈ [0.0, 2.0], z ∈ [-3.0, 0.0]
+                 topology: (Periodic, Periodic, Bounded)
+  resolution (Nx, Ny, Nz): (32, 32, 32)
+   halo size (Hx, Hy, Hz): (1, 1, 1)
+grid spacing (Δx, Δy, Δz): (0.03125, 0.0625, 0.09375)
 ```
 
-```julia
+```jldoctest
+julia> using Oceananigans
+
 julia> grid = RegularCartesianGrid(Float32; size=(32, 32, 16), x=(0, 8), y=(-10, 10), z=(-π, π))
-RegularCartesianGrid{Float32}
-domain: x ∈ [0.0, 8.0], y ∈ [-10.0, 10.0], z ∈ [3.141592653589793, -3.141592653589793]
-  resolution (Nx, Ny, Nz) = (32, 32, 16)
-   halo size (Hx, Hy, Hz) = (1, 1, 1)
-grid spacing (Δx, Δy, Δz) = (0.25f0, 0.625f0, 0.3926991f0)
+RegularCartesianGrid{Float32, Periodic, Periodic, Bounded}
+                   domain: x ∈ [0.0, 8.0], y ∈ [-10.0, 10.0], z ∈ [-3.1415927, 3.1415927]
+                 topology: (Periodic, Periodic, Bounded)
+  resolution (Nx, Ny, Nz): (32, 32, 16)
+   halo size (Hx, Hy, Hz): (1, 1, 1)
+grid spacing (Δx, Δy, Δz): (0.25f0, 0.625f0, 0.3926991f0)
 ```
 """
 function RegularCartesianGrid(FT=Float64;

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -1,28 +1,28 @@
 """
-    Checkpointer{I, T, P, A} <: AbstractOutputWriter
+    Checkpointer{I, T, P} <: AbstractOutputWriter
 
 An output writer for checkpointing models to a JLD2 file from which models can be restored.
 """
 mutable struct Checkpointer{I, T, P} <: AbstractOutputWriter
-         frequency :: I
-          interval :: T
-          previous :: Float64
-               dir :: String
-            prefix :: String
-        properties :: P
-             force :: Bool
-           verbose :: Bool
+    iteration_interval :: I
+         time_interval :: T
+              previous :: Float64
+                   dir :: String
+                prefix :: String
+            properties :: P
+                 force :: Bool
+               verbose :: Bool
 end
 
 """
-    Checkpointer(model; frequency=nothing, interval=nothing, dir=".",
+    Checkpointer(model; iteration_interval=nothing, time_interval=nothing, dir=".",
                  prefix="checkpoint", force=false, verbose=false,
                  properties = [:architecture, :boundary_conditions, :grid, :clock, :coriolis,
                                :buoyancy, :closure, :velocities, :tracers, :timestepper])
 
 Construct a `Checkpointer` that checkpoints the model to a JLD2 file every so often as
-specified by `frequency` or `interval`. The `model.clock.iteration` is included in the
-filename to distinguish between multiple checkpoint files.
+specified by `iteration_interval` or `time_interval`. The `model.clock.iteration` is included
+in the filename to distinguish between multiple checkpoint files.
 
 Note that extra model `properties` can be safely specified, but removing crucial properties
 such as `:velocities` will make restoring from the checkpoint impossible.
@@ -34,21 +34,21 @@ file (and you will have to manually restore them).
 
 Keyword arguments
 =================
-- `frequency::Int`   : Save output every `n` model iterations.
-- `interval::Int`    : Save output every `t` units of model clock time.
-- `dir::String`      : Directory to save output to. Default: "." (current working directory).
-- `prefix::String`   : Descriptive filename prefixed to all output files. Default: "checkpoint".
-- `force::Bool`      : Remove existing files if their filenames conflict. Default: `false`.
-- `verbose::Bool`    : Log what the output writer is doing with statistics on compute/write times and file sizes.
-                       Default: `false`.
-- `properties::Array`: List of model properties to checkpoint.
+- `iteration_interval`: Save output every `n` model iterations.
+- `time_interval`: Save output every `t` units of model clock time.
+- `dir`: Directory to save output to. Default: "." (current working directory).
+- `prefix`: Descriptive filename prefixed to all output files. Default: "checkpoint".
+- `force`: Remove existing files if their filenames conflict. Default: `false`.
+- `verbose`: Log what the output writer is doing with statistics on compute/write times
+  and file sizes. Default: `false`.
+- `properties`: List of model properties to checkpoint. Some are required.
 """
-function Checkpointer(model; frequency=nothing, interval=nothing, dir=".",
-                      prefix="checkpoint", force=false, verbose=false,
+function Checkpointer(model; iteration_interval=nothing, time_interval=nothing,
+                      dir=".", prefix="checkpoint", force=false, verbose=false,
                       properties = [:architecture, :grid, :clock, :coriolis,
                                     :buoyancy, :closure, :velocities, :tracers, :timestepper])
 
-    validate_interval(frequency, interval)
+    validate_interval(iteration_interval, time_interval)
 
     # Certain properties are required for `restore_from_checkpoint` to work.
     required_properties = (:grid, :architecture, :velocities, :tracers, :timestepper)
@@ -70,7 +70,7 @@ function Checkpointer(model; frequency=nothing, interval=nothing, dir=".",
     end
 
     mkpath(dir)
-    return Checkpointer(frequency, interval, 0.0, dir, prefix, properties, force, verbose)
+    return Checkpointer(iteration_interval, time_interval, 0.0, dir, prefix, properties, force, verbose)
 end
 
 function write_output(model, c::Checkpointer)

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -48,7 +48,7 @@ function Checkpointer(model; iteration_interval=nothing, time_interval=nothing,
                       properties = [:architecture, :grid, :clock, :coriolis,
                                     :buoyancy, :closure, :velocities, :tracers, :timestepper])
 
-    validate_interval(iteration_interval, time_interval)
+    validate_intervals(iteration_interval, time_interval)
 
     # Certain properties are required for `restore_from_checkpoint` to work.
     required_properties = (:grid, :architecture, :velocities, :tracers, :timestepper)

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -59,7 +59,7 @@ function JLD2OutputWriter(model, outputs; iteration_interval=nothing, time_inter
                           part=1, max_filesize=Inf, force=false, async=false, verbose=false,
                           jld2_kw=Dict{Symbol, Any}())
 
-    validate_interval(iteration_interval, time_interval)
+    validate_intervals(iteration_interval, time_interval)
 
     mkpath(dir)
     filepath = joinpath(dir, prefix * ".jld2")

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -167,19 +167,6 @@ FieldOutput(field) = FieldOutput(Array, field) # default
 Returns a dictionary of `FieldOutput` objects with key, value
 pairs corresponding to each name and value in the `NamedTuple` `fields`.
 Intended for use with `JLD2OutputWriter`.
-
-Examples
-========
-
-```jldoctest
-julia> output_writer = JLD2OutputWriter(model, FieldOutputs(model.velocities));
-
-julia> keys(output_writer.outputs)
-Base.KeySet for a Dict{Symbol,FieldOutput{UnionAll,F} where F} with 3 entries. Keys:
-  :w
-  :v
-  :u
-```
 """
 function FieldOutputs(fields)
     names = propertynames(fields)

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -2,7 +2,7 @@ using Dates: now
 using NCDatasets
 using Oceananigans.Fields
 using Oceananigans.Fields: cpudata
-using Oceananigans.Utils: validate_interval, versioninfo_with_gpu, oceananigans_versioninfo
+using Oceananigans.Utils: validate_intervals, versioninfo_with_gpu, oceananigans_versioninfo
 using Oceananigans.Grids: topology, interior_x_indices, interior_y_indices, interior_z_indices,
                           all_x_indices, all_y_indices, all_z_indices
 
@@ -163,7 +163,7 @@ function NetCDFOutputWriter(model, outputs; filename,
     )
 
     mode = clobber ? "c" : "a"
-    validate_interval(iteration_interval, time_interval)
+    validate_intervals(iteration_interval, time_interval)
 
     # Generates a dictionary with keys "xC", "xF", etc, whose values give the slices to be saved.
     slice_keywords = Dict(name => a for (name, a) in zip(("xC", "yC", "zC", "xF", "yF", "zF"),

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -95,7 +95,7 @@ NetCDFOutputWriter (interval=60): fields.nc
 ```jldoctest netcdf1
 simulation.output_writers[:surface_slice_writer] =
     NetCDFOutputWriter(model, fields, filename="surface_xy_slice.nc",
-                       interval=60, zC=grid.Nz, zF=grid.Nz+1)
+                       time_interval=60, zC=grid.Nz, zF=grid.Nz+1)
 
 # output
 NetCDFOutputWriter (interval=60): surface_xy_slice.nc

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -20,24 +20,24 @@ const default_output_attributes = Dict(
 )
 
 """
-    NetCDFOutputWriter{D, O, I, F, S} <: AbstractOutputWriter
+    NetCDFOutputWriter{D, O, I, T, S} <: AbstractOutputWriter
 
 An output writer for writing to NetCDF files.
 """
-mutable struct NetCDFOutputWriter{D, O, I, F, S} <: AbstractOutputWriter
-     filename :: String
-      dataset :: D
-      outputs :: O
-     interval :: I
-    frequency :: F
-      clobber :: Bool
-       slices :: S
-     previous :: Float64
-      verbose :: Bool
+mutable struct NetCDFOutputWriter{D, O, I, T, S} <: AbstractOutputWriter
+              filename :: String
+               dataset :: D
+               outputs :: O
+    iteration_interval :: I
+         time_interval :: T
+               clobber :: Bool
+                slices :: S
+              previous :: Float64
+               verbose :: Bool
 end
 
 """
-    NetCDFOutputWriter(model, outputs; filename, frequency=nothing, interval=nothing,
+    NetCDFOutputWriter(model, outputs; filename, iteration_interval=nothing, time_interval=nothing,
                        global_attributes=Dict(), output_attributes=Dict(), dimensions=Dict(),
                        clobber=true, compression=0, with_halos=false, verbose=false, slice_kwargs...)
 
@@ -49,8 +49,8 @@ specified.
 
 Keyword arguments
 =================
-- `frequency`: Save output every `n` model iterations.
-- `interval`: Save output every `t` units of model clock time.
+- `iteration_interval`: Save output every `n` model iterations.
+- `time_interval`: Save output every `t` units of model clock time.
 - `filename`: Filepath to save output to.
 - `global_attributes`: Dict of model properties to save with every file (deafult: `Dict()`)
 - `output_attributes`: Dict of attributes to be saved with each field variable (reasonable
@@ -84,7 +84,7 @@ simulation = Simulation(model, Δt=12, stop_time=3600);
 fields = Dict("u" => model.velocities.u, "T" => model.tracers.T);
 
 simulation.output_writers[:field_writer] =
-    NetCDFOutputWriter(model, fields, filename="fields.nc", interval=60)
+    NetCDFOutputWriter(model, fields, filename="fields.nc", time_interval=60)
 
 # output
 NetCDFOutputWriter (interval=60): fields.nc
@@ -135,25 +135,25 @@ global_attributes = Dict("location" => "Bay of Fundy", "onions" => 7);
 
 simulation.output_writers[:things] =
     NetCDFOutputWriter(model, outputs,
-                       frequency=1, filename="things.nc", dimensions=dims, verbose=true,
+                       iteration_interval=1, filename="things.nc", dimensions=dims, verbose=true,
                        global_attributes=global_attributes, output_attributes=output_attributes)
 
 # output
-NetCDFOutputWriter (frequency=1): things.nc
+NetCDFOutputWriter (iteration_interval=1): things.nc
 ├── dimensions: zC(16), zF(17), xC(16), yF(16), xF(16), yC(16), time(0)
 └── 3 outputs: ["profile", "slice", "scalar"]
 ```
 """
 function NetCDFOutputWriter(model, outputs; filename,
-             interval = nothing,
-            frequency = nothing,
-    global_attributes = Dict(),
-    output_attributes = Dict(),
-           dimensions = Dict(),
-              clobber = true,
-          compression = 0,
-        with_halos = false,
-              verbose = false,
+    iteration_interval = nothing,
+         time_interval = nothing,
+     global_attributes = Dict(),
+     output_attributes = Dict(),
+            dimensions = Dict(),
+               clobber = true,
+           compression = 0,
+            with_halos = false,
+               verbose = false,
     xC = with_halos ? all_x_indices(Cell, model.grid) : interior_x_indices(Cell, model.grid),
     xF = with_halos ? all_x_indices(Face, model.grid) : interior_x_indices(Face, model.grid),
     yC = with_halos ? all_y_indices(Cell, model.grid) : interior_y_indices(Cell, model.grid),
@@ -163,7 +163,7 @@ function NetCDFOutputWriter(model, outputs; filename,
     )
 
     mode = clobber ? "c" : "a"
-    validate_interval(interval, frequency)
+    validate_interval(iteration_interval, time_interval)
 
     # Generates a dictionary with keys "xC", "xF", etc, whose values give the slices to be saved.
     slice_keywords = Dict(name => a for (name, a) in zip(("xC", "yC", "zC", "xF", "yF", "zF"),
@@ -210,7 +210,7 @@ function NetCDFOutputWriter(model, outputs; filename,
     slices = Dict(name => slice_indices(field; xC=xC, yC=yC, zC=zC, xF=xF, yF=yF, zF=zF)
                   for (name, field) in field_outputs)
 
-    return NetCDFOutputWriter(filename, dataset, outputs, interval, frequency,
+    return NetCDFOutputWriter(filename, dataset, outputs, iteration_interval, time_interval,
                               clobber, slices, 0.0, verbose)
 end
 
@@ -375,10 +375,10 @@ function write_grid_and_attributes(model;
 end
 
 function Base.show(io::IO, ow::NetCDFOutputWriter)
-    freq_int = isnothing(ow.frequency) && isnothing(ow.interval) ? "" :
-               isnothing(ow.frequency) ? "(interval=$(ow.interval))" :
-               isnothing(ow.interval)  ? "(frequency=$(ow.frequency))" :
-               "(frequency=$(ow.frequency), interval=$(ow.interval))"
+    freq_int = isnothing(ow.iteration_interval) && isnothing(ow.time_interval) ? "" :
+               isnothing(ow.iteration_interval) ? "(time_interval=$(ow.time_interval))" :
+               isnothing(ow.time_interval)      ? "(iteration_interval=$(ow.iteration_interval))" :
+               "(iteration_interval=$(ow.iteration_interval), time_interval=$(ow.time_interval))"
 
     dims = join([dim * "(" * string(length(ow.dataset[dim])) * "), "
                  for dim in keys(ow.dataset.dim)])[1:end-2]

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -87,7 +87,7 @@ simulation.output_writers[:field_writer] =
     NetCDFOutputWriter(model, fields, filename="fields.nc", time_interval=60)
 
 # output
-NetCDFOutputWriter (interval=60): fields.nc
+NetCDFOutputWriter (time_interval=60): fields.nc
 ├── dimensions: zC(16), zF(17), xC(16), yF(16), xF(16), yC(16), time(0)
 └── 2 outputs: ["T", "u"]
 ```
@@ -98,7 +98,7 @@ simulation.output_writers[:surface_slice_writer] =
                        time_interval=60, zC=grid.Nz, zF=grid.Nz+1)
 
 # output
-NetCDFOutputWriter (interval=60): surface_xy_slice.nc
+NetCDFOutputWriter (time_interval=60): surface_xy_slice.nc
 ├── dimensions: zC(1), zF(1), xC(16), yF(16), xF(16), yC(16), time(0)
 └── 2 outputs: ["T", "u"]
 ```

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -68,7 +68,7 @@ function run!(sim)
             [write_output(sim.model, out)    for out  in values(sim.output_writers)]
         end
 
-        for n in 1:sim.progress_frequency
+        for n in 1:sim.iteration_interval
             euler = clock.iteration == 0 || (sim.Δt isa TimeStepWizard && n == 1)
             time_step!(model, get_Δt(sim.Δt), euler=euler)
 

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -11,7 +11,7 @@ mutable struct Simulation{M, Δ, C, I, T, W, R, D, O, P, F, Π}
            diagnostics :: D
         output_writers :: O
               progress :: P
-    progress_frequency :: F
+    iteration_interval :: F
             parameters :: Π
 end
 
@@ -24,7 +24,7 @@ end
            diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
         output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
               progress = nothing,
-    progress_frequency = 1,
+    iteration_interval = 1,
             parameters = nothing)
 
 Construct an Oceananigans.jl `Simulation` for a `model` with time step `Δt`.
@@ -41,8 +41,8 @@ Keyword arguments
 - `wall_time_limit`: Stop the simulation if it's been running for longer than this many
    seconds of wall clock time.
 - `progress`: A function with a single argument, the `simulation`. Will be called every
-  `progress_frequency` iterations. Useful for logging simulation health.
-- `progress_frequency`: How often to update the time step, check stop criteria, and call
+  `iteration_interval` iterations. Useful for logging simulation health.
+- `iteration_interval`: How often to update the time step, check stop criteria, and call
   `progress` function (in number of iterations).
 - `parameters`: Parameters that can be accessed in the `progress` function.
 """
@@ -54,7 +54,7 @@ function Simulation(model; Δt,
           diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
        output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
              progress = nothing,
-   progress_frequency = 1,
+   iteration_interval = 1,
            parameters = nothing)
 
    if stop_iteration == Inf && stop_time == Inf && wall_time_limit == Inf
@@ -62,15 +62,15 @@ function Simulation(model; Δt,
              "= wall time limit = Inf."
    end
 
-   if Δt isa TimeStepWizard && progress_frequency == 1
-       @warn "You have used the default progress_frequency=1. This simulation will " *
+   if Δt isa TimeStepWizard && iteration_interval == 1
+       @warn "You have used the default iteration_interval=1. This simulation will " *
              "recalculate the time step every iteration which can be slow."
    end
 
    run_time = 0.0
 
    return Simulation(model, Δt, stop_criteria, stop_iteration, stop_time, wall_time_limit,
-                     run_time, diagnostics, output_writers, progress, progress_frequency,
+                     run_time, diagnostics, output_writers, progress, iteration_interval,
                      parameters)
 end
 
@@ -78,10 +78,9 @@ Base.show(io::IO, s::Simulation) =
     print(io, "Simulation{$(typeof(s.model).name){$(typeof(s.model.architecture)), $(eltype(s.model.grid))}}\n",
             "├── Model clock: time = $(prettytime(s.model.clock.time)), iteration = $(s.model.clock.iteration) \n",
             "├── Next time step ($(typeof(s.Δt))): $(prettytime(get_Δt(s.Δt))) \n",
-            "├── Progress frequency: $(s.progress_frequency)\n",
+            "├── Iteration interval: $(s.iteration_interval)\n",
             "├── Stop criteria: $(s.stop_criteria)\n",
             "├── Run time: $(prettytime(s.run_time)), wall time limit: $(s.wall_time_limit)\n",
             "├── Stop time: $(prettytime(s.stop_time)), stop iteration: $(s.stop_iteration)\n",
             "├── Diagnostics: $(ordered_dict_show(s.diagnostics, "│"))\n",
             "└── Output writers: $(ordered_dict_show(s.output_writers, "│"))")
-

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -8,7 +8,7 @@ export
     TimeStepWizard, update_Δt!,
     prettytime, pretty_filesize,
     tupleit, parenttuple, datatuple, datatuples,
-    validate_interval, time_to_run,
+    validate_intervals, time_to_run,
     ordered_dict_show,
     with_tracers,
     versioninfo_with_gpu, oceananigans_versioninfo

--- a/src/Utils/output_writer_diagnostic_utils.jl
+++ b/src/Utils/output_writer_diagnostic_utils.jl
@@ -29,38 +29,37 @@ function push!(container::DiagOrWriterDict, elems...)
 end
 
 """
-    validate_interval(frequency, interval)
+    validate_intervals(iteration_interval, time_interval)
 
-Ensure that frequency and interval are not both `nothing`.
+Warn the user if iteration and time intervals are both `nothing`.
 """
-function validate_interval(frequency, interval)
-    isnothing(frequency) && isnothing(interval) && @error "Must specify a frequency or interval!"
+function validate_intervals(iteration_interval, time_interval)
+    isnothing(iteration_interval) && isnothing(time_interval) && @warn "You have not specified any intervals."
     return nothing
 end
 
-has_interval(obj) = :interval in propertynames(obj) && obj.interval != nothing
-has_frequency(obj) = :frequency in propertynames(obj) && obj.frequency != nothing
+has_iteration_interval(obj) = :iteration_interval in propertynames(obj) && obj.iteration_interval != nothing
+has_time_interval(obj) = :time_interval in propertynames(obj) && obj.time_interval != nothing
 
-function interval_is_ripe(clock, obj)
-    if has_interval(obj) && clock.time >= obj.previous + obj.interval
-        obj.previous = clock.time - rem(clock.time, obj.interval)
+iteration_interval_is_ripe(clock, obj) = has_iteration_interval(obj) && clock.iteration % obj.iteration_interval == 0
+
+function time_interval_is_ripe(clock, obj)
+    if has_time_interval(obj) && clock.time >= obj.previous + obj.time_interval
+        obj.previous = clock.time - rem(clock.time, obj.time_interval)
         return true
     else
         return false
     end
 end
 
-frequency_is_ripe(clock, obj) = has_frequency(obj) && clock.iteration % obj.frequency == 0
+function time_to_run(clock, diag)
+    iteration_interval_is_ripe(clock, diag) && return true
+    has_time_interval(clock, diag) && return true
 
-function time_to_run(clock, output_writer)
-
-    interval_is_ripe(clock, output_writer) && return true
-    frequency_is_ripe(clock, output_writer) && return true
-
-    # If the output writer does not specify an interval or frequency,
+    # If the output writer does not specify any intervals,
     # it is unable to write output and we throw an error as a convenience.
-    has_interval(output_writer) || has_frequency(output_writer) ||
-        error("$(typeof(output_writer)) must have a frequency or interval specified!")
+    iteration_interval_is_ripe(diag) || has_time_interval(diag) ||
+        error("$(typeof(diag)) must have an iteration or time interval specified!")
 
     return false
 end

--- a/src/Utils/output_writer_diagnostic_utils.jl
+++ b/src/Utils/output_writer_diagnostic_utils.jl
@@ -54,11 +54,11 @@ end
 
 function time_to_run(clock, diag)
     iteration_interval_is_ripe(clock, diag) && return true
-    has_time_interval(clock, diag) && return true
+    time_interval_is_ripe(clock, diag) && return true
 
     # If the output writer does not specify any intervals,
     # it is unable to write output and we throw an error as a convenience.
-    iteration_interval_is_ripe(diag) || has_time_interval(diag) ||
+    has_iteration_interval(diag) || has_time_interval(diag) ||
         error("$(typeof(diag)) must have an iteration or time interval specified!")
 
     return false

--- a/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
+++ b/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
@@ -53,7 +53,7 @@ function run_ocean_large_eddy_simulation_regression_test(arch, closure)
     simulation.stop_iteration = spinup_steps-test_steps
     run!(simulation)
 
-    checkpointer = Checkpointer(model, frequency = test_steps, prefix = name,
+    checkpointer = Checkpointer(model, iteration_interval = test_steps, prefix = name,
                                 dir = joinpath(dirname(@__FILE__), "data"))
 
     simulation.output_writers[:checkpointer] = checkpointer
@@ -104,16 +104,16 @@ function run_ocean_large_eddy_simulation_regression_test(arch, closure)
 
     field_names = ["u", "v", "w", "T", "S"]
 
-    test_fields = (model.velocities.u.data.parent, 
+    test_fields = (model.velocities.u.data.parent,
                    model.velocities.v.data.parent,
-                   model.velocities.w.data.parent, 
+                   model.velocities.w.data.parent,
                    model.tracers.T.data.parent,
                    model.tracers.S.data.parent)
 
     correct_fields = (solution₁.u,
-                      solution₁.v, 
+                      solution₁.v,
                       solution₁.w,
-                      solution₁.T, 
+                      solution₁.T,
                       solution₁.S)
 
     summarize_regression_test(field_names, test_fields, correct_fields)

--- a/test/regression_tests/rayleigh_benard_regression_test.jl
+++ b/test/regression_tests/rayleigh_benard_regression_test.jl
@@ -56,7 +56,7 @@ function run_rayleigh_benard_regression_test(arch)
 
     prefix = "rayleigh_benard"
 
-    checkpointer = Checkpointer(model, frequency=test_steps, prefix=prefix,
+    checkpointer = Checkpointer(model, iteration_interval=test_steps, prefix=prefix,
                                 dir=joinpath(dirname(@__FILE__), "data"))
 
     #####
@@ -120,16 +120,16 @@ function run_rayleigh_benard_regression_test(arch)
 
     field_names = ["u", "v", "w", "b", "c"]
 
-    test_fields = (model.velocities.u.data.parent, 
+    test_fields = (model.velocities.u.data.parent,
                    model.velocities.v.data.parent,
-                   model.velocities.w.data.parent, 
+                   model.velocities.w.data.parent,
                    model.tracers.b.data.parent,
                    model.tracers.c.data.parent)
 
-    correct_fields = (solution₁.u, 
-                      solution₁.v, 
+    correct_fields = (solution₁.u,
+                      solution₁.v,
                       solution₁.w,
-                      solution₁.b, 
+                      solution₁.b,
                       solution₁.c)
 
     summarize_regression_test(field_names, test_fields, correct_fields)

--- a/test/regression_tests/thermal_bubble_regression_test.jl
+++ b/test/regression_tests/thermal_bubble_regression_test.jl
@@ -33,7 +33,7 @@ function run_thermal_bubble_regression_test(arch)
                    "T" => model.tracers.T,
                    "S" => model.tracers.S)
 
-    nc_writer = NetCDFOutputWriter(model, outputs, filename=regression_data_filepath, frequency=10)
+    nc_writer = NetCDFOutputWriter(model, outputs, filename=regression_data_filepath, iteration_interval=10)
     push!(simulation.output_writers, nc_writer)
     =#
 
@@ -53,10 +53,10 @@ function run_thermal_bubble_regression_test(arch)
 
     field_names = ["u", "v", "w", "T", "S"]
 
-    test_fields = (interior(model.velocities.u), 
-                   interior(model.velocities.v), 
+    test_fields = (interior(model.velocities.u),
+                   interior(model.velocities.v),
                    interior(model.velocities.w),
-                   interior(model.tracers.T), 
+                   interior(model.tracers.T),
                    interior(model.tracers.S))
 
     correct_fields = [uᶜ, vᶜ, wᶜ, Tᶜ, Sᶜ]

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -5,7 +5,7 @@ function horizontal_average_is_correct(arch, FT)
     T₀(x, y, z) = z
     set!(model; T=T₀)
 
-    T̅ = HorizontalAverage(model.tracers.T; interval=0.5second)
+    T̅ = HorizontalAverage(model.tracers.T; time_interval=0.5second)
     computed_profile = dropdims(T̅(model), dims=(1, 2))
 
     zC = znodes(Cell, grid)

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -19,7 +19,7 @@ function nan_checker_aborts_simulation(arch, FT)
     model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT)
 
     # It checks for NaNs in w by default.
-    nc = NaNChecker(model; frequency=1, fields=Dict(:w => model.velocities.w.data.parent))
+    nc = NaNChecker(model; iteration_interval=1, fields=Dict(:w => model.velocities.w.data.parent))
     push!(model.diagnostics, nc)
 
     model.velocities.w[4, 3, 2] = NaN
@@ -83,7 +83,7 @@ function timeseries_diagnostic_works(arch, FT)
     model = TestModel(arch, FT)
     Δt = FT(1e-16)
     simulation = Simulation(model, Δt=Δt, stop_iteration=1)
-    iter_diag = TimeSeries(get_iteration, model, frequency=1)
+    iter_diag = TimeSeries(get_iteration, model, iteration_interval=1)
     push!(simulation.diagnostics, iter_diag)
     run!(simulation)
     return iter_diag.time[end] == Δt && iter_diag.data[end] == 1
@@ -93,7 +93,7 @@ function timeseries_diagnostic_tuples(arch, FT)
     model = TestModel(arch, FT)
     Δt = FT(1e-16)
     simulation = Simulation(model, Δt=Δt, stop_iteration=2)
-    timeseries = TimeSeries((iters=get_iteration, itertimes=get_time), model, frequency=2)
+    timeseries = TimeSeries((iters=get_iteration, itertimes=get_time), model, iteration_interval=2)
     simulation.diagnostics[:timeseries] = timeseries
     run!(simulation)
     return timeseries.iters[end] == 2 && timeseries.itertimes[end] == 2Δt
@@ -115,7 +115,7 @@ function diagnostics_setindex(arch, FT)
 
     iter_timeseries = TimeSeries(get_iteration, model)
     time_timeseries = TimeSeries(get_time, model)
-    max_abs_u_timeseries = TimeSeries(FieldMaximum(abs, model.velocities.u), model, frequency=1)
+    max_abs_u_timeseries = TimeSeries(FieldMaximum(abs, model.velocities.u), model, iteration_interval=1)
 
     push!(simulation.diagnostics, iter_timeseries, time_timeseries)
     simulation.diagnostics[2] = max_abs_u_timeseries

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -80,7 +80,7 @@ end
 
             replace_strings = [
                 ("Nz = 32", "Nz = 16"),
-                ("progress_frequency=10", "progress_frequency=1"),
+                ("iteration_interval=10", "iteration_interval=1"),
                 ("for i in 1:100", "for i in 1:1"),
                 ("stop_iteration += 10", "stop_iteration += 1"),
                 ("mp4(", "# mp4(")
@@ -101,7 +101,7 @@ end
 
         replace_strings = [
             ("Nz = 128", "Nz = 16"),
-            ("progress_frequency=100", "progress_frequency=1"),
+            ("iteration_interval=100", "iteration_interval=1"),
             ("for i = 1:100", "for i = 1:1"),
             ("stop_iteration += 100", "stop_iteration += 1"),
             ("mp4(", "# mp4(")
@@ -115,7 +115,7 @@ end
 
         replace_strings = [
             ("Nx = 128", "Nx = 16"),
-            ("progress_frequency = 20", "progress_frequency = 1"),
+            ("iteration_interval = 20", "iteration_interval = 1"),
             ("for i=1:100", "for i=1:1"),
             ("stop_iteration += 20", "stop_iteration += 1"),
             ("mp4(", "# mp4(")

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -24,7 +24,7 @@ function run_thermal_bubble_netcdf_tests(arch)
         "S" => model.tracers.S
     )
     nc_filename = "test_dump_$(typeof(arch)).nc"
-    nc_writer = NetCDFOutputWriter(model, outputs, filename=nc_filename, frequency=10, verbose=true)
+    nc_writer = NetCDFOutputWriter(model, outputs, filename=nc_filename, iteration_interval=10, verbose=true)
     push!(simulation.output_writers, nc_writer)
 
     xC_slice = 1:10
@@ -36,7 +36,7 @@ function run_thermal_bubble_netcdf_tests(arch)
 
     nc_sliced_filename = "test_dump_sliced_$(typeof(arch)).nc"
     nc_sliced_writer =
-        NetCDFOutputWriter(model, outputs, filename=nc_sliced_filename, frequency=10, verbose=true,
+        NetCDFOutputWriter(model, outputs, filename=nc_sliced_filename, iteration_interval=10, verbose=true,
                            xC=xC_slice, xF=xF_slice, yC=yC_slice,
                            yF=yF_slice, zC=zC_slice, zF=zF_slice)
 
@@ -156,7 +156,7 @@ function run_thermal_bubble_netcdf_tests_with_halos(arch)
         "S" => model.tracers.S
     )
     nc_filename = "test_dump_with_halos_$(typeof(arch)).nc"
-    nc_writer = NetCDFOutputWriter(model, outputs, filename=nc_filename, frequency=10, with_halos=true)
+    nc_writer = NetCDFOutputWriter(model, outputs, filename=nc_filename, iteration_interval=10, with_halos=true)
     push!(simulation.output_writers, nc_writer)
 
     run!(simulation)
@@ -236,7 +236,7 @@ function run_netcdf_function_output_tests(arch)
     nc_filename = "test_function_outputs_$(typeof(arch)).nc"
     simulation.output_writers[:food] =
         NetCDFOutputWriter(model, outputs;
-            frequency=1, filename=nc_filename, dimensions=dims, verbose=true,
+            iteration_interval=1, filename=nc_filename, dimensions=dims, verbose=true,
             global_attributes=global_attributes, output_attributes=output_attributes)
 
     run!(simulation)
@@ -311,7 +311,7 @@ function run_jld2_file_splitting_tests(arch)
         file["boundary_conditions/fake"] = π
     end
 
-    ow = JLD2OutputWriter(model, fields; dir=".", prefix="test", frequency=1,
+    ow = JLD2OutputWriter(model, fields; dir=".", prefix="test", iteration_interval=1,
                           init=fake_bc_init, including=[:grid],
                           max_filesize=200KiB, force=true)
 
@@ -367,7 +367,7 @@ function run_thermal_bubble_checkpointer_tests(arch)
     run!(true_simulation)
 
     checkpointed_simulation = Simulation(checkpointed_model, Δt=Δt, stop_iteration=5)
-    checkpointer = Checkpointer(checkpointed_model, frequency=5, force=true)
+    checkpointer = Checkpointer(checkpointed_model, iteration_interval=5, force=true)
     push!(checkpointed_simulation.output_writers, checkpointer)
 
     # Checkpoint should be saved as "checkpoint5.jld" after the 5th iteration.

--- a/verification/convergence_tests/ConvergenceTests/DoublyPeriodicTaylorGreen.jl
+++ b/verification/convergence_tests/ConvergenceTests/DoublyPeriodicTaylorGreen.jl
@@ -32,7 +32,7 @@ function setup_simulation(; Nx, Δt, stop_iteration, U=1, architecture=CPU(), di
     simulation.output_writers[:fields] = JLD2OutputWriter(model, FieldOutputs(model.velocities);
                                                           dir = dir, force = true,
                                                           prefix = @sprintf("taylor_green_Nx%d_Δt%.1e", Nx, Δt),
-                                                          interval = stop_iteration * Δt / 10)
+                                                          time_interval = stop_iteration * Δt / 10)
 
     return simulation
 end

--- a/verification/convergence_tests/ConvergenceTests/DoublyPeriodicTaylorGreen.jl
+++ b/verification/convergence_tests/ConvergenceTests/DoublyPeriodicTaylorGreen.jl
@@ -14,7 +14,7 @@ v(x, y, t, U=1) =   - exp(-2t) * sin(x - U*t) * cos(y)
 
 function setup_simulation(; Nx, Δt, stop_iteration, U=1, architecture=CPU(), dir="data")
 
-    grid = RegularCartesianGrid(size=(Nx, Nx, 1), x=(0, 2π), y=(0, 2π), z=(0, 1), 
+    grid = RegularCartesianGrid(size=(Nx, Nx, 1), x=(0, 2π), y=(0, 2π), z=(0, 1),
                                 topology=(Periodic, Periodic, Bounded))
 
     model = IncompressibleModel(architecture = architecture,
@@ -24,13 +24,13 @@ function setup_simulation(; Nx, Δt, stop_iteration, U=1, architecture=CPU(), di
                                      tracers = nothing,
                                      closure = ConstantIsotropicDiffusivity(ν=1))
 
-    set!(model, u = (x, y, z) -> u(x, y, 0, U), 
+    set!(model, u = (x, y, z) -> u(x, y, 0, U),
                 v = (x, y, z) -> v(x, y, 0, U))
 
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
 
     simulation.output_writers[:fields] = JLD2OutputWriter(model, FieldOutputs(model.velocities);
-                                                          dir = dir, force = true, 
+                                                          dir = dir, force = true,
                                                           prefix = @sprintf("taylor_green_Nx%d_Δt%.1e", Nx, Δt),
                                                           interval = stop_iteration * Δt / 10)
 
@@ -42,9 +42,9 @@ function setup_and_run(; setup...)
     simulation = setup_simulation(; setup...)
 
     println("""
-            Running decaying Taylor-Green vortex simulation in x, y with 
+            Running decaying Taylor-Green vortex simulation in x, y with
 
-                Nx = $(setup[:Nx]) 
+                Nx = $(setup[:Nx])
                 Δt = $(setup[:Δt])
 
             """)

--- a/verification/convergence_tests/ConvergenceTests/ForcedFlowFixedSlip.jl
+++ b/verification/convergence_tests/ConvergenceTests/ForcedFlowFixedSlip.jl
@@ -60,7 +60,7 @@ function setup_xy_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir=
     simulation.output_writers[:fields] = JLD2OutputWriter(model, outputs,
                                                           dir = dir, force = true,
                                                           prefix = @sprintf("forced_fixed_slip_xy_Nx%d_Δt%.1e", Nx, Δt),
-                                                          interval = stop_iteration * Δt / 2)
+                                                          time_interval = stop_iteration * Δt / 2)
 
     return simulation
 end
@@ -104,7 +104,7 @@ function setup_xz_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir=
     simulation.output_writers[:fields] = JLD2OutputWriter(model, outputs,
                                                           dir = dir, force = true,
                                                           prefix = @sprintf("forced_fixed_slip_xz_Nx%d_Δt%.1e", Nx, Δt),
-                                                          interval = stop_iteration * Δt / 2)
+                                                          time_interval = stop_iteration * Δt / 2)
 
     return simulation
 end

--- a/verification/convergence_tests/ConvergenceTests/ForcedFlowFixedSlip.jl
+++ b/verification/convergence_tests/ConvergenceTests/ForcedFlowFixedSlip.jl
@@ -32,7 +32,7 @@ function setup_xy_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir=
     u_forcing = SimpleForcing((x, y, z, t) -> Fᵘ(x, y, t))
     v_forcing = SimpleForcing((x, y, z, t) -> Fᵛ(x, y, t))
 
-    grid = RegularCartesianGrid(size=(Nx, Nx, 1), x=(0, 2π), y=(0, 1), z=(0, 1), 
+    grid = RegularCartesianGrid(size=(Nx, Nx, 1), x=(0, 2π), y=(0, 1), z=(0, 1),
                                 topology=(Periodic, Bounded, Bounded))
 
     # "Fixed slip" boundary conditions (eg, no-slip on south wall, finite slip on north wall)."
@@ -51,8 +51,8 @@ function setup_xy_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir=
     set!(model, u = (x, y, z) -> u(x, y, 0),
                 v = (x, y, z) -> v(x, y, 0))
 
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
-    
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
+
     outputs = Dict()
     outputs[:p] = model -> parent(model.pressures.pHY′) .+ parent(model.pressures.pNHS)
     outputs = merge(outputs, FieldOutputs(model.velocities))
@@ -76,7 +76,7 @@ function setup_xz_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir=
     u_forcing = SimpleForcing((x, y, z, t) -> Fᵘ(x, z, t))
     w_forcing = SimpleForcing((x, y, z, t) -> Fᵛ(x, z, t))
 
-    grid = RegularCartesianGrid(size=(Nx, 1, Nx), x=(0, 2π), y=(0, 1), z=(0, 1), 
+    grid = RegularCartesianGrid(size=(Nx, 1, Nx), x=(0, 2π), y=(0, 1), z=(0, 1),
                                 topology=(Periodic, Bounded, Bounded))
 
     # "Fixed slip" boundary conditions (eg, no-slip on bottom and finite slip on top)."
@@ -95,7 +95,7 @@ function setup_xz_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir=
     set!(model, u = (x, y, z) -> u(x, z, 0),
                 w = (x, y, z) -> v(x, z, 0))
 
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
 
     outputs = Dict()
     outputs[:p] = model -> parent(model.pressures.pHY′) .+ parent(model.pressures.pNHS)

--- a/verification/convergence_tests/ConvergenceTests/ForcedFlowFreeSlip.jl
+++ b/verification/convergence_tests/ConvergenceTests/ForcedFlowFreeSlip.jl
@@ -25,7 +25,7 @@ v(x, y, t) = -fₓ(x, t) * sin(y)
 
 function setup_xz_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir="data")
 
-    grid = RegularCartesianGrid(size=(Nx, 1, Nx), x=(0, 2π), y=(0, 1), z=(0, π), 
+    grid = RegularCartesianGrid(size=(Nx, 1, Nx), x=(0, 2π), y=(0, 1), z=(0, π),
                                 topology=(Periodic, Periodic, Bounded))
 
     model = IncompressibleModel(architecture = architecture,
@@ -34,14 +34,14 @@ function setup_xz_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir=
                                     buoyancy = nothing,
                                      tracers = nothing,
                                      closure = ConstantIsotropicDiffusivity(ν=1),
-                                     forcing = ModelForcing(u = SimpleForcing((x, y, z, t) -> Fᵘ(x, z, t)), 
+                                     forcing = ModelForcing(u = SimpleForcing((x, y, z, t) -> Fᵘ(x, z, t)),
                                                             w = SimpleForcing((x, y, z, t) -> Fᵛ(x, z, t)))
                                 )
 
-    set!(model, u = (x, y, z) -> u(x, z, 0), 
+    set!(model, u = (x, y, z) -> u(x, z, 0),
                 w = (x, y, z) -> v(x, z, 0))
 
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
 
     simulation.output_writers[:fields] = JLD2OutputWriter(model, FieldOutputs(model.velocities);
                                                           dir = dir, force = true,
@@ -64,7 +64,7 @@ end
 
 function setup_xy_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir="data")
 
-    grid = RegularCartesianGrid(size=(Nx, Nx, 1), x=(0, 2π), y=(0, π), z=(0, 1), 
+    grid = RegularCartesianGrid(size=(Nx, Nx, 1), x=(0, 2π), y=(0, π), z=(0, 1),
                                 topology=(Periodic, Bounded, Bounded))
 
     model = IncompressibleModel(architecture = architecture,
@@ -73,14 +73,14 @@ function setup_xy_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir=
                                     buoyancy = nothing,
                                      tracers = nothing,
                                      closure = ConstantIsotropicDiffusivity(ν=1),
-                                     forcing = ModelForcing(u = SimpleForcing((x, y, z, t) -> Fᵘ(x, y, t)), 
+                                     forcing = ModelForcing(u = SimpleForcing((x, y, z, t) -> Fᵘ(x, y, t)),
                                                             v = SimpleForcing((x, y, z, t) -> Fᵛ(x, y, t)))
                                 )
 
-    set!(model, u = (x, y, z) -> u(x, y, 0), 
+    set!(model, u = (x, y, z) -> u(x, y, 0),
                 v = (x, y, z) -> v(x, y, 0))
 
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
 
     simulation.output_writers[:fields] = JLD2OutputWriter(model, FieldOutputs(model.velocities);
                                                           dir = dir, force = true,

--- a/verification/convergence_tests/ConvergenceTests/ForcedFlowFreeSlip.jl
+++ b/verification/convergence_tests/ConvergenceTests/ForcedFlowFreeSlip.jl
@@ -46,7 +46,7 @@ function setup_xz_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir=
     simulation.output_writers[:fields] = JLD2OutputWriter(model, FieldOutputs(model.velocities);
                                                           dir = dir, force = true,
                                                           prefix = @sprintf("forced_free_slip_xz_Nx%d_Δt%.1e", Nx, Δt),
-                                                          interval = stop_iteration * Δt / 2)
+                                                          time_interval = stop_iteration * Δt / 2)
 
     return simulation
 end
@@ -85,7 +85,7 @@ function setup_xy_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir=
     simulation.output_writers[:fields] = JLD2OutputWriter(model, FieldOutputs(model.velocities);
                                                           dir = dir, force = true,
                                                           prefix = @sprintf("forced_free_slip_xy_Nx%d_Δt%.1e", Nx, Δt),
-                                                          interval=stop_iteration * Δt / 2)
+                                                          time_interval=stop_iteration * Δt / 2)
 
     return simulation
 end

--- a/verification/convergence_tests/ConvergenceTests/OneDimensionalCosineAdvectionDiffusion.jl
+++ b/verification/convergence_tests/ConvergenceTests/OneDimensionalCosineAdvectionDiffusion.jl
@@ -11,7 +11,7 @@ c(x, y, z, t, U, κ) = exp(-κ * t) * cos(x - U * t)
 
 function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4,
                   architecture = CPU(), topo = (Periodic, Periodic, Bounded))
-                                      
+
     #####
     ##### Test c and v-advection
     #####
@@ -25,11 +25,11 @@ function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4,
                                      tracers = :c,
                                      closure = ConstantIsotropicDiffusivity(ν=κ, κ=κ))
 
-    set!(model, u = U, 
+    set!(model, u = U,
                 v = (x, y, z) -> c(x, y, z, 0, U, κ),
                 c = (x, y, z) -> c(x, y, z, 0, U, κ))
 
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
 
     println("Running 1D in x cosine advection diffusion test for v and c with Nx = $Nx and Δt = $Δt...")
     run!(simulation)
@@ -49,7 +49,7 @@ function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4,
     #####
     ##### Test u-advection
     #####
-    
+
     ygrid = RegularCartesianGrid(size=(1, Nx, 1), x=(0, 1), y=(0, 2π), z=(0, 1), topology=topo)
 
     model = IncompressibleModel(architecture = architecture,
@@ -59,11 +59,11 @@ function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4,
                                      tracers = :c,
                                      closure = ConstantIsotropicDiffusivity(ν=κ, κ=κ))
 
-    set!(model, v = U, 
+    set!(model, v = U,
                 u = (x, y, z) -> c(y, x, z, 0, U, κ),
                 c = (x, y, z) -> c(y, x, z, 0, U, κ))
 
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
 
     println("Running 1D in y cosine advection diffusion test for u and c with Ny = $Nx and Δt = $Δt...")
     run!(simulation)

--- a/verification/convergence_tests/ConvergenceTests/OneDimensionalGaussianAdvectionDiffusion.jl
+++ b/verification/convergence_tests/ConvergenceTests/OneDimensionalGaussianAdvectionDiffusion.jl
@@ -12,7 +12,7 @@ c(x, y, z, t, U, κ, t₀) = 1 / √(4π * κ * (t + t₀)) * exp(-(x - U * t)^2
 
 function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4, width = 0.05,
                   architecture = CPU(), topo = (Periodic, Periodic, Bounded))
-                                      
+
     t₀ = width^2 / 4κ
 
     #####
@@ -28,11 +28,11 @@ function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4, width = 0.05,
                                      tracers = :c,
                                      closure = ConstantIsotropicDiffusivity(ν=κ, κ=κ))
 
-    set!(model, u = U, 
+    set!(model, u = U,
                 v = (x, y, z) -> c(x, y, z, 0, U, κ, t₀),
                 c = (x, y, z) -> c(x, y, z, 0, U, κ, t₀))
 
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
 
     println("Running Gaussian advection diffusion test for v and c with Nx = $Nx and Δt = $Δt...")
     run!(simulation)
@@ -52,7 +52,7 @@ function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4, width = 0.05,
     #####
     ##### Test u-advection
     #####
-    
+
     ygrid = RegularCartesianGrid(size=(1, Nx, 1), x=(0, 1), y=(-1, 1.5), z=(0, 1), topology=topo)
 
     model = IncompressibleModel(architecture = architecture,
@@ -62,11 +62,11 @@ function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4, width = 0.05,
                                      tracers = :c,
                                      closure = ConstantIsotropicDiffusivity(ν=κ, κ=κ))
 
-    set!(model, v = U, 
+    set!(model, v = U,
                 c = (x, y, z) -> c(y, x, z, 0, U, κ, t₀),
                 u = (x, y, z) -> c(y, x, z, 0, U, κ, t₀))
 
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
 
     println("Running Gaussian advection diffusion test for u with Nx = $Nx and Δt = $Δt...")
     run!(simulation)

--- a/verification/convergence_tests/ConvergenceTests/PointExponentialDecay.jl
+++ b/verification/convergence_tests/ConvergenceTests/PointExponentialDecay.jl
@@ -1,9 +1,9 @@
 # Exponential decay at a point
 #
-# We set up a problem in which a tracer obeys 
+# We set up a problem in which a tracer obeys
 #
 # ∂c/∂t = - c
-# 
+#
 # at a single point. This leads to exponential decay,
 #
 # c(t) = exp(-t)
@@ -35,7 +35,7 @@ function run_test(; Δt, stop_iteration, architecture = CPU())
                                      forcing = ModelForcing(c=Fᶜ))
 
     set!(model, c=1)
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
 
     println("Running Point exponential decay test for Δt = $Δt...")
     run!(simulation)

--- a/verification/convergence_tests/ConvergenceTests/TwoDimensionalDiffusion.jl
+++ b/verification/convergence_tests/ConvergenceTests/TwoDimensionalDiffusion.jl
@@ -45,7 +45,7 @@ function setup_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir="da
         simulation.output_writers[:fields] =
             JLD2OutputWriter(model, FieldOutputs(model.tracers); dir = dir, force = true,
                              prefix = @sprintf("%s_%s_diffusion_Nx%d_Δt%.1e", "$(topo[1])", "$(topo[2])", Nx, Δt),
-                             interval = stop_iteration * Δt / 10)
+                             time_interval = stop_iteration * Δt / 10)
     end
 
     return simulation

--- a/verification/convergence_tests/ConvergenceTests/TwoDimensionalDiffusion.jl
+++ b/verification/convergence_tests/ConvergenceTests/TwoDimensionalDiffusion.jl
@@ -37,13 +37,13 @@ function setup_simulation(; Nx, Δt, stop_iteration, architecture=CPU(), dir="da
                                      tracers = :c,
                                      closure = ConstantIsotropicDiffusivity(κ=1))
 
-    set!(model, c = (x, y, z) -> c(x, y, 0)) 
+    set!(model, c = (x, y, z) -> c(x, y, 0))
 
-    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, progress_frequency=stop_iteration)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=stop_iteration, iteration_interval=stop_iteration)
 
     if output
-        simulation.output_writers[:fields] = 
-            JLD2OutputWriter(model, FieldOutputs(model.tracers); dir = dir, force = true, 
+        simulation.output_writers[:fields] =
+            JLD2OutputWriter(model, FieldOutputs(model.tracers); dir = dir, force = true,
                              prefix = @sprintf("%s_%s_diffusion_Nx%d_Δt%.1e", "$(topo[1])", "$(topo[2])", Nx, Δt),
                              interval = stop_iteration * Δt / 10)
     end

--- a/verification/stratified_couette_flow/stratified_couette_flow.jl
+++ b/verification/stratified_couette_flow/stratified_couette_flow.jl
@@ -182,7 +182,7 @@ function simulate_stratified_couette_flow(; Nxy, Nz, arch=GPU(), h=1, U_wall=1,
 
     field_writer =
         JLD2OutputWriter(model, fields, dir=base_dir, prefix=prefix * "_fields",
-                         init=init_save_parameters_and_bcs, interval=10,
+                         init=init_save_parameters_and_bcs, time_interval=10,
                          force=true, verbose=true)
 
     #####
@@ -206,7 +206,7 @@ function simulate_stratified_couette_flow(; Nxy, Nz, arch=GPU(), h=1, U_wall=1,
 
     profile_writer =
         JLD2OutputWriter(model, profiles, dir=base_dir, prefix=prefix * "_profiles",
-                         init=init_save_parameters_and_bcs, interval=1,
+                         init=init_save_parameters_and_bcs, time_interval=1,
                          force=true, verbose=true)
 
     #####
@@ -222,7 +222,7 @@ function simulate_stratified_couette_flow(; Nxy, Nz, arch=GPU(), h=1, U_wall=1,
 
     statistics_writer =
         JLD2OutputWriter(model, statistics, dir=base_dir, prefix=prefix * "_statistics",
-                         init=init_save_parameters_and_bcs, interval=1/2,
+                         init=init_save_parameters_and_bcs, time_interval=1/2,
                          force=true, verbose=true)
 
     #####

--- a/verification/stratified_couette_flow/stratified_couette_flow.jl
+++ b/verification/stratified_couette_flow/stratified_couette_flow.jl
@@ -58,7 +58,7 @@ function (Reτ::FrictionReynoldsNumber)(model)
 
     return h * uτ_top / ν, h * uτ_bottom / ν
 end
- 
+
 """ Nusselt number. See equation (20) of Vreugdenhil & Taylor (2018). """
 function (Nu::NusseltNumber)(model)
     κ = model.closure.κ.T
@@ -259,7 +259,7 @@ function simulate_stratified_couette_flow(; Nxy, Nz, arch=GPU(), h=1, U_wall=1,
     end
 
     simulation = Simulation(model, Δt=wizard, stop_time=end_time,
-                            progress=print_progress, progress_frequency=Ni)
+                            progress=print_progress, iteration_interval=Ni)
     push!(simulation.output_writers, field_writer, profile_writer, statistics_writer)
     run!(simulation)
 


### PR DESCRIPTION
This PR changes the confusing names `frequency` and `interval` for diagnostics and output writers to the clearer `iteration_interval` and `time_interval`. It also changes `progress_frequency` to `iteration_interval` for simulations. It also converts some examples to doctests.

Resolves #672 