### PR TITLE
Output writer "diagnostic dependencies"

### DIFF
--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -47,7 +47,7 @@ function wall_time_limit_exceeded(sim)
 end
 
 add_dependency!(diagnostics, output) = nothing # fallback
-add_dependency!(diags, wta::WindowedTimeAverage) = !(wta ∈ values(diags)) && push!(diags, wta)
+add_dependency!(diags, wta::WindowedTimeAverage) = wta ∈ values(diags) || push!(diags, wta)
 
 add_dependencies!(diags, writer) = [add_dependency!(diags, out) for out in values(writer.outputs)]
 add_dependencies!(sim, ::Checkpointer) = nothing # Checkpointer does not have "outputs"

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -50,9 +50,9 @@ get_dependency(output) = nothing
 get_dependency(wta::WindowedTimeAverage) = wta
 
 function add_dependencies!(sim, writer)
-    for output in writer.outputs
+    for output in values(writer.outputs)
         dependency = get_dependency(output)
-        if !isnothing(dependency) && !(dependency ∈ sim.diagnostics.vals)
+        if !isnothing(dependency) && !(dependency ∈ values(sim.diagnostics))
             push!(sim.diagnostics, dependency)
         end
     end
@@ -76,9 +76,9 @@ function run!(sim)
     model = sim.model
     clock = model.clock
 
-    [open(out) for out in values(sim.output_writers)]
+    [open(writer) for writer in values(sim.output_writers)]
 
-    [add_dependencies!(sim, out) for out in values(sim.output_writers)]
+    [add_dependencies!(sim, writer) for writer in values(sim.output_writers)]
 
     while !stop(sim)
         time_before = time()

--- a/test/test_simulations.jl
+++ b/test/test_simulations.jl
@@ -25,35 +25,35 @@ end
             model.clock.iteration = 0
 
             simulation = Simulation(model, Δt=Δt, stop_iteration=1)
-    
+
             # Just make sure we can construct a simulation without any errors.
             @test simulation isa Simulation
-    
+
             @test iteration_limit_exceeded(simulation) == false
             @test stop(simulation) == false
-    
+
             run!(simulation)
-    
+
             # Just make sure run! executes without any errors.
             @test simulation isa Simulation
-    
+
             # Some basic tests
             @test iteration_limit_exceeded(simulation) == true
             @test stop(simulation) == true
-    
+
             t = Δt isa Number ? 3 : 5
             @test model.clock.time ≈ t
             @test model.clock.iteration == 1
             @test simulation.run_time > 0
-    
+
             @test stop_time_exceeded(simulation) == false
             simulation.stop_time = 1e-12
             @test stop_time_exceeded(simulation) == true
-    
+
             @test wall_time_limit_exceeded(simulation) == false
             simulation.wall_time_limit = 1e-12
             @test wall_time_limit_exceeded(simulation) == true
-    
+
         end
 
         windowed_time_average = WindowedTimeAverage(model.velocities.u, time_window=2.0, time_interval=4.0)
@@ -64,14 +64,14 @@ end
 
         @test dependencies_added_correctly!(model, windowed_time_average, jld2_output_writer)
 
-        #attributes = Dict(:time_average => Dict("longname" => "A time average", 
-        #                                        "units" => "arbitrary")windowed_time_average_attributes)
-        #
-        #dimensions = Dict(:time_average => ("xF", "yC", "zC"))
-        #
-        #netcdf_output_writer = NetCDFOutputWriter(model, output, time_interval=4.0, filename="test.nc",
-        #                                          output_attributes=attributes, dimensions=dimensions)
-        #
-        #@test dependencies_added_correctly!(model, windowed_time_average, netcdf_output_writer)
+        output = Dict("time_average" => windowed_time_average)
+        attributes = Dict("time_average" => Dict("longname" => "A time average",  "units" => "arbitrary"))
+        dimensions = Dict("time_average" => ("xF", "yC", "zC"))
+
+        netcdf_output_writer =
+            NetCDFOutputWriter(model, output, time_interval=4.0, filename="test.nc", with_halos=true,
+                               output_attributes=attributes, dimensions=dimensions)
+
+        @test dependencies_added_correctly!(model, windowed_time_average, netcdf_output_writer)
     end
 end

--- a/test/test_simulations.jl
+++ b/test/test_simulations.jl
@@ -1,40 +1,77 @@
 using Oceananigans.Simulations:
     stop, iteration_limit_exceeded, stop_time_exceeded, wall_time_limit_exceeded, TimeStepWizard
 
