### PR TITLE
Split tests into four groups for CI job matrices

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ environment:
   - julia_version: nightly
 
 platform:
-  - x64 # 64-bit
+  - x64
 
 matrix:
   fast_finish: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
   - julia_version: 1.4
-  - julia_version: nightly
   - TEST_GROUP: unit
   - TEST_GROUP: integration
   - TEST_GROUP: regression

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,18 +1,13 @@
 environment:
+  julia_version: 1.5
   matrix:
-  - julia_version: 1.4
-  - TEST_GROUP: unit
-  - TEST_GROUP: integration
-  - TEST_GROUP: regression
-  - TEST_GROUP: scripts
+  - test_group: unit
+  - test_group: integration
+  - test_group: regression
+  - test_group: scripts
 
 platform:
   - x64
-
-matrix:
-  fast_finish: true
-  allow_failures:
-  - julia_version: nightly
 
 branches:
   only:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,11 +6,17 @@ environment:
 platform:
   - x64 # 64-bit
 
-# Uncomment the following lines to allow failures on nightly julia
-# (tests will run but not make your overall status red)
 matrix:
+  fast_finish: true
   allow_failures:
   - julia_version: nightly
+
+environment:
+  matrix:
+    - TEST_GROUP: unit
+    - TEST_GROUP: integration
+    - TEST_GROUP: regression
+    - TEST_GROUP: scripts
 
 branches:
   only:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,10 @@ environment:
   matrix:
   - julia_version: 1.4
   - julia_version: nightly
+  - TEST_GROUP: unit
+  - TEST_GROUP: integration
+  - TEST_GROUP: regression
+  - TEST_GROUP: scripts
 
 platform:
   - x64
@@ -10,13 +14,6 @@ matrix:
   fast_finish: true
   allow_failures:
   - julia_version: nightly
-
-environment:
-  matrix:
-    - TEST_GROUP: unit
-    - TEST_GROUP: integration
-    - TEST_GROUP: regression
-    - TEST_GROUP: scripts
 
 branches:
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,46 +39,6 @@ julia:1.4:scripts:
   tags:
     - nvidia
 
-julia:nightly:unit:
-  extends:
-    - .julia:nightly
-    - .test
-  variables:
-    TEST_GROUP: 'unit'
-  tags:
-    - nvidia
-  allow_failure: true
-
-julia:nightly:integration:
-  extends:
-    - .julia:nightly
-    - .test
-  variables:
-    TEST_GROUP: 'integration'
-  tags:
-    - nvidia
-  allow_failure: true
-
-julia:nightly:regression:
-  extends:
-    - .julia:nightly
-    - .test
-  variables:
-    TEST_GROUP: 'regression'
-  tags:
-    - nvidia
-  allow_failure: true
-
-julia:nightly:scripts:
-  extends:
-    - .julia:nightly
-    - .test
-  variables:
-    TEST_GROUP: 'scripts'
-  tags:
-    - nvidia
-  allow_failure: true
-
 coverage:
   extends:
     - .julia:1.4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,3 +83,4 @@ coverage:
   extends:
     - .julia:1.4
     - .coverage
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,31 +3,81 @@ include:
 
 image: ubuntu:bionic
 
-variables:
-  CI_IMAGE_TAG: 'cuda'
-  JULIA_NUM_THREADS: '1'
-
-# Julia versions
-
-# the "primary" target, where we require a new GPU to make sure all tests are run
-julia:1.4:
+julia:1.4:unit:
   extends:
     - .julia:1.4
     - .test
+  variables:
+    - TEST_GROUP: 'unit'
   tags:
     - nvidia
-    - sm_70
-  variables:
-    CI_THOROUGH: 'true'
 
-julia:nightly:
+julia:1.4:integration:
+  extends:
+    - .julia:1.4
+    - .test
+  variables:
+    - TEST_GROUP: 'integration'
+  tags:
+    - nvidia
+
+julia:1.4:regression:
+  extends:
+    - .julia:1.4
+    - .test
+  variables:
+    - TEST_GROUP: 'regression'
+  tags:
+    - nvidia
+
+julia:1.4:scripts:
+  extends:
+    - .julia:1.4
+    - .test
+  variables:
+    - TEST_GROUP: 'scripts'
+  tags:
+    - nvidia
+
+julia:nightly:unit:
   extends:
     - .julia:nightly
     - .test
+  variables:
+    - TEST_GROUP: 'unit'
   tags:
     - nvidia
   allow_failure: true
 
