### PR TITLE
New framework for high-order advection schemes

### DIFF
--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -22,7 +22,12 @@ export
 using Oceananigans.Operators
 
 abstract type AbstractAdvectionScheme end
+abstract type AbstractCenteredAdvectionScheme <: AbstractAdvectionScheme end
+abstract type AbstractUpwindBiasedAdvectionScheme <: AbstractAdvectionScheme end
 
+include("topologically_conditional_interpolation.jl")
+include("centered_advective_fluxes.jl")
+include("upwind_biased_advective_fluxes.jl")
 include("centered_second_order.jl")
 include("centered_fourth_order.jl")
 include("momentum_advection_operators.jl")

--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -27,11 +27,14 @@ abstract type AbstractCenteredAdvectionScheme <: AbstractAdvectionScheme end
 abstract type AbstractUpwindBiasedAdvectionScheme <: AbstractAdvectionScheme end
 
 include("topologically_conditional_interpolation.jl")
+
 include("centered_advective_fluxes.jl")
 include("upwind_biased_advective_fluxes.jl")
+
 include("centered_second_order.jl")
 include("upwind_biased_third_order.jl")
 include("centered_fourth_order.jl")
+
 include("momentum_advection_operators.jl")
 include("tracer_advection_operators.jl")
 

--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -17,6 +17,7 @@ export
     advective_tracer_flux_z,
 
     CenteredSecondOrder,
+    UpwindBiasedThirdOrder,
     CenteredFourthOrder
 
 using Oceananigans.Operators
@@ -29,6 +30,7 @@ include("topologically_conditional_interpolation.jl")
 include("centered_advective_fluxes.jl")
 include("upwind_biased_advective_fluxes.jl")
 include("centered_second_order.jl")
+include("upwind_biased_third_order.jl")
 include("centered_fourth_order.jl")
 include("momentum_advection_operators.jl")
 include("tracer_advection_operators.jl")

--- a/src/Advection/centered_advective_fluxes.jl
+++ b/src/Advection/centered_advective_fluxes.jl
@@ -1,4 +1,12 @@
+#####
+##### Momentum and tracer advection operators for centered advection schemes
+#####
+
 const Centered = AbstractCenteredAdvectionScheme
+
+#####
+##### Momentum advection operators
+#####
 
 @inline momentum_flux_uu(i, j, k, grid, scheme::Centered, u)    = Axᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
 @inline momentum_flux_uv(i, j, k, grid, scheme::Centered, u, v) = Ayᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
@@ -6,11 +14,15 @@ const Centered = AbstractCenteredAdvectionScheme
 
 @inline momentum_flux_vu(i, j, k, grid, scheme::Centered, u, v) = Axᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
 @inline momentum_flux_vv(i, j, k, grid, scheme::Centered, v)    = Ayᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
-@inline momentum_flux_vw(i, j, k, grid, scheme::Centered, u, w) = Azᵃᵃᵃ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
+@inline momentum_flux_vw(i, j, k, grid, scheme::Centered, v, w) = Azᵃᵃᵃ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
 
 @inline momentum_flux_wu(i, j, k, grid, scheme::Centered, u, w) = Axᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
 @inline momentum_flux_wv(i, j, k, grid, scheme::Centered, v, w) = Ayᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
 @inline momentum_flux_ww(i, j, k, grid, scheme::Centered, w)    = Azᵃᵃᵃ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
+
+#####
+##### Tracer advection operators
+#####
     
 @inline advective_tracer_flux_x(i, j, k, grid, scheme::Centered, u, c) = Ax_ψᵃᵃᶠ(i, j, k, grid, u) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
 @inline advective_tracer_flux_y(i, j, k, grid, scheme::Centered, v, c) = Ay_ψᵃᵃᶠ(i, j, k, grid, v) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)

--- a/src/Advection/centered_advective_fluxes.jl
+++ b/src/Advection/centered_advective_fluxes.jl
@@ -1,0 +1,17 @@
+const Centered = AbstractCenteredAdvectionScheme
+
+@inline momentum_flux_uu(i, j, k, grid, scheme::Centered, u)    = Axᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
+@inline momentum_flux_uv(i, j, k, grid, scheme::Centered, u, v) = Ayᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
+@inline momentum_flux_uw(i, j, k, grid, scheme::Centered, u, w) = Azᵃᵃᵃ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
+
+@inline momentum_flux_vu(i, j, k, grid, scheme::Centered, u, v) = Axᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
+@inline momentum_flux_vv(i, j, k, grid, scheme::Centered, v)    = Ayᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
+@inline momentum_flux_vw(i, j, k, grid, scheme::Centered, u, w) = Azᵃᵃᵃ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
+
+@inline momentum_flux_wu(i, j, k, grid, scheme::Centered, u, w) = Axᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
+@inline momentum_flux_wv(i, j, k, grid, scheme::Centered, v, w) = Ayᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
+@inline momentum_flux_ww(i, j, k, grid, scheme::Centered, w)    = Azᵃᵃᵃ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
+    
+@inline advective_tracer_flux_x(i, j, k, grid, scheme::Centered, u, c) = Ax_ψᵃᵃᶠ(i, j, k, grid, u) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_y(i, j, k, grid, scheme::Centered, v, c) = Ay_ψᵃᵃᶠ(i, j, k, grid, v) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_z(i, j, k, grid, scheme::Centered, w, c) = Az_ψᵃᵃᵃ(i, j, k, grid, w) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)

--- a/src/Advection/centered_advective_fluxes.jl
+++ b/src/Advection/centered_advective_fluxes.jl
@@ -1,11 +1,15 @@
 #####
 ##### Momentum and tracer advection operators for centered advection schemes
 #####
+##### See topologically_conditional_interpolation.jl for an explanation of the underscore-prepended functions _symmetric_interpolate_*.
+#####
 
 const Centered = AbstractCenteredAdvectionScheme
 
 #####
 ##### Momentum advection operators
+#####
+##### Note the convention "momentum_flux_AB" corresponds to the advection _of_ B _by_ A.
 #####
 
 @inline momentum_flux_uu(i, j, k, grid, scheme::Centered, u)    = Axᵃᵃᶠ(i, j, k, grid) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
@@ -24,6 +28,6 @@ const Centered = AbstractCenteredAdvectionScheme
 ##### Tracer advection operators
 #####
     
-@inline advective_tracer_flux_x(i, j, k, grid, scheme::Centered, u, c) = Ax_ψᵃᵃᶠ(i, j, k, grid, u) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
-@inline advective_tracer_flux_y(i, j, k, grid, scheme::Centered, v, c) = Ay_ψᵃᵃᶠ(i, j, k, grid, v) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
-@inline advective_tracer_flux_z(i, j, k, grid, scheme::Centered, w, c) = Az_ψᵃᵃᵃ(i, j, k, grid, w) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_x(i, j, k, grid, scheme::Centered, u, c) = @inbounds Axᵃᵃᶠ(i, j, k, grid) * u[i, j, k] * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_y(i, j, k, grid, scheme::Centered, v, c) = @inbounds Ayᵃᵃᶠ(i, j, k, grid) * v[i, j, k] * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_z(i, j, k, grid, scheme::Centered, w, c) = @inbounds Azᵃᵃᵃ(i, j, k, grid) * w[i, j, k] * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)

--- a/src/Advection/centered_fourth_order.jl
+++ b/src/Advection/centered_fourth_order.jl
@@ -6,7 +6,7 @@ using Oceananigans.Grids
 
 struct CenteredFourthOrder <: AbstractCenteredAdvectionScheme end
 