+function dependencies_added_correctly!(model, windowed_time_average, output_writer)
+
+    model.clock.iteration = 0
+    model.clock.time = 0.0
+    simulation = Simulation(model, Δt=1.0, stop_iteration=1)
+    push!(simulation.output_writers, output_writer)
+    run!(simulation)
+
+    return windowed_time_average ∈ values(simulation.diagnostics)
+end
+
 @testset "Simulations" begin
     @info "Testing simulations..."
 
-    for arch in archs, Δt in (3, TimeStepWizard(Δt=5.0))
+    for arch in archs
+
         grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
         model = IncompressibleModel(architecture=arch, grid=grid)
-        simulation = Simulation(model, Δt=Δt, stop_iteration=1)
 
-        # Just make sure we can construct a simulation without any errors.
-        @test simulation isa Simulation
+        for Δt in (3, TimeStepWizard(Δt=5.0))
+            model.clock.time = 0.0
+            model.clock.iteration = 0
 
-        @test iteration_limit_exceeded(simulation) == false
-        @test stop(simulation) == false
+            simulation = Simulation(model, Δt=Δt, stop_iteration=1)
+    
+            # Just make sure we can construct a simulation without any errors.
+            @test simulation isa Simulation
+    
+            @test iteration_limit_exceeded(simulation) == false
+            @test stop(simulation) == false
+    
+            run!(simulation)
+    
+            # Just make sure run! executes without any errors.
+            @test simulation isa Simulation
+    
+            # Some basic tests
+            @test iteration_limit_exceeded(simulation) == true
+            @test stop(simulation) == true
+    
+            t = Δt isa Number ? 3 : 5
+            @test model.clock.time ≈ t
+            @test model.clock.iteration == 1
+            @test simulation.run_time > 0
+    
+            @test stop_time_exceeded(simulation) == false
+            simulation.stop_time = 1e-12
+            @test stop_time_exceeded(simulation) == true
+    
+            @test wall_time_limit_exceeded(simulation) == false
+            simulation.wall_time_limit = 1e-12
+            @test wall_time_limit_exceeded(simulation) == true
+    
+        end
 
-        run!(simulation)
+        windowed_time_average = WindowedTimeAverage(model.velocities.u, time_window=2.0, time_interval=4.0)
 
-        # Just make sure run! executes without any errors.
-        @test simulation isa Simulation
+        output = Dict(:time_average => windowed_time_average)
 
-        # Some basic tests
-        @test iteration_limit_exceeded(simulation) == true
-        @test stop(simulation) == true
+        jld2_output_writer = JLD2OutputWriter(model, output, time_interval=4.0, dir=".", prefix="test", force=true)
 
-        t = Δt isa Number ? 3 : 5
-        @test model.clock.time ≈ t
-        @test model.clock.iteration == 1
-        @test simulation.run_time > 0
+        @test dependencies_added_correctly!(model, windowed_time_average, jld2_output_writer)
 
-        @test stop_time_exceeded(simulation) == false
-        simulation.stop_time = 1e-12
-        @test stop_time_exceeded(simulation) == true
-
-        @test wall_time_limit_exceeded(simulation) == false
-        simulation.wall_time_limit = 1e-12
-        @test wall_time_limit_exceeded(simulation) == true
+        #attributes = Dict(:time_average => Dict("longname" => "A time average", 
+        #                                        "units" => "arbitrary")windowed_time_average_attributes)
+        #
+        #dimensions = Dict(:time_average => ("xF", "yC", "zC"))
+        #
+        #netcdf_output_writer = NetCDFOutputWriter(model, output, time_interval=4.0, filename="test.nc",
+        #                                          output_attributes=attributes, dimensions=dimensions)
+        #
+        #@test dependencies_added_correctly!(model, windowed_time_average, netcdf_output_writer)
     end
 end


### PR DESCRIPTION
This PR introduces the concept of an output writer "diagnostic dependency": a diagnostic which must be added to `simulation.diagnostics` in order for output to be correct.

If a type of output has a "diagnostic dependency", it must define the function `add_dependency!(diagnostics, output)`, which will add any appropriate diagnostics to the ordered dictionary `diagnostics`.

Currently we only have one type of output that requires a diagnostic, which is the `WindowedTimeAverage`. For `WindowedTimeAverage`, `add_dependency!` is

```julia
add_dependency!(diags, wta::WindowedTimeAverage) = !(wta ∈ values(diags)) && push!(diags, wta)
```

(As a side note, we could require that all values of `diagnostics` are unique, which would obviate the check above.)