+julia:nightly:integration:
+  extends:
+    - .julia:nightly
+    - .test
+  variables:
+    - TEST_GROUP: 'integration'
+  tags:
+    - nvidia
+  allow_failure: true
+
+julia:nightly:regression:
+  extends:
+    - .julia:nightly
+    - .test
+  variables:
+    - TEST_GROUP: 'regression'
+  tags:
+    - nvidia
+  allow_failure: true
+
+julia:nightly:scripts:
+  extends:
+    - .julia:nightly
+    - .test
+  variables:
+    - TEST_GROUP: 'scripts'
+  tags:
+    - nvidia
+  allow_failure: true
 
 coverage:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ julia:1.4:unit:
     - .julia:1.4
     - .test
   variables:
-    - TEST_GROUP: 'unit'
+    TEST_GROUP: 'unit'
   tags:
     - nvidia
 
@@ -17,7 +17,7 @@ julia:1.4:integration:
     - .julia:1.4
     - .test
   variables:
-    - TEST_GROUP: 'integration'
+    TEST_GROUP: 'integration'
   tags:
     - nvidia
 
@@ -26,7 +26,7 @@ julia:1.4:regression:
     - .julia:1.4
     - .test
   variables:
-    - TEST_GROUP: 'regression'
+    TEST_GROUP: 'regression'
   tags:
     - nvidia
 
@@ -35,7 +35,7 @@ julia:1.4:scripts:
     - .julia:1.4
     - .test
   variables:
-    - TEST_GROUP: 'scripts'
+    TEST_GROUP: 'scripts'
   tags:
     - nvidia
 
@@ -44,7 +44,7 @@ julia:nightly:unit:
     - .julia:nightly
     - .test
   variables:
-    - TEST_GROUP: 'unit'
+    TEST_GROUP: 'unit'
   tags:
     - nvidia
   allow_failure: true
@@ -54,7 +54,7 @@ julia:nightly:integration:
     - .julia:nightly
     - .test
   variables:
-    - TEST_GROUP: 'integration'
+    TEST_GROUP: 'integration'
   tags:
     - nvidia
   allow_failure: true
@@ -64,7 +64,7 @@ julia:nightly:regression:
     - .julia:nightly
     - .test
   variables:
-    - TEST_GROUP: 'regression'
+    TEST_GROUP: 'regression'
   tags:
     - nvidia
   allow_failure: true
@@ -74,7 +74,7 @@ julia:nightly:scripts:
     - .julia:nightly
     - .test
   variables:
-    - TEST_GROUP: 'scripts'
+    TEST_GROUP: 'scripts'
   tags:
     - nvidia
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,4 +83,3 @@ coverage:
   extends:
     - .julia:1.4
     - .coverage
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ julia:
 env:
   global:
     - PYTHON=''
+  - TEST_GROUP=unit
+  - TEST_GROUP=integration
+  - TEST_GROUP=regression
+  - TEST_GROUP=scripts
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,13 @@ julia:
   - 1.4
 
 env:
+  jobs:
+    - TEST_GROUP=unit
+    - TEST_GROUP=integration
+    - TEST_GROUP=regression
+    - TEST_GROUP=scripts
   global:
     - PYTHON=''
-  - TEST_GROUP=unit
-  - TEST_GROUP=integration
-  - TEST_GROUP=regression
-  - TEST_GROUP=scripts
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ notifications:
   email: true
 
 after_success:
-  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ env:
     - TEST_GROUP=regression
     - TEST_GROUP=scripts
 
+# Only build pushes to master (PRs still build merge commits)
+# See: https://stackoverflow.com/a/31882307
+branches:
+  only: 
+    - master
+
 notifications:
   email: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ env:
     - TEST_GROUP=integration
     - TEST_GROUP=regression
     - TEST_GROUP=scripts
-  global:
-    - PYTHON=''
 
 notifications:
   email: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.3
+FROM julia:1.4
 LABEL maintainer="Ali Ramadhan <alir@mit.edu>"
 
 RUN apt-get update && apt-get install -y hdf5-tools

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@
   <a href="https://codecov.io/gh/clima/Oceananigans.jl">
     <img alt="Codecov coverage" src="https://img.shields.io/codecov/c/github/clima/Oceananigans.jl/master?label=Codecov&logo=codecov&logoColor=white&style=flat-square">
   </a>