-@inline halo_buffer(::CenteredFourthOrder) = 1
+@inline boundary_buffer(::CenteredFourthOrder) = 1
 
 @inline ℑ³xᶠᵃᵃ(i, j, k, grid, u) = @inbounds u[i, j, k] - δxᶠᵃᵃ(i, j, k, grid, δxᶜᵃᵃ, u) / 6
 @inline ℑ³xᶜᵃᵃ(i, j, k, grid, c) = @inbounds c[i, j, k] - δxᶜᵃᵃ(i, j, k, grid, δxᶠᵃᵃ, c) / 6
@@ -17,11 +17,11 @@ struct CenteredFourthOrder <: AbstractCenteredAdvectionScheme end
 @inline ℑ³zᵃᵃᶠ(i, j, k, grid, w) = @inbounds w[i, j, k] - δzᵃᵃᶠ(i, j, k, grid, δzᵃᵃᶜ, w) / 6
 @inline ℑ³zᵃᵃᶜ(i, j, k, grid, c) = @inbounds c[i, j, k] - δzᵃᵃᶜ(i, j, k, grid, δzᵃᵃᶠ, c) / 6
 
-symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, ::CenteredFourthOrder, u) = ℑxᶜᵃᵃ(i, j, k, grid, ℑ³xᶠᵃᵃ, u)
-symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, ::CenteredFourthOrder, c) = ℑxᶠᵃᵃ(i, j, k, grid, ℑ³xᶜᵃᵃ, c)
+@inline symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, ::CenteredFourthOrder, u) = ℑxᶜᵃᵃ(i, j, k, grid, ℑ³xᶠᵃᵃ, u)
+@inline symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, ::CenteredFourthOrder, c) = ℑxᶠᵃᵃ(i, j, k, grid, ℑ³xᶜᵃᵃ, c)
 
-symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, ::CenteredFourthOrder, v) = ℑyᵃᶜᵃ(i, j, k, grid, ℑ³yᵃᶠᵃ, v)
-symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, ::CenteredFourthOrder, c) = ℑyᵃᶠᵃ(i, j, k, grid, ℑ³yᵃᶜᵃ, c)
+@inline symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, ::CenteredFourthOrder, v) = ℑyᵃᶜᵃ(i, j, k, grid, ℑ³yᵃᶠᵃ, v)
+@inline symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, ::CenteredFourthOrder, c) = ℑyᵃᶠᵃ(i, j, k, grid, ℑ³yᵃᶜᵃ, c)
 
-symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, ::CenteredFourthOrder, w) = ℑzᵃᵃᶜ(i, j, k, grid, ℑ³zᵃᵃᶠ, w)
-symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, ::CenteredFourthOrder, c) = ℑzᵃᵃᶠ(i, j, k, grid, ℑ³zᵃᵃᶜ, c)
+@inline symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, ::CenteredFourthOrder, w) = ℑzᵃᵃᶜ(i, j, k, grid, ℑ³zᵃᵃᶠ, w)
+@inline symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, ::CenteredFourthOrder, c) = ℑzᵃᵃᶠ(i, j, k, grid, ℑ³zᵃᵃᶜ, c)

--- a/src/Advection/centered_fourth_order.jl
+++ b/src/Advection/centered_fourth_order.jl
@@ -115,7 +115,7 @@ end
 end
 
 @inline function momentum_flux_ww(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, ::C4, w) where {FT, TX, TY}
-    if k > 1 && i < grid.Nz
+    if k > 1 && k < grid.Nz
         return fourth_order_momentum_flux_ww(i, j, k, grid, w)
     else
         return momentum_flux_ww(i, j, k, grid, centered_second_order, w)
@@ -142,7 +142,7 @@ end
 end
 
 @inline function advective_tracer_flux_y(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, ::C4, v, c) where {FT, TX}
-    if j > 1 && i < grid.Ny
+    if j > 1 && j < grid.Ny
         return fourth_order_advective_tracer_flux_y(i, j, k, grid, v, c)
     else
         return advective_tracer_flux_y(i, j, k, grid, centered_second_order, v, c)
@@ -150,7 +150,7 @@ end
 end
 
 @inline function advective_tracer_flux_z(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, ::C4, w, c) where {FT, TX, TY}
-    if k > 1 && i < grid.Nz
+    if k > 1 && k < grid.Nz
         return fourth_order_advective_tracer_flux_z(i, j, k, grid, w, c)
     else
         return advective_tracer_flux_z(i, j, k, grid, centered_second_order, w, c)

--- a/src/Advection/centered_fourth_order.jl
+++ b/src/Advection/centered_fourth_order.jl
@@ -6,9 +6,7 @@ using Oceananigans.Grids
 
 struct CenteredFourthOrder <: AbstractAdvectionScheme end
 
-const C4 = CenteredFourthOrder
-
-const centered_second_order = CenteredSecondOrder()
+@inline halo_buffer(::CenteredFourthOrder) = 1
 
 @inline ℑ³xᶠᵃᵃ(i, j, k, grid, u) = @inbounds u[i, j, k] - δxᶠᵃᵃ(i, j, k, grid, δxᶜᵃᵃ, u) / 6
 @inline ℑ³xᶜᵃᵃ(i, j, k, grid, c) = @inbounds c[i, j, k] - δxᶜᵃᵃ(i, j, k, grid, δxᶠᵃᵃ, c) / 6
@@ -19,140 +17,11 @@ const centered_second_order = CenteredSecondOrder()
 @inline ℑ³zᵃᵃᶠ(i, j, k, grid, w) = @inbounds w[i, j, k] - δzᵃᵃᶠ(i, j, k, grid, δzᵃᵃᶜ, w) / 6
 @inline ℑ³zᵃᵃᶜ(i, j, k, grid, c) = @inbounds c[i, j, k] - δzᵃᵃᶜ(i, j, k, grid, δzᵃᵃᶠ, c) / 6
 
-# Momentum
+symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, ::CenteredFourthOrder, u) = ℑxᶜᵃᵃ(i, j, k, grid, ℑ³xᶠᵃᵃ, u)
+symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, ::CenteredFourthOrder, c) = ℑxᶠᵃᵃ(i, j, k, grid, ℑ³xᶜᵃᵃ, c)
 
-@inline fourth_order_momentum_flux_uu(i, j, k, grid, u)    = ℑxᶜᵃᵃ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) * ℑxᶜᵃᵃ(i, j, k, grid, ℑ³xᶠᵃᵃ, u)
-@inline fourth_order_momentum_flux_uv(i, j, k, grid, u, v) = ℑxᶠᵃᵃ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) * ℑyᵃᶠᵃ(i, j, k, grid, ℑ³yᵃᶜᵃ, u)
-@inline fourth_order_momentum_flux_uw(i, j, k, grid, u, w) = ℑxᶠᵃᵃ(i, j, k, grid, Az_ψᵃᵃᵃ, w) * ℑzᵃᵃᶠ(i, j, k, grid, ℑ³zᵃᵃᶜ, u)
+symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, ::CenteredFourthOrder, v) = ℑyᵃᶜᵃ(i, j, k, grid, ℑ³yᵃᶠᵃ, v)
+symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, ::CenteredFourthOrder, c) = ℑyᵃᶠᵃ(i, j, k, grid, ℑ³yᵃᶜᵃ, c)
 
