### PR TITLE
Bump v0.34.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.34.0"
+version = "0.34.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Release notes:

This is a bugfix release that disables CuArray scalar operations by default (to avoid surprise scalar operations that can cause huge slowdowns) and **fixes a related bug where writing GPU fields to NetCDF was very slow**. Also includes small updates to the documentation.