### PR TITLE
Functionality for output as fields with JLD2

### DIFF
--- a/src/OutputWriters/OutputWriters.jl
+++ b/src/OutputWriters/OutputWriters.jl
@@ -20,6 +20,7 @@ Base.open(ow::AbstractOutputWriter) = nothing
 Base.close(ow::AbstractOutputWriter) = nothing
 
 include("output_writer_utils.jl")
+include("fetch_output.jl")
 include("jld2_output_writer.jl")
 include("netcdf_output_writer.jl")
 include("checkpointer.jl")

--- a/src/OutputWriters/fetch_output.jl
+++ b/src/OutputWriters/fetch_output.jl
@@ -1,0 +1,11 @@
+using Oceananigans.Fields: AbstractField, compute!
+
+fetch_output(output, model, writer) = output(model)
+
+convert_output(output, writer) = output
+convert_output(output::AbstractArray, writer) = writer.array_type(parent(output))
+
+function fetch_output(field::AbstractField, model, writer)
+    compute!(field)
+    return convert_output(data(field), writer)
+end

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -9,7 +9,7 @@ import Oceananigans.Diagnostics: get_kernel
 
 An output writer for writing to JLD2 files.
 """
-mutable struct JLD2OutputWriter{I, T, O, IF, IN, KW} <: AbstractOutputWriter
+mutable struct JLD2OutputWriter{I, T, O, IF, IN, KW, D} <: AbstractOutputWriter
               filepath :: String
                outputs :: O
     iteration_interval :: I
@@ -19,9 +19,9 @@ mutable struct JLD2OutputWriter{I, T, O, IF, IN, KW} <: AbstractOutputWriter
               previous :: Float64
                   part :: Int
           max_filesize :: Float64
-                 async :: Bool
                  force :: Bool
                verbose :: Bool
+            array_type :: D
                jld2_kw :: KW
 end
 
@@ -37,10 +37,10 @@ noinit(args...) = nothing
                                               max_filesize = Inf,
                                                      force = false,
                                                       init = noinit,
-                                                     async = false,
                                                    verbose = false,
                                                  including = [:grid, :coriolis, :buoyancy, :closure],
                                                       part = 1,
+                                                array_type = Array{Float32},
                                                    jld2_kw = Dict{Symbol, Any}())
 
 Construct a `JLD2OutputWriter` that writes `label, func` pairs in `outputs` (which can be a `Dict` or `NamedTuple`)
@@ -49,48 +49,49 @@ that returns the data to be saved.
 
 Keyword arguments
 =================
-- `prefix`: Descriptive filename prefixed to all output files.
 
-- `dir`: Directory to save output to.
-         Default: "." (current working directory).
-
-- `iteration_interval`: Save output every `n` model iterations.
-
-- `time_interval`: Save output every `t` units of model clock time.
-
-- `time_averaging_window`: Specifies a time window over which each member of `output` is averaged before    
-                           being saved. For this each member of output is converted to 
-                           `Oceananigans.Diagnostics.WindowedTimeAverage`.
-                           Default `nothing` indicates no averaging.
-
-- `time_averaging_stride`: Specifies a iteration 'stride' between the calculation of each `output` during
-                           time-averaging. Longer strides means that output is calculated less frequently,
-                           and that the resulting time-average is less accurate.
-                           Default: 1.
-
-- `max_filesize`: The writer will stop writing to the output file once the file size exceeds `max_filesize`,
-                  and write to a new one with a consistent naming scheme ending in `part1`, `part2`, etc.
-                  Defaults to `Inf`.
-
-- `force`: Remove existing files if their filenames conflict.
-           Default: `false`.
-
-- `init`: A function of the form `init(file, model)` that runs when a JLD2 output file is initialized.
-          Default: `noinit(args...) = nothing`.
-
-- `async`: Write output asynchronously.
-           Default: `false`.
-
-- `verbose`: Log what the output writer is doing with statistics on compute/write times and file sizes.
-             Default: `false`.
-
-- `including`: List of model properties to save with every file.
-               Default: `[:grid, :coriolis, :buoyancy, :closure]`
-
-- `part`: The starting part number used if `max_filesize` is finite.
-          Default: 1.
-
-- `jld2_kw`: Dict of kwargs to be passed to `jldopen` when data is written.
+    - `prefix`: Descriptive filename prefixed to all output files.
+    
+    - `dir`: Directory to save output to.
+             Default: "." (current working directory).
+    
+    - `iteration_interval`: Save output every `n` model iterations.
+    
+    - `time_interval`: Save output every `t` units of model clock time.
+    
+    - `time_averaging_window`: Specifies a time window over which each member of `output` is averaged before    
+                               being saved. For this each member of output is converted to 
+                               `Oceananigans.Diagnostics.WindowedTimeAverage`.
+                               Default `nothing` indicates no averaging.
+    
+    - `time_averaging_stride`: Specifies a iteration 'stride' between the calculation of each `output` during
+                               time-averaging. Longer strides means that output is calculated less frequently,
+                               and that the resulting time-average is less accurate.
+                               Default: 1.
+    
+    - `max_filesize`: The writer will stop writing to the output file once the file size exceeds `max_filesize`,
+                      and write to a new one with a consistent naming scheme ending in `part1`, `part2`, etc.
+                      Defaults to `Inf`.
+    
+    - `force`: Remove existing files if their filenames conflict.
+               Default: `false`.
+    
+    - `init`: A function of the form `init(file, model)` that runs when a JLD2 output file is initialized.
+              Default: `noinit(args...) = nothing`.
+    
+    - `verbose`: Log what the output writer is doing with statistics on compute/write times and file sizes.
+                 Default: `false`.
+    
+    - `including`: List of model properties to save with every file.
+                   Default: `[:grid, :coriolis, :buoyancy, :closure]`
+    
+    - `part`: The starting part number used if `max_filesize` is finite.
+              Default: 1.
+    
+    - `array_type`: The array type to which field data is converted to prior to saving.
+                    Default: Array{Float32}.
+    
+    - `jld2_kw`: Dict of kwargs to be passed to `jldopen` when data is written.
 """
 function JLD2OutputWriter(model, outputs; prefix,
                                                             dir = ".",
@@ -101,10 +102,10 @@ function JLD2OutputWriter(model, outputs; prefix,
                                                    max_filesize = Inf,
                                                           force = false,
                                                            init = noinit,
-                                                          async = false,
                                                         verbose = false,
                                                       including = [:grid, :coriolis, :buoyancy, :closure],
                                                            part = 1,
+                                                     array_type = Array{Float32},
                                                         jld2_kw = Dict{Symbol, Any}())
 
     validate_intervals(iteration_interval, time_interval)
@@ -134,35 +135,38 @@ function JLD2OutputWriter(model, outputs; prefix,
     end
 
     return JLD2OutputWriter(filepath, outputs, iteration_interval, time_interval, init,
-                            including, 0.0, part, max_filesize, async, force, verbose, jld2_kw)
+                            including, 0.0, part, max_filesize, force, verbose, array_type, jld2_kw)
 end
 
-function write_output(model, fw::JLD2OutputWriter)
-    verbose = fw.verbose
-    verbose && @info @sprintf("Calculating JLD2 output %s...", keys(fw.outputs))
-    tc = Base.@elapsed data = Dict((name, f(model)) for (name, f)
-                                    in zip(keys(fw.outputs), values(fw.outputs)))
-    verbose && @info "Calculation time: $(prettytime(tc))"
+function write_output(model, writer::JLD2OutputWriter)
 
-    iter = model.clock.iteration
-    time = model.clock.time
+    verbose = writer.verbose
 
-    filesize(fw.filepath) >= fw.max_filesize && start_next_file(model, fw)
+    # Fetch JLD2 output and store in dictionary `data`
+    verbose && @info @sprintf("Fetching JLD2 output %s...", keys(writer.outputs))
 
-    path = fw.filepath
-    verbose && @info "Writing JLD2 output $(keys(fw.outputs)) to $path..."
-    t0, sz = time_ns(), filesize(path)
+    tc = Base.@elapsed data = Dict((name, fetch_output(output, model, writer)) for (name, output)
+                                   in zip(keys(writer.outputs), values(writer.outputs)))
 
-    if fw.async
-        @async remotecall(jld2output!, 2, path, iter, time, data, fw.jld2_kw)
-    else
-        jld2output!(path, iter, time, data, fw.jld2_kw)
-    end
+    verbose && @info "Fetching time: $(prettytime(tc))"
 
-    t1, newsz = time_ns(), filesize(path)
+    # Start a new file if the filesize exceeds max_filesize
+    filesize(writer.filepath) >= writer.max_filesize && start_next_file(model, writer)
+
+    # Write output from `data`
+    path = writer.filepath
+    verbose && @info "Writing JLD2 output $(keys(writer.outputs)) to $path..."
+
+    start_time, old_filesize = time_ns(), filesize(path)
+
+    jld2output!(path, model.clock.iteration, model.clock.time, data, writer.jld2_kw)
+
+    end_time, new_filesize = time_ns(), filesize(path)
 
     verbose && @info @sprintf("Writing done: time=%s, size=%s, Δsize=%s",
-                              prettytime((t1-t0)/1e9), pretty_filesize(newsz), pretty_filesize(newsz-sz))
+                              prettytime((start_time - end_time) / 1e9),
+                              pretty_filesize(new_filesize),
+                              pretty_filesize(new_filesize - old_filesize))
 
     return nothing
 end
