### PR TITLE
Checkpointer bug fixes and improved interface

### DIFF
--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -85,10 +85,10 @@ Convenience method for restoring checkpointed models that returns the already-in
 function TracerFields(arch, grid, proposed_tracer_fields::NamedTuple, bcs; kwargs...)
     grid = proposed_tracer_fields[1].grid
 
-    tracer_fields = 
+    tracer_fields =
         Tuple(c ∈ keys(bcs) ?
               Field{Cell, Cell, Cell}(proposed_tracer_fields[c].data, grid, bcs[c]) :
-              Field{Cell, Cell, Cell}(proposed_tracer_fields[c].data, grid, TracerBoundaryConditions(grid))
+              proposed_tracer_fields[c]
               for c in tracernames(proposed_tracer_fields))
 
     return NamedTuple{tracernames(proposed_tracer_fields)}(tracer_fields)

--- a/src/Fields/show_fields.jl
+++ b/src/Fields/show_fields.jl
@@ -7,6 +7,7 @@ location_str(::Cell) = "Cell"
 show_location(X, Y, Z) = "($(location_str(X())), $(location_str(Y())), $(location_str(Z())))"
 show_location(field::AbstractField{X, Y, Z}) where {X, Y, Z} = show_location(X, Y, Z)
 
+short_show(m::Missing) = "$m"
 short_show(field::Field) = string("Field located at ", show_location(field))
 
 show(io::IO, field::Field) =

