### PR TITLE
Adds functionality for AbstractField isotropic viscosities and diffusivities

### DIFF
--- a/src/Fields/abstract_field.jl
+++ b/src/Fields/abstract_field.jl
@@ -142,7 +142,7 @@ total_size(f::AbstractField) = total_size(location(f), f.grid)
 @hascuda const OffsetCuArray = OffsetArray{T, D, <:CuArray} where {T, D}
 
 @hascuda @inline cpudata(f::AbstractField{X, Y, Z, <:OffsetCuArray}) where {X, Y, Z} =
-    OffsetArray(Array(parent(f)), f.grid, location(f))
+    offset_data(Array(parent(f)), f.grid, location(f))
 
 # Endpoint for recursive `datatuple` function:
 @inline datatuple(obj::AbstractField) = data(obj)

--- a/src/Fields/new_data.jl
+++ b/src/Fields/new_data.jl
@@ -1,6 +1,6 @@
 using Oceananigans.Grids: total_length, topology
 
-import OffsetArrays: OffsetArray
+using OffsetArrays: OffsetArray
 
 #####
 ##### Creating offset arrays for field data by dispatching on architecture.
@@ -24,13 +24,13 @@ Return a range of indices for a field along a 'reduced' dimension.
 offset_indices(::Type{Nothing}, topo, N, H=0) = 1 : 1
 
 """
-    OffsetArray(underlying_data, grid::AbstractGrid, loc)
+    offset_underlying_data(underlying_data, grid::AbstractGrid, loc)
 
 Returns an `OffsetArray` that maps to `underlying_data` in memory,
 with offset indices appropriate for the `data` of a field on
 a `grid` of `size(grid)` and located at `loc`.
 """
-function OffsetArray(underlying_data, grid::AbstractGrid, loc)
+function offset_underlying_data(underlying_data, grid::AbstractGrid, loc)
     ii = offset_indices(loc[1], topology(grid, 1), grid.Nx, grid.Hx)
     jj = offset_indices(loc[2], topology(grid, 2), grid.Ny, grid.Hy)
     kk = offset_indices(loc[3], topology(grid, 3), grid.Nz, grid.Hz)
@@ -50,7 +50,7 @@ function new_data(FT, ::CPU, grid, loc)
                                 total_length(loc[2], topology(grid, 2), grid.Ny, grid.Hy),
                                 total_length(loc[3], topology(grid, 3), grid.Nz, grid.Hz))
 
-    return OffsetArray(underlying_data, grid, loc)
+    return offset_underlying_data(underlying_data, grid, loc)
 end
 
 """
@@ -67,7 +67,7 @@ function new_data(FT, ::GPU, grid, loc)
 
     underlying_data .= 0 # Ensure data is initially 0.
 
-    return OffsetArray(underlying_data, grid, loc)
+    return offset_underlying_data(underlying_data, grid, loc)
 end
 
 # Default to type of Grid

--- a/src/Fields/new_data.jl
+++ b/src/Fields/new_data.jl
@@ -24,13 +24,13 @@ Return a range of indices for a field along a 'reduced' dimension.
 offset_indices(::Type{Nothing}, topo, N, H=0) = 1 : 1
 
 """
-    offset_underlying_data(underlying_data, grid::AbstractGrid, loc)
+    offset_data(underlying_data, grid::AbstractGrid, loc)
 
 Returns an `OffsetArray` that maps to `underlying_data` in memory,
 with offset indices appropriate for the `data` of a field on
 a `grid` of `size(grid)` and located at `loc`.
 """
-function offset_underlying_data(underlying_data, grid::AbstractGrid, loc)
+function offset_data(underlying_data, grid::AbstractGrid, loc)
     ii = offset_indices(loc[1], topology(grid, 1), grid.Nx, grid.Hx)
     jj = offset_indices(loc[2], topology(grid, 2), grid.Ny, grid.Hy)
     kk = offset_indices(loc[3], topology(grid, 3), grid.Nz, grid.Hz)
@@ -50,7 +50,7 @@ function new_data(FT, ::CPU, grid, loc)
                                 total_length(loc[2], topology(grid, 2), grid.Ny, grid.Hy),
                                 total_length(loc[3], topology(grid, 3), grid.Nz, grid.Hz))
 
-    return offset_underlying_data(underlying_data, grid, loc)
+    return offset_data(underlying_data, grid, loc)
 end
 
 """
