### PR TITLE
Simplifies boundary condition interface, types, and constructors

### DIFF
--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -217,8 +217,10 @@ Oceananigans.FieldBoundaryConditions (NamedTuple{(:x, :y, :z)}), with boundary c
 for horizontally periodic grid topologies.
 The default `Periodic` boundary conditions in $x$ and $y$ are inferred from the `topology` of `grid`.
 
-For $u$, $v$, and $w$, use the [`UVelocityBoundaryConditions`](@ref),
-[`VVelocityBoundaryConditions`](@ref), and [`WVelocityBoundaryConditions`](@ref) constructors, respectively.
+For $u$, $v$, and $w$, use the 
+`UVelocityBoundaryConditions`
+`VVelocityBoundaryConditions`, and 
+`WVelocityBoundaryConditions` constructors, respectively.
 
 ## Specifying model boundary conditions
 

--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -60,7 +60,7 @@ end
 ```
 
 Boundary conditions may be specified with constants, functions, or arrays.
-In this section we illustrate usage of the `BoundaryCondition` constructor.
+In this section we illustrate usage of the [`BoundaryCondition`](@ref) constructor.
 
 ##### 1. Constant `Value` (Dirchlet) boundary condition
 
@@ -69,9 +69,9 @@ julia> constant_T_bc = ValueBoundaryCondition(20.0)
 BoundaryCondition: type=Value, condition=20.0
 ```
 
-A constant `Value` boundary condition can be used to specify constant tracer (such as temperature),
+A constant [`Value`](@ref) boundary condition can be used to specify constant tracer (such as temperature),
 or a constant _tangential_ velocity component at a boundary. Note that boundary conditions on the
-_normal_ velocity component must use the `NormalFlow` boundary condition type.
+_normal_ velocity component must use the [`NormalFlow`](@ref) boundary condition type.
 
 Finally, note that `ValueBoundaryCondition(condition)` is an alias for `BoundaryCondition(Value, condition)`.
 
@@ -83,10 +83,10 @@ julia> ρ₀ = 1027;  # Reference density [kg/m³]
 julia> τₓ = 0.08;  # Wind stress [N/m²]
 
 julia> wind_stress_bc = FluxBoundaryCondition(-τₓ/ρ₀)
-BoundaryCondition: type=Flux, condition=7.789678675754625e-5
+BoundaryCondition: type=Flux, condition=-7.789678675754625e-5
 ```
 
-A constant `Flux` boundary condition can be imposed on tracers and tangential velocity components
+A constant [`Flux`](@ref) boundary condition can be imposed on tracers and tangential velocity components
 can can be used, for example, to specify cooling, heating, evaporation, or wind stress at the ocean surface.
 
 !!! info "The flux convention in Oceananigans"
@@ -95,12 +95,14 @@ can can be used, for example, to specify cooling, heating, evaporation, or wind 
     This means, for example, that a _negative_ flux of momentum or velocity at a _top_
     boundary, such as in the above example, produces currents in the _positive_ direction,
     because it prescribes a downwards flux of momentum into the domain from the top.
-    Likewise, a _positive_ temperature flux at the top boundary leads
+    Likewise, a _positive_ temperature flux at the top boundary
     causes _cooling_, because it transports heat _upwards_, out of the domain.
     Conversely, a positive flux at a _bottom_ boundary acts to increase the interior
     values of a quantity.
 
 ##### 3. Spatially- and temporally-varying flux
+
+Boundary conditions may be specified by functions,
 
 ```jldoctest
 julia> @inline surface_flux(x, y, t) = cos(2π * x) * cos(t);
@@ -118,10 +120,12 @@ BoundaryCondition: type=Flux, condition=surface_flux(x, y, t) in Main at none:1
     * `f(y, z, t)` on `x`-boundaries;
     * `f(x, z, t)` on `y`-boundaries;
     * `f(x, y, t)` on `z`-boundaries.
-    Other function signatures are possible by providing keyword arguments to
+    Alternative function signatures are specified by keyword arguments to
     `BoundaryCondition`, as illustrated in subsequent examples.
 
 ##### 4. Spatially- and temporally-varying flux with parameters
+
+Boundary condition functions may be 'parameterized',
 
 ```jldoctest
 julia> @inline wind_stress(x, y, t, p) = - p.τ * cos(p.k * x) * cos(p.ω * t); # function with parameters
@@ -149,7 +153,7 @@ BoundaryCondition: type=Flux, condition=linear_drag(i, j, grid, clock, state) in
 ```
 
 !!! info "The 'discrete form' for boundary condition functions"
-    The argument `discrete_form=true` indicates to `BoundaryCondition` that `linear_drag`
+    The argument `discrete_form=true` indicates to [`BoundaryCondition`](@ref) that `linear_drag`
     uses the 'discrete form'. Boundary condition functions that use the 'discrete form'
     are called with the signature 
     ```julia
@@ -194,7 +198,7 @@ When running on the GPU, `Q` must be converted to a `CuArray`.
 
 ## Building boundary conditions on a field
 
-To create, for example, a set of horizontally periodic field boundary conditions
+To create, for example, a set of horizontally-periodic field boundary conditions, write
 
 ```jldoctest
 julia> topology = (Periodic, Periodic, Bounded);
@@ -213,12 +217,13 @@ Oceananigans.FieldBoundaryConditions (NamedTuple{(:x, :y, :z)}), with boundary c
 for horizontally periodic grid topologies.
 The default `Periodic` boundary conditions in $x$ and $y$ are inferred from the `topology` of `grid`.
 
-For $u$, $v$, and $w$, use the `UVelocityBoundaryConditions`, `VVelocityBoundaryConditions`, and `WVelocityBoundaryConditions` constructors, respectively.
+For $u$, $v$, and $w$, use the [`UVelocityBoundaryConditions`](@ref),
+[`VVelocityBoundaryConditions`](@ref), and [`WVelocityBoundaryConditions`](@ref) constructors, respectively.
 
 ## Specifying model boundary conditions
 
 To specify non-default boundary conditions, a named tuple of [`FieldBoundaryConditions`](@ref) objects is
