### PR TITLE
Bump v0.34.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.33.0"
+version = "0.34.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Release notes:

This release adds some new features, fixes some bugs, and improves the API (so there are some breaking changes, listed below).

Major changes:
* Triply periodic models are now available by passing the `topology = (Periodic, Periodic, Periodic)` keyword argument to grids.
* All 1D, 2D, and 3D averages are now available through the `Average` diagnostic with the `dims` keyword argument.
* Fixed some checkpointing bugs.
* **BREAKING:** Use `Average(..., dims=(1, 2))` instead of `HorizontalAverage(...)`.
* **BREAKING:** Use `iteration_interval` and `time_interval` instead of `frequency` and `interval` for diagnostics and output writers.
* **BREAKING:** Use `iteration_interval` instead of `progress_frequency` for simulations.
* **BREAKING:** Use `IsotropicDiffusivity` and `AnisotropicDiffusivity` instead of `ConstantIsotropicDiffusivity` and `ConstantAnisotropicDiffusivity`. Also, use `νz` instead of `νv` and `κz` instead of `κv`.
* **BREAKING:** To `restore_from_checkpoint`, pass model constructor arguments as you would to a normal constructor, e.g. `restore_from_checkpoint("my_checkpoint.jld2", boundary_conditions=custom_bcs)`. Previous behavior was to pass a dictionary which was less user friendly.