### PR TITLE
Avoiding unnecessary recomputation of fields in output evaluation

### DIFF
--- a/src/AbstractOperations/averages_of_operations.jl
+++ b/src/AbstractOperations/averages_of_operations.jl
@@ -4,21 +4,25 @@ using Statistics
 import Oceananigans.Fields: AveragedField
 
 """
-    AveragedField(op::AbstractOperation; dims, data=nothing, computed_data=nothing)
+    AveragedField(op::AbstractOperation; dims, data=nothing, operand_data=nothing,
+                  recompute_safely=false, recompute_operand_safely=false)
 
 Forms a `ComputedField` to store the result of computing `op`, and returns an
 `AveragedField` whose operand is the new `ComputedField`, representing an average over
 `dims`.
 
 If `data` is not provided, memory is allocated to store the result of the average.
-See `AveragedField(field::AbstratField)`.
+See `AveragedField(field::AbstractField)`.
 
-The keyword argument `computed_data` can be used to specify memory or scratch space
+The keyword argument `operand_data` can be used to specify memory or scratch space
 for the new `ComputedField` data.
 """
-function AveragedField(op::AbstractOperation; dims, data=nothing, computed_data=nothing)
-    computed = ComputedField(op, data=computed_data)
-    return AveragedField(computed, dims=dims, data=data)
+function AveragedField(op::AbstractOperation; dims, data=nothing, operand_data=nothing,
+                       recompute_safely=false, recompute_operand_safely=false)
+
+    computed = ComputedField(op, data=operand_data, recompute_safely=recompute_operand_safely)
+
+    return AveragedField(computed, dims=dims, data=data, recompute_safely=recompute_safely)
 end
 
 """

--- a/src/Buoyancy/buoyancy_field.jl
+++ b/src/Buoyancy/buoyancy_field.jl
@@ -24,7 +24,7 @@ struct BuoyancyField{B, S, A, G, T} <: AbstractField{Cell, Cell, Cell, A, G}
     Returns a `BuoyancyField` with `data` on `grid` corresponding to
     `buoyancy` computed from `tracers`.
     """
-    function BuoyancyField(data, grid, buoyancy, tracers)
+    function BuoyancyField(data, grid, buoyancy, tracers, recompute_safely)
 
         validate_field_data(Cell, Cell, Cell, data, grid)
 
@@ -42,7 +42,7 @@ Returns a `BuoyancyField` corresponding to `model.buoyancy`.
 Calling `compute!(b::BuoyancyField)` computes the current buoyancy field
 associated with `model` and stores the result in `b.data`.
 """
-BuoyancyField(model; data=nothing) = _buoyancy_field(model.buoyancy, model.tracers, model.architecture, model.grid; data=data)
+BuoyancyField(model; kwargs...) = _buoyancy_field(model.buoyancy, model.tracers, model.architecture, model.grid; kwargs...)
 
 # Convenience for buoyancy=nothing
 _buoyancy_field(::Nothing, args...; kwargs...) = nothing
@@ -52,7 +52,7 @@ _buoyancy_field(::Nothing, args...; kwargs...) = nothing
 #####
 
 _buoyancy_field(buoyancy::BuoyancyTracer, tracers, arch, grid; kwargs...) =
-    BuoyancyField(tracers.b.data, grid, buoyancy, tracers)
+    BuoyancyField(tracers.b.data, grid, buoyancy, tracers, false)
 
 compute!(::BuoyancyField{<:BuoyancyTracer}) = nothing
  
@@ -60,13 +60,14 @@ compute!(::BuoyancyField{<:BuoyancyTracer}) = nothing
 ##### Other buoyancy types
 #####
 
-function _buoyancy_field(buoyancy::AbstractBuoyancy, tracers, arch, grid; data=nothing)
+function _buoyancy_field(buoyancy::AbstractBuoyancy, tracers, arch, grid; data=nothing, recompute_safely=false)
 
     if isnothing(data)
         data = new_data(arch, grid, (Cell, Cell, Cell))
+        recompute_safely = true
     end
 
-    return BuoyancyField(data, grid, buoyancy, tracers)
+    return BuoyancyField(data, grid, buoyancy, tracers, recompute_safely)
 end
 
 """

--- a/src/Buoyancy/buoyancy_field.jl
+++ b/src/Buoyancy/buoyancy_field.jl
@@ -1,6 +1,7 @@
 using Adapt
 using KernelAbstractions
