### PR TITLE
Slims down model size for many tests

### DIFF
--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -411,7 +411,7 @@ end
                 model = IncompressibleModel(
                     architecture = arch,
                       float_type = FT,
-                            grid = RegularCartesianGrid(FT, size=(16, 16, 16), extent=(1, 1, 1),
+                            grid = RegularCartesianGrid(FT, size=(4, 4, 4), extent=(1, 1, 1),
                                                         topology=(Periodic, Periodic, Bounded))
                 )
 

--- a/test/test_benchmarks.jl
+++ b/test/test_benchmarks.jl
@@ -17,7 +17,7 @@ benchmark_filepath(benchmark_name, benchmarks_dir=BENCHMARKS_DIR) =
 
             replace_strings = [
                 ("Ns = [(16, 16, 16), (32, 32, 32), (64, 64, 64), (128, 128, 128), (256, 256, 256)]",
-                 "Ns = [(16, 16, 16)]")
+                 "Ns = [(1, 1, 1)]")
             ]
 
             @test run_script(replace_strings, "static_ocean", benchmark_filepath("static_ocean"))
@@ -28,7 +28,7 @@ benchmark_filepath(benchmark_name, benchmarks_dir=BENCHMARKS_DIR) =
 
             replace_strings = [
                 ("Ns = [(32, 32, 32), (64, 64, 64), (128, 128, 128), (256, 256, 256)]",
-                 "Ns = [(16, 16, 16)]")
+                 "Ns = [(1, 1, 1)]")
             ]
 
             @test run_script(replace_strings, "channel", benchmark_filepath("channel"))
@@ -39,7 +39,7 @@ benchmark_filepath(benchmark_name, benchmarks_dir=BENCHMARKS_DIR) =
 
             replace_strings = [
                 ("Ns = [(32, 32, 32), (256, 256, 128)]",
-                 "Ns = [(16, 16, 16)]")
+                 "Ns = [(1, 1, 1)]")
             ]
 
             @test run_script(replace_strings, "turbulence_closures", benchmark_filepath("turbulence_closures"))
@@ -49,8 +49,8 @@ benchmark_filepath(benchmark_name, benchmarks_dir=BENCHMARKS_DIR) =
             @info "    Running tracers benchmark..."
 
             replace_strings = [
-                ("(32, 32, 32)", "(16, 16, 16)"),
-                ("(256, 256, 128)", "(16, 16, 16)"),
+                ("(32, 32, 32)", "(1, 1, 1)"),
+                ("(256, 256, 128)", "(1, 1, 1)"),
                 ("test_cases = [(0, 0), (0, 1), (0, 2), (1, 0), (2, 0), (2, 3), (2, 5), (2, 10)]",
                  "test_cases = [(0, 0), (2, 0), (2, 3)]")
             ]

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -47,7 +47,7 @@ complicated_parameterized_bc(i, j, grid, clock, state, p) = p.a * rand()
 
         # Triply periodic
         ppp_topology = (Periodic, Periodic, Periodic)
-        ppp_grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1), topology=ppp_topology)
+        ppp_grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1), topology=ppp_topology)
 
         u_bcs = UVelocityBoundaryConditions(ppp_grid)
         v_bcs = VVelocityBoundaryConditions(ppp_grid)
@@ -88,7 +88,7 @@ complicated_parameterized_bc(i, j, grid, clock, state, p) = p.a * rand()
 
         # Doubly periodic. Engineers call this a "Channel geometry".
         ppb_topology = (Periodic, Periodic, Bounded)
-        ppb_grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1), topology=ppb_topology)
+        ppb_grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1), topology=ppb_topology)
 
         u_bcs = UVelocityBoundaryConditions(ppb_grid)
         v_bcs = VVelocityBoundaryConditions(ppb_grid)
@@ -129,7 +129,7 @@ complicated_parameterized_bc(i, j, grid, clock, state, p) = p.a * rand()
 
         # Singly periodic. Oceanographers call this a "Channel", engineers call it a "Pipe"
         pbb_topology = (Periodic, Bounded, Bounded)