-passed to the keyword argument `boundary_conditions` in the `IncompressibleModel` constructor.
+passed to the keyword argument `boundary_conditions` in the [`IncompressibleModel`](@ref) constructor.
 The keys of `boundary_conditions` indicate the field to which the boundary condition is applied.
 Below, non-default boundary conditions are imposed on the $u$-velocity and temperature.
 

--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -247,13 +247,7 @@ IncompressibleModel{CPU, Float64}(time = 0.000 s, iteration = 0)
 ├── closure: IsotropicDiffusivity{Float64,NamedTuple{(:T, :S),Tuple{Float64,Float64}}}
 ├── buoyancy: SeawaterBuoyancy{Float64,LinearEquationOfState{Float64},Nothing,Nothing}
 └── coriolis: Nothing
-```
 
-The keyword argument `boundary_conditions` assigns boundary conditions to the corresponding
-fields:
-
-
-```jldoctest
 julia> model.velocities.u
 Field located at (Face, Cell, Cell)
 ├── data: OffsetArrays.OffsetArray{Float64,3,Array{Float64,3}}, size: (18, 18, 18)
@@ -267,4 +261,5 @@ Field located at (Cell, Cell, Cell)
 └── boundary conditions: x=(west=Periodic, east=Periodic), y=(south=Periodic, north=Periodic), z=(bottom=Gradient, top=Value)
 ```
 
-Note the non-default boundary conditions at top and bottom on both `model.velocities.u` and `model.tracers.T`.
+Notice that the specified non-default boundary conditions have been applied at
+top and bottom of both `model.velocities.u` and `model.tracers.T`.

--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -33,165 +33,168 @@ Oceananigans uses a hierarchical structure to express boundary conditions.
 1. A [`BoundaryCondition`](@ref) is associated with every field, dimension, and endpoint.
 2. Boundary conditions specifying the condition at the left and right endpoints are
    grouped into [`CoordinateBoundaryConditions`](@ref).
-3. A set of three `CoordinateBoundaryConditions` specifying the boundary conditions along the x, y, and z dimensions
-   for a single field are grouped into a [`FieldBoundaryConditions`](@ref) named tuple.
-4. A set of `FieldBoundaryConditions`, up to one for each field, are grouped together into a named tuple and passed
+3. A set of three `CoordinateBoundaryConditions` specifying the boundary conditions along the $x$-, $y$-,
+   and $z$-dimensions.
+   for a single field are grouped into a [`FieldBoundaryConditions`](@ref) `NamedTuple`.
+4. A set of `FieldBoundaryConditions`, up to one for each field, are grouped into a `NamedTuple` and passed
    to the model constructor.
 
-Boundary conditions are defined at model construction time by passing a named tuple of `FieldBoundaryConditions`
-specifying non-default boundary conditions for fields such as velocities ($u$, $v$, $w$) and tracers. Not passing
-in a `FieldBoundaryConditions` for one field means it gets the default boundary conditions.
+Boundary conditions are defined at model construction time by passing a `NamedTuple` of `FieldBoundaryConditions`
+specifying non-default boundary conditions for fields such as velocities ($u$, $v$, $w$) and tracers.
+Fields for which boundary conditions are not specified are assigned a default boundary conditions.
+Note that default boundary conditions depend on the grid topology.
 
-See the sections below for more details. The examples and verification experiments also provide examples for setting up
-different kinds of boundary conditions.
+A few illustrations are provided below. See the verification experiments and examples for
+further illustrations of boundary condition specification.
 
-## Creating individual boundary conditions
+## Creating individual boundary conditions with `BoundaryCondition`
 
 ```@meta
 DocTestSetup = quote
-   using Random
    using Oceananigans
-   using Oceananigans.Fields
    using Oceananigans.BoundaryConditions
+
+   using Random
    Random.seed!(1234)
 end
 ```
 
-Some examples of creating individual boundary conditions:
+Boundary conditions may be specified with constants, functions, or arrays.
+In this section we illustrate usage of the `BoundaryCondition` constructor.
 
-1. A constant `Value` (Dirchlet) boundary condition, perhaps representing a constant temperature at some boundary.
-
-   ```jldoctest
-   julia> constant_T_bc = ValueBoundaryCondition(20.0)
-   BoundaryCondition: type=Value, condition=20.0
-   ```
-
-2. A constant flux boundary condition, perhaps representing a constant wind stress at some boundary such as the ocean
-   surface.
-
-   ```jldoctest
-   julia> ρ₀ = 1027;  # Reference density [kg/m³]
-
-   julia> τₓ = 0.08;  # Wind stress [N/m²]
-
-   julia> wind_stress_bc = FluxBoundaryCondition(τₓ/ρ₀)
-   BoundaryCondition: type=Flux, condition=7.789678675754625e-5
-   ```
-
-3. A spatially varying (white noise) cooling flux to be imposed at some boundary. Note that the boundary condition
-   is given by the array `Q` here. When running on the GPU, `Q` must be converted to a `CuArray`.
-
-   ```jldoctest
-   julia> Nx = Ny = 16;  # Number of grid points.
-
-   julia> ρ₀ = 1027;  # Reference density [kg/m³]
-
-   julia> cₚ = 4000;  # Heat capacity of water at constant pressure [J/kg/K]
-
-   julia> Q  = randn(Nx, Ny) ./ (ρ₀ * cₚ);
-
-   julia> white_noise_T_bc = FluxBoundaryCondition(Q)
-   BoundaryCondition: type=Flux, condition=16×16 Array{Float64,2}
-   ```
-
-## Specifying boundary conditions with functions
-
-If you need maximum flexibility you can also specify the boundary condition via a function. There are a few different
-interfaces for doing this depending on whether you want access to the grid indices `i, j, k` or grid coordinates
-`x, y, z` in the function signature, or whether you need to make use of parameters such as length scales or scaling
-exponents in the function.
-
-!!! info "Performance of functions in boundary conditions"
-    For performance reasons, you should define all functions used in boundary conditions as inline functions via the
-    `@inline` macro. If any arrays are accessed within the function, disabling bounds-checking with `@inbounds` will
-    also speed things up. These are important considerations as these functions will be called many times every
-    time step.
-
-### Boundary condition functions with grid index access
-
-Boundary condition functions with grid index `i, j, k` access, for example for the z dimension, must be specified
-with the signature
-
-```julia
-f(i, j, grid, clock, state)
-```
-
-where `i, j` is the grid index, `grid` is `model.grid`, `clock` is the `model.clock`, and `state` is a named tuple
-containing `state.velocities`, `state.tracers`, and `state.diffusivities`. The signature is similar for x and y
-boundary conditions expect that `i, j` is replaced with `j, k` and `i, k` respectively.
+##### 1. Constant `Value` (Dirchlet) boundary condition
 
 ```jldoctest
