### PR TITLE
Nicer `Base.show` for abstract operations

### DIFF
--- a/src/AbstractOperations/show_abstract_operations.jl
+++ b/src/AbstractOperations/show_abstract_operations.jl
@@ -14,7 +14,7 @@ Base.show(io::IO, operation::AbstractOperation) =
           "├── grid: ", typeof(operation.grid), '\n',
           "│   ├── size: ", size(operation.grid), '\n',
           "│   └── domain: ", show_domain(operation.grid), '\n',
-          "└── tree: ", "\n"^2, tree_show(operation, 0, 0))
+          "└── tree: ", "\n", tree_show(operation, 1, 0))
 
 "Return a representaion of number or function leaf within a tree visualization of an `AbstractOperation`."
 tree_show(a::Union{Number, Function}, depth, nesting) = string(a)

--- a/src/AbstractOperations/show_abstract_operations.jl
+++ b/src/AbstractOperations/show_abstract_operations.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Grids: show_domain, short_show
+using Oceananigans.Grids: domain_string, short_show
 using Oceananigans.Fields: show_location
 
 for op_string in ("UnaryOperation", "BinaryOperation", "MultiaryOperation", "Derivative")
@@ -13,7 +13,7 @@ Base.show(io::IO, operation::AbstractOperation) =
           operation_name(operation), " at ", show_location(operation), '\n',
           "├── grid: ", typeof(operation.grid), '\n',
           "│   ├── size: ", size(operation.grid), '\n',
-          "│   └── domain: ", show_domain(operation.grid), '\n',
+          "│   └── domain: ", domain_string(operation.grid), '\n',
           "└── tree: ", "\n", "    ", tree_show(operation, 1, 0))
 
 "Return a representaion of number or function leaf within a tree visualization of an `AbstractOperation`."

--- a/src/AbstractOperations/show_abstract_operations.jl
+++ b/src/AbstractOperations/show_abstract_operations.jl
@@ -14,7 +14,7 @@ Base.show(io::IO, operation::AbstractOperation) =
           "├── grid: ", typeof(operation.grid), '\n',
           "│   ├── size: ", size(operation.grid), '\n',
           "│   └── domain: ", show_domain(operation.grid), '\n',
-          "└── tree: ", "\n", tree_show(operation, 1, 0))
+          "└── tree: ", "\n", "    ", tree_show(operation, 1, 0))
 
 "Return a representaion of number or function leaf within a tree visualization of an `AbstractOperation`."
 tree_show(a::Union{Number, Function}, depth, nesting) = string(a)

--- a/src/Fields/show_fields.jl
+++ b/src/Fields/show_fields.jl
@@ -1,6 +1,5 @@
 import Base: show
 import Oceananigans.Grids: short_show
-using Oceananigans.Grids: show_domain
 
 location_str(::Face) = "Face"
 location_str(::Cell) = "Cell"

--- a/src/Grids/regular_cartesian_grid.jl
+++ b/src/Grids/regular_cartesian_grid.jl
@@ -168,17 +168,16 @@ end
 short_show(grid::RegularCartesianGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
     "RegularCartesianGrid{$FT, $TX, $TY, $TZ}(Nx=$(grid.Nx), Ny=$(grid.Ny), Nz=$(grid.Nz))"
 
-show_domain(grid) = string("x ∈ [", grid.xF[1], ", ", grid.xF[end], "], ",
-                           "y ∈ [", grid.yF[1], ", ", grid.yF[end], "], ",
-                           "z ∈ [", grid.zF[1], ", ", grid.zF[end], "]")
+function domain_string(grid)
+    xₗ, xᵣ = x_domain(grid)
+    yₗ, yᵣ = y_domain(grid)
+    zₗ, zᵣ = z_domain(grid)
+    return "x ∈ [$xₗ, $xᵣ], y ∈ [$yₗ, $yᵣ], z ∈ [$zₗ, $zᵣ]"
+end
 
 function show(io::IO, g::RegularCartesianGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
-    xₗ, xᵣ = x_domain(g)
-    yₗ, yᵣ = y_domain(g)
-    zₗ, zᵣ = z_domain(g)
-
     print(io, "RegularCartesianGrid{$FT, $TX, $TY, $TZ}\n",
-              "                   domain: x ∈ [$xₗ, $xᵣ], y ∈ [$yₗ, $yᵣ], z ∈ [$zₗ, $zᵣ]\n",
+          "                       domain: $(domain_string(g))\n",
               "                 topology: ", (TX, TY, TZ), '\n',
               "  resolution (Nx, Ny, Nz): ", (g.Nx, g.Ny, g.Nz), '\n',
               "   halo size (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz), '\n',

--- a/src/Grids/regular_cartesian_grid.jl
+++ b/src/Grids/regular_cartesian_grid.jl
@@ -177,7 +177,7 @@ end
 
 function show(io::IO, g::RegularCartesianGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
     print(io, "RegularCartesianGrid{$FT, $TX, $TY, $TZ}\n",
-          "                       domain: $(domain_string(g))\n",
+              "                   domain: $(domain_string(g))\n",
               "                 topology: ", (TX, TY, TZ), '\n',
               "  resolution (Nx, Ny, Nz): ", (g.Nx, g.Ny, g.Nz), '\n',
               "   halo size (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz), '\n',

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -244,6 +244,12 @@ end
                 @test_throws ArgumentError RegularCartesianGrid(FT, size=(16, 16, 16), extent=(1, 1, 1), topology=(Periodic, Periodic, Flux))
             end
         end
+
+        # Testing show function
+        topo = (Periodic, Periodic, Periodic)
+        grid = RegularCartesianGrid(topology=topo, size=(3, 7, 9), x=(0, 1), y=(-π, π), z=(0, 2π))
+        show(grid); println();
+        @test grid isa RegularCartesianGrid
     end
 
     @testset "Vertically stretched Cartesian grid" begin


### PR DESCRIPTION
Before:
```
BinaryOperation at (Cell, Cell, Cell)
├── grid: RegularCartesianGrid{Float64,Periodic,Periodic,Bounded,OffsetArrays.OffsetArray{Float64,1,StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}}}
│   ├── size: (16, 16, 16)
│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0625]
└── tree: 

* at (Cell, Cell, Cell) via identity
├── OffsetArray{Float64, 3, Array{Float64,3}}
└── OffsetArray{Float64, 3, Array{Float64,3}}
```

After:
```
BinaryOperation at (Cell, Cell, Cell)
├── grid: RegularCartesianGrid{Float64,Periodic,Periodic,Bounded,OffsetArrays.OffsetArray{Float64,1,StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}}}
│   ├── size: (16, 16, 16)
│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
└── tree: 
    * at (Cell, Cell, Cell) via identity
    ├── OffsetArray{Float64, 3, Array{Float64,3}}
    └── OffsetArray{Float64, 3, Array{Float64,3}}
```

Resolves #893