@@ -185,28 +189,28 @@ function jld2output!(path, iter, time, data, kwargs)
     return nothing
 end
 
-function start_next_file(model, fw::JLD2OutputWriter)
-    verbose = fw.verbose
-    sz = filesize(fw.filepath)
+function start_next_file(model, writer::JLD2OutputWriter)
+    verbose = writer.verbose
+    sz = filesize(writer.filepath)
     verbose && @info begin
-        "Filesize $(pretty_filesize(sz)) has exceeded maximum file size $(pretty_filesize(fw.max_filesize))."
+        "Filesize $(pretty_filesize(sz)) has exceeded maximum file size $(pretty_filesize(writer.max_filesize))."
     end
 
-    if fw.part == 1
-        part1_path = replace(fw.filepath, r".jld2$" => "_part1.jld2")
-        verbose && @info "Renaming first part: $(fw.filepath) -> $part1_path"
-        mv(fw.filepath, part1_path, force=fw.force)
-        fw.filepath = part1_path
+    if writer.part == 1
+        part1_path = replace(writer.filepath, r".jld2$" => "_part1.jld2")
+        verbose && @info "Renaming first part: $(writer.filepath) -> $part1_path"
+        mv(writer.filepath, part1_path, force=writer.force)
+        writer.filepath = part1_path
     end
 
-    fw.part += 1
-    fw.filepath = replace(fw.filepath, r"part\d+.jld2$" => "part" * string(fw.part) * ".jld2")
-    fw.force && isfile(fw.filepath) && rm(fw.filepath, force=true)
-    verbose && @info "Now writing to: $(fw.filepath)"
+    writer.part += 1
+    writer.filepath = replace(writer.filepath, r"part\d+.jld2$" => "part" * string(writer.part) * ".jld2")
+    writer.force && isfile(writer.filepath) && rm(writer.filepath, force=true)
+    verbose && @info "Now writing to: $(writer.filepath)"
 
-    jldopen(fw.filepath, "a+"; fw.jld2_kw...) do file
-        fw.init(file, model)
-        saveproperties!(file, model, fw.including)
+    jldopen(writer.filepath, "a+"; writer.jld2_kw...) do file
+        writer.init(file, model)
+        saveproperties!(file, model, writer.including)
     end
 end
 


### PR DESCRIPTION
This PR modifies the `JLD2OutputWriter` so that fields can be used as output.

This renders `FieldOutputs` obsolete; however we leave this in place for now for backward compatibility. Eventually it should be removed.