-        pbb_grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1), topology=pbb_topology)
+        pbb_grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1), topology=pbb_topology)
 
         u_bcs = UVelocityBoundaryConditions(pbb_grid)
         v_bcs = VVelocityBoundaryConditions(pbb_grid)
@@ -170,7 +170,7 @@ complicated_parameterized_bc(i, j, grid, clock, state, p) = p.a * rand()
 
         # Triply bounded. Oceanographers call this a "Basin", engineers call it a "Box"
         bbb_topology = (Bounded, Bounded, Bounded)
-        bbb_grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1), topology=bbb_topology)
+        bbb_grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1), topology=bbb_topology)
 
         u_bcs = UVelocityBoundaryConditions(bbb_grid)
         v_bcs = VVelocityBoundaryConditions(bbb_grid)

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -94,21 +94,21 @@ function run_volume_average_tests(arch, FT)
 end
 
 function nan_checker_aborts_simulation(arch, FT)
-    grid = RegularCartesianGrid(size=(16, 16, 2), extent=(1, 1, 1))
+    grid = RegularCartesianGrid(size=(4, 2, 1), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT)
 
     # It checks for NaNs in w by default.
     nc = NaNChecker(model; iteration_interval=1, fields=Dict(:w => model.velocities.w.data.parent))
     push!(model.diagnostics, nc)
 
-    model.velocities.w[4, 3, 2] = NaN
+    model.velocities.w[3, 2, 1] = NaN
 
     time_step!(model, 1, 1)
 end
 
 TestModel(::GPU, FT, ν=1.0, Δx=0.5) =
     IncompressibleModel(
-          grid = RegularCartesianGrid(FT, size=(16, 16, 16), extent=(16Δx, 16Δx, 16Δx)),
+          grid = RegularCartesianGrid(FT, size=(3, 3, 3), extent=(3Δx, 3Δx, 3Δx)),
        closure = IsotropicDiffusivity(FT, ν=ν, κ=ν),
   architecture = GPU(),
     float_type = FT

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -16,7 +16,7 @@ function time_step_with_forcing_functions(arch)
 
     forcing = ModelForcing(u=Fu, v=Fv, w=Fw)
 
-    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=forcing)
     time_step!(model, 1, euler=true)
 
@@ -35,7 +35,7 @@ function time_step_with_parameterized_forcing(arch)
 
     forcing = ModelForcing(u=Fu, v=Fv, w=Fw)
 
-    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=forcing)
     time_step!(model, 1, euler=true)
 
@@ -49,7 +49,7 @@ function time_step_with_forcing_functions_sin_exp(arch)
 
     forcing = ModelForcing(u=Fu, T=FT)
 
-    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=forcing)
     time_step!(model, 1, euler=true)
 
@@ -59,7 +59,7 @@ end
 """ Take one time step with a SimpleForcing forcing function. """
 function time_step_with_simple_forcing(arch)
     u_forcing = SimpleForcing((x, y, z, t) -> sin(x))
-    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, euler=true)
     return true
@@ -68,7 +68,7 @@ end
 """ Take one time step with a SimpleForcing forcing function with parameters. """
 function time_step_with_simple_forcing_parameters(arch)
     u_forcing = SimpleForcing((x, y, z, t, p) -> sin(p.ω * x), parameters=(ω=π,))
-    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, euler=true)
     return true
@@ -77,7 +77,7 @@ end
 """ Take one time step with a SimpleForcing forcing function with parameters. """
 function time_step_with_simple_u_dependent_forcing(arch)
     u_forcing = SimpleForcing((x, y, z, t, u) -> -u, field_in_signature=true)
-    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, euler=true)
     return true
@@ -86,7 +86,7 @@ end
 """ Take one time step with a SimpleForcing forcing function with parameters. """
 function time_step_with_simple_tracer_dependent_forcing(arch)
     u_forcing = SimpleForcing((x, y, z, t, u) -> -u, field_in_signature=true)
-    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, euler=true)
     return true
