### PR TITLE
Bump v0.36.0 (JOSS release)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,6 @@ env:
     - TEST_GROUP=regression
     - TEST_GROUP=scripts
 
-# Only build pushes to master (PRs still build merge commits)
-# See: https://stackoverflow.com/a/31882307
-branches:
-  only: 
-    - master
-
 notifications:
   email: true
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.35.0"
+version = "0.36.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
OK so looks like this will have to be the JOSS release and include the JOSS paper in the repository (#564).

I'd also like to include PRs #910 and #915 in this release.

@glwagner Do you want to include any PRs in v0.36.0?

Release notes:

This release coincides with the publication of the Oceananigans.jl Journal of Open Source Software (JOSS) paper.

Changelog:
* Simplified boundary condition interface, types, and constructors. (@glwagner do you want add to this, maybe include a list of breaking changes?)
* Support for a `NonTraditionalBetaPlane` Coriolis force implementation.
* The `AnisotropicBiharmonicDiffusivity` closure now works properly in closed domains with zero `Flux` boundary conditions, as higher-order boundary conditions are enforced.
* Bug fix: Appending to NetCDF files with `NetCDFOutputWriter` works now.
* Bug fix: Computations of abstract operations compute the right end point of face-centered fields along bounded dimensions.
* Bug fix: Averages `with_halos=false` return results with the correct dimensions for face-centered results along bounded dimensions.
* Small bug fixes for `show` methods.

Breaking changes:
* When constructing a `NetCDFOutputWriter`, use `mode="c"` instead of `clobber=true` and `mode="a"` instead of `clobber=false`.