-@inline fourth_order_momentum_flux_vu(i, j, k, grid, u, v) = ℑyᵃᶠᵃ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) * ℑxᶠᵃᵃ(i, j, k, grid, ℑ³xᶜᵃᵃ, v)
-@inline fourth_order_momentum_flux_vv(i, j, k, grid, v)    = ℑyᵃᶜᵃ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) * ℑyᵃᶜᵃ(i, j, k, grid, ℑ³yᵃᶠᵃ, v)
-@inline fourth_order_momentum_flux_vw(i, j, k, grid, v, w) = ℑyᵃᶠᵃ(i, j, k, grid, Az_ψᵃᵃᵃ, w) * ℑzᵃᵃᶠ(i, j, k, grid, ℑ³zᵃᵃᶜ, v)
-
-@inline fourth_order_momentum_flux_wu(i, j, k, grid, u, w) = ℑzᵃᵃᶠ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) * ℑxᶠᵃᵃ(i, j, k, grid, ℑ³xᶜᵃᵃ, w)
-@inline fourth_order_momentum_flux_wv(i, j, k, grid, v, w) = ℑzᵃᵃᶠ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) * ℑyᵃᶠᵃ(i, j, k, grid, ℑ³yᵃᶜᵃ, w)
-@inline fourth_order_momentum_flux_ww(i, j, k, grid, w)    = ℑzᵃᵃᶜ(i, j, k, grid, Az_ψᵃᵃᵃ, w) * ℑzᵃᵃᶜ(i, j, k, grid, ℑ³zᵃᵃᶠ, w)
-
-# Periodic directions!
-
-@inline momentum_flux_uu(i, j, k, grid, ::C4, u)    = fourth_order_momentum_flux_uu(i, j, k, grid, u)
-@inline momentum_flux_uv(i, j, k, grid, ::C4, u, v) = fourth_order_momentum_flux_uv(i, j, k, grid, u, v)
-@inline momentum_flux_uw(i, j, k, grid, ::C4, u, w) = fourth_order_momentum_flux_uw(i, j, k, grid, u, w)
-
-@inline momentum_flux_vu(i, j, k, grid, ::C4, u, v) = fourth_order_momentum_flux_vu(i, j, k, grid, u, v)
-@inline momentum_flux_vv(i, j, k, grid, ::C4, v)    = fourth_order_momentum_flux_vv(i, j, k, grid, v)
-@inline momentum_flux_vw(i, j, k, grid, ::C4, v, w) = fourth_order_momentum_flux_vw(i, j, k, grid, v, w)
-
-@inline momentum_flux_wu(i, j, k, grid, ::C4, u, w) = fourth_order_momentum_flux_wu(i, j, k, grid, u, w)
-@inline momentum_flux_wv(i, j, k, grid, ::C4, v, w) = fourth_order_momentum_flux_wv(i, j, k, grid, v, w)
-@inline momentum_flux_ww(i, j, k, grid, ::C4, w)    = fourth_order_momentum_flux_ww(i, j, k, grid, w)
-
-# Bounded directions
-
-@inline function momentum_flux_uu(i, j, k, grid::AbstractGrid{FT, <:Bounded}, ::C4, u) where FT
-    if i > 1 && i < grid.Nx
-        return fourth_order_momentum_flux_uu(i, j, k, grid, u)
-    else
-        return momentum_flux_uu(i, j, k, grid, centered_second_order, u)
-    end
-end
-
-@inline function momentum_flux_uv(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, ::C4, u, v) where {FT, TX}
-    if j > 1 && j < grid.Ny
-        return fourth_order_momentum_flux_uv(i, j, k, grid, u, v)
-    else
-        return momentum_flux_uv(i, j, k, grid, centered_second_order, u, v)
-    end
-end
-
-@inline function momentum_flux_uw(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, ::C4, u, w) where {FT, TX, TY}
-    if k > 1 && k < grid.Nz
-        return fourth_order_momentum_flux_uw(i, j, k, grid, u, w)
-    else
-        return momentum_flux_uw(i, j, k, grid, centered_second_order, u, w)
-    end
-end
-
-@inline function momentum_flux_vu(i, j, k, grid::AbstractGrid{FT, <:Bounded}, ::C4, u, v) where {FT}
-    if i > 1 && i < grid.Nx
-        return fourth_order_momentum_flux_vu(i, j, k, grid, u, v)
-    else
-        return momentum_flux_vu(i, j, k, grid, centered_second_order, u, v)
-    end
-end
-    
-
-@inline function momentum_flux_vv(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, ::C4, v) where {FT, TX}
-    if j > 1 && j < grid.Ny
-        return fourth_order_momentum_flux_vv(i, j, k, grid, v)
-    else
-        return momentum_flux_vv(i, j, k, grid, centered_second_order, v)
-    end
-end
-
-@inline function momentum_flux_vw(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, ::C4, v, w) where {FT, TX, TY}
-    if k > 1 && k < grid.Nz
-        return fourth_order_momentum_flux_vw(i, j, k, grid, v, w)
-    else
-        return momentum_flux_vw(i, j, k, grid, centered_second_order, v, w)
-    end
-end
-
-@inline function momentum_flux_wu(i, j, k, grid::AbstractGrid{FT, <:Bounded}, ::C4, u, w) where FT
-    if i > 1 && i < grid.Nx
-        return fourth_order_momentum_flux_wu(i, j, k, grid, u, w)
-    else
-        return momentum_flux_wu(i, j, k, grid, centered_second_order, u, w)
-    end
-end
-
-@inline function momentum_flux_wv(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, ::C4, v, w) where {FT, TX}
-    if j > 1 && j < grid.Ny
-        return fourth_order_momentum_flux_wv(i, j, k, grid, v, w)
-    else
-        return momentum_flux_wv(i, j, k, grid, centered_second_order, v, w)
-    end
-end
-
-@inline function momentum_flux_ww(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, ::C4, w) where {FT, TX, TY}
-    if k > 1 && k < grid.Nz
-        return fourth_order_momentum_flux_ww(i, j, k, grid, w)
-    else
-        return momentum_flux_ww(i, j, k, grid, centered_second_order, w)
-    end
-end
-
-
-# Tracers
-
-@inline fourth_order_advective_tracer_flux_x(i, j, k, grid, u, c) = Ax_ψᵃᵃᶠ(i, j, k, grid, u) * ℑxᶠᵃᵃ(i, j, k, grid, ℑ³xᶜᵃᵃ, c)
-@inline fourth_order_advective_tracer_flux_y(i, j, k, grid, v, c) = Ay_ψᵃᵃᶠ(i, j, k, grid, v) * ℑyᵃᶠᵃ(i, j, k, grid, ℑ³yᵃᶜᵃ, c)
-@inline fourth_order_advective_tracer_flux_z(i, j, k, grid, w, c) = Az_ψᵃᵃᵃ(i, j, k, grid, w) * ℑzᵃᵃᶠ(i, j, k, grid, ℑ³zᵃᵃᶜ, c)
-
-@inline advective_tracer_flux_x(i, j, k, grid, ::C4, u, c) = fourth_order_advective_tracer_flux_x(i, j, k, grid, u, c)
-@inline advective_tracer_flux_y(i, j, k, grid, ::C4, v, c) = fourth_order_advective_tracer_flux_y(i, j, k, grid, v, c)
-@inline advective_tracer_flux_z(i, j, k, grid, ::C4, w, c) = fourth_order_advective_tracer_flux_z(i, j, k, grid, w, c)
-
-@inline function advective_tracer_flux_x(i, j, k, grid::AbstractGrid{FT, <:Bounded}, ::C4, u, c) where FT
-    if i > 1 && i < grid.Nx
-        return fourth_order_advective_tracer_flux_x(i, j, k, grid, u, c)
-    else
-        return advective_tracer_flux_x(i, j, k, grid, centered_second_order, u, c)
-    end
-end
-
-@inline function advective_tracer_flux_y(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, ::C4, v, c) where {FT, TX}
-    if j > 1 && j < grid.Ny
-        return fourth_order_advective_tracer_flux_y(i, j, k, grid, v, c)
-    else
-        return advective_tracer_flux_y(i, j, k, grid, centered_second_order, v, c)
-    end
-end
-
-@inline function advective_tracer_flux_z(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, ::C4, w, c) where {FT, TX, TY}
-    if k > 1 && k < grid.Nz
-        return fourth_order_advective_tracer_flux_z(i, j, k, grid, w, c)
-    else
-        return advective_tracer_flux_z(i, j, k, grid, centered_second_order, w, c)
-    end
-end
+symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, ::CenteredFourthOrder, w) = ℑzᵃᵃᶜ(i, j, k, grid, ℑ³zᵃᵃᶠ, w)
+symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, ::CenteredFourthOrder, c) = ℑzᵃᵃᶠ(i, j, k, grid, ℑ³zᵃᵃᶜ, c)