@@ -97,7 +97,7 @@ end
 """ Take one time step with a SimpleForcing forcing function with parameters. """
 function time_step_with_simple_field_dependent_forcing_parameters(arch)
     u_forcing = SimpleForcing((x, y, z, t, u, p) -> sin(p.ω * x) * u, parameters=(ω=π,), field_in_signature=true)
-    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, euler=true)
     return true
@@ -113,7 +113,7 @@ function relaxed_time_stepping(arch)
     z_relax = Relaxation(rate = 1/60,   mask = GaussianMask{:z}(center=0.5, width=0.1),
                                       target = π)
 
-    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
 
     model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=x_relax, v=y_relax, w=z_relax))
     time_step!(model, 1, euler=true)

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -1,5 +1,5 @@
 function time_stepping_works_with_coriolis(arch, FT, Coriolis)
-    grid = RegularCartesianGrid(FT, size=(16, 16, 2), extent=(1, 2, 3))
+    grid = RegularCartesianGrid(FT, size=(1, 1, 1), extent=(1, 2, 3))
     c = Coriolis(FT, latitude=45)
     model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, coriolis=c)
 
@@ -10,7 +10,7 @@ end
 
 function time_stepping_works_with_closure(arch, FT, Closure)
     # Use halos of size 2 to accomadate time stepping with AnisotropicBiharmonicDiffusivity.
-    grid = RegularCartesianGrid(FT; size=(16, 16, 16), halo=(2, 2, 2), extent=(1, 2, 3))
+    grid = RegularCartesianGrid(FT; size=(1, 1, 1), halo=(2, 2, 2), extent=(1, 2, 3))
 
     model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, closure=Closure(FT))
     time_step!(model, 1, euler=true)
@@ -19,7 +19,7 @@ function time_stepping_works_with_closure(arch, FT, Closure)
 end
 
 function time_stepping_works_with_nonlinear_eos(arch, FT, EOS)
-    grid = RegularCartesianGrid(FT; size=(16, 16, 16), extent=(1, 2, 3))
+    grid = RegularCartesianGrid(FT; size=(1, 1, 1), extent=(1, 2, 3))
 
     eos = EOS()
     b = SeawaterBuoyancy(equation_of_state=eos)

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -112,7 +112,7 @@ function time_step_with_variable_isotropic_diffusivity(arch)
 
     model = IncompressibleModel(
         architecture=arch, closure=closure,
-        grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 2, 3))
+        grid=RegularCartesianGrid(size=(1, 1, 1), extent=(1, 2, 3))
     )
 
     time_step!(model, 1, euler=true)
@@ -133,7 +133,7 @@ function time_step_with_variable_anisotropic_diffusivity(arch)
 
     model = IncompressibleModel(
         architecture=arch, closure=closure,
-        grid=RegularCartesianGrid(size=(16, 16, 16), extent=(1, 2, 3))
+        grid=RegularCartesianGrid(size=(1, 1, 1), extent=(1, 2, 3))
     )
 
     time_step!(model, 1, euler=true)
@@ -146,7 +146,7 @@ function time_step_with_tupled_closure(FT, arch)
 
     model = IncompressibleModel(
         architecture=arch, float_type=FT, closure=closure_tuple,
-        grid=RegularCartesianGrid(FT, size=(16, 16, 16), extent=(1, 2, 3))
+        grid=RegularCartesianGrid(FT, size=(1, 1, 1), extent=(1, 2, 3))
     )
 
     time_step!(model, 1, euler=true)
@@ -154,7 +154,7 @@ function time_step_with_tupled_closure(FT, arch)
 end
 
 function compute_closure_specific_diffusive_cfl(closurename)
-    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 2, 3))
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 2, 3))
     closure = getproperty(TurbulenceClosures, closurename)()
 
     model = IncompressibleModel(grid=grid, closure=closure)


### PR DESCRIPTION
Many models of size (16, 16, 16) are reduced to size (1, 1, 1). Oftentimes the test just executes a time-step to ensure there's no error. For this, a size (1, 1, 1) is sufficient.