### PR TITLE
Do not zero out halo regions in directions that arent averaged

### DIFF
--- a/src/BoundaryConditions/zero_halo_regions.jl
+++ b/src/BoundaryConditions/zero_halo_regions.jl
@@ -6,10 +6,10 @@ using Oceananigans: location
 
 Zero out the halo regions of each field in `fields`.
 """
-function zero_halo_regions!(fields::Union{Tuple, NamedTuple})
+function zero_halo_regions!(fields::Union{Tuple, NamedTuple}; kwargs...)
 
     for field in fields
-        zero_halo_regions!(field)
+        zero_halo_regions!(field; kwargs...)
     end
 
     return nothing
@@ -20,7 +20,7 @@ end
 
 Zero out the halo regions of `field`.
 """
-zero_halo_regions!(field) = zero_halo_regions!(parent(field), location(field), field.grid)
+zero_halo_regions!(field; dims=(1, 2, 3)) = zero_halo_regions!(parent(field), location(field), field.grid, dims=dims)
 
 """
     zero_halo_regions!(underlying_data, loc, grid)
@@ -28,19 +28,26 @@ zero_halo_regions!(field) = zero_halo_regions!(parent(field), location(field), f
 Zero out the halo regions of the `underlying_data` of a field
 at `loc`ation on `grid`.
 """
-function zero_halo_regions!(underlying_data, loc, grid)
+function zero_halo_regions!(underlying_data, loc, grid; dims=(1, 2, 3))
 
+    dims = tuple(dims...)
     Lx, Ly, Lz = loc
     Tx, Ty, Tz = topology(grid)
 
-      zero_west_halo!(underlying_data,  underlying_left_halo_indices(Lx, Tx, grid.Nx, grid.Hx))
-      zero_east_halo!(underlying_data, underlying_right_halo_indices(Lx, Tx, grid.Nx, grid.Hx))
+    if 1 ∈ dims
+        zero_west_halo!(underlying_data,  underlying_left_halo_indices(Lx, Tx, grid.Nx, grid.Hx))
+        zero_east_halo!(underlying_data, underlying_right_halo_indices(Lx, Tx, grid.Nx, grid.Hx))
+    end
 
-     zero_south_halo!(underlying_data,  underlying_left_halo_indices(Ly, Ty, grid.Ny, grid.Hy))
-     zero_north_halo!(underlying_data, underlying_right_halo_indices(Ly, Ty, grid.Ny, grid.Hy))
+    if 2 ∈ dims
+        zero_south_halo!(underlying_data,  underlying_left_halo_indices(Ly, Ty, grid.Ny, grid.Hy))
+        zero_north_halo!(underlying_data, underlying_right_halo_indices(Ly, Ty, grid.Ny, grid.Hy))
+    end
 
-       zero_top_halo!(underlying_data,  underlying_left_halo_indices(Lz, Tz, grid.Nz, grid.Hz))
-    zero_bottom_halo!(underlying_data, underlying_right_halo_indices(Lz, Tz, grid.Nz, grid.Hz))
+    if 3 ∈ dims
+           zero_top_halo!(underlying_data,  underlying_left_halo_indices(Lz, Tz, grid.Nz, grid.Hz))
+        zero_bottom_halo!(underlying_data, underlying_right_halo_indices(Lz, Tz, grid.Nz, grid.Hz))
+    end
 
     return nothing
 end

--- a/src/Fields/averaged_field.jl
+++ b/src/Fields/averaged_field.jl
@@ -46,7 +46,7 @@ Compute the average of `avg.operand` and store the result in `avg.data`.
 function compute!(avg::AveragedField)
     compute!(avg.operand)
 
-    zero_halo_regions!(avg.operand)
+    zero_halo_regions!(avg.operand, dims=avg.dims)
 
     sum!(parent(avg.data), parent(avg.operand))
 

--- a/test/test_averaged_field.jl
+++ b/test/test_averaged_field.jl
@@ -24,7 +24,13 @@ using Oceananigans.Grids: halo_size
                 set!(w, trilinear)
 
                 @compute T̃ = mean(T, dims=(1, 2, 3))
+
+                # Note: halo regions must be *filled* prior to computing an average
+                # if the average within halo regions is to be correct.
+                fill_halo_regions!(T, arch)
                 @compute T̅ = mean(T, dims=(1, 2))
+
+                fill_halo_regions!(T, arch)
                 @compute T̂ = mean(T, dims=1)
 
                 @compute w̃ = mean(w, dims=(1, 2, 3))
@@ -34,8 +40,8 @@ using Oceananigans.Grids: halo_size
                 Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
 
                 @test T̃[1, 1, 1] ≈ 3
-                @test Array(T̅[1, 1, 1:Nz]) ≈ [2.5, 3.5]
-                @test Array(T̂[1, 1:Ny, 1:Nz]) ≈ [[2, 3] [3, 4]]
+                @test Array(parent(T̅)[1, 1, :]) ≈ [2.5, 2.5, 3.5, 3.5]
+                @test Array(parent(T̂)[1, :, :]) ≈ [[3, 2, 3, 2] [3, 2, 3, 2] [4, 3, 4, 3] [4, 3, 4, 3]]
 
                 @test w̃[1, 1, 1] ≈ 4.5
                 @test Array(w̅[1, 1, 1:Nz+1]) ≈ [2, 3, 4]


### PR DESCRIPTION
This PR adds a `dims` keyword argument to `zero_halo_regions`, so that we can avoid zeroing out halo regions in directions that are not averaged. It also adds tests to ensure that this works.

This PR does not solve all the issues with averaging halo regions, however. In particular, the halo regions are not guaranteed to be correct because they may have been previously zeroed out.

This can be solved by calling `fill_halo_regions` prior to computing an average. However, this solution is not possible with the current syntax, because field boundary conditions can depend on other fields of model that are not available within `compute!(averaged_field)`. I will raise an issue after this PR to discuss this other problem, which involves some difficult trade-offs.