### PR TITLE
Bump v0.37.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.36.0"
+version = "0.37.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
I think we should tag a v0.37.0 release to ensure we have a code checkpoint before which we were recomputing w and after which we were not (since it's a change to the numerical methods). Might be good if we do this before merging in RK3.