--- a/src/Advection/centered_fourth_order.jl
+++ b/src/Advection/centered_fourth_order.jl
@@ -4,7 +4,7 @@ using Oceananigans.Grids
 ##### Centered fourth-order advection scheme
 #####
 
-struct CenteredFourthOrder <: AbstractAdvectionScheme end
+struct CenteredFourthOrder <: AbstractCenteredAdvectionScheme end
 
 @inline halo_buffer(::CenteredFourthOrder) = 1
 

--- a/src/Advection/centered_schemes.jl
+++ b/src/Advection/centered_schemes.jl
@@ -1,0 +1,115 @@
+# Momentum
+
+@inline momentum_flux_uu(i, j, k, grid, adv::AbstractSymmetricAdvectionScheme, u) = 
+    Axᵃᵃᶠ(i, j, k, grid) * symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, adv, u) * symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, adv, u)
+
+@inline fourth_order_momentum_flux_uv(i, j, k, grid, u, v) = ℑxᶠᵃᵃ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) * ℑyᵃᶠᵃ(i, j, k, grid, ℑ³yᵃᶜᵃ, u)
+@inline fourth_order_momentum_flux_uw(i, j, k, grid, u, w) = ℑxᶠᵃᵃ(i, j, k, grid, Az_ψᵃᵃᵃ, w) * ℑzᵃᵃᶠ(i, j, k, grid, ℑ³zᵃᵃᶜ, u)
+
+@inline fourth_order_momentum_flux_vu(i, j, k, grid, u, v) = ℑyᵃᶠᵃ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) * ℑxᶠᵃᵃ(i, j, k, grid, ℑ³xᶜᵃᵃ, v)
+@inline fourth_order_momentum_flux_vv(i, j, k, grid, v)    = ℑyᵃᶜᵃ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) * ℑyᵃᶜᵃ(i, j, k, grid, ℑ³yᵃᶠᵃ, v)
+@inline fourth_order_momentum_flux_vw(i, j, k, grid, v, w) = ℑyᵃᶠᵃ(i, j, k, grid, Az_ψᵃᵃᵃ, w) * ℑzᵃᵃᶠ(i, j, k, grid, ℑ³zᵃᵃᶜ, v)
+
+@inline fourth_order_momentum_flux_wu(i, j, k, grid, u, w) = ℑzᵃᵃᶠ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) * ℑxᶠᵃᵃ(i, j, k, grid, ℑ³xᶜᵃᵃ, w)
+@inline fourth_order_momentum_flux_wv(i, j, k, grid, v, w) = ℑzᵃᵃᶠ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) * ℑyᵃᶠᵃ(i, j, k, grid, ℑ³yᵃᶜᵃ, w)
+@inline fourth_order_momentum_flux_ww(i, j, k, grid, w)    = ℑzᵃᵃᶜ(i, j, k, grid, Az_ψᵃᵃᵃ, w) * ℑzᵃᵃᶜ(i, j, k, grid, ℑ³zᵃᵃᶠ, w)
+
+# Periodic directions!
+
+@inline momentum_flux_uu(i, j, k, grid, ::C4, u)    = fourth_order_momentum_flux_uu(i, j, k, grid, u)
+@inline momentum_flux_uv(i, j, k, grid, ::C4, u, v) = fourth_order_momentum_flux_uv(i, j, k, grid, u, v)
+@inline momentum_flux_uw(i, j, k, grid, ::C4, u, w) = fourth_order_momentum_flux_uw(i, j, k, grid, u, w)
+
+@inline momentum_flux_vu(i, j, k, grid, ::C4, u, v) = fourth_order_momentum_flux_vu(i, j, k, grid, u, v)
+@inline momentum_flux_vv(i, j, k, grid, ::C4, v)    = fourth_order_momentum_flux_vv(i, j, k, grid, v)
+@inline momentum_flux_vw(i, j, k, grid, ::C4, v, w) = fourth_order_momentum_flux_vw(i, j, k, grid, v, w)
+
+@inline momentum_flux_wu(i, j, k, grid, ::C4, u, w) = fourth_order_momentum_flux_wu(i, j, k, grid, u, w)
+@inline momentum_flux_wv(i, j, k, grid, ::C4, v, w) = fourth_order_momentum_flux_wv(i, j, k, grid, v, w)
+@inline momentum_flux_ww(i, j, k, grid, ::C4, w)    = fourth_order_momentum_flux_ww(i, j, k, grid, w)
+
+# Bounded directions
+
+@inline function momentum_flux_uu(i, j, k, grid::AbstractGrid{FT, <:Bounded}, ::C4, u) where FT
+    if i > 1 && i < grid.Nx
+        return fourth_order_momentum_flux_uu(i, j, k, grid, u)
+    else
+        return momentum_flux_uu(i, j, k, grid, centered_second_order, u)
+    end
+end
+
+@inline function momentum_flux_uv(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, ::C4, u, v) where {FT, TX}
+    if j > 1 && j < grid.Ny
+        return fourth_order_momentum_flux_uv(i, j, k, grid, u, v)
+    else
+        return momentum_flux_uv(i, j, k, grid, centered_second_order, u, v)
+    end
+end
+
+@inline function momentum_flux_uw(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, ::C4, u, w) where {FT, TX, TY}
+    if k > 1 && k < grid.Nz
+        return fourth_order_momentum_flux_uw(i, j, k, grid, u, w)
+    else
+        return momentum_flux_uw(i, j, k, grid, centered_second_order, u, w)
+    end
+end
+
+@inline function momentum_flux_vu(i, j, k, grid::AbstractGrid{FT, <:Bounded}, ::C4, u, v) where {FT}
+    if i > 1 && i < grid.Nx
+        return fourth_order_momentum_flux_vu(i, j, k, grid, u, v)
+    else
+        return momentum_flux_vu(i, j, k, grid, centered_second_order, u, v)
+    end
+end
+    
+
+@inline function momentum_flux_vv(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, ::C4, v) where {FT, TX}
+    if j > 1 && j < grid.Ny
+        return fourth_order_momentum_flux_vv(i, j, k, grid, v)
+    else
+        return momentum_flux_vv(i, j, k, grid, centered_second_order, v)
+    end
+end
+
+@inline function momentum_flux_vw(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, ::C4, v, w) where {FT, TX, TY}
+    if k > 1 && k < grid.Nz
+        return fourth_order_momentum_flux_vw(i, j, k, grid, v, w)
+    else
+        return momentum_flux_vw(i, j, k, grid, centered_second_order, v, w)
+    end
+end
+
+@inline function momentum_flux_wu(i, j, k, grid::AbstractGrid{FT, <:Bounded}, ::C4, u, w) where FT
+    if i > 1 && i < grid.Nx
+        return fourth_order_momentum_flux_wu(i, j, k, grid, u, w)
+    else
+        return momentum_flux_wu(i, j, k, grid, centered_second_order, u, w)
+    end
+end
+
+@inline function momentum_flux_wv(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, ::C4, v, w) where {FT, TX}
+    if j > 1 && j < grid.Ny
+        return fourth_order_momentum_flux_wv(i, j, k, grid, v, w)
+    else
+        return momentum_flux_wv(i, j, k, grid, centered_second_order, v, w)
+    end
+end
+
+@inline function momentum_flux_ww(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, ::C4, w) where {FT, TX, TY}
+    if k > 1 && k < grid.Nz
+        return fourth_order_momentum_flux_ww(i, j, k, grid, w)
+    else
+        return momentum_flux_ww(i, j, k, grid, centered_second_order, w)
+    end
+end
+
+
+# Tracers
+
+@inline fourth_order_advective_tracer_flux_x(i, j, k, grid, u, c) = Ax_ψᵃᵃᶠ(i, j, k, grid, u) * ℑxᶠᵃᵃ(i, j, k, grid, ℑ³xᶜᵃᵃ, c)
+@inline fourth_order_advective_tracer_flux_y(i, j, k, grid, v, c) = Ay_ψᵃᵃᶠ(i, j, k, grid, v) * ℑyᵃᶠᵃ(i, j, k, grid, ℑ³yᵃᶜᵃ, c)
+@inline fourth_order_advective_tracer_flux_z(i, j, k, grid, w, c) = Az_ψᵃᵃᵃ(i, j, k, grid, w) * ℑzᵃᵃᶠ(i, j, k, grid, ℑ³zᵃᵃᶜ, c)
+
+@inline advective_tracer_flux_x(i, j, k, grid, ::C4, u, c) = fourth_order_advective_tracer_flux_x(i, j, k, grid, u, c)
+@inline advective_tracer_flux_y(i, j, k, grid, ::C4, v, c) = fourth_order_advective_tracer_flux_y(i, j, k, grid, v, c)
+@inline advective_tracer_flux_z(i, j, k, grid, ::C4, w, c) = fourth_order_advective_tracer_flux_z(i, j, k, grid, w, c)

