### PR TITLE
Bump v0.39.0

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -236,12 +236,6 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[[PyCall]]
-deps = ["Conda", "Dates", "Libdl", "LinearAlgebra", "MacroTools", "Serialization", "VersionParsing"]
-git-tree-sha1 = "3a3fdb9000d35958c9ba2323ca7c4958901f115d"
-uuid = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
-version = "1.91.4"
-
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
@@ -249,11 +243,6 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-
-[[RecipesBase]]
-git-tree-sha1 = "6ee6c35fe69e79e17c455a386c1ccdc66d9f7da4"
-uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "1.1.0"
 
 [[Reexport]]
 deps = ["Pkg"]
@@ -307,12 +296,6 @@ version = "0.12.4"
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-
-[[SymPy]]
-deps = ["LinearAlgebra", "PyCall", "RecipesBase", "SpecialFunctions"]
-git-tree-sha1 = "bddd1869741b7bebc63c244ba13c8745cb34f274"
-uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.0.28"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.38.0"
+version = "0.39.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 
 [compat]
 Adapt = "^2"
@@ -38,7 +37,6 @@ OrderedCollections = "^1.1"
 SafeTestsets = "0.0.1"
 SeawaterPolynomials = "^0.2"
 StaticArrays = "0.12"
-SymPy = "1"
 julia = "^1.4"
 
 [extras]

--- a/src/Advection/weno_reconstruction.jl
+++ b/src/Advection/weno_reconstruction.jl
@@ -1,5 +1,5 @@
 using StaticArrays
-using SymPy
+# using SymPy
 
 """
 WENO reconstruction schemes following the lecture notes by Shu (1998) and
@@ -112,7 +112,7 @@ x(j) = j  # Assume uniform grid for now.
 Return a symbolic expression for the `j`th Lagrange basis polynomial ℓ(ξ) for an
 ENO reconstruction scheme of order k and left shift `r` with field values `ϕ`.
 """
-ℓ(ξ, k, r, j) = prod((ξ - x(m-r)) / (x(j-r) - x(m-r)) for m in 0:k-1 if m != j)
+# ℓ(ξ, k, r, j) = prod((ξ - x(m-r)) / (x(j-r) - x(m-r)) for m in 0:k-1 if m != j)
 
 """
     L(ξ, k, r, ϕ)
@@ -120,7 +120,7 @@ ENO reconstruction scheme of order k and left shift `r` with field values `ϕ`.
 Return a symbolic expression for the interpolating Lagrange polynomial p(ξ) for an
 ENO reconstruction scheme of order k and left shift `r` with field values `ϕ`.
 """
-p(ξ, k, r, ϕ) = sum(ℓ(ξ, k, r, j) * ϕ[j+1] for j in 0:k-1)
+# p(ξ, k, r, ϕ) = sum(ℓ(ξ, k, r, j) * ϕ[j+1] for j in 0:k-1)
 
 """
     β(k, r, ϕ)
@@ -129,10 +129,10 @@ Return a symbolic expression for the smoothness indicator β for a WENO reconstr
 scheme with stencils of size `k` and left shift `r` (WENO scheme of order 2k-1). The
 field values are represented by the symbols in `ϕ` which should have length k.
 """