-using Oceananigans.Fields: AbstractField, FieldStatus, validate_field_data, new_data, datatuple, architecture
+using Oceananigans.Fields: AbstractField, FieldStatus, validate_field_data, new_data, conditional_compute!
+using Oceananigans.Fields: datatuple, architecture
 using Oceananigans.Architectures: device
 using Oceananigans.Utils: work_layout
 

--- a/src/Buoyancy/buoyancy_field.jl
+++ b/src/Buoyancy/buoyancy_field.jl
@@ -1,6 +1,6 @@
 using Adapt
 using KernelAbstractions
-using Oceananigans.Fields: AbstractField, validate_field_data, new_data, datatuple, architecture
+using Oceananigans.Fields: AbstractField, FieldStatus, validate_field_data, new_data, datatuple, architecture
 using Oceananigans.Architectures: device
 using Oceananigans.Utils: work_layout
 

--- a/src/Fields/abstract_field.jl
+++ b/src/Fields/abstract_field.jl
@@ -75,6 +75,10 @@ function conditional_compute!(field, time)
     return nothing
 end
 
+# This edge case occurs if `fetch_output` is called with `model::Nothing`.
+# We do the safe thing here and always compute.
+conditional_compute!(field, ::Nothing) = compute!(field)
+
 """
     @compute(exprs...)
 

--- a/src/Fields/abstract_field.jl
+++ b/src/Fields/abstract_field.jl
@@ -69,7 +69,7 @@ function conditional_compute!(field, time)
 
     if time != field.status.time
         compute!(field)
-        avg.status.time = time
+        field.status.time = time
     end
 
     return nothing

--- a/src/Fields/averaged_field.jl
+++ b/src/Fields/averaged_field.jl
@@ -23,7 +23,7 @@ struct AveragedField{X, Y, Z, S, A, G, N, O} <: AbstractReducedField{X, Y, Z, A,
 
         status = recompute_safely ? FieldStatus(0.0) : nothing
         
-        return new{X, Y, Z, typeof(data),
+        return new{X, Y, Z, typeof(status), typeof(data),
                    typeof(grid), length(dims), typeof(operand)}(data, grid, dims,
                                                                 operand, status)
     end

--- a/src/Fields/averaged_field.jl
+++ b/src/Fields/averaged_field.jl
@@ -8,24 +8,33 @@ using Oceananigans.BoundaryConditions: zero_halo_regions!
 
 Type representing an average over a field-like object.
 """
-struct AveragedField{X, Y, Z, A, G, N, O} <: AbstractReducedField{X, Y, Z, A, G, N}
+struct AveragedField{X, Y, Z, S, A, G, N, O} <: AbstractReducedField{X, Y, Z, A, G, N}
        data :: A
        grid :: G
        dims :: NTuple{N, Int}
     operand :: O
+     status :: S
 
-    function AveragedField{X, Y, Z}(data, grid, dims, operand) where {X, Y, Z}
+    function AveragedField{X, Y, Z}(data, grid, dims, operand, recompute_safely) where {X, Y, Z}
 
         dims = validate_reduced_dims(dims)
         validate_reduced_locations(X, Y, Z, dims)
         validate_field_data(X, Y, Z, data, grid)
+
+        status = recompute_safely ? FieldStatus(0.0) : nothing
         
         return new{X, Y, Z, typeof(data),
-                   typeof(grid), length(dims), typeof(operand)}(data, grid, dims, operand)
+                   typeof(grid), length(dims), typeof(operand)}(data, grid, dims,
+                                                                operand, status)
     end
 end
 
-function AveragedField(operand::AbstractField; dims, data=nothing)
+"""
+    AveragedField(operand::AbstractField; dims, data=nothing, recompute_safely=false)
+
+Returns an AveragedField.
+"""
+function AveragedField(operand::AbstractField; dims, data=nothing, recompute_safely=false)
     
     arch = architecture(operand)
     loc = reduced_location(location(operand), dims=dims)
@@ -33,9 +42,10 @@ function AveragedField(operand::AbstractField; dims, data=nothing)
 
     if isnothing(data)
         data = new_data(arch, grid, loc)
+        recompute_safely = true
     end
 