-julia> @inline linear_drag(i, j, grid, clock, state) = @inbounds -0.2*state.velocities.u[i, j, 1];
-
-julia> u_bottom_bc = FluxBoundaryCondition(linear_drag)
-BoundaryCondition: type=Flux, condition=linear_drag(i, j, grid, clock, state) in Main at none:1
+julia> constant_T_bc = ValueBoundaryCondition(20.0)
+BoundaryCondition: type=Value, condition=20.0
 ```
 
-Instead of hard-coding in the drag coefficient of 0.2, we may want to turn it, and other magic numbers, into parameters.
-We would then use a [`ParameterizedBoundaryCondition`](@ref) and use the signature
+A constant `Value` boundary condition can be used to specify constant tracer (such as temperature),
+or a constant _tangential_ velocity component at a boundary. Note that boundary conditions on the
+_normal_ velocity component must use the `NormalFlow` boundary condition type.
 
-```julia
-f(i, j, grid, clock, state, parameters)
-```
+Finally, note that `ValueBoundaryCondition(condition)` is an alias for `BoundaryCondition(Value, condition)`.
 
-which would convert the above example into
+##### 2. Constant `Flux` boundary condition
 
 ```jldoctest
-julia> C = 0.2;  # drag coefficient
+julia> ρ₀ = 1027;  # Reference density [kg/m³]
 
-julia> parameters = (C=C,);
+julia> τₓ = 0.08;  # Wind stress [N/m²]
 
-julia> @inline linear_drag(i, j, grid, clock, state, parameters) =
-           @inbounds - parameters.C * state.velocities.u[i, j, 1];
-
-julia> u_bottom_bc = ParameterizedBoundaryCondition(Flux, linear_drag, parameters)
-BoundaryCondition: type=Flux, condition=linear_drag(i, j, grid, clock, state, parameters) in Main at none:1
+julia> wind_stress_bc = FluxBoundaryCondition(-τₓ/ρ₀)
+BoundaryCondition: type=Flux, condition=7.789678675754625e-5
 ```
 
-### Boundary condition functions with grid coordinate access
+A constant `Flux` boundary condition can be imposed on tracers and tangential velocity components
+can can be used, for example, to specify cooling, heating, evaporation, or wind stress at the ocean surface.
 
-To define boundary condition function with grid coordinate access, you should use a [`BoundaryFunction`](@ref). For example
-for the z dimension, you must use the signature
+!!! info "The flux convention in Oceananigans"
+    `Oceananigans` uses the convention that positive fluxes produce transport in the
+    _positive_ direction (east, north, and up for $x$, $y$, $z$).
+    This means, for example, that a _negative_ flux of momentum or velocity at a _top_
+    boundary, such as in the above example, produces currents in the _positive_ direction,
+    because it prescribes a downwards flux of momentum into the domain from the top.
+    Likewise, a _positive_ temperature flux at the top boundary leads
+    causes _cooling_, because it transports heat _upwards_, out of the domain.
+    Conversely, a positive flux at a _bottom_ boundary acts to increase the interior
+    values of a quantity.
 
-```julia
-f(x, y, t)
-```
-
-where `x, y` are the grid coordinates and `t` is the `model.clock.time`. The signature is similar for x and y
-boundary conditions expect that `x, y` is replaced with `y, z` and `x, z` respectively.
+##### 3. Spatially- and temporally-varying flux
 
 ```jldoctest
-julia> surface_flux(x, y, t) = cos(2π*x) * cos(t);
+julia> @inline surface_flux(x, y, t) = cos(2π * x) * cos(t);
 
-julia> top_tracer_boundary_function = BoundaryFunction{:z, Cell, Cell}(surface_flux);
-
-julia> top_tracer_bc = FluxBoundaryCondition(top_tracer_boundary_function)
+julia> top_tracer_bc = FluxBoundaryCondition(surface_flux)
 BoundaryCondition: type=Flux, condition=surface_flux(x, y, t) in Main at none:1
 ```
 
-To add user-defined parameters such as a length-scale or scaling exponent, for example to a boundary condition function
-in the z dimension, you would use the signature
+!!! info "Boundary condition functions"
+    By default, a function boundary condition is called with the signature
+    ```julia
+    f(ξ, η, t)
+    ```
+    where `t` is time and `ξ, η` are spatial coordinates that vary along the boundary:
+    * `f(y, z, t)` on `x`-boundaries;
+    * `f(x, z, t)` on `y`-boundaries;
+    * `f(x, y, t)` on `z`-boundaries.
+    Other function signatures are possible by providing keyword arguments to
+    `BoundaryCondition`, as illustrated in subsequent examples.
 
-```julia
-f(x, y, t, parameters)
-```
-
-where `parameters` can be any structure that is passed to the [`BoundaryFunction`](@ref).
+##### 4. Spatially- and temporally-varying flux with parameters
 
 ```jldoctest
-julia> params = (k=4π, ω=3.0);
+julia> @inline wind_stress(x, y, t, p) = - p.τ * cos(p.k * x) * cos(p.ω * t); # function with parameters
 