--- a/src/Models/incompressible_model.jl
+++ b/src/Models/incompressible_model.jl
@@ -95,14 +95,12 @@ function IncompressibleModel(;
     closure = with_tracers(tracernames(tracers), closure)
 
     # Instantiate tracer fields if not already instantiated
-    if tracers isa Tuple
-        tracers = TracerFields(architecture, grid, tracers, boundary_conditions)
-    end
+    tracer_fields = TracerFields(architecture, grid, tracers, boundary_conditions)
 
     # Instantiate timestepper if not already instantiated
     timestepper = TimeStepper(timestepper, float_type, architecture, grid, velocities, tracernames(tracers))
 
     return IncompressibleModel(architecture, grid, clock, advection, buoyancy, coriolis, surface_waves,
-                               forcing, closure, velocities, tracers, pressures, diffusivities,
+                               forcing, closure, velocities, tracer_fields, pressures, diffusivities,
                                timestepper, pressure_solver)
 end

--- a/src/Models/incompressible_model.jl
+++ b/src/Models/incompressible_model.jl
@@ -52,6 +52,7 @@ Construct an incompressible `Oceananigans.jl` model on `grid`.
 
 Keyword arguments
 =================
+
 - `grid`: (required) The resolution and discrete geometry on which `model` is solved.
 - `architecture`: `CPU()` or `GPU()`. The computer architecture used to time-step `model`.
 - `float_type`: `Float32` or `Float64`. The floating point type used for `model` data.
@@ -94,12 +95,14 @@ function IncompressibleModel(;
     closure = with_tracers(tracernames(tracers), closure)
 
     # Instantiate tracer fields if not already instantiated
-    tracer_fields = TracerFields(architecture, grid, tracers, boundary_conditions)
+    if tracers isa Tuple
+        tracers = TracerFields(architecture, grid, tracers, boundary_conditions)
+    end
 
     # Instantiate timestepper if not already instantiated
     timestepper = TimeStepper(timestepper, float_type, architecture, grid, velocities, tracernames(tracers))
 
     return IncompressibleModel(architecture, grid, clock, advection, buoyancy, coriolis, surface_waves,
-                               forcing, closure, velocities, tracer_fields, pressures, diffusivities,
+                               forcing, closure, velocities, tracers, pressures, diffusivities,
                                timestepper, pressure_solver)
 end

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -91,7 +91,7 @@ end
 defaultname(::Checkpointer, nelems) = :checkpointer
 
 function restore_if_not_missing(file, address)
-    if file[address] !== missing
+    if !ismissing(file[address])
         return file[address]
     else
         @warn "Checkpoint file does not contain $address. Returning missing. " *

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -63,7 +63,7 @@ function Checkpointer(model; iteration_interval=nothing, time_interval=nothing,
         p isa Symbol || @error "Property $p to be checkpointed must be a Symbol."
         p ∉ propertynames(model) && @error "Cannot checkpoint $p, it is not a model property!"
 
-        if has_reference(Function, getproperty(model, p))
+        if has_reference(Function, getproperty(model, p)) && (p ∉ required_properties)
             @warn "model.$p contains a function somewhere in its hierarchy and will not be checkpointed."
             filter!(e -> e != p, properties)
         end

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -91,7 +91,7 @@ end
 defaultname(::Checkpointer, nelems) = :checkpointer
 
 function restore_if_not_missing(file, address)
-    if haskey(file, address)
+    if file[address] !== missing
         return file[address]
     else
         @warn "Checkpoint file does not contain $address. Returning missing. " *
@@ -123,7 +123,13 @@ function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
     file = jldopen(filepath, "r")
     cps = file["checkpointed_properties"]
 
-    arch = file["architecture"]
+    if haskey(kwargs, :architecture)
+        arch = kwargs[:architecture]
+        filter!(p -> p ≠ :architecture, cps)
+    else
+        arch = file["architecture"]
+    end
+
     grid = file["grid"]
 
     # Restore velocity fields

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -119,7 +119,9 @@ Restore a model from the checkpoint file stored at `filepath`. `kwargs` can be p
 to the model constructor, which can be especially useful if you need to manually
 restore forcing functions or boundary conditions that rely on functions.
 """
-function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
+function restore_from_checkpoint(filepath; kwargs...)
+    kwargs = length(kwargs) == 0 ? Dict{Symbol,Any}() : Dict{Symbol,Any}(kwargs)
+
     file = jldopen(filepath, "r")
     cps = file["checkpointed_properties"]
 

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -109,9 +109,11 @@ function restore_field(file, address, arch, grid, loc, kwargs)
     # apply the same BCs on T and T tendencies).
     field_name = split(address, "/")[2:end] |> join |> Symbol
 
+    # If the user specified a non-default boundary condition through the kwargs
+    # in restore_from_checkpoint, then use them when restoring the field. Otherwise
+    # restore the BCs from the checkpoint file as long as they're not missing.
     if :boundary_conditions in keys(kwargs) && field_name in keys(kwargs[:boundary_conditions])
         bcs = kwargs[:boundary_conditions][field_name]
-        @show bcs
     else
         bcs = restore_if_not_missing(file, address * "/boundary_conditions")
     end

--- a/src/OutputWriters/output_writer_utils.jl
+++ b/src/OutputWriters/output_writer_utils.jl
@@ -50,7 +50,7 @@ serializeproperty!(file, location, p::Function) = @warn "Cannot serialize Functi
 function serializeproperty!(file, location, p::FieldBoundaryConditions)
     if has_reference(Function, p)
         @warn "Cannot serialize $location as it contains functions. Will replace with missing. " *
-              " Function boundary conditions must be restored manually."
+              "Function boundary conditions must be restored manually."
         file[location] = missing
     else
         file[location] = p

--- a/src/Utils/versioninfo.jl
+++ b/src/Utils/versioninfo.jl
@@ -6,7 +6,7 @@ using Oceananigans.Architectures
 function versioninfo_with_gpu()
     s = sprint(versioninfo)
     @hascuda begin
-        gpu_name = CuCurrentContext() |> device |> name
+        gpu_name = CUDA.CuCurrentContext() |> CUDA.device |> CUDA.name
         s = s * "  GPU: $gpu_name\n"
     end
     return s

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -406,8 +406,8 @@ end
 function run_checkpoint_with_function_bcs_tests(arch)
     grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
 
-    @inline some_flux(x, y, t, p) = 2x + exp(y)
-    some_flux_bf = BoundaryFunction{:z, Cell, Cell}(some_flux, nothing)
+    @inline some_flux(x, y, t) = 2x + exp(y)
+    some_flux_bf = BoundaryFunction{:z, Cell, Cell}(some_flux)
     top_u_bc = top_T_bc = FluxBoundaryCondition(some_flux_bf)
     u_bcs = UVelocityBoundaryConditions(grid, top=top_u_bc)
     T_bcs = TracerBoundaryConditions(grid, top=top_T_bc)
@@ -457,7 +457,7 @@ function run_checkpoint_with_function_bcs_tests(arch)
     @test u.boundary_conditions.z.left  isa ZFBC
     @test u.boundary_conditions.z.right isa FBC
     @test u.boundary_conditions.z.right.condition isa BoundaryFunction
-    @test u.boundary_conditions.z.right.condition.func(1, 2, 3, nothing) == some_flux(1, 2, 3, nothing)
+    @test u.boundary_conditions.z.right.condition.func(1, 2, 3) == some_flux(1, 2, 3)
 
     @test T.boundary_conditions.x.left  isa PBC
     @test T.boundary_conditions.x.right isa PBC
@@ -466,7 +466,7 @@ function run_checkpoint_with_function_bcs_tests(arch)
     @test T.boundary_conditions.z.left  isa ZFBC
     @test T.boundary_conditions.z.right isa FBC
     @test T.boundary_conditions.z.right.condition isa BoundaryFunction
-    @test T.boundary_conditions.z.right.condition.func(1, 2, 3, nothing) == some_flux(1, 2, 3, nothing)
+    @test T.boundary_conditions.z.right.condition.func(1, 2, 3) == some_flux(1, 2, 3)
 
     # Test that the restored model can be time stepped
     time_step!(properly_restored_model, 1)

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -1,4 +1,6 @@
-using NCDatasets, Statistics
+using Statistics
+using NCDatasets
+using Oceananigans.BoundaryConditions: PBC, FBC, ZFBC
 
 function run_thermal_bubble_netcdf_tests(arch)
     Nx, Ny, Nz = 16, 16, 16
@@ -397,6 +399,8 @@ function run_thermal_bubble_checkpointer_tests(arch)
     @test all(restored_model.timestepper.Gⁿ.w.data .≈ true_model.timestepper.Gⁿ.w.data)
     @test all(restored_model.timestepper.Gⁿ.T.data .≈ true_model.timestepper.Gⁿ.T.data)
     @test all(restored_model.timestepper.Gⁿ.S.data .≈ true_model.timestepper.Gⁿ.S.data)
+
+    return nothing
 end
 
 function run_checkpoint_with_function_bcs_tests(arch)
@@ -463,6 +467,45 @@ function run_checkpoint_with_function_bcs_tests(arch)
     @test T.boundary_conditions.z.right isa FBC
     @test T.boundary_conditions.z.right.condition isa BoundaryFunction
     @test T.boundary_conditions.z.right.condition.func(1, 2, 3, nothing) == some_flux(1, 2, 3, nothing)
+
+    # Test that the restored model can be time stepped
+    time_step!(properly_restored_model, 1)
+    @test properly_restored_model isa IncompressibleModel
+
+    return nothing
+end
+
+function run_cross_architecture_checkpointer_tests(arch1, arch2)
+    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    model = IncompressibleModel(architecture=arch1, grid=grid)
+    set!(model, u=π/2, v=ℯ, T=Base.MathConstants.γ, S=Base.MathConstants.φ)
+
+    checkpointer = Checkpointer(model)
+    write_output(model, checkpointer)
+    model = nothing
+
+    restored_model = restore_from_checkpoint("checkpoint_iteration0.jld2", architecture=arch2)
+
+    @test restored_model.architecture == arch2
+
+    ArrayType = array_type(restored_model.architecture)
+    @test restored_model.velocities.u.data.parent isa ArrayType
+    @test restored_model.velocities.v.data.parent isa ArrayType
+    @test restored_model.velocities.w.data.parent isa ArrayType
+    @test restored_model.tracers.T.data.parent isa ArrayType
+    @test restored_model.tracers.S.data.parent isa ArrayType
+
+    @test all(interior(restored_model.velocities.u) .≈ π/2)
+    @test all(interior(restored_model.velocities.v) .≈ ℯ)
+    @test all(interior(restored_model.velocities.w) .== 0)
+    @test all(interior(restored_model.tracers.T) .≈ Base.MathConstants.γ)
+    @test all(interior(restored_model.tracers.S) .≈ Base.MathConstants.φ)
+
+    # Test that the restored model can be time stepped
+    time_step!(restored_model, 1)
+    @test restored_model isa IncompressibleModel
+
+    return nothing
 end
 
 @testset "Output writers" begin
@@ -485,6 +528,8 @@ end
             @info "  Testing Checkpointer [$(typeof(arch))]..."
             run_thermal_bubble_checkpointer_tests(arch)
             run_checkpoint_with_function_bcs_tests(arch)
+            @hascuda run_cross_architecture_checkpointer_tests(CPU(), GPU())
+            @hascuda run_cross_architecture_checkpointer_tests(GPU(), CPU())
         end
     end
 end


### PR DESCRIPTION
This PR fixes some checkpointer bugs and improves the `restore_from_checkpoint` interface. The checkpointer has more comprehensive tests now. This PR was originally @sandreza's PR #797 but was accidently merged prematurely then reverted.

* `restore_from_checkpoint` now takes kwargs like a model constructor instead of a dictionary. This should be more intuitive and easier to use.
* Checkpointing and restoring from a checkpoint with function boundary conditions works now. If function boundary conditions are not manually restored, they are replaced with `missing`. They are restored correctly if passed via the `boundary_conditions` kwarg to `restore_from_checkpoint` and the model can be time stepped.
* Checkpointing and restoring between architectures works now. I've tested CPU -> GPU and GPU -> CPU restoration.
* Added more comprehensive checkpointing tests.