-    return AveragedField{loc[1], loc[2], loc[3]}(data, grid, dims, operand)
+    return AveragedField{loc[1], loc[2], loc[3]}(data, grid, dims, operand, recompute_safely)
 end
 
 """
@@ -56,6 +66,9 @@ function compute!(avg::AveragedField)
     return nothing
 end
 
+compute!(avg::AveragedField{X, Y, Z, <:FieldStatus}, time) where {X, Y, Z} =
+    conditional_compute!(avg, time)
+
 #####
 ##### Very sugar
 #####
@@ -70,4 +83,5 @@ Adapt.adapt_structure(to, averaged_field::AveragedField{X, Y, Z}) where {X, Y, Z
     AveragedField{X, Y, Z}(Adapt.adapt(to, averaged_field.data),
                            Adapt.adapt(to, averaged_field.grid),
                            Adapt.adapt(to, averaged_field.dims),
-                           Adapt.adapt(to, averaged_field.operand))
+                           Adapt.adapt(to, averaged_field.operand),
+                           Adapt.adapt(to, averaged_field.status))

--- a/src/Fields/computed_field.jl
+++ b/src/Fields/computed_field.jl
@@ -9,14 +9,19 @@ using Oceananigans.BoundaryConditions: zero_halo_regions!
 
 Type representing a field computed from an operand.
 """
-struct ComputedField{X, Y, Z, A, G, O} <: AbstractField{X, Y, Z, A, G}
+struct ComputedField{X, Y, Z, S, A, G, O} <: AbstractField{X, Y, Z, A, G}
        data :: A
        grid :: G
     operand :: O
+     status :: S
 
-    function ComputedField{X, Y, Z}(data, grid, operand) where {X, Y, Z}
+    function ComputedField{X, Y, Z}(data, grid, operand, recompute_safely) where {X, Y, Z}
         validate_field_data(X, Y, Z, data, grid)
-        return new{X, Y, Z, typeof(data), typeof(grid), typeof(operand)}(data, grid, operand)
+
+        status = recompute_safely ? FieldStatus(0.0) : nothing
+
+        return new{X, Y, Z, typeof(status), typeof(data),
+                   typeof(grid), typeof(operand)}(data, grid, operand, status)
     end
 end
 
@@ -27,7 +32,7 @@ Returns a field whose data is `computed` from `operand`.
 If the keyword argument `data` is not provided, memory is allocated to store
 the result. The `arch`itecture of `data` is inferred from `operand`.
 """
-function ComputedField(operand; data=nothing)
+function ComputedField(operand; data=nothing, recompute_safely=false)
     
     loc = location(operand)
     arch = architecture(operand)
@@ -35,9 +40,10 @@ function ComputedField(operand; data=nothing)
 
     if isnothing(data)
         data = new_data(arch, grid, loc)
+        recompute_safely = true
     end
 
-    return ComputedField{loc[1], loc[2], loc[3]}(data, grid, operand)
+    return ComputedField{loc[1], loc[2], loc[3]}(data, grid, operand, recompute_safely)
 end
 
 """
@@ -64,6 +70,9 @@ function compute!(comp::ComputedField{X, Y, Z}) where {X, Y, Z}
     return nothing
 end
 
+compute!(field::ComputedField{X, Y, Z, <:FieldStatus}, time) where {X, Y, Z} =
+    conditional_compute!(field, time)
+
 """Compute an `operand` and store in `data`."""
 @kernel function _compute!(data, operand)
     i, j, k = @index(Global, NTuple)
@@ -77,4 +86,5 @@ end
 Adapt.adapt_structure(to, computed_field::ComputedField{X, Y, Z}) where {X, Y, Z} = 
     ComputedField{X, Y, Z}(Adapt.adapt(to, computed_field.data),
                            Adapt.adapt(to, computed_field.grid),
-                           Adapt.adapt(to, computed_field.operand))
+                           Adapt.adapt(to, computed_field.operand),
+                           Adapt.adapt(to, computed_field.status))

--- a/src/Fields/pressure_field.jl
+++ b/src/Fields/pressure_field.jl
@@ -1,6 +1,5 @@
 using Oceananigans.Fields: ComputedField
 
-function PressureField(model, data=model.pressures.pHY′.data)
-    p = ComputedField(model.pressures.pHY′ + model.pressures.pNHS, data=data)
-    return p
-end
+PressureField(model, data=model.pressures.pHY′.data, recompute_safely=false) =
+    ComputedField(model.pressures.pHY′ + model.pressures.pNHS, data=data,
+                      recompute_safely=recompute_safely)

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -1,6 +1,6 @@
 module Models
 
-export IncompressibleModel, NonDimensionalModel, Clock, tick!, state
+export IncompressibleModel, NonDimensionalModel, Clock, tick!, state, fields
 
 using Adapt
 
@@ -30,6 +30,8 @@ corresponding to `NamedTuple`s of `OffsetArray`s that reference each of the fiel
 @inline state(model) = (   velocities = datatuple(model.velocities),
                               tracers = datatuple(model.tracers),
                         diffusivities = datatuple(model.diffusivities))
