### PR TITLE
Clean up Fields module

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -11,6 +11,11 @@ export
 using Oceananigans.Grids
 using Oceananigans.BoundaryConditions
 
+Base.zeros(FT, ::CPU, Nx, Ny, Nz) = zeros(FT, Nx, Ny, Nz)
+Base.zeros(FT, ::GPU, Nx, Ny, Nz) = zeros(FT, Nx, Ny, Nz) |> CuArray
+Base.zeros(arch, grid, Nx, Ny, Nz) = zeros(eltype(grid), arch, Nx, Ny, Nz)
+
+include("new_data.jl")
 include("field.jl")
 include("set!.jl")
 include("field_tuples.jl")

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -8,6 +8,7 @@ export
     set!,
     VelocityFields, TracerFields, tracernames, PressureFields, TendencyFields
 
+using Oceananigans.Architectures
 using Oceananigans.Grids
 using Oceananigans.BoundaryConditions
 

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -49,7 +49,7 @@ end
 
 """
     Field(X, Y, Z, arch, grid, [  bcs = FieldBoundaryConditions(grid, (X, Y, Z)),
-                                 data = zeros(arch, grid, (X, Y, Z)) ] )
+                                 data = new_data(arch, grid, (X, Y, Z)) ] )
 
 Construct a `Field` on `grid` with `data` on architecture `arch` with
 boundary conditions `bcs`. Each of `(X, Y, Z)` is either `Cell` or `Face` and determines
@@ -63,7 +63,7 @@ julia> ω = Field(Face, Face, Cell, CPU(), RegularCartesianmodel.grid)
 """
 function Field(X, Y, Z, arch, grid,
                 bcs = FieldBoundaryConditions(grid, (X, Y, Z)),
-               data = zeros(eltype(grid), arch, grid, (X, Y, Z)))
+               data = new_data(eltype(grid), arch, grid, (X, Y, Z)))
 
     return Field{X, Y, Z}(data, grid, bcs)
 end
@@ -91,14 +91,14 @@ Field(L::Tuple, args...) = Field(destantiate.(L)..., args...)
 """
     CellField([ FT=eltype(grid) ], arch::AbstractArchitecture, grid,
               [  bcs = TracerBoundaryConditions(grid),
-                data = zeros(FT, arch, grid, (Cell, Cell, Cell) ] )
+                data = new_data(FT, arch, grid, (Cell, Cell, Cell) ] )
 
 Return a `Field{Cell, Cell, Cell}` on architecture `arch` and `grid` containing `data`
 with field boundary conditions `bcs`.
 """
 function CellField(FT::DataType, arch, grid,
                     bcs = TracerBoundaryConditions(grid),
-                   data = zeros(FT, arch, grid, (Cell, Cell, Cell)))
+                   data = new_data(FT, arch, grid, (Cell, Cell, Cell)))
 
     return Field{Cell, Cell, Cell}(data, grid, bcs)
 end
@@ -106,14 +106,14 @@ end
 """
     XFaceField([ FT=eltype(grid) ], arch::AbstractArchitecture, grid,
                [  bcs = UVelocityBoundaryConditions(grid),
-                 data = zeros(FT, arch, grid, (Face, Cell, Cell) ] )
+                 data = new_data(FT, arch, grid, (Face, Cell, Cell) ] )
 
 Return a `Field{Face, Cell, Cell}` on architecture `arch` and `grid` containing `data`
 with field boundary conditions `bcs`.
 """
 function XFaceField(FT::DataType, arch, grid,
                      bcs = UVelocityBoundaryConditions(grid),
-                    data = zeros(FT, arch, grid, (Face, Cell, Cell)))
+                    data = new_data(FT, arch, grid, (Face, Cell, Cell)))
 
     return Field{Face, Cell, Cell}(data, grid, bcs)
 end
@@ -121,14 +121,14 @@ end
 """
     YFaceField([ FT=eltype(grid) ], arch::AbstractArchitecture, grid,
                [  bcs = VVelocityBoundaryConditions(grid),
-                 data = zeros(FT, arch, grid, (Cell, Face, Cell)) ] )
+                 data = new_data(FT, arch, grid, (Cell, Face, Cell)) ] )
 
 Return a `Field{Cell, Face, Cell}` on architecture `arch` and `grid` containing `data`
 with field boundary conditions `bcs`.
 """
 function YFaceField(FT::DataType, arch, grid,
                      bcs = VVelocityBoundaryConditions(grid),
-                    data = zeros(FT, arch, grid, (Cell, Face, Cell)))
+                    data = new_data(FT, arch, grid, (Cell, Face, Cell)))
 
     return Field{Cell, Face, Cell}(data, grid, bcs)
 end
