### PR TITLE
BuoyancyField

### DIFF
--- a/src/Buoyancy/Buoyancy.jl
+++ b/src/Buoyancy/Buoyancy.jl
@@ -74,4 +74,6 @@ Base.show(io::IO, b::SeawaterBuoyancy{FT}) where FT =
 Base.show(io::IO, eos::LinearEquationOfState{FT}) where FT =
     println(io, "LinearEquationOfState{$FT}: ", @sprintf("α = %.2e, β = %.2e", eos.α, eos.β))
 
+include("buoyancy_field.jl")
+
 end

--- a/src/Buoyancy/Buoyancy.jl
+++ b/src/Buoyancy/Buoyancy.jl
@@ -3,7 +3,8 @@ module Buoyancy
 export
     BuoyancyTracer, SeawaterBuoyancy, buoyancy_perturbation,
     LinearEquationOfState, RoquetIdealizedNonlinearEquationOfState, TEOS10,
-    ∂x_b, ∂y_b, ∂z_b, buoyancy_perturbation, buoyancy_frequency_squared
+    ∂x_b, ∂y_b, ∂z_b, buoyancy_perturbation, buoyancy_frequency_squared,
+    BuoyancyField
 
 using Printf
 using Oceananigans.Grids

--- a/src/Buoyancy/buoyancy_field.jl
+++ b/src/Buoyancy/buoyancy_field.jl
@@ -1,6 +1,8 @@
 using Adapt
 using KernelAbstractions
-using Oceananigans.Fields: AbstractField, validate_field_data, new_data
+using Oceananigans.Fields: AbstractField, validate_field_data, new_data, datatuple, architecture
+using Oceananigans.Architectures: device
+using Oceananigans.Utils: work_layout
 
 import Oceananigans.Fields: compute!
 

--- a/src/Buoyancy/buoyancy_field.jl
+++ b/src/Buoyancy/buoyancy_field.jl
@@ -1,0 +1,105 @@
+using Adapt
+using KernelAbstractions
+using Oceananigans.Fields: AbstractField, validate_field_data, new_data
+
+import Oceananigans.Fields: compute!
+
+"""
+    struct BuoyancyField{B, A, G, T} <: AbstractField{X, Y, Z, A, G}
+
+Type representing buoyancy computed on the model grid.
+"""
+struct BuoyancyField{B, A, G, T} <: AbstractField{Cell, Cell, Cell, A, G}
+        data :: A
+        grid :: G
+    buoyancy :: B
+     tracers :: T
+
+    """
+        BuoyancyField(data, grid, buoyancy, tracers)
+    
+    Returns a `BuoyancyField` with `data` on `grid` corresponding to
+    `buoyancy` computed from `tracers`.
+    """
+    function BuoyancyField(data, grid, buoyancy, tracers)
+
+        validate_field_data(Cell, Cell, Cell, data, grid)
+
+        return new{typeof(buoyancy), typeof(data),
+                   typeof(grid), typeof(tracers)}(data, grid, buoyancy, tracers)
+    end
+end
+
+"""
+    BuoyancyField(model; data=nothing)
+
+Returns a `BuoyancyField` corresponding to `model.buoyancy`.
+Calling `compute!(b::BuoyancyField)` computes the current buoyancy field
+associated with `model` and stores the result in `b.data`.
+"""
+BuoyancyField(model; data=nothing) = _buoyancy_field(model.buoyancy, model.tracers, model.architecture, model.grid; data=data)
+
+# Convenience for buoyancy=nothing
+_buoyancy_field(::Nothing, args...; kwargs...) = nothing
+
+#####
+##### BuoyancyTracer
+#####
+
+_buoyancy_field(buoyancy::BuoyancyTracer, tracers, arch, grid; kwargs...) =
+    BuoyancyField(tracers.b.data, grid, buoyancy, tracers)
+
+compute!(::BuoyancyField{<:BuoyancyTracer}) = nothing
+ 
+#####
+##### Other buoyancy types
+#####
+
+function _buoyancy_field(buoyancy::AbstractBuoyancy, tracers, arch, grid; data=nothing)
+
+    if isnothing(data)
+        data = new_data(arch, grid, (Cell, Cell, Cell))
+    end
+
+    return BuoyancyField(data, grid, buoyancy, tracers)
+end
+
+"""
+    compute!(buoyancy_field::BuoyancyField)
+
+Compute the current `buoyancy_field` associated with `buoyancy_field.tracers` and store
+the result in `buoyancy_field.data`.
+"""
+function compute!(buoyancy_field::BuoyancyField)
+
+    data = buoyancy_field.data
+    grid = buoyancy_field.grid
+    tracers = datatuple(buoyancy_field.tracers)
+    arch = architecture(data)
+
+    workgroup, worksize = work_layout(grid, :xyz)
+
+    compute_kernel! = compute_buoyancy!(device(arch), workgroup, worksize) 
+
+    event = compute_kernel!(data, grid, buoyancy_field.buoyancy, tracers; dependencies=Event(device(arch)))
+
+    wait(device(arch), event)
+
+    return nothing
+end
+
+"""Compute an `operation` and store in `data`."""
+@kernel function compute_buoyancy!(data, grid, buoyancy, C)
+    i, j, k = @index(Global, NTuple)
+    @inbounds data[i, j, k] = buoyancy_perturbation(i, j, k, grid, buoyancy, C)
+end
+
+#####
+##### Adapt
+#####
+
+Adapt.adapt_structure(to, buoyancy_field::BuoyancyField) =
+    BuoyancyField(Adapt.adapt(to, buoyancy_field.data),
+                  Adapt.adapt(to, buoyancy_field.grid),
+                  Adapt.adapt(to, buoyancy_field.buoyancy),
+                  Adapt.adapt(to, buoyancy_field.tracers))