+
+fields(model) = merge(model.velocities, model.tracers)
 
 include("clock.jl")
 include("incompressible_model.jl")

--- a/src/OutputWriters/fetch_output.jl
+++ b/src/OutputWriters/fetch_output.jl
@@ -2,8 +2,12 @@ using Oceananigans.Fields: AbstractField, compute!
 
 fetch_output(output, model, field_slicer) = output(model)
 
+# Needed to support `fetch_output` with `model::Nothing`.
+time(model) = model.clock.time
+time(::Nothing) = nothing
+
 function fetch_output(field::AbstractField, model, field_slicer)
-    compute!(field, model.clock.time)
+    compute!(field, time(model))
     return slice_parent(field_slicer, field)
 end
 

--- a/src/OutputWriters/fetch_output.jl
+++ b/src/OutputWriters/fetch_output.jl
@@ -3,7 +3,7 @@ using Oceananigans.Fields: AbstractField, compute!
 fetch_output(output, model, field_slicer) = output(model)
 
 function fetch_output(field::AbstractField, model, field_slicer)
-    compute!(field)
+    compute!(field, model.clock.time)
     return slice_parent(field_slicer, field)
 end
 

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -314,6 +314,7 @@ function computations_with_buoyancy_field(FT, arch, buoyancy)
     b = BuoyancyField(model)
     u, v, w = model.velocities
 
+    compute!(b)
     @compute ub = ComputedField(u * b)
     @compute vb = ComputedField(v * b)
     @compute wb = ComputedField(w * b)
@@ -445,11 +446,13 @@ end
 
     for arch in archs
         @testset "AbstractOperations and ComputedFields [$(typeof(arch))]" begin
+
             @info "  Testing combined binary operations and derivatives..."
+
             for FT in float_types
 
                 grid = RegularCartesianGrid(FT, size=(4, 4, 4), extent=(1, 1, 1),
-                                            topology=(Periodic, Periodic, Bounded),
+                                            topology=(Periodic, Periodic, Bounded))
 
                 buoyancy = SeawaterBuoyancy(gravitational_acceleration = 1,
                                                      equation_of_state = LinearEquationOfState(α=1, β=1))
@@ -462,8 +465,7 @@ end
                 @testset "Construction of abstract operations [$FT, $(typeof(arch))]" begin
                     @info "    Testing construction of abstract operations [$FT, $(typeof(arch))]..."
 
-                    u, v, w = model.velocities
-                    T, S = model.tracers
+                    u, v, w, T, S = fields(model)
 
                     @test_throws ArgumentError @at (Nothing, Nothing, Cell) T * S
 
@@ -580,32 +582,40 @@ end
                 buoyancies = (BuoyancyTracer(), SeawaterBuoyancy(FT),
                               (SeawaterBuoyancy(FT, equation_of_state=eos(FT)) for eos in EquationsOfState)...)
 
-                @testset "BuoyancyField" begin
-                    for buoyancy in buoyancies
-                        @info "      Testing computations with BuoyancyField [$(typeof(buoyancy).name.wrapper)]"
+                for buoyancy in buoyancies
+                    @testset "BuoyancyField computations [$FT, $(typeof(arch)), $(typeof(buoyancy).name.wrapper)]" begin
+                        @info "      Testing computations with BuoyancyField..."
                         @test computations_with_buoyancy_field(FT, arch, buoyancy)
                     end
                 end
 
-                @testset "Conditional computation of ComputedField and BuoyancyField" begin
-                    u, v, w, T, S = fields(model)
-                    uT = ComputedField(u * T)
-                    b = BuoyancyField(model) # using linear equation of state with g=α=1
+                @testset "Conditional computation of ComputedField and BuoyancyField [$FT, $(typeof(arch))]" begin
+                    @info "      Testing conditional computation of ComputedField and BuoyancyField..."
 
-                    set!(model, u=2, T=3)
+                    set!(model, u=2, v=0, w=0, T=3, S=0)
+                    u, v, w, T, S = fields(model)
+
+                    uT = ComputedField(u * T)
+
+                    α = model.buoyancy.equation_of_state.α
+                    g = model.buoyancy.gravitational_acceleration
+                    b = BuoyancyField(model)
+
                     compute!(uT, 1.0)
                     compute!(b, 1.0)
-                    @test all(uT .== 6) 
-                    @test all(b .== 3) 
+                    @test all(interior(uT) .== 6)
+                    @test all(interior(b) .== g * α * 3) 
 
                     set!(model, u=2, T=4)
                     compute!(uT, 1.0)
