### PR TITLE
Use allowscalar when converting output

### DIFF
--- a/src/OutputWriters/fetch_output.jl
+++ b/src/OutputWriters/fetch_output.jl
@@ -1,3 +1,5 @@
+using CUDA
+
 using Oceananigans.Fields: AbstractField, compute!
 
 fetch_output(output, model, field_slicer) = output(model)
@@ -12,7 +14,7 @@ function fetch_output(field::AbstractField, model, field_slicer)
 end
 
 convert_output(output, writer) = output
-convert_output(output::AbstractArray, writer) = writer.array_type(output)
+convert_output(output::AbstractArray, writer) = CUDA.@allowscalar writer.array_type(output)
 
 fetch_and_convert_output(output, model, writer) =
     convert_output(fetch_output(output, model, writer.field_slicer), writer)

--- a/src/OutputWriters/field_slicer.jl
+++ b/src/OutputWriters/field_slicer.jl
@@ -67,7 +67,7 @@ end
 
 Returns a view over parent(field) associated with slice.i, slice.j, slice.k.
 """
-function slice_parent(slicer, field)
+function slice_parent(slicer, field::AbstractField)
 
     # Unpack
     Nx, Ny, Nz = field.grid.Nx, field.grid.Ny, field.grid.Nz
@@ -84,7 +84,7 @@ function slice_parent(slicer, field)
     y_parent_range = parent_slice_indices(Ly, Ty, Ny, Hy, y_data_range, slicer.with_halos)
     z_parent_range = parent_slice_indices(Lz, Tz, Nz, Hz, z_data_range, slicer.with_halos)
 
-    return view(parent(field), x_parent_range, y_parent_range, z_parent_range)
+    return field.data.parent[x_parent_range, y_parent_range, z_parent_range]
 end
 
 slice_parent(::Nothing, field) = parent(field)

--- a/src/OutputWriters/field_slicer.jl
+++ b/src/OutputWriters/field_slicer.jl
@@ -67,7 +67,7 @@ end
 
 Returns a view over parent(field) associated with slice.i, slice.j, slice.k.
 """
-function slice_parent(slicer, field::AbstractField)
+function slice_parent(slicer, field)
 
     # Unpack
     Nx, Ny, Nz = field.grid.Nx, field.grid.Ny, field.grid.Nz


### PR DESCRIPTION
Array conversions when fetching output trigger `copyto!` and then `getindex`, which is in turn disallowed.

This PR fixes an issue with output on the GPU on master.

I'm a bit perplexed why the `jld2_field_output` test didn't pick this up.