@@ -136,14 +136,14 @@ end
 """
     ZFaceField([ FT=eltype(grid) ], arch::AbstractArchitecture, grid,
                [  bcs = WVelocityBoundaryConditions(grid),
-                 data = zeros(FT, arch, grid, (Cell, Cell, Face)) ] )
+                 data = new_data(FT, arch, grid, (Cell, Cell, Face)) ] )
 
 Return a `Field{Cell, Cell, Face}` on architecture `arch` and `grid` containing `data`
 with field boundary conditions `bcs`.
 """
 function ZFaceField(FT::DataType, arch, grid,
                      bcs = WVelocityBoundaryConditions(grid),
-                    data = zeros(FT, arch, grid, (Cell, Cell, Face)))
+                    data = new_data(FT, arch, grid, (Cell, Cell, Face)))
 
     return Field{Cell, Cell, Face}(data, grid, bcs)
 end
@@ -248,73 +248,3 @@ znodes(ψ::AbstractField) = znodes(location(ψ, 3), ψ.grid)
 
 nodes(ψ::AbstractField; kwargs...) = nodes(location(ψ), ψ.grid; kwargs...)
 
-#####
-##### Creating offset arrays for field data by dispatching on architecture.
-#####
-
-"""
-Return a range of indices for a field located at `Cell` centers
-`along a grid dimension of length `N` and with halo points `H`.
-"""
-offset_indices(loc, topo, N, H=0) = 1 - H : N + H
-
-"""
-Return a range of indices for a field located at cell `Face`s
-`along a grid dimension of length `N` and with halo points `H`.
-"""
-offset_indices(::Type{Face}, ::Type{Bounded}, N, H=0) = 1 - H : N + H + 1
-
-"""
-    OffsetArray(underlying_data, grid, loc)
-
-Returns an `OffsetArray` that maps to `underlying_data` in memory,
-with offset indices appropriate for the `data` of a field on
-a `grid` of `size(grid)` and located at `loc`.
-"""
-function OffsetArray(underlying_data, grid, loc)
-    ii = offset_indices(loc[1], topology(grid, 1), grid.Nx, grid.Hx)
-    jj = offset_indices(loc[2], topology(grid, 2), grid.Ny, grid.Hy)
-    kk = offset_indices(loc[3], topology(grid, 3), grid.Nz, grid.Hz)
-
-    return OffsetArray(underlying_data, ii, jj, kk)
-end
-
-"""
-    zeros([FT=Float64], ::CPU, grid, loc)
-
-Returns an `OffsetArray` of zeros of float type `FT`, with
-parent data in CPU memory and indices corresponding to a field on a
-`grid` of `size(grid)` and located at `loc`.
-"""
-function Base.zeros(FT, ::CPU, grid, loc=(Cell, Cell, Cell))
-    underlying_data = zeros(FT, total_length(loc[1], topology(grid, 1), grid.Nx, grid.Hx),
-                                total_length(loc[2], topology(grid, 2), grid.Ny, grid.Hy),
-                                total_length(loc[3], topology(grid, 3), grid.Nz, grid.Hz))
-
-    return OffsetArray(underlying_data, grid, loc)
-end
-
-"""
-    zeros([FT=Float64], ::GPU, grid, loc)
-
-Returns an `OffsetArray` of zeros of float type `FT`, with
-parent data in GPU memory and indices corresponding to a field on a `grid`
-of `size(grid)` and located at `loc`.
-"""
-function Base.zeros(FT, ::GPU, grid, loc=(Cell, Cell, Cell))
-    underlying_data = CuArray{FT}(undef, total_length(loc[1], topology(grid, 1), grid.Nx, grid.Hx),
-                                         total_length(loc[2], topology(grid, 2), grid.Ny, grid.Hy),
-                                         total_length(loc[3], topology(grid, 3), grid.Nz, grid.Hz))
-
-    underlying_data .= 0 # Ensure data is initially 0.
-
-    return OffsetArray(underlying_data, grid, loc)
-end
-
-# Default to type of Grid
-Base.zeros(arch, grid, loc=(Cell, Cell, Cell)) = zeros(eltype(grid), arch, grid, loc)
-
-Base.zeros(FT, ::CPU, Nx, Ny, Nz) = zeros(FT, Nx, Ny, Nz)
-Base.zeros(FT, ::GPU, Nx, Ny, Nz) = zeros(FT, Nx, Ny, Nz) |> CuArray
-
-Base.zeros(arch, grid, Nx, Ny, Nz) = zeros(eltype(grid), arch, Nx, Ny, Nz)

