### PR TITLE
Starts process of modernizing WindowedTimeAverage

### DIFF
--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -222,7 +222,7 @@ struct FieldOutput{O, F}
 end
 
 FieldOutput(field) = FieldOutput(Array, field) # default
-(fo::FieldOutput)(model) = fo.return_type(fo.field.data.parent)
+(fo::FieldOutput)(args...) = fo.return_type(fo.field.data.parent)
 
 get_kernel(kernel::FieldOutput) = parent(kernel.field)
 


### PR DESCRIPTION
Mostly, this PR ensures that `compute!(field)` is called before fetching the "operand" (previously called `kernel`) of the `WindowedTimeAverage`.

This anticipates the new types `AveragedField` and `ComputedField` that will replace `Average` and `Computation`.