### PR TITLE
Bump v0.40.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.39.0"
+version = "0.40.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
We should tag and release v0.40.0 once PR #1020 is merged since GPU tests fail on v0.39.0 and #1020 fixes things so all tests pass.