--- a/src/Fields/new_data.jl
+++ b/src/Fields/new_data.jl
@@ -1,0 +1,67 @@
+import OffsetArrays: OffsetArray
+
+#####
+##### Creating offset arrays for field data by dispatching on architecture.
+#####
+
+"""
+Return a range of indices for a field located at `Cell` centers
+`along a grid dimension of length `N` and with halo points `H`.
+"""
+offset_indices(loc, topo, N, H=0) = 1 - H : N + H
+
+"""
+Return a range of indices for a field located at cell `Face`s
+`along a grid dimension of length `N` and with halo points `H`.
+"""
+offset_indices(::Type{Face}, ::Type{Bounded}, N, H=0) = 1 - H : N + H + 1
+
+"""
+    OffsetArray(underlying_data, grid, loc)
+
+Returns an `OffsetArray` that maps to `underlying_data` in memory,
+with offset indices appropriate for the `data` of a field on
+a `grid` of `size(grid)` and located at `loc`.
+"""
+function OffsetArray(underlying_data, grid, loc)
+    ii = offset_indices(loc[1], topology(grid, 1), grid.Nx, grid.Hx)
+    jj = offset_indices(loc[2], topology(grid, 2), grid.Ny, grid.Hy)
+    kk = offset_indices(loc[3], topology(grid, 3), grid.Nz, grid.Hz)
+
+    return OffsetArray(underlying_data, ii, jj, kk)
+end
+
+"""
+    new_data([FT=Float64], ::CPU, grid, loc)
+
+Returns an `OffsetArray` of zeros of float type `FT`, with
+parent data in CPU memory and indices corresponding to a field on a
+`grid` of `size(grid)` and located at `loc`.
+"""
+function new_data(FT, ::CPU, grid, loc)
+    underlying_data = zeros(FT, total_length(loc[1], topology(grid, 1), grid.Nx, grid.Hx),
+                                total_length(loc[2], topology(grid, 2), grid.Ny, grid.Hy),
+                                total_length(loc[3], topology(grid, 3), grid.Nz, grid.Hz))
+
+    return OffsetArray(underlying_data, grid, loc)
+end
+
+"""
+    new_data([FT=Float64], ::GPU, grid, loc)
+
+Returns an `OffsetArray` of zeros of float type `FT`, with
+parent data in GPU memory and indices corresponding to a field on a `grid`
+of `size(grid)` and located at `loc`.
+"""
+function new_data(FT, ::GPU, grid, loc)
+    underlying_data = CuArray{FT}(undef, total_length(loc[1], topology(grid, 1), grid.Nx, grid.Hx),
+                                         total_length(loc[2], topology(grid, 2), grid.Ny, grid.Hy),
+                                         total_length(loc[3], topology(grid, 3), grid.Nz, grid.Hz))
+
+    underlying_data .= 0 # Ensure data is initially 0.
+
+    return OffsetArray(underlying_data, grid, loc)
+end
+
+# Default to type of Grid
+new_data(arch, grid, loc) = new_data(eltype(grid), arch, grid, loc)

--- a/src/TurbulenceClosures/diffusivity_fields.jl
+++ b/src/TurbulenceClosures/diffusivity_fields.jl
@@ -2,10 +2,8 @@
 DiffusivityFields(arch::AbstractArchitecture, grid::AbstractGrid, args...) = nothing
 
 # For a tuple of closures
-DiffusivityFields(
-    arch::AbstractArchitecture, grid::AbstractGrid, tracers,
-    bcs::NamedTuple, closure_tuple::Tuple
-) = Tuple(DiffusivityFields(arch, grid, tracers, bcs, closure) for closure in closure_tuple)
+DiffusivityFields(arch, grid, tracers, bcs::NamedTuple, closure_tuple::Tuple) =
+    Tuple(DiffusivityFields(arch, grid, tracers, bcs, closure) for closure in closure_tuple)
 
 #####
 ##### For closures that only require an eddy viscosity νₑ field.