--- a/src/Fields/abstract_field.jl
+++ b/src/Fields/abstract_field.jl
@@ -130,6 +130,12 @@ total_size(f::AbstractField) = total_size(location(f), f.grid)
                             interior_parent_indices(Z, topology(f, 3), f.grid.Nz, f.grid.Hz)]
 
 #####
+##### getindex
+#####
+
+@propagate_inbounds Base.getindex(f::AbstractField, inds...) = @inbounds getindex(f.data, inds...)
+
+#####
 ##### Coordinates of fields
 #####
 

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -122,7 +122,6 @@ XFaceField(arch::AbstractArchitecture, grid, args...) = XFaceField(eltype(grid),
 YFaceField(arch::AbstractArchitecture, grid, args...) = YFaceField(eltype(grid), arch, grid, args...)
 ZFaceField(arch::AbstractArchitecture, grid, args...) = ZFaceField(eltype(grid), arch, grid, args...)
 
-@propagate_inbounds Base.getindex(f::Field, inds...) = @inbounds getindex(f.data, inds...)
 @propagate_inbounds Base.setindex!(f::Field, v, inds...) = @inbounds setindex!(f.data, v, inds...)
 
 gpufriendly(f::Field) = data(f)

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -1,4 +1,5 @@
 using Oceananigans.AbstractOperations: UnaryOperation, Derivative, BinaryOperation, MultiaryOperation
+using Oceananigans.Buoyancy: BuoyancyField
 
 function simple_binary_operation(op, a, b, num1, num2)
     a_b = op(a, b)


### PR DESCRIPTION
This PR adds a `BuoyancyField` which is a type of lazily computed field constructed via `b = BuoyancyField(model)`. 

`BuoyancyField` represents model buoyancy in abstract operations:

```julia
b = BuoyancyField(model)
wb = ComputedField(w * b)
```

etc. This is important for nonlinear equations of state, where statistics that depend on buoyancy need to be calculated online.

cc @BrodiePearson

Side note: we need the same for `PressureField`.