--- a/src/Advection/topologically_conditional_interpolation.jl
+++ b/src/Advection/topologically_conditional_interpolation.jl
@@ -1,0 +1,28 @@
+# Translation for periodic biasections, logic for bounded biasections
+
+@inline outside_buffer(i, N, scheme) = i > halo_buffer(scheme) && i < N + 1 - halo_buffer(scheme)
+
+for bias in (:symmetric, :left_biased, :right_biased)
+
+    altbias = Symbol(:_, bias)
+
+    @eval begin
+        @inline $(altbias)_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u) = $(bias)_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
+        @inline $(altbias)_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c) = $(bias)_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
+
+        @inline $(altbias)_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v) = $(bias)_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
+        @inline $(altbias)_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c) = $(bias)_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
+
+        @inline $(altbias)_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w) = $(bias)_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
+        @inline $(altbias)_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c) = $(bias)_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
+
+        @inline $(altbias)_interpolate_xᶜᵃᵃ(i, j, k, grid::AbstractGrid{FT, <:Bounded},         scheme, u) where FT           = ifelse(outside_buffer(i, grid.Nx, scheme), $(bias)_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u), ℑxᶜᵃᵃ(i, j, k, grid, u)) 
+        @inline $(altbias)_interpolate_xᶠᵃᵃ(i, j, k, grid::AbstractGrid{FT, <:Bounded},         scheme, c) where FT           = ifelse(outside_buffer(i, grid.Nx, scheme), $(bias)_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c), ℑxᶠᵃᵃ(i, j, k, grid, c))
+
+        @inline $(altbias)_interpolate_yᵃᶜᵃ(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded},     scheme, v) where {FT, TX}     = ifelse(outside_buffer(j, grid.Ny, scheme), $(bias)_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v), ℑyᵃᶜᵃ(i, j, k, grid, v))
+        @inline $(altbias)_interpolate_yᵃᶠᵃ(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded},     scheme, c) where {FT, TX}     = ifelse(outside_buffer(j, grid.Ny, scheme), $(bias)_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c), ℑyᵃᶠᵃ(i, j, k, grid, c))
+
+        @inline $(altbias)_interpolate_zᵃᵃᶜ(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, scheme, w) where {FT, TX, TY} = ifelse(outside_buffer(k, grid.Nz, scheme), $(bias)_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w), ℑzᵃᵃᶜ(i, j, k, grid, w))
+        @inline $(altbias)_interpolate_zᵃᵃᶠ(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, scheme, c) where {FT, TX, TY} = ifelse(outside_buffer(k, grid.Nz, scheme), $(bias)_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c), ℑzᵃᵃᶠ(i, j, k, grid, c))
+    end
+end

--- a/src/Advection/topologically_conditional_interpolation.jl
+++ b/src/Advection/topologically_conditional_interpolation.jl
@@ -1,28 +1,38 @@
 # Translation for periodic biasections, logic for bounded biasections
 
+using Oceananigans.Grids: AbstractGrid, Bounded
+
 @inline outside_buffer(i, N, scheme) = i > halo_buffer(scheme) && i < N + 1 - halo_buffer(scheme)
 
 for bias in (:symmetric, :left_biased, :right_biased)
+    for (d, ξ) in enumerate((:x, :y, :z))
 
-    altbias = Symbol(:_, bias)
+        code = [:ᵃ, :ᵃ, :ᵃ]
 
-    @eval begin
-        @inline $(altbias)_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u) = $(bias)_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
-        @inline $(altbias)_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c) = $(bias)_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
+        for loc in (:ᶜ, :ᶠ)
+            code[d] = loc
+            second_order_interp = Symbol(:ℑ, ξ, code...)
+            interp = Symbol(bias, :_interpolate_, ξ, code...)
+            alt_interp = Symbol(:_, interp)
 
-        @inline $(altbias)_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v) = $(bias)_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
-        @inline $(altbias)_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c) = $(bias)_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
+            @eval $alt_interp(i, j, k, grid, scheme, ψ) = $interp(i, j, k, grid, scheme, ψ)
 
-        @inline $(altbias)_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w) = $(bias)_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
-        @inline $(altbias)_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c) = $(bias)_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
-
-        @inline $(altbias)_interpolate_xᶜᵃᵃ(i, j, k, grid::AbstractGrid{FT, <:Bounded},         scheme, u) where FT           = ifelse(outside_buffer(i, grid.Nx, scheme), $(bias)_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u), ℑxᶜᵃᵃ(i, j, k, grid, u)) 
-        @inline $(altbias)_interpolate_xᶠᵃᵃ(i, j, k, grid::AbstractGrid{FT, <:Bounded},         scheme, c) where FT           = ifelse(outside_buffer(i, grid.Nx, scheme), $(bias)_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c), ℑxᶠᵃᵃ(i, j, k, grid, c))
-
-        @inline $(altbias)_interpolate_yᵃᶜᵃ(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded},     scheme, v) where {FT, TX}     = ifelse(outside_buffer(j, grid.Ny, scheme), $(bias)_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v), ℑyᵃᶜᵃ(i, j, k, grid, v))
-        @inline $(altbias)_interpolate_yᵃᶠᵃ(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded},     scheme, c) where {FT, TX}     = ifelse(outside_buffer(j, grid.Ny, scheme), $(bias)_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c), ℑyᵃᶠᵃ(i, j, k, grid, c))
-
-        @inline $(altbias)_interpolate_zᵃᵃᶜ(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, scheme, w) where {FT, TX, TY} = ifelse(outside_buffer(k, grid.Nz, scheme), $(bias)_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w), ℑzᵃᵃᶜ(i, j, k, grid, w))
-        @inline $(altbias)_interpolate_zᵃᵃᶠ(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, scheme, c) where {FT, TX, TY} = ifelse(outside_buffer(k, grid.Nz, scheme), $(bias)_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c), ℑzᵃᵃᶠ(i, j, k, grid, c))
+            if ξ == :x
+                @eval begin
+                    $alt_interp(i, j, k, grid::AbstractGrid{FT, <:Bounded}, scheme, ψ) where FT =
+                        ifelse(outside_buffer(i, grid.Nx, scheme), $interp(i, j, k, grid, scheme, ψ), $second_order_interp(i, j, k, grid, ψ))
+                end
+            elseif ξ == :y
+                @eval begin
+                    $alt_interp(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, scheme, ψ) where {FT, TX} =
+                        ifelse(outside_buffer(j, grid.Ny, scheme), $interp(i, j, k, grid, scheme, ψ), $second_order_interp(i, j, k, grid, ψ))
+                end
+            elseif ξ == :z
+                @eval begin
+                    $alt_interp(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, scheme, ψ) where {FT, TX, TY} =
+                        ifelse(outside_buffer(k, grid.Nz, scheme), $interp(i, j, k, grid, scheme, ψ), $second_order_interp(i, j, k, grid, ψ))
+                end
+            end
+        end
     end
 end