-  <a href="https://coveralls.io/github/clima/Oceananigans.jl?branch=master">
-    <img alt="Coveralls coverage" src="https://img.shields.io/coveralls/github/clima/Oceananigans.jl/master?label=Coveralls&style=flat-square">
-  </a>
 </p>
 
 Oceananigans.jl is a fast and friendly incompressible fluid flow solver written in Julia that can be run in 1-3 dimensions on CPUs and GPUs. It is designed to solve the rotating Boussinesq equations used in non-hydrostatic ocean modeling but can be used to solve for any incompressible flow.

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,9 +5,16 @@ codecov:
     - !travis
 
 coverage:
+  range: 50..90
+  round: down
+  precision: 2
+
   status:
     project:
       default:
         target: auto
-        threshold: 50
-        base: auto
+        threshold: 5%
+    patch:
+      default:
+        target: auto
+        threshold: 20%

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,5 +11,3 @@ coverage:
         target: auto
         threshold: 50
         base: auto
-
-comment: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,3 @@
-# Ignore Travis CI and Appveyor so accurate GPU coverage is reported by GitLab.
-codecov:
-  ci:
-    - !appveyor
-    - !travis
-
 coverage:
   range: 50..90
   round: down

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,31 +72,44 @@ closures = (
 ##### Run tests!
 #####
 
+group = get(ENV, "TEST_GROUP", "all")
+
 include("runtests_utils.jl")
 
 @testset "Oceananigans" begin
-    include("test_grids.jl")
-    include("test_operators.jl")
-    include("test_boundary_conditions.jl")
-    include("test_fields.jl")
-    include("test_halo_regions.jl")
-    include("test_solvers.jl")
-    include("test_pressure_solvers.jl")
-    include("test_coriolis.jl")
-    include("test_buoyancy.jl")
-    include("test_surface_waves.jl")
-    include("test_models.jl")
-    include("test_simulations.jl")
-    include("test_time_stepping.jl")
-    include("test_time_stepping_bcs.jl")
-    include("test_forcings.jl")
-    include("test_turbulence_closures.jl")
-    include("test_dynamics.jl")
-    include("test_diagnostics.jl")
-    include("test_output_writers.jl")
-    include("test_abstract_operations.jl")
-    include("test_regression.jl")
-    include("test_examples.jl")
-    include("test_verification.jl")
-    include("test_benchmarks.jl")
+    if group == "unit" || group == "all"
+        @testset "Unit tests" begin
+            include("test_grids.jl")
+            include("test_operators.jl")
+            include("test_boundary_conditions.jl")
+            include("test_fields.jl")
+            include("test_halo_regions.jl")
+            include("test_solvers.jl")
+            include("test_pressure_solvers.jl")
+            include("test_coriolis.jl")
+            include("test_buoyancy.jl")
+            include("test_surface_waves.jl")
+        end
+    elseif group == "integration" || group == "all"
+        @testset "Integration tests" begin
+            include("test_models.jl")
+            include("test_simulations.jl")
+            include("test_time_stepping.jl")
+            include("test_time_stepping_bcs.jl")
+            include("test_forcings.jl")
+            include("test_turbulence_closures.jl")
+            include("test_dynamics.jl")
+            include("test_diagnostics.jl")
+            include("test_output_writers.jl")
+            include("test_abstract_operations.jl")
+        end
+    elseif group == "regression" || group == "all"
+        include("test_regression.jl")
+    elseif group == "scripts" || group == "all"
+        @testset "Scripts" begin
+            include("test_examples.jl")
+            include("test_verification.jl")
+            include("test_benchmarks.jl")
+        end
+    end
 end


### PR DESCRIPTION
This PR splits the tests into four test groups, selectable with the `TEST_GROUP` environment variable: `unit`, `integration`, `regression`, and `scripts`. Using `TEST_GROUP=all` (the default if `TEST_GROUP` is not defined) will run all tests.

The purpose of this PR is to address long test build times (see #860) that time out at 50 minutes on Travis CI and at 60 minutes on GitLab CI by splitting tests into multiple jobs (i.e. building a job matrix) that each should individually run much faster.

If the different jobs could be run in parallel this would speed up our test builds significantly, but alas we are stuck with free-tier CI pipelines so we can't run too many jobs in parallel and will probably end up waiting longer. But at least our jobs won't time out.

In working on this PR I was also able to revive the Appveyor and Docker CI pipelines (I think Appveyor will only show up for future PRs).

Resolves #139 