-function β(k, r, ϕ)
-    @vars ξ
-    return sum(integrate(diff(p(ξ, k, r, ϕ), ξ, l)^2, (ξ, Sym(-1//2), Sym(1//2))) for l in 1:k-1)
-end
+# function β(k, r, ϕ)
+#     @vars ξ
+#     return sum(integrate(diff(p(ξ, k, r, ϕ), ξ, l)^2, (ξ, Sym(-1//2), Sym(1//2))) for l in 1:k-1)
+# end
 
 """
     subscript(n)
@@ -157,20 +157,20 @@ The `B[m, n, r]` coefficient corresponds to the coefficient of the
 `ϕ[r-k+m+1] * ϕ[r-k+n+1]` term where r-k+1 <= m, n <= r and `r` is the left shift of
 the ENO interpolants.
 """
-function β_coefficients(FT, k)
-    B = zeros(Float64, k, k, k)
+# function β_coefficients(FT, k)
+#     B = zeros(Float64, k, k, k)
     
-    for r in 0:k-1
-        ϕ = [Sym("ϕᵢ" * subscript_index(n)) for n in r:-1:r-k+1]
-        β_symbolic = β(k, r, ϕ) |> expand
+#     for r in 0:k-1
+#         ϕ = [Sym("ϕᵢ" * subscript_index(n)) for n in r:-1:r-k+1]
+#         β_symbolic = β(k, r, ϕ) |> expand
 
-        for m in 1:k, n in 1:k
-            B[m, n, r+1] = β_symbolic.coeff(ϕ[m] * ϕ[n])
-        end
-    end
+#         for m in 1:k, n in 1:k
+#             B[m, n, r+1] = β_symbolic.coeff(ϕ[m] * ϕ[n])
+#         end
+#     end
     
-    B = rationalize.(B, tol=√eps(Float64))
-    return SArray{Tuple{k,k,k},FT}(B)
-end
+#     B = rationalize.(B, tol=√eps(Float64))
+#     return SArray{Tuple{k,k,k},FT}(B)
+# end
 
-β_coefficients(k) = β_coefficients(Rational, k)
+# β_coefficients(k) = β_coefficients(Rational, k)

--- a/test/test_weno_reconstruction.jl
+++ b/test/test_weno_reconstruction.jl
@@ -1,4 +1,4 @@
-using SymPy
+# using SymPy
 
 using Oceananigans.Advection:
     eno_coefficients, optimal_weno_weights, β,
@@ -115,17 +115,17 @@ end
         end
     end
 
-    @testset "WENO smoothness indicators" begin
-        @testset "WENO-5" begin
-            @vars ϕᵢ₋₂  ϕᵢ₋₁ ϕᵢ ϕᵢ₊₁ ϕᵢ₊₂
+    # @testset "WENO smoothness indicators" begin
+    #     @testset "WENO-5" begin
+    #         @vars ϕᵢ₋₂  ϕᵢ₋₁ ϕᵢ ϕᵢ₊₁ ϕᵢ₊₂
             
-            β₀_correct = 13//12 * (ϕᵢ₋₂ - 2ϕᵢ₋₁ + ϕᵢ  )^2 + 1//4 * ( ϕᵢ₋₂ - 4ϕᵢ₋₁ + 3ϕᵢ  )^2 |> expand
-            β₁_correct = 13//12 * (ϕᵢ₋₁ - 2ϕᵢ   + ϕᵢ₊₁)^2 + 1//4 * ( ϕᵢ₋₁         -  ϕᵢ₊₁)^2 |> expand
-            β₂_correct = 13//12 * (ϕᵢ   - 2ϕᵢ₊₁ + ϕᵢ₊₂)^2 + 1//4 * (3ϕᵢ   - 4ϕᵢ₊₁ +  ϕᵢ₊₂)^2 |> expand
+    #         β₀_correct = 13//12 * (ϕᵢ₋₂ - 2ϕᵢ₋₁ + ϕᵢ  )^2 + 1//4 * ( ϕᵢ₋₂ - 4ϕᵢ₋₁ + 3ϕᵢ  )^2 |> expand
+    #         β₁_correct = 13//12 * (ϕᵢ₋₁ - 2ϕᵢ   + ϕᵢ₊₁)^2 + 1//4 * ( ϕᵢ₋₁         -  ϕᵢ₊₁)^2 |> expand
+    #         β₂_correct = 13//12 * (ϕᵢ   - 2ϕᵢ₊₁ + ϕᵢ₊₂)^2 + 1//4 * (3ϕᵢ   - 4ϕᵢ₊₁ +  ϕᵢ₊₂)^2 |> expand
 
-            @test β(3, 0, (ϕᵢ, ϕᵢ₋₁, ϕᵢ₋₂)) |> expand == β₀_correct
-            @test β(3, 1, (ϕᵢ₊₁, ϕᵢ, ϕᵢ₋₁)) |> expand == β₁_correct
-            @test β(3, 2, (ϕᵢ₊₂, ϕᵢ₊₁, ϕᵢ)) |> expand == β₂_correct
-        end
-    end
+    #         @test β(3, 0, (ϕᵢ, ϕᵢ₋₁, ϕᵢ₋₂)) |> expand == β₀_correct
+    #         @test β(3, 1, (ϕᵢ₊₁, ϕᵢ, ϕᵢ₋₁)) |> expand == β₁_correct
+    #         @test β(3, 2, (ϕᵢ₊₂, ϕᵢ₊₁, ϕᵢ)) |> expand == β₂_correct
+    #     end
+    # end
 end


### PR DESCRIPTION
To make use of the new forcing function API in #989 and to fix #990 and #991 I think we should tag v0.39.0 once the current batch of PRs has been merged.