-                    @test all(uT .== 6) 
-                    @test all(b .== 3) 
+                    compute!(b, 1.0)
+                    @test all(interior(uT) .== 6) 
+                    @test all(interior(b) .== g * α * 3) 
 
                     compute!(uT, 2.0)
-                    @test all(uT .== 8) 
-                    @test all(b .== 4) 
+                    compute!(b, 2.0)
+                    @test all(interior(uT) .== 8) 
+                    @test all(interior(b) .== g * α * 4) 
                 end
             end
         end

--- a/test/test_averaged_field.jl
+++ b/test/test_averaged_field.jl
@@ -42,5 +42,29 @@ using Oceananigans.Grids: halo_size
                 @test Array(ŵ[1, 1:Ny, 1:Nz+1]) ≈ [[1.5, 2.5] [2.5, 3.5] [3.5, 4.5]]
             end
         end
+
+        @testset "Conditional computation of AveragedFields [$(typeof(arch))]" begin
+            @info "  Testing conditional computation of AveragedFields [$(typeof(arch))]"
+            for FT in float_types
+                grid = RegularCartesianGrid(size=(2, 2, 2), extent=(1, 1, 1)) 
+                c = CellField(FT, arch, grid)
+
+                for dims in (1, 2, 3, (1, 2), (2, 3), (1, 3), (1, 2, 3))
+                    C = AveragedField(c, dims=dims)
+
+                    # Test conditional computation
+                    set!(c, 1)
+                    compute!(C, 1.0)
+                    @test all(interior(C) .== 1)
+
+                    set!(c, 2)
+                    compute!(C, 1.0)
+                    @test all(interior(C) .== 1)
+
+                    compute!(C, 2.0)
+                    @test all(interior(C) .== 2)
+                end
+            end
+        end
     end
 end

--- a/test/test_fields.jl
+++ b/test/test_fields.jl
@@ -127,29 +127,6 @@ end
         end
     end
 
-    @testset "Conditional computation" begin
-        for arch in archs, FT in float_types
-            grid = RegularCartesianGrid(size=(2, 2, 2), extent=(1, 1, 1)) 
-            c = CellField(FT, arch, grid)
-
-            for dims in (1, 2, 3, (1, 2), (2, 3), (1, 3), (1, 2, 3))
-                C = AveragedField(c, dims=dims)
-
-                # Test conditional computation
-                set!(c, 1)
-                compute!(C, 1.0)
-                @test all(C.data .== 1)
-
-                set!(c, 2)
-                compute!(C, 1.0)
-                @test all(C.data .== 1)
-
-                compute!(C, 2.0)
-                @test all(C.data .== 2)
-            end
-        end
-    end
-
     @testset "Field utils" begin
         @info "  Testing field utils..."
 

--- a/test/test_fields.jl
+++ b/test/test_fields.jl
@@ -127,6 +127,29 @@ end
         end
     end
 
+    @testset "Conditional computation" begin
+        for arch in archs, FT in float_types
+            grid = RegularCartesianGrid(size=(2, 2, 2), extent=(1, 1, 1)) 
+            c = CellField(FT, arch, grid)
+
+            for dims in (1, 2, 3, (1, 2), (2, 3), (1, 3), (1, 2, 3))
+                C = AveragedField(c, dims=dims)
+
+                # Test conditional computation
+                set!(c, 1)
+                compute!(C, 1.0)
+                @test all(C.data .== 1)
+
+                set!(c, 2)
+                compute!(C, 1.0)
+                @test all(C.data .== 1)
+
+                compute!(C, 2.0)
+                @test all(C.data .== 2)
+            end
+        end
+    end
+
     @testset "Field utils" begin
         @info "  Testing field utils..."
 


### PR DESCRIPTION
This PR implements an optimization that (potentially) avoids redundant recompilation of fields when `compute!(output)` is called in `fetch_output`. This optimization was discussed on #955 .

The idea is to use `model.clock.time` as a "key" which is checked prior to computation. Fields that opt-in to avoid recomputation then check if `model.clock.time == field.status.time`. If the two are equal, no computation is performed.

This will hopefully speed up expressions that involve `AveragedField`s, `ComputedField`s, and `BuoyancyField`. Note that in the case that users specify scratch space for a field, they must opt-in to this optimization by passing `recompute_safely=false` to the field constructor. If scratch space is not specified (and we therefore know it is unique), recomputation is avoided by default.

This PR also changes the keyword `computed_data` to `operand_data` in the constructor for `AveragedField(op::AbstractOperation)`. 

Todo:

- [x] Tests

Resolves #955 
Resolves #967 