-julia> flux_func(x, y, t, p) = cos(p.k * x) * cos(p.ω * t); # function with parameters
-
-julia> parameterized_u_velocity_flux = BoundaryFunction{:z, Face, Cell}(flux_func, params);
-
-julia> top_u_bc = BoundaryCondition(Flux, parameterized_u_velocity_flux)
-BoundaryCondition: type=Flux, condition=flux_func(x, y, t, p) in Main at none:1
+julia> top_u_bc = BoundaryCondition(Flux, wind_stress, parameters=(k=4π, ω=3.0, τ=1e-4))
+BoundaryCondition: type=Flux, condition=wind_stress(x, y, t, p) in Main at none:1
 ```
 
-## Specifying boundary conditions on a field
+!!! info "Boundary condition functions with parameters"
+    The keyword argument `parameters` above specifies that `wind_stress` is called
+    with the signature `wind_stress(x, y, t, parameters)`. In principle, `parameters` is arbitrary.
+    However, relatively simple objects such as floating point numbers or `NamedTuple`s must be used
+    when running on the GPU.
 
-To, for example, create a set of horizontally periodic field boundary conditions
+##### 5. 'Field-dependent' boundary conditions
+
+Boundary conditions may also depend on model fields. For example, a linear drag boundary condition
+is implemented with
+
+```jldoctest
+julia> @inline linear_drag(i, j, grid, clock, state) = @inbounds - 0.2 * state.velocities.u[i, j, 1];
+
+julia> u_bottom_bc = FluxBoundaryCondition(linear_drag, discrete_form=true)
+BoundaryCondition: type=Flux, condition=linear_drag(i, j, grid, clock, state) in Main at none:1
+```
+
+!!! info "The 'discrete form' for boundary condition functions"
+    The argument `discrete_form=true` indicates to `BoundaryCondition` that `linear_drag`
+    uses the 'discrete form'. Boundary condition functions that use the 'discrete form'
+    are called with the signature 
+    ```julia
+    f(i, j, grid, clock, state)
+    ```
+    where `i, j` are grid indices that vary along the boundary, `grid` is `model.grid`,
+    `clock` is the `model.clock`, and `state` is a `NamedTuple`
+    containing `state.velocities`, `state.tracers`, and `state.diffusivities`.
+    The signature is similar for $x$ and $y$ boundary conditions expect that `i, j` is replaced
+    with `j, k` and `i, k` respectively.
+
+##### 6. Discrete-form boundary condition with parameters
+
+```jldoctest
+julia> Cd = 0.2;  # drag coefficient
+
+julia> @inline linear_drag(i, j, grid, clock, state, Cd) = @inbounds - Cd * state.velocities.u[i, j, 1];
+
+julia> u_bottom_bc = BoundaryCondition(Flux, linear_drag, discrete_form=true, parameters=Cd)
+BoundaryCondition: type=Flux, condition=linear_drag(i, j, grid, clock, state, Cd) in Main at none:1
+```
+
+!!! info "Inlining and avoiding bounds-checking in boundary condition functions"
+    Boundary condition functions should be decorated with `@inline` when running on CPUs for performance reasons.
+    On the GPU, all functions are force-inlined by default.
+    In addition, the annotation `@inbounds` should be used when accessing the elements of an array
+    in a boundary condition function (such as `state.velocities[i, j, 1]` in the above example).
+    Using `@inbounds` will avoid a relatively expensive check that the index `i, j, 1` is 'in bounds'.
+
+##### 7. A random, spatially-varying, constant-in-time temperature flux specified by an array
+
+```jldoctest
+julia> Nx = Ny = 16;  # Number of grid points.
+
+julia> Q = randn(Nx, Ny); # temperature flux
+
+julia> white_noise_T_bc = FluxBoundaryCondition(Q)
+BoundaryCondition: type=Flux, condition=16×16 Array{Float64,2}
+```
+
+When running on the GPU, `Q` must be converted to a `CuArray`.
+
+## Building boundary conditions on a field
+
+To create, for example, a set of horizontally periodic field boundary conditions
 
 ```jldoctest
 julia> topology = (Periodic, Periodic, Bounded);
@@ -206,13 +209,18 @@ Oceananigans.FieldBoundaryConditions (NamedTuple{(:x, :y, :z)}), with boundary c
 └── z: CoordinateBoundaryConditions{BoundaryCondition{Gradient,Float64},BoundaryCondition{Value,Int64}}
 ```
 
-which will create a [`FieldBoundaryConditions`](@ref) object for temperature `T` appropriate for horizontally periodic
-model configurations where the x and y boundary conditions are all periodic.
+`T_bcs` is a [`FieldBoundaryConditions`](@ref) object for temperature `T` appropriate
+for horizontally periodic grid topologies.
+The default `Periodic` boundary conditions in $x$ and $y$ are inferred from the `topology` of `grid`.
+
+For $u$, $v$, and $w$, use the `UVelocityBoundaryConditions`, `VVelocityBoundaryConditions`, and `WVelocityBoundaryConditions` constructors, respectively.
 
 ## Specifying model boundary conditions
 
-A named tuple of [`FieldBoundaryConditions`](@ref) objects must be passed to the Model constructor specifying boundary
-conditions on all fields. To, for example, impose non-default boundary conditions on the u-velocity and temperature
+To specify non-default boundary conditions, a named tuple of [`FieldBoundaryConditions`](@ref) objects is
+passed to the keyword argument `boundary_conditions` in the `IncompressibleModel` constructor.
+The keys of `boundary_conditions` indicate the field to which the boundary condition is applied.
+Below, non-default boundary conditions are imposed on the $u$-velocity and temperature.
 
 ```jldoctest
 julia> topology = (Periodic, Periodic, Bounded);
