### PR TITLE
Bump v0.35.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.34.1"
+version = "0.35.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
This release will go alongside the JOSS paper.

Release notes:

* Support for multithreaded CPU simulations! Set the number of threads via the `JULIA_NUM_THREADS` environment variable or via the `-t` flag in Julia 1.5+.
* New `OceananigansLogger` for fancy log messages with time stamps.
* New experimental diagnostic `WindowedTimeAverage`.
* `Average` diagnostic can include or exclude halos via the `with_halos` keyword argument.
* Improved testing infrastructure made possible by splitting tests into four groups.
* Cleaned up convergence test scripts and plots. Convergence tests can be run via the `TEST_GROUP=convergence`.
* Numerous bug fixes and documentation updates.