--- a/src/Advection/topologically_conditional_interpolation.jl
+++ b/src/Advection/topologically_conditional_interpolation.jl
@@ -1,8 +1,18 @@
-# Translation for periodic biasections, logic for bounded biasections
+#####
+##### This file provides functions that conditionally-evaluate interpolation operators
+##### near boundaries in bounded directions.
+#####
+##### For example, the function _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c) either
+#####
+#####     1. Always returns symmetric_interpolate_xᶠᵃᵃ if the x-direction is Periodic; or
+#####
+#####     2. Returns symmetric_interpolate_xᶠᵃᵃ if the x-direction is Bounded and index i is not
+#####        close to the boundary, or a second-order interpolation if i is close to a boundary.
+#####
 
 using Oceananigans.Grids: AbstractGrid, Bounded
 
-@inline outside_buffer(i, N, scheme) = i > halo_buffer(scheme) && i < N + 1 - halo_buffer(scheme)
+@inline outside_buffer(i, N, scheme) = i > boundary_buffer(scheme) && i < N + 1 - boundary_buffer(scheme)
 
 for bias in (:symmetric, :left_biased, :right_biased)
     for (d, ξ) in enumerate((:x, :y, :z))
@@ -15,22 +25,24 @@ for bias in (:symmetric, :left_biased, :right_biased)
             interp = Symbol(bias, :_interpolate_, ξ, code...)
             alt_interp = Symbol(:_, interp)
 
+            # Simple translation for Periodic directions (fallback)
             @eval $alt_interp(i, j, k, grid, scheme, ψ) = $interp(i, j, k, grid, scheme, ψ)
 
+            # Conditional high-order interpolation in Bounded directions
             if ξ == :x
                 @eval begin
-                    $alt_interp(i, j, k, grid::AbstractGrid{FT, <:Bounded}, scheme, ψ) where FT =
-                        ifelse(outside_buffer(i, grid.Nx, scheme), $interp(i, j, k, grid, scheme, ψ), $second_order_interp(i, j, k, grid, ψ))
+                    @inline $alt_interp(i, j, k, grid::AbstractGrid{FT, <:Bounded}, scheme, ψ) where FT =
+                        outside_buffer(i, grid.Nx, scheme) ? $interp(i, j, k, grid, scheme, ψ) : $second_order_interp(i, j, k, grid, ψ)
                 end
             elseif ξ == :y
                 @eval begin
-                    $alt_interp(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, scheme, ψ) where {FT, TX} =
-                        ifelse(outside_buffer(j, grid.Ny, scheme), $interp(i, j, k, grid, scheme, ψ), $second_order_interp(i, j, k, grid, ψ))
+                    @inline $alt_interp(i, j, k, grid::AbstractGrid{FT, TX, <:Bounded}, scheme, ψ) where {FT, TX} =
+                        outside_buffer(j, grid.Ny, scheme) ? $interp(i, j, k, grid, scheme, ψ) : $second_order_interp(i, j, k, grid, ψ)
                 end
             elseif ξ == :z
                 @eval begin
-                    $alt_interp(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, scheme, ψ) where {FT, TX, TY} =
-                        ifelse(outside_buffer(k, grid.Nz, scheme), $interp(i, j, k, grid, scheme, ψ), $second_order_interp(i, j, k, grid, ψ))
+                    @inline $alt_interp(i, j, k, grid::AbstractGrid{FT, TX, TY, <:Bounded}, scheme, ψ) where {FT, TX, TY} =
+                        outside_buffer(k, grid.Nz, scheme) ? $interp(i, j, k, grid, scheme, ψ) : $second_order_interp(i, j, k, grid, ψ)
                 end
             end
         end

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -1,6 +1,9 @@
 #####
 ##### Momentum and tracer advective flux operators for upwind-biased advection schemes
 #####
+##### See topologically_conditional_interpolation.jl for an explanation of the underscore-prepended
+##### functions _symmetric_interpolate_*, _left_biased_interpolate_*, and _right_biased_interpolate_*.
+#####
 
 @inline upwind_biased_product(ũ, ψᴸ, ψᴿ) = ((ũ + abs(ũ)) * ψᴸ + (ũ - abs(ũ)) * ψᴿ) / 2
 

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -1,0 +1,115 @@
+@inline upwind_biased_product(ũ, ψᴸ, ψᴿ) = ((ũ + abs(ũ)) * ψᴸ + (ũ - abs(ũ)) * ψᴿ) / 2
+
+""" Advection of u by u. """
+@inline function momentum_flux_uu(i, j, k, grid, scheme, u)
+
+    ũ  =    _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u) 
+    uᴸ =  _left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
+    uᴿ = _right_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
+
+    return Axᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ũ, uᴸ, uᴿ)
+end
+
+""" Advection of u by v. """
+@inline function momentum_flux_uv(i, j, k, grid, scheme, u, v)
+
+    ṽ  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
+    uᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
+    uᴿ = _right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
+
+    return Ayᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ṽ, uᴸ, uᴿ)
+end
+
+""" Advection of u by w. """
+@inline function momentum_flux_uw(i, j, k, grid, scheme, u, w)
+
+    w̃  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
+    uᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
+    uᴿ = _right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
+
+    return Azᵃᵃᵃ(i, j, k, grid) * upwind_biased_product(w̃, uᴸ, uᴿ)
+end
+
+""" Advection of v by u. """
+@inline function momentum_flux_vu(i, j, k, grid, scheme, u, v)
+
+    ũ  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
+    vᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
+    vᴿ = _right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
+ 
+    return Axᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ũ, vᴸ, vᴿ)
+end
+
+""" Advection of v by v. """
+@inline function momentum_flux_vv(i, j, k, grid, scheme, v)
+
+    ṽ  =    _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
+    vᴸ =  _left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
+    vᴿ = _right_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
+
+    return Ayᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ṽ, vᴸ, vᴿ)
+end
+
+""" Advection of v by w. """
+@inline function momentum_flux_vw(i, j, k, grid, scheme, u, w)
+
+    w̃  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
+    vᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
+    vᴿ = _right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
+
+    return Azᵃᵃᵃ(i, j, k, grid) * upwind_biased_product(w̃, vᴸ, vᴿ)
+end
+
+""" Advection of u by w. """
+@inline function momentum_flux_wu(i, j, k, grid, scheme, u, w)
+
+    ũ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
+    wᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
+    wᴿ = _right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
+
+    return Axᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ũ, wᴸ, wᴿ)
+end
+
+@inline function momentum_flux_wv(i, j, k, grid, scheme, v, w)
+
+    ṽ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
+    wᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
+    wᴿ = _right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
+
+    return Ayᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ṽ, wᴸ, wᴿ)
+end
+
+@inline function momentum_flux_ww(i, j, k, grid, scheme, w)
+
+    w̃  =    _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
+    wᴸ =  _left_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
+    wᴿ = _right_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
+
+    return Azᵃᵃᵃ(i, j, k, grid) * upwind_biased_product(w̃, wᴸ, wᴿ)
+    
+@inline function advective_tracer_flux_x(i, j, k, grid, scheme, u, c) 
+
+    @inbounds ũ = u[i, j, k]
+    cᴸ = _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
+    cᴿ = _right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
+
+    Axᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ũ, cᴸ, cᴿ)
+end
+
+@inline function advective_tracer_flux_y(i, j, k, grid, scheme, v, c)
+
+    @inbounds ṽ = v[i, j, k]
+    cᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
+    cᴿ = _right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
+
+    return Ayᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ṽ, cᴸ, cᴿ)
+end
+
+@inline function advective_tracer_flux_z(i, j, k, grid, scheme, w, c)
+
+    @inbounds w̃ = w[i, j, k]
+    cᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
+    cᴿ = _right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
+
+    return Az_ψᵃᵃᵃ(i, j, k, grid) * upwind_biased_product(w̃, cᴸ, cᴿ) 
+end

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -1,9 +1,17 @@
+#####
+##### Momentum and tracer advective flux operators for upwind-biased advection schemes
+#####
+
 @inline upwind_biased_product(ũ, ψᴸ, ψᴿ) = ((ũ + abs(ũ)) * ψᴸ + (ũ - abs(ũ)) * ψᴿ) / 2
 