@@ -233,3 +241,23 @@ IncompressibleModel{CPU, Float64}(time = 0.000 s, iteration = 0)
 ├── buoyancy: SeawaterBuoyancy{Float64,LinearEquationOfState{Float64},Nothing,Nothing}
 └── coriolis: Nothing
 ```
+
+The keyword argument `boundary_conditions` assigns boundary conditions to the corresponding
+fields:
+
+
+```jldoctest
+julia> model.velocities.u
+Field located at (Face, Cell, Cell)
+├── data: OffsetArrays.OffsetArray{Float64,3,Array{Float64,3}}, size: (18, 18, 18)
+├── grid: RegularCartesianGrid{Float64, Periodic, Periodic, Bounded}(Nx=16, Ny=16, Nz=16)
+└── boundary conditions: x=(west=Periodic, east=Periodic), y=(south=Periodic, north=Periodic), z=(bottom=Value, top=Value)
+
+julia> model.tracers.T
+Field located at (Cell, Cell, Cell)
+├── data: OffsetArrays.OffsetArray{Float64,3,Array{Float64,3}}, size: (18, 18, 18)
+├── grid: RegularCartesianGrid{Float64, Periodic, Periodic, Bounded}(Nx=16, Ny=16, Nz=16)
+└── boundary conditions: x=(west=Periodic, east=Periodic), y=(south=Periodic, north=Periodic), z=(bottom=Gradient, top=Value)
+```
+
+Note the non-default boundary conditions at top and bottom on both `model.velocities.u` and `model.tracers.T`.

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -57,11 +57,18 @@ grid = RegularCartesianGrid(size=(Nh, Nh, Nz), halo=(2, 2, 2),
 
 bc_parameters = (μ=μ, H=Lz)
 
-@inline τ₁₃_linear_drag(i, j, grid, clock, state, p) = @inbounds p.μ * p.H * state.velocities.u[i, j, 1]
-@inline τ₂₃_linear_drag(i, j, grid, clock, state, p) = @inbounds p.μ * p.H * state.velocities.v[i, j, 1]
+@inline τ₁₃_linear_drag(i, j, grid, clock, state, params) =
+    @inbounds params.μ * params.H * state.velocities.u[i, j, 1]
 
-ubcs = UVelocityBoundaryConditions(grid, bottom = ParameterizedBoundaryCondition(Flux, τ₁₃_linear_drag, bc_parameters))
-vbcs = VVelocityBoundaryConditions(grid, bottom = ParameterizedBoundaryCondition(Flux, τ₂₃_linear_drag, bc_parameters))
+@inline τ₂₃_linear_drag(i, j, grid, clock, state, params) =
+    @inbounds params.μ * params.H * state.velocities.v[i, j, 1]
+
+ubcs = UVelocityBoundaryConditions(grid, bottom = BoundaryCondition(Flux, τ₁₃_linear_drag,
+                                                                    discrete_form=true, parameters=bc_parameters))
+
+vbcs = VVelocityBoundaryConditions(grid, bottom = BoundaryCondition(Flux, τ₂₃_linear_drag,
+                                                                    discrete_form=true, parameters=bc_parameters))
+                                   
 bbcs = TracerBoundaryConditions(grid,    top = BoundaryCondition(Value, 0),
                                       bottom = BoundaryCondition(Value, -N² * Lz))
 

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -70,9 +70,9 @@ T_bcs = TracerBoundaryConditions(grid,    top = BoundaryCondition(Flux, Qᵀ),
                                        bottom = BoundaryCondition(Gradient, ∂T∂z))
 
 ## Salinity flux: Qˢ = - E * S
-@inline Qˢ(i, j, grid, clock, state, p) = @inbounds -p.evaporation * state.tracers.S[i, j, 1]
+@inline Qˢ(i, j, grid, clock, state, evaporation) = @inbounds - evaporation * state.tracers.S[i, j, 1]
 
-S_bcs = TracerBoundaryConditions(grid, top = ParameterizedBoundaryCondition(Flux, Qˢ, (evaporation=evaporation,)))
+S_bcs = TracerBoundaryConditions(grid, top = BoundaryCondition(Flux, Qˢ, discrete_form=true, parameters=evaporation))
 nothing # hide
 
 # ## Model instantiation

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -15,11 +15,6 @@ export
 
     DiffusivityBoundaryConditions,
 
-    BoundaryFunction, TracerBoundaryCondition,
-    UVelocityBoundaryCondition, VVelocityBoundaryCondition, WVelocityBoundaryCondition,
-
-    ParameterizedBoundaryCondition, ParameterizedBoundaryConditionFunction,
-
     apply_x_bcs!, apply_y_bcs!, apply_z_bcs!,
 
     fill_halo_regions!, zero_halo_regions!
@@ -32,11 +27,11 @@ using Oceananigans.Utils: work_layout, launch!
 using Oceananigans.Grids
 
 include("boundary_condition_types.jl")
+include("boundary_function.jl")
+include("parameterized_boundary_condition.jl")
 include("boundary_condition.jl")
 include("coordinate_boundary_conditions.jl")
 include("field_boundary_conditions.jl")
-include("boundary_function.jl")
-include("parameterized_boundary_condition.jl")
 include("show_boundary_conditions.jl")
 
 include("fill_halo_regions.jl")

--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -23,7 +23,7 @@ BoundaryCondition(BC, condition) = BoundaryCondition{BC, typeof(condition)}(cond
 
 Construct a boundary condition of type `BC` with a function boundary `condition`.
 
-By default, the function boudnary `condition` is assumed to have the 'short form'
+By default, the function boudnary `condition` is assumed to have the 'continuous form'
 `condition(ξ, η, t)`, where `t` is time and `ξ` and `η` vary along the boundary.
 In particular:
 

--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -89,10 +89,10 @@ const ZFBC = BoundaryCondition{Flux, Nothing} # "zero" flux
       NoFluxBoundaryCondition() = BoundaryCondition(Flux,       nothing)
 ImpenetrableBoundaryCondition() = BoundaryCondition(NormalFlow, nothing)
 
-      FluxBoundaryCondition(val) = BoundaryCondition(Flux, val)
-     ValueBoundaryCondition(val) = BoundaryCondition(Value, val)
-  GradientBoundaryCondition(val) = BoundaryCondition(Gradient, val)
-NormalFlowBoundaryCondition(val) = BoundaryCondition(NormalFlow, val)
+      FluxBoundaryCondition(val; kwargs...) = BoundaryCondition(Flux, val; kwargs...)
+     ValueBoundaryCondition(val; kwargs...) = BoundaryCondition(Value, val; kwargs...)
+  GradientBoundaryCondition(val; kwargs...) = BoundaryCondition(Gradient, val; kwargs...)
+NormalFlowBoundaryCondition(val; kwargs...) = BoundaryCondition(NormalFlow, val; kwargs...)
 
 # Support for various types of boundary conditions
 @inline getbc(bc::BC{<:NormalFlow, Nothing}, args...) = 0

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -14,9 +14,25 @@ Construct a `FieldBoundaryConditions` using a `CoordinateBoundaryCondition` for 
 """
 FieldBoundaryConditions(x, y, z) = FieldBoundaryConditions((x, y, z))
 
+"""
+    DefaultBoundaryCondition(::Union{Type{Periodic}, Type{Flat}}, loc)
+
+Returns [`PeriodicBoundaryCondition`](@ref).
+"""
 DefaultBoundaryCondition(::Union{Type{Grids.Periodic}, Type{Flat}}, loc) = PeriodicBoundaryCondition()
 
+"""
+    DefaultBoundaryCondition(::Type{Bounded}, ::Type{Cell})
+
+Returns [`NoFluxBoundaryCondition`](@ref).
+"""
 DefaultBoundaryCondition(::Type{Bounded}, ::Type{Cell}) = NoFluxBoundaryCondition()
+
+"""
+    DefaultBoundaryCondition(::Type{Bounded}, ::Type{Face})
+
+Returns [`ImpenetrableBoundaryCondition`](@ref).
+"""
 DefaultBoundaryCondition(::Type{Bounded}, ::Type{Face}) = ImpenetrableBoundaryCondition()
 
 function validate_bcs(topology, left_bc, right_bc, default_bc, left_name, right_name, dir)
@@ -34,29 +50,31 @@ relocate_function_boundary_condition(bc::BoundaryCondition{C, <:BoundaryFunction
     BoundaryCondition(C, BoundaryFunction{boundary, loc1, loc2}(bc.condition.func; parameters=bc.condition.parameters))
 
 """
-    FieldBoundaryConditions(grid, loc;
-          east = DefaultBoundaryCondition(topology(grid)[1], loc[1]),
-          west = DefaultBoundaryCondition(topology(grid)[1], loc[1]),
-         south = DefaultBoundaryCondition(topology(grid)[2], loc[2]),
-         north = DefaultBoundaryCondition(topology(grid)[2], loc[2]),
-        bottom = DefaultBoundaryCondition(topology(grid)[3], loc[3]),
-           top = DefaultBoundaryCondition(topology(grid)[3], loc[3]))
+    FieldBoundaryConditions(grid, loc;   east = DefaultBoundaryCondition(topology(grid, 1), loc[1]),
+                                         west = DefaultBoundaryCondition(topology(grid, 1], loc[1]),
+                                        south = DefaultBoundaryCondition(topology(grid, 2), loc[2]),
+                                        north = DefaultBoundaryCondition(topology(grid, 2), loc[2]),
+                                       bottom = DefaultBoundaryCondition(topology(grid, 3), loc[3]),
+                                          top = DefaultBoundaryCondition(topology(grid, 3), loc[3]))
 
 Construct `FieldBoundaryConditions` for a field with location `loc` (a 3-tuple of `Face` or `Cell`)
-defined on `grid` (the grid's topology is what defined the default boundary conditions that are
-imposed).
+defined on `grid`.
 
-Specific boundary conditions can be applied along the x dimension with the `west` and `east` kwargs,
-along the y-dimension with the `south` and `north` kwargs, and along the z-dimension with the `bottom`
-and `top` kwargs.
+Boundary conditions on `x`-, `y`-, and `z`-boundaries are specified via
+keyword arguments:
+
+    * `west` and `east` for the `-x` and `+x` boundary;
+    * `south` and `north` for the `-y` and `+y` boundary;
+    * `bottom` and `top` for the `-z` and `+z` boundary.
+
+Default boundary conditions depend on `topology(grid)` and `loc`.
 """
-function FieldBoundaryConditions(grid, loc;
-      east = DefaultBoundaryCondition(topology(grid)[1], loc[1]),
-      west = DefaultBoundaryCondition(topology(grid)[1], loc[1]),
-     south = DefaultBoundaryCondition(topology(grid)[2], loc[2]),
-     north = DefaultBoundaryCondition(topology(grid)[2], loc[2]),
-    bottom = DefaultBoundaryCondition(topology(grid)[3], loc[3]),
-       top = DefaultBoundaryCondition(topology(grid)[3], loc[3]))
+function FieldBoundaryConditions(grid, loc;   east = DefaultBoundaryCondition(topology(grid, 1), loc[1]),
+                                              west = DefaultBoundaryCondition(topology(grid, 1), loc[1]),
+                                             south = DefaultBoundaryCondition(topology(grid, 2), loc[2]),
+                                             north = DefaultBoundaryCondition(topology(grid, 2), loc[2]),
+                                            bottom = DefaultBoundaryCondition(topology(grid, 3), loc[3]),
+                                               top = DefaultBoundaryCondition(topology(grid, 3), loc[3]))
 
     east = relocate_function_boundary_condition(east, :x, loc[2], loc[3])
     west = relocate_function_boundary_condition(west, :x, loc[2], loc[3])
@@ -66,9 +84,9 @@ function FieldBoundaryConditions(grid, loc;
     top = relocate_function_boundary_condition(top, :z, loc[1], loc[2])
 
     TX, TY, TZ = topology(grid)
-    x_default_bc = DefaultBoundaryCondition(topology(grid)[1], loc[1])
-    y_default_bc = DefaultBoundaryCondition(topology(grid)[2], loc[2])
-    z_default_bc = DefaultBoundaryCondition(topology(grid)[3], loc[3])
+    x_default_bc = DefaultBoundaryCondition(topology(grid, 1), loc[1])
+    y_default_bc = DefaultBoundaryCondition(topology(grid, 2), loc[2])
+    z_default_bc = DefaultBoundaryCondition(topology(grid, 3), loc[3])
 
     validate_bcs(TX, west,   east, x_default_bc, :west,   :east, :x)
     validate_bcs(TY, south, north, y_default_bc, :south, :north, :y)
@@ -81,9 +99,85 @@ function FieldBoundaryConditions(grid, loc;
     return FieldBoundaryConditions(x, y, z)
 end
 
-  UVelocityBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Face, Cell, Cell); user_defined_bcs...)
-  VVelocityBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Face, Cell); user_defined_bcs...)
-  WVelocityBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Cell, Face); user_defined_bcs...)
-     TracerBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Cell, Cell); user_defined_bcs...)
-   PressureBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Cell, Cell); user_defined_bcs...)
-DiffusivityBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Cell, Cell); user_defined_bcs...)
+"""
+    UVelocityBoundaryConditions(grid;   east = DefaultBoundaryCondition(topology(grid, 1), Face),
+                                        west = DefaultBoundaryCondition(topology(grid, 1), Face),
+                                       south = DefaultBoundaryCondition(topology(grid, 2), Cell),
+                                       north = DefaultBoundaryCondition(topology(grid, 2), Cell),
+                                      bottom = DefaultBoundaryCondition(topology(grid, 3), Cell),
+                                         top = DefaultBoundaryCondition(topology(grid, 3), Cell))
+
+Construct `FieldBoundaryConditions` for the `u`-velocity field on `grid`.
+Boundary conditions on `x`-, `y`-, and `z`-boundaries are specified via
+keyword arguments:
+
+    * `west` and `east` for the `-x` and `+x` boundary;
+    * `south` and `north` for the `-y` and `+y` boundary;
+    * `bottom` and `top` for the `-z` and `+z` boundary.
+
+Default boundary conditions depend on `topology(grid)`. See ['DefaultBoundaryCondition'](@ref)
+"""
+UVelocityBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Face, Cell, Cell); user_defined_bcs...)
+
+"""
+    VVelocityBoundaryConditions(grid;   east = DefaultBoundaryCondition(topology(grid, 1), Cell),
+                                        west = DefaultBoundaryCondition(topology(grid, 1), Cell),
+                                       south = DefaultBoundaryCondition(topology(grid, 2), Face),
+                                       north = DefaultBoundaryCondition(topology(grid, 2), Face),
+                                      bottom = DefaultBoundaryCondition(topology(grid, 3), Cell),
+                                         top = DefaultBoundaryCondition(topology(grid, 3), Cell))
+
+Construct `FieldBoundaryConditions` for the `v`-velocity field on `grid`.
+Boundary conditions on `x`-, `y`-, and `z`-boundaries are specified via
+keyword arguments:
+
+    * `west` and `east` for the `-x` and `+x` boundary;
+    * `south` and `north` for the `-y` and `+y` boundary;
+    * `bottom` and `top` for the `-z` and `+z` boundary.
+
+Default boundary conditions depend on `topology(grid)`. See ['DefaultBoundaryCondition'](@ref)
+"""
+VVelocityBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Face, Cell); user_defined_bcs...)
+
+"""
+    WVelocityBoundaryConditions(grid;   east = DefaultBoundaryCondition(topology(grid, 1), Cell),
+                                        west = DefaultBoundaryCondition(topology(grid, 1), Cell),
+                                       south = DefaultBoundaryCondition(topology(grid, 2), Cell),
+                                       north = DefaultBoundaryCondition(topology(grid, 2), Cell),
+                                      bottom = DefaultBoundaryCondition(topology(grid, 3), Face),
+                                         top = DefaultBoundaryCondition(topology(grid, 3), Face))
+
+Construct `FieldBoundaryConditions` for the `w`-velocity field on `grid`.
+Boundary conditions on `x`-, `y`-, and `z`-boundaries are specified via
+keyword arguments:
+
+    * `west` and `east` for the `-x` and `+x` boundary;
+    * `south` and `north` for the `-y` and `+y` boundary;
+    * `bottom` and `top` for the `-z` and `+z` boundary.
+
+Default boundary conditions depend on `topology(grid)`. See ['DefaultBoundaryCondition'](@ref)
+"""
+WVelocityBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Cell, Face); user_defined_bcs...)
+
+"""
+    TracerBoundaryConditions(grid;   east = DefaultBoundaryCondition(topology(grid, 1), Cell),
+                                     west = DefaultBoundaryCondition(topology(grid, 1), Cell),
+                                    south = DefaultBoundaryCondition(topology(grid, 2), Cell),
+                                    north = DefaultBoundaryCondition(topology(grid, 2), Cell),
+                                   bottom = DefaultBoundaryCondition(topology(grid, 3), Cell),
+                                      top = DefaultBoundaryCondition(topology(grid, 3), Cell))
+
+Construct `FieldBoundaryConditions` for a tracer field on `grid`.
+Boundary conditions on `x`-, `y`-, and `z`-boundaries are specified via
+keyword arguments:
+
+    * `west` and `east` for the `-x` and `+x` boundary;
+    * `south` and `north` for the `-y` and `+y` boundary;
+    * `bottom` and `top` for the `-z` and `+z` boundary.
+
+Default boundary conditions depend on `topology(grid)`. See ['DefaultBoundaryCondition'](@ref)
+"""
+TracerBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Cell, Cell); user_defined_bcs...)
+
+const PressureBoundaryConditions = TracerBoundaryConditions
+const DiffusivityBoundaryConditions = TracerBoundaryConditions

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -115,7 +115,7 @@ keyword arguments:
     * `south` and `north` for the `-y` and `+y` boundary;
     * `bottom` and `top` for the `-z` and `+z` boundary.
 
-Default boundary conditions depend on `topology(grid)`. See ['DefaultBoundaryCondition'](@ref)
+Default boundary conditions depend on `topology(grid)`. See `DefaultBoundaryCondition`.
 """
 UVelocityBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Face, Cell, Cell); user_defined_bcs...)
 
@@ -135,7 +135,7 @@ keyword arguments:
     * `south` and `north` for the `-y` and `+y` boundary;
     * `bottom` and `top` for the `-z` and `+z` boundary.
 
-Default boundary conditions depend on `topology(grid)`. See ['DefaultBoundaryCondition'](@ref)
+Default boundary conditions depend on `topology(grid)`. See `DefaultBoundaryCondition`.
 """
 VVelocityBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Face, Cell); user_defined_bcs...)
 
@@ -155,7 +155,7 @@ keyword arguments:
     * `south` and `north` for the `-y` and `+y` boundary;
     * `bottom` and `top` for the `-z` and `+z` boundary.
 
-Default boundary conditions depend on `topology(grid)`. See ['DefaultBoundaryCondition'](@ref)
+Default boundary conditions depend on `topology(grid)`. See `DefaultBoundaryCondition`.
 """
 WVelocityBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Cell, Face); user_defined_bcs...)
 
@@ -175,7 +175,7 @@ keyword arguments:
     * `south` and `north` for the `-y` and `+y` boundary;
     * `bottom` and `top` for the `-z` and `+z` boundary.
 
-Default boundary conditions depend on `topology(grid)`. See ['DefaultBoundaryCondition'](@ref)
+Default boundary conditions depend on `topology(grid)`. See `DefaultBoundaryCondition`.
 """
 TracerBoundaryConditions(grid; user_defined_bcs...) = FieldBoundaryConditions(grid, (Cell, Cell, Cell); user_defined_bcs...)
 

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -28,6 +28,11 @@ function validate_bcs(topology, left_bc, right_bc, default_bc, left_name, right_
     return true
 end
 
+relocate_function_boundary_condition(bc, args...) = bc # fallback
+
+relocate_function_boundary_condition(bc::BoundaryCondition{C, <:BoundaryFunction}, boundary, loc1, loc2) where C =
+    BoundaryCondition(C, BoundaryFunction{boundary, loc1, loc2}(bc.condition.func; parameters=bc.condition.parameters))
+
 """
     FieldBoundaryConditions(grid, loc;
           east = DefaultBoundaryCondition(topology(grid)[1], loc[1]),
@@ -52,6 +57,13 @@ function FieldBoundaryConditions(grid, loc;
      north = DefaultBoundaryCondition(topology(grid)[2], loc[2]),
     bottom = DefaultBoundaryCondition(topology(grid)[3], loc[3]),
        top = DefaultBoundaryCondition(topology(grid)[3], loc[3]))
+
+    east = relocate_function_boundary_condition(east, :x, loc[2], loc[3])
+    west = relocate_function_boundary_condition(west, :x, loc[2], loc[3])
+    south = relocate_function_boundary_condition(south, :y, loc[1], loc[3])
+    north = relocate_function_boundary_condition(north, :y, loc[1], loc[3])
+    bottom = relocate_function_boundary_condition(bottom, :z, loc[1], loc[2])
+    top = relocate_function_boundary_condition(top, :z, loc[1], loc[2])
 
     TX, TY, TZ = topology(grid)
     x_default_bc = DefaultBoundaryCondition(topology(grid)[1], loc[1])

--- a/src/BoundaryConditions/parameterized_boundary_condition.jl
+++ b/src/BoundaryConditions/parameterized_boundary_condition.jl
@@ -1,5 +1,5 @@
 """
-    ParameterizedBoundaryConditionFunction(func, parameters)
+    ParameterizedDiscreteBoundaryFunction(func, parameters)
 
 A wrapper for boundary condition functions implemented as functions with parameters.
 The boundary condition `func` is called with the signature
@@ -19,18 +19,9 @@ Example
 
 u_boundary_condition = ParameterizedBoundaryCondition(linear_drag, (μ=π,))
 """
-struct ParameterizedBoundaryConditionFunction{F, P} <: Function
+struct ParameterizedDiscreteBoundaryFunction{F, P} <: Function
     func :: F
     parameters :: P
 end
 
-"""
-    ParameterizedBoundaryCondition(bctype, func, parameters)
-
-Returns a `BoundaryCondition` of `bctype` with a `ParameterizedBoundaryConditionFunction`
-with function `func` and `parameters`.
-"""
-ParameterizedBoundaryCondition(bctype, func, parameters) =
-    BoundaryCondition(bctype, ParameterizedBoundaryConditionFunction(func, parameters))    
-
-@inline (bc::ParameterizedBoundaryConditionFunction)(args...) = bc.func(args..., bc.parameters)
+@inline (bc::ParameterizedDiscreteBoundaryFunction)(args...) = bc.func(args..., bc.parameters)

--- a/src/BoundaryConditions/show_boundary_conditions.jl
+++ b/src/BoundaryConditions/show_boundary_conditions.jl
@@ -6,7 +6,7 @@ import Oceananigans.Grids: short_show
 
 print_condition(n::Union{Nothing, Number}) = "$n"
 print_condition(A::AbstractArray) = "$(Base.dims2string(size(A))) $(typeof(A))"
-print_condition(bf::Union{ParameterizedBoundaryConditionFunction, BoundaryFunction}) = print_condition(bf.func)
+print_condition(bf::Union{ParameterizedDiscreteBoundaryFunction, BoundaryFunction}) = print_condition(bf.func)
 
 function print_condition(f::Function)
     ms = methods(f).ms

--- a/test/test_time_stepping_bcs.jl
+++ b/test/test_time_stepping_bcs.jl
@@ -1,3 +1,5 @@
+using Oceananigans.BoundaryConditions: BoundaryFunction
+
 function test_z_boundary_condition_simple(arch, FT, fldname, bctype, bc, Nx, Ny)
     Nz = 16
     grid = RegularCartesianGrid(FT, size=(Nx, Ny, Nz), extent=(0.1, 0.2, 0.3))


### PR DESCRIPTION
This PR simplifies the API for specifying boundary conditions that are functions.

We build boundary conditions by writing

```julia
bc = BoundaryCondition(BCType, condition)
```

where `BCType` is the "type" of the boundary condition (`Value`, `Gradient`, `Flux`, `NormalFlow`), and `condition` is the boundary condition.

If `condition` is a function, it is now assumed it can be called with the signature `condition(ξ, η, t)`, where `(ξ, η)` are spatial coordinates that vary along the boundary in question (`y, z` for `x`-boundaries, `x, z` for `y`-boundaries, and `x, y` for `z`-boundaries).

Different behavior is achieved by specifying keyword arguments of `BoundaryCondition`. For example, a non-`nothing` `parameters` keyword argument means that the last argument of condition is `parameters`: `condition(ξ, η, t, parameters)`.

If `discrete_form=true`, the original behavior of `BoundaryCondition` is recovered, so that `condition` is called with the "discrete form" `condition(i, j, grid, clock, state)`, where `i, j` are indicies that vary along the boundary in question. Specifying both `discrete_form=true` and non-`nothing` `parameters` transforms `condition` into a `ParameterizedDiscreteBoundaryFunction`, which is called with `condition(i, j, grid, clock, state, parameters)`.

Under the hood, this functionality is achieved by assuming that boundary conditions for fields are always built with `FieldBoundaryConditions`. This assumptions means we can use the information provided there to ensure that `BoundaryFunction`s are always tagged with the correct boundary plane and cell location. This relieves the user from having to specify the boundary plane and cell location of a `BoundaryFunction` explicitly. We hope this simplifies the API.

Resolves #769 