### PR TITLE
Multithreading benchmarks

### DIFF
--- a/benchmark/benchmark_static_ocean.jl
+++ b/benchmark/benchmark_static_ocean.jl
@@ -13,11 +13,17 @@ const timer = TimerOutput()
 
 Nt = 10  # Number of iterations to use for benchmarking time stepping.
 
-# Model resolutions to benchmarks. Focusing on 3D models for GPU benchmarking.
-            Ns = [(16, 16, 16), (32, 32, 32), (64, 64, 64), (128, 128, 128), (256, 256, 256)]
-   float_types = [Float32, Float64]  # Float types to benchmark.
-         archs = [CPU()]             # Architectures to benchmark on.
-@hascuda archs = [CPU(), GPU()]      # Benchmark GPU on systems with CUDA-enabled GPUs.
+threads = Threads.nthreads()
+
+if threads == 1
+    Ns = [(16, 16, 16), (32, 32, 32), (64, 64, 64), (128, 128, 128), (256, 256, 256)]
+else
+    Ns = [(256, 256, 256)]
+end
+
+   float_types = [Float32, Float64]
+         archs = [CPU()]
+@hascuda archs = [CPU(), GPU()]
 
 #####
 ##### Run benchmarks
@@ -44,7 +50,10 @@ println()
 println(oceananigans_versioninfo())
 println(versioninfo_with_gpu())
 
-print_timer(timer, title="Static ocean benchmarks", sortby=:name)
+title = "Static ocean benchmarks"
+title *= threads > 1 ? " ($threads threads)" : ""
+
+print_timer(timer, title=title, sortby=:name)
 
 println("\n\nCPU Float64 -> Float32 speedup:")
 for N in Ns

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -158,12 +158,20 @@ using .Simulations
 
 function __init__()
     Logging.global_logger(OceananigansLogger())
+
+    threads = Threads.nthreads()
+    if threads > 1
+        @info "Oceananigans will use $threads threads"
+        FFTW.set_num_threads(threads)
+    end
+
     @hascuda begin
         @debug "CUDA-enabled GPU(s) detected:"
         for (gpu, dev) in enumerate(CUDA.devices())
             @debug "$dev: $(CUDA.name(dev))"
         end
-	CUDA.allowscalar(false)
+
+        CUDA.allowscalar(false)
     end
 end
 


### PR DESCRIPTION
Converted `benchmark_static_ocean.jl` to do a strong scaling test on a 256³ simulation when `Threads.nthreads() > 1`.

Results are pretty sweet for multithreading that we basically got for free from KernelAbstractions.jl. Not sure what kind of speedups to expect for multithreading though. Maybe @leios, @christophernhill, or @vchuravy have a better idea.

Some results on number of threads and wall clock time per time step:

# Tartarus

```zsh
#!/bin/zsh
for threads in 1 4 8 16 24 32 40; ~/julia-1.5.0/bin/julia  --project -t $threads benchmark_static_ocean.jl
```

```
Julia 1.5.0 + Intel(R) Xeon(R) Silver 4214 CPU @ 2.20GHz

 1 thread:   3.78 s
 4 threads:  1.35 s (2.8x)
 8 threads:  839 ms (4.5x)
16 threads:  585 ms (6.5x)
24 threads:  551 ms (6.9x)
32 threads:  539 ms (7.0x)
40 threads:  483 ms (10.6x)
48 threads:  479 ms (10.7x)
```

# Satori

```bash
#!/bin/bash
for threads in 1 4 8 16 32 64 128 160; do JULIA_NUM_THREADS=$threads julia --project benchmark_static_ocean.jl; done
```

```
Julia 1.4.1 + IBM Power System AC922 (8335-GTH)

  1 thread:   5.13 s
  4 threads:  2.44 s (2.1x)
  8 threads:  1.35 s (3.8x)
 16 threads:  796 ms (6.4x)
 32 threads:  637 ms (8.0x)
 64 threads:  503 ms (10.2x)
128 threads:  501 ms (10.2x)
160 threads:  511 ms (10.0x)
```

A beautiful scene from Satori:

![image](https://user-images.githubusercontent.com/20099589/91370150-96ad1100-e7db-11ea-9bf2-12e40de5ff93.png)