-""" Advection of u by u. """
-@inline function momentum_flux_uu(i, j, k, grid, scheme, u)
+#####
+##### Momentum advection operators
+#####
 
-    ũ  =    _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u) 
+""" Advection of u by u. """
+@inline function momentum_flux_uu(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, u)
+
+    ũ  =    _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
     uᴸ =  _left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
     uᴿ = _right_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
 
@@ -11,7 +19,7 @@
 end
 
 """ Advection of u by v. """
-@inline function momentum_flux_uv(i, j, k, grid, scheme, u, v)
+@inline function momentum_flux_uv(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, u, v)
 
     ṽ  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
     uᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
@@ -21,7 +29,7 @@ end
 end
 
 """ Advection of u by w. """
-@inline function momentum_flux_uw(i, j, k, grid, scheme, u, w)
+@inline function momentum_flux_uw(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, u, w)
 
     w̃  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
     uᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
@@ -31,7 +39,7 @@ end
 end
 
 """ Advection of v by u. """
-@inline function momentum_flux_vu(i, j, k, grid, scheme, u, v)
+@inline function momentum_flux_vu(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, u, v)
 
     ũ  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
     vᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
@@ -41,7 +49,7 @@ end
 end
 
 """ Advection of v by v. """
-@inline function momentum_flux_vv(i, j, k, grid, scheme, v)
+@inline function momentum_flux_vv(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, v)
 
     ṽ  =    _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
     vᴸ =  _left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
@@ -51,7 +59,7 @@ end
 end
 
 """ Advection of v by w. """
-@inline function momentum_flux_vw(i, j, k, grid, scheme, u, w)
+@inline function momentum_flux_vw(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, v, w)
 
     w̃  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
     vᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
@@ -61,7 +69,7 @@ end
 end
 
 """ Advection of u by w. """
-@inline function momentum_flux_wu(i, j, k, grid, scheme, u, w)
+@inline function momentum_flux_wu(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, u, w)
 
     ũ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
     wᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
@@ -70,7 +78,7 @@ end
     return Axᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ũ, wᴸ, wᴿ)
 end
 
-@inline function momentum_flux_wv(i, j, k, grid, scheme, v, w)
+@inline function momentum_flux_wv(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, v, w)
 
     ṽ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
     wᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
@@ -79,24 +87,29 @@ end
     return Ayᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ṽ, wᴸ, wᴿ)
 end
 
-@inline function momentum_flux_ww(i, j, k, grid, scheme, w)
+@inline function momentum_flux_ww(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, w)
 
     w̃  =    _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
     wᴸ =  _left_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
     wᴿ = _right_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
 
     return Azᵃᵃᵃ(i, j, k, grid) * upwind_biased_product(w̃, wᴸ, wᴿ)
+end
+
+#####
+##### Tracer advection operators
+#####
     
-@inline function advective_tracer_flux_x(i, j, k, grid, scheme, u, c) 
+@inline function advective_tracer_flux_x(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, u, c) 
 
     @inbounds ũ = u[i, j, k]
-    cᴸ = _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
+    cᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
     cᴿ = _right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
 
     Axᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ũ, cᴸ, cᴿ)
 end
 
-@inline function advective_tracer_flux_y(i, j, k, grid, scheme, v, c)
+@inline function advective_tracer_flux_y(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, v, c)
 
     @inbounds ṽ = v[i, j, k]
     cᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
@@ -105,11 +118,11 @@ end
     return Ayᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ṽ, cᴸ, cᴿ)
 end
 
-@inline function advective_tracer_flux_z(i, j, k, grid, scheme, w, c)
+@inline function advective_tracer_flux_z(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, w, c)
 
     @inbounds w̃ = w[i, j, k]
     cᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
     cᴿ = _right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
 
-    return Az_ψᵃᵃᵃ(i, j, k, grid) * upwind_biased_product(w̃, cᴸ, cᴿ) 
+    return Azᵃᵃᵃ(i, j, k, grid) * upwind_biased_product(w̃, cᴸ, cᴿ) 
 end

--- a/src/Advection/upwind_biased_third_order.jl
+++ b/src/Advection/upwind_biased_third_order.jl
@@ -1,0 +1,33 @@
+using Oceananigans.Grids
+
+#####
+##### Centered fourth-order advection scheme
+#####
+
+struct UpwindBiasedThirdOrder <: AbstractUpwindBiasedAdvectionScheme end
+
+@inline halo_buffer(::UpwindBiasedThirdOrder) = 1
+
+symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = ℑxᶠᵃᵃ(i, j, k, grid, c)
+symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = ℑyᵃᶠᵃ(i, j, k, grid, c)
+symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = ℑzᵃᵃᶠ(i, j, k, grid, c)
+
+symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, u) = ℑxᶜᵃᵃ(i, j, k, grid, u)
+symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, v) = ℑyᵃᶜᵃ(i, j, k, grid, v)
+symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, ::UpwindBiasedThirdOrder, w) = ℑzᵃᵃᶜ(i, j, k, grid, w)
+
+left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (6 * ℑxᶠᵃᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑxᶠᵃᵃ(i-1, j, k, grid, c)) / 6 
+left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (6 * ℑyᵃᶠᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑyᵃᶠᵃ(i, j-1, k, grid, c)) / 6 
+left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (6 * ℑzᵃᵃᶠ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑzᵃᵃᶠ(i, j, k-1, grid, c)) / 6 
+
+left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, u) = left_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, u)
+left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, v) = left_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, v)
+left_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, w) = left_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, w)
+
+right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (2 * ℑxᶠᵃᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑxᶠᵃᵃ(i+1, j, k, grid, c)) / 6 
+right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (2 * ℑyᵃᶠᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑyᵃᶠᵃ(i, j+1, k, grid, c)) / 6
+right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (2 * ℑzᵃᵃᶠ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑzᵃᵃᶠ(i, j, k+1, grid, c)) / 6
+
+right_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, u) = right_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, u)
+right_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, v) = right_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, v)
+right_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, w) = right_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, w)

--- a/src/Advection/upwind_biased_third_order.jl
+++ b/src/Advection/upwind_biased_third_order.jl
@@ -6,28 +6,28 @@ using Oceananigans.Grids
 
 struct UpwindBiasedThirdOrder <: AbstractUpwindBiasedAdvectionScheme end
 
-@inline halo_buffer(::UpwindBiasedThirdOrder) = 1
+@inline boundary_buffer(::UpwindBiasedThirdOrder) = 1
 
-symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = ℑxᶠᵃᵃ(i, j, k, grid, c)
-symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = ℑyᵃᶠᵃ(i, j, k, grid, c)
-symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = ℑzᵃᵃᶠ(i, j, k, grid, c)
+@inline symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = ℑxᶠᵃᵃ(i, j, k, grid, c)
+@inline symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = ℑyᵃᶠᵃ(i, j, k, grid, c)
+@inline symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = ℑzᵃᵃᶠ(i, j, k, grid, c)
 
-symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, u) = ℑxᶜᵃᵃ(i, j, k, grid, u)
-symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, v) = ℑyᵃᶜᵃ(i, j, k, grid, v)
-symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, ::UpwindBiasedThirdOrder, w) = ℑzᵃᵃᶜ(i, j, k, grid, w)
+@inline symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, u) = ℑxᶜᵃᵃ(i, j, k, grid, u)
+@inline symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, v) = ℑyᵃᶜᵃ(i, j, k, grid, v)
+@inline symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, ::UpwindBiasedThirdOrder, w) = ℑzᵃᵃᶜ(i, j, k, grid, w)
 
-left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (6 * ℑxᶠᵃᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑxᶠᵃᵃ(i-1, j, k, grid, c)) / 6 
-left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (6 * ℑyᵃᶠᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑyᵃᶠᵃ(i, j-1, k, grid, c)) / 6 
-left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (6 * ℑzᵃᵃᶠ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑzᵃᵃᶠ(i, j, k-1, grid, c)) / 6 
+@inline left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (6 * ℑxᶠᵃᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑxᶠᵃᵃ(i-1, j, k, grid, c)) / 6 
+@inline left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (6 * ℑyᵃᶠᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑyᵃᶠᵃ(i, j-1, k, grid, c)) / 6 
+@inline left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (6 * ℑzᵃᵃᶠ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑzᵃᵃᶠ(i, j, k-1, grid, c)) / 6 
 
-left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, u) = left_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, u)
-left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, v) = left_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, v)
-left_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, w) = left_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, w)
+@inline left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, u) = left_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, u)
+@inline left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, v) = left_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, v)
+@inline left_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, w) = left_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, w)
 
-right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (2 * ℑxᶠᵃᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑxᶠᵃᵃ(i+1, j, k, grid, c)) / 6 
-right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (2 * ℑyᵃᶠᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑyᵃᶠᵃ(i, j+1, k, grid, c)) / 6
-right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (2 * ℑzᵃᵃᶠ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑzᵃᵃᶠ(i, j, k+1, grid, c)) / 6
+@inline right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (2 * ℑxᶠᵃᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑxᶠᵃᵃ(i+1, j, k, grid, c)) / 6 
+@inline right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (2 * ℑyᵃᶠᵃ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑyᵃᶠᵃ(i, j+1, k, grid, c)) / 6
+@inline right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, ::UpwindBiasedThirdOrder, c) = @inbounds (2 * ℑzᵃᵃᶠ(i, j, k, grid, c) + 4 * c[i, j, k] - ℑzᵃᵃᶠ(i, j, k+1, grid, c)) / 6
 
-right_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, u) = right_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, u)
-right_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, v) = right_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, v)
-right_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, w) = right_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, w)
+@inline right_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, u) = right_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, u)
+@inline right_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, v) = right_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, v)
+@inline right_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme::UpwindBiasedThirdOrder, w) = right_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, w)

--- a/src/Operators/interpolation_operators.jl
+++ b/src/Operators/interpolation_operators.jl
@@ -32,17 +32,6 @@ const RCG = RegularCartesianGrid
 @inline ℑzᵃᵃᶠ(i, j, k, grid::AG{FT}, f::F, args...) where {FT, F<:Function} = FT(0.5) * (f(i, j, k-1, grid, args...) + f(i, j, k,   grid, args...))
 
 #####
-##### "Flux interpolation" operators of the form ℑ(A*f) where A is an area and f is an array.
-#####
-
-@inline ℑᴶxᶜᵃᵃ(i, j, k, grid, u) = ℑxᶜᵃᵃ(i, j, k, grid, Ax_u, u)
-@inline ℑᴶxᶠᵃᵃ(i, j, k, grid, c) = ℑxᶠᵃᵃ(i, j, k, grid, Ax_c, c)
-@inline ℑᴶyᵃᶜᵃ(i, j, k, grid, v) = ℑyᵃᶜᵃ(i, j, k, grid, Ay_v, v)
-@inline ℑᴶyᵃᶠᵃ(i, j, k, grid, c) = ℑyᵃᶠᵃ(i, j, k, grid, Ay_c, c)
-@inline ℑᴶzᵃᵃᶜ(i, j, k, grid, w) = ℑzᵃᵃᶜ(i, j, k, grid, Az_w, w)
-@inline ℑᴶzᵃᵃᶠ(i, j, k, grid, c) = ℑzᵃᵃᶠ(i, j, k, grid, Az_c, c)
-
-#####
 ##### Convenience operators for "interpolating constants"
 #####
 

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -18,6 +18,14 @@ function time_stepping_works_with_closure(arch, FT, Closure)
     return true  # Test that no errors/crashes happen when time stepping.
 end
 
+function time_stepping_works_with_advection_scheme(arch, advection_scheme)
+    # Use halo=(2, 2, 2) to accomodate fourth-order advection scheme
+    grid = RegularCartesianGrid(size=(1, 1, 1), halo=(2, 2, 2), extent=(1, 2, 3))
+    model = IncompressibleModel(grid=grid, architecture=arch, advection=advection_scheme)
+    time_step!(model, 1, euler=true)
+    return true  # Test that no errors/crashes happen when time stepping.
+end
+
 function time_stepping_works_with_nothing_closure(arch, FT)
     grid = RegularCartesianGrid(FT; size=(1, 1, 1), extent=(1, 2, 3))
     model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, closure=nothing)
@@ -153,6 +161,8 @@ Closures = (IsotropicDiffusivity, AnisotropicDiffusivity,
             SmagorinskyLilly, BlasiusSmagorinsky,
             AnisotropicMinimumDissipation, RozemaAnisotropicMinimumDissipation)
 
+advection_schemes = (CenteredSecondOrder(), UpwindBiasedThirdOrder(), CenteredFourthOrder())
+
 timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
 
 @testset "Time stepping" begin
@@ -180,6 +190,13 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
         for arch in archs, FT in [Float64], Coriolis in Planes
             @info "  Testing that time stepping works [$(typeof(arch)), $FT, $Coriolis]..."
             @test time_stepping_works_with_coriolis(arch, FT, Coriolis)
+        end
+    end
+
+    @testset "Advection schemes" begin
+        for arch in archs, advection_scheme in advection_schemes
+            @info "  Testing time stepping with advection schemes [$(typeof(arch)), $(typeof(advection_scheme))]"
+            @test time_stepping_works_with_advection_scheme(arch, advection_scheme)
         end
     end
 


### PR DESCRIPTION
This PR implements a new framework for high-order advection schemes.

There are two types of advection schemes: `AbstractCenteredAdvectionScheme` and `AbstractUpwindBiasedAdvectionScheme`.

This PR implements momentum and tracer flux operators such that an centered advection scheme needs only to implement 7 functions: 6 `symmetric_interpolate_*` functions for `x, y, z` at cell centers and interfaces, and a `boundary_buffer` scheme that indicates the buffer needed around boundaries in `Bounded` directions`. 

Upwind biased advection schemes need 19 functions: `halo_buffer`, 12 functions for `left_biased_interpolate_*` and `right_biased_interpolate_*`, and 6 functions for `symmetric_interpolate_*` that use a symmetric interpolation (typically of order `m-1`, where `m` is the order of the upwind scheme). These are used for momentum advection.

This PR refactors fourth order advection to use the framework. It still needs:

- [x] third-order upwind biased advection (as an example)
- [x] tests

Resolves #965 