@@ -13,15 +11,15 @@ DiffusivityFields(
 
 const ViscosityClosures = Union{AbstractSmagorinsky, AbstractLeith}
 
-DiffusivityFields(
-    arch::AbstractArchitecture, grid::AbstractGrid, tracers, ::ViscosityClosures;
-    νₑ = CellField(arch, grid, DiffusivityBoundaryConditions(grid), zeros(arch, grid))
-) = (νₑ=νₑ,)
+DiffusivityFields(arch, grid, tracers, ::ViscosityClosures;
+                  νₑ = CellField(arch, grid, DiffusivityBoundaryConditions(grid))) = (νₑ=νₑ,)
 
-function DiffusivityFields(arch::AbstractArchitecture, grid::AbstractGrid, tracers,
-                           bcs::NamedTuple, ::ViscosityClosures)
+function DiffusivityFields(arch, grid, tracers, bcs::NamedTuple, ::ViscosityClosures)
+
     νₑ_bcs = :νₑ ∈ keys(bcs) ? bcs[:νₑ] : DiffusivityBoundaryConditions(grid)
-    νₑ = CellField(arch, grid, νₑ_bcs, zeros(arch, grid))
+
+    νₑ = CellField(arch, grid, νₑ_bcs)
+
     return (νₑ=νₑ,)
 end
 
@@ -32,39 +30,41 @@ end
 const ViscosityDiffusivityClosures = Union{VAMD, RAMD}
 
 function TracerDiffusivityFields(arch, grid, tracer_names; kwargs...)
-    κ_fields =
-        Tuple(c ∈ keys(kwargs) ?
-              kwargs[c] :
-              CellField(arch, grid, DiffusivityBoundaryConditions(grid), zeros(arch, grid))
-              for c in tracer_names)
+
+    κ_fields = Tuple(c ∈ keys(kwargs) ?
+                     kwargs[c] :
+                     CellField(arch, grid, DiffusivityBoundaryConditions(grid))
+                     for c in tracer_names)
+
     return NamedTuple{tracer_names}(κ_fields)
 end
 
 function TracerDiffusivityFields(arch, grid, tracer_names, bcs::NamedTuple)
-    κ_fields =
-        Tuple(c ∈ keys(bcs) ?
-              CellField(arch, grid, bcs[c],                              zeros(arch, grid)) :
-              CellField(arch, grid, DiffusivityBoundaryConditions(grid), zeros(arch, grid))
-              for c in tracer_names)
+
+    κ_fields = Tuple(c ∈ keys(bcs) ? CellField(arch, grid, bcs[c]) :
+                                     CellField(arch, grid, DiffusivityBoundaryConditions(grid))
+                     for c in tracer_names)
+
     return NamedTuple{tracer_names}(κ_fields)
 end
 
-function DiffusivityFields(
-    arch::AbstractArchitecture, grid::AbstractGrid, tracers, ::ViscosityDiffusivityClosures;
-    νₑ = CellField(arch, grid, DiffusivityBoundaryConditions(grid), zeros(arch, grid)), kwargs...)
+function DiffusivityFields(arch, grid, tracers, ::ViscosityDiffusivityClosures;
+                           νₑ = CellField(arch, grid, DiffusivityBoundaryConditions(grid)),
+                           kwargs...)
+
     κₑ = TracerDiffusivityFields(arch, grid, tracers; kwargs...)
+
     return (νₑ=νₑ, κₑ=κₑ)
 end
 
-function DiffusivityFields(arch::AbstractArchitecture, grid::AbstractGrid, tracers,
-                           bcs::NamedTuple, ::ViscosityDiffusivityClosures)
+function DiffusivityFields(arch, grid, tracers, bcs::NamedTuple, ::ViscosityDiffusivityClosures)
 
     νₑ_bcs = :νₑ ∈ keys(bcs) ? bcs[:νₑ] : DiffusivityBoundaryConditions(grid)
-    νₑ = CellField(arch, grid, νₑ_bcs, zeros(arch, grid))
 
-    κₑ = :κₑ ∈ keys(bcs) ?
-        TracerDiffusivityFields(arch, grid, tracers, bcs[:κₑ]) :
-        TracerDiffusivityFields(arch, grid, tracers)
+    νₑ = CellField(arch, grid, νₑ_bcs)
+
+    κₑ = :κₑ ∈ keys(bcs) ? TracerDiffusivityFields(arch, grid, tracers, bcs[:κₑ]) :
+                           TracerDiffusivityFields(arch, grid, tracers)
 
     return (νₑ=νₑ, κₑ=κₑ)
 end


### PR DESCRIPTION
This PR cleans up the `Fields` module: previously, `zeros` was overloaded in a confusing way that would return either `Array` / `CuArray` or an `OffsetArray` depending on the arguments. 

This PR introduces a function `new_data` that returns an `OffsetArray`. `new_data` is intended to build `OffsetArrays` that hold the data associated with a field, using the architecture, grid eltype, and the field location to determine array type, size, and indexing.

This PR moves the vanilla `zeros` definitions (convenience methods that use `eltype(grid)` to determine floating point type and `arch` to determine whether or not an array is converted to `CuArray`) to `Fields.jl` top-level.