@@ -67,7 +67,7 @@ function new_data(FT, ::GPU, grid, loc)
 
     underlying_data .= 0 # Ensure data is initially 0.
 
-    return offset_underlying_data(underlying_data, grid, loc)
+    return offset_data(underlying_data, grid, loc)
 end
 
 # Default to type of Grid

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -102,7 +102,7 @@ end
 
 function restore_field(file, address, arch, grid, loc, kwargs)
     field_address = file[address * "/location"]
-    data = OffsetArray(convert_to_arch(arch, file[address * "/data"]), grid, loc)
+    data = offset_data(convert_to_arch(arch, file[address * "/data"]), grid, loc)
 
     # Extract field name from address. We use 2:end so "tracers/T "gets extracted
     # as :T while "timestepper/Gⁿ/T" gets extracted as :Gⁿ/T (we don't want to

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Fields: offset_data
+
 """
     Checkpointer{I, T, P} <: AbstractOutputWriter
 

--- a/src/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/TurbulenceClosures/TurbulenceClosures.jl
@@ -102,55 +102,6 @@ principle with model parameters stored as properties of type `FT`.
 abstract type AbstractLeith{FT} <: AbstractTurbulenceClosure end
 
 #####
-##### 'Tupled closure' implementation
-#####
-
-for stress_div in (:∂ⱼ_2ν_Σ₁ⱼ, :∂ⱼ_2ν_Σ₂ⱼ, :∂ⱼ_2ν_Σ₃ⱼ)
-    @eval begin
-        @inline function $stress_div(i, j, k, grid::AbstractGrid{FT}, clock, closure_tuple::Tuple, U,
-                                     K_tuple, args...) where FT
-
-            stress_div_ijk = zero(FT)
-
-            ntuple(Val(length(closure_tuple))) do α
-                @inbounds closure = closure_tuple[α]
-                @inbounds K = K_tuple[α]
-                stress_div_ijk += $stress_div(i, j, k, grid, clock, closure, U, K, args...)
-            end
-
-            return stress_div_ijk
-        end
-    end
-end
-
-@inline function ∇_κ_∇c(i, j, k, grid::AbstractGrid{FT}, clock, closure_tuple::Tuple,
-                        c, tracer_index, K_tuple, args...) where FT
-
-    flux_div_ijk = zero(FT)
-
-    ntuple(Val(length(closure_tuple))) do α
-        @inbounds closure = closure_tuple[α]
-        @inbounds K = K_tuple[α]
-        flux_div_ijk +=  ∇_κ_∇c(i, j, k, grid, clock, closure, c, tracer_index, K, args...)
-    end
-
-    return flux_div_ijk
-end
-
-function calculate_diffusivities!(K_tuple::Tuple, arch, grid, closure_tuple::Tuple, args...)
-    ntuple(Val(length(closure_tuple))) do α
-        @inbounds closure = closure_tuple[α]
-        @inbounds K = K_tuple[α]
-        calculate_diffusivities!(K, arch, grid, closure, args...)
-    end
-
-    return nothing
-end
-
-with_tracers(tracers, closure_tuple::Tuple) =
-    Tuple(with_tracers(tracers, closure) for closure in closure_tuple)
-
-#####
 ##### Include module code
 #####
 

--- a/src/TurbulenceClosures/diffusion_operators.jl
+++ b/src/TurbulenceClosures/diffusion_operators.jl
@@ -16,6 +16,10 @@
 
 @inline diffusive_flux_z(i, j, k, grid, clock, κ::Function, c) =
         diffusive_flux_z(i, j, k, grid, clock, κ(xnode(Cell, i, grid), ynode(Cell, j, grid), znode(Face, k, grid), clock.time), c)
+
+@inline diffusive_flux_x(i, j, k, grid, clock, κ::AbstractField, c) = ℑxᶠᵃᵃ(i, j, k, grid, κ) * Axᵃᵃᶠ(i, j, k, grid) * ∂xᶠᵃᵃ(i, j, k, grid, c)
+@inline diffusive_flux_y(i, j, k, grid, clock, κ::AbstractField, c) = ℑyᵃᶠᵃ(i, j, k, grid, κ) * Ayᵃᵃᶠ(i, j, k, grid) * ∂yᵃᶠᵃ(i, j, k, grid, c)
+@inline diffusive_flux_z(i, j, k, grid, clock, κ::AbstractField, c) = ℑzᵃᵃᶠ(i, j, k, grid, κ) * Azᵃᵃᵃ(i, j, k, grid) * ∂zᵃᵃᶠ(i, j, k, grid, c)
                      
 #####
 ##### Laplacian diffusion operator

--- a/src/TurbulenceClosures/turbulence_closure_implementations/isotropic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/isotropic_diffusivity.jl
@@ -40,7 +40,17 @@ function with_tracers(tracers, closure::IsotropicDiffusivity)
     return IsotropicDiffusivity(closure.ν, κ)
 end
 
-calculate_diffusivities!(K, arch, grid, closure::IsotropicDiffusivity, args...) = nothing
+# Support for ComputedField diffusivities
+function calculate_diffusivities!(K, arch, grid, closure::IsotropicDiffusivity, args...)
+
+    compute!(closure.ν)
+
+    for κ in closure.κ
+        compute!(κ)
+    end
+
+    return nothing
+end
 
 @inline function ∇_κ_∇c(i, j, k, grid, clock, closure::IsotropicDiffusivity,
                         c, ::Val{tracer_index}, args...) where tracer_index

--- a/src/TurbulenceClosures/turbulence_closure_utils.jl
+++ b/src/TurbulenceClosures/turbulence_closure_utils.jl
@@ -1,4 +1,4 @@
-tracer_diffusivities(tracers, κ::Union{Number, Function}) = with_tracers(tracers, NamedTuple(), (tracers, init) -> κ)
+tracer_diffusivities(tracers, κ) = with_tracers(tracers, NamedTuple(), (tracers, init) -> κ)
 
 function tracer_diffusivities(tracers, κ::NamedTuple)
 

--- a/src/TurbulenceClosures/viscous_dissipation_operators.jl
+++ b/src/TurbulenceClosures/viscous_dissipation_operators.jl
@@ -44,6 +44,19 @@
 @inline viscous_flux_wz(i, j, k, grid, clock, ν::Function, w) =
         viscous_flux_wz(i, j, k, grid, clock, ν(xnode(Cell, i, grid), ynode(Cell, j, grid), znode(Cell, k, grid), clock.time), w)
                         
+# Viscosities-as-fields
+
+@inline viscous_flux_ux(i, j, k, grid, clock, ν::AbstractField, u) = @inbounds ν[i, j, k]     * ℑxᶜᵃᵃ(i, j, k, grid, Axᵃᵃᶜ) * ∂xᶜᵃᵃ(i, j, k, grid, u)
+@inline viscous_flux_uy(i, j, k, grid, clock, ν::AbstractField, u) = ℑxyᶠᶠᵃ(i, j, k, grid, ν) * ℑyᵃᶠᵃ(i, j, k, grid, Ayᵃᵃᶜ) * ∂yᵃᶠᵃ(i, j, k, grid, u)
+@inline viscous_flux_uz(i, j, k, grid, clock, ν::AbstractField, u) = ℑxzᶠᵃᶠ(i, j, k, grid, ν) * ℑzᵃᵃᶠ(i, j, k, grid, Azᵃᵃᵃ) * ∂zᵃᵃᶠ(i, j, k, grid, u)
+
+@inline viscous_flux_vx(i, j, k, grid, clock, ν::AbstractField, v) = ℑxyᶠᶠᵃ(i, j, k, grid, ν) * ℑxᶠᵃᵃ(i, j, k, grid, Axᵃᵃᶜ) * ∂xᶠᵃᵃ(i, j, k, grid, v)
+@inline viscous_flux_vy(i, j, k, grid, clock, ν::AbstractField, v) = @inbounds ν[i, j, k]     * ℑyᵃᶜᵃ(i, j, k, grid, Ayᵃᵃᶜ) * ∂yᵃᶜᵃ(i, j, k, grid, v)
+@inline viscous_flux_vz(i, j, k, grid, clock, ν::AbstractField, v) = ℑyzᵃᶠᶠ(i, j, k, grid, ν) * ℑzᵃᵃᶠ(i, j, k, grid, Azᵃᵃᵃ) * ∂zᵃᵃᶠ(i, j, k, grid, v)
+
+@inline viscous_flux_wx(i, j, k, grid, clock, ν::AbstractField, w) = ℑxzᶠᵃᶠ(i, j, k, grid, ν) * ℑxᶠᵃᵃ(i, j, k, grid, Axᵃᵃᶜ) * ∂xᶠᵃᵃ(i, j, k, grid, w)
+@inline viscous_flux_wy(i, j, k, grid, clock, ν::AbstractField, w) = ℑyzᵃᶠᶠ(i, j, k, grid, ν) * ℑyᵃᶠᵃ(i, j, k, grid, Ayᵃᵃᶜ) * ∂yᵃᶠᵃ(i, j, k, grid, w)
+@inline viscous_flux_wz(i, j, k, grid, clock, ν::AbstractField, w) = @inbounds ν[i, j, k]     * ℑzᵃᵃᶜ(i, j, k, grid, Azᵃᵃᵃ) * ∂zᵃᵃᶜ(i, j, k, grid, w)
 
 #####
 ##### Viscous dissipation operators


### PR DESCRIPTION
This PR extends the implementation of `IsotropicDiffusivity` to accept `AbstractField`s (such as `ComputedField`) as diffusivities and viscosities.

Using this implementation with `model.velocities` or `model.tracers` requires that users instantiate the velocity and tracer fields prior to building the model.

The test provided with this PR gives an example:

```julia
arch = CPU()
grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 2, 3)) 

tracer_names = (:T, :S, :c) 
u, v, w = velocities = VelocityFields(arch, grid)
T, S, c = tracers = TracerFields(arch, grid, tracer_names)

ν = @at (Cell, Cell, Cell) u^2 * ∂z(T)
κ = @at (Cell, Cell, Cell) S * c * sin(T)

closure = IsotropicDiffusivity(ν = ComputedField(ν),
                               κ = ComputedField(κ))

model = IncompressibleModel(architecture=arch, grid=grid, closure=closure,
                            velocities=velocities, tracers=tracers)
```

A major gotcha with this implementation is that users _must_ pass the velocity and tracer fields on to `IncompressibleModel` (or the prescribed viscosity will be meaningless.

We should probably also ensure that diffusivities-as-`Field`s are located at `Cell, Cell, Cell`, as the viscous and diffusive flux operators assume.

A way we can prevent this error is to check that `ComputedField` viscosities or diffusivities contain references to `model.velocities` or `model.tracers`. However, this could --- in principle anyways --- exclude valid cases.

I'm happy to merge as-is, or to make the implementation more robust, somehow.

Possible todo:

- [ ] Allow specification of `AbstractOperation`s rather than `ComputedField`s in `IsotropicDiffusivity` constructor
- [ ] Check that `Field`-viscosities and diffusivities have correct location in `IsotropicDiffusivity` constructor
- [ ] Make implementation more robust / less error-prone?