### PR TITLE
Better Buildkite CI pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,6 @@ env:
 
 steps:
   - label: ":rabbit2: unit tests"
-    env:
-      TEST_GROUP: "unit"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
       - "eval "$(bash install_julia.sh $JULIA_VERSION)"
@@ -13,44 +11,45 @@ steps:
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
+    env:
+      TEST_GROUP: "unit"
 
 
   - label: ":dolphin: model tests"
+    commands:
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: tartarus
     env:
       TEST_GROUP: "model"
-    commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
-    agents:
-      queue: tartarus
 
   - label: ":whale: simulation tests"
+    commands:
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: tartarus
     env:
       TEST_GROUP: "simulation"
-    commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
-    agents:
-      queue: tartarus
  
   - label: ":camel: regression tests"
+    commands:
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: tartarus
     env:
       TEST_GROUP: "regression"
-    commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
-    agents:
-      queue: tartarus
 
   - label: ":gorilla: scripts"
-    env:
-      TEST_GROUP: "scripts"
+
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
       - "eval "$(bash install_julia.sh $JULIA_VERSION)"
@@ -58,10 +57,10 @@ steps:
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
+    env:
+      TEST_GROUP: "scripts"
 
   # - label: ":sauropod: convergence tests"
-  #   env:
-  #     TEST_GROUP: "convergence"
   #   commands:
   #     - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
   #     - "eval "$(bash install_julia.sh $JULIA_VERSION)"
@@ -69,6 +68,8 @@ steps:
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
   #   agents:
   #     queue: tartarus
+  #   env:
+  #     TEST_GROUP: "convergence"
 
   - label: ":owl: documentation"
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,77 +4,76 @@ env:
 
 steps:
   - label: ":rabbit2: unit tests"
+    env:
+      TEST_GROUP: "unit"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
-    env:
-      TEST_GROUP: "unit"
 
 
   - label: ":dolphin: model tests"
-    commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
-    agents:
-      queue: tartarus
     env:
       TEST_GROUP: "model"
+    commands:
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: tartarus
 
   - label: ":whale: simulation tests"
-    commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
-    agents:
-      queue: tartarus
     env:
       TEST_GROUP: "simulation"
+    commands:
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: tartarus
  
   - label: ":camel: regression tests"
-    commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
-    agents:
-      queue: tartarus
     env:
       TEST_GROUP: "regression"
-
-  - label: ":gorilla: scripts"
-
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
+
+  - label: ":gorilla: scripts"
     env:
       TEST_GROUP: "scripts"
+    commands:
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: tartarus
 
   # - label: ":sauropod: convergence tests"
+  #   env:
+  #     TEST_GROUP: "convergence"
   #   commands:
   #     - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-  #     - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+  #     - "eval \$(bash install_julia.sh $JULIA_VERSION)"
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
   #   agents:
   #     queue: tartarus
-  #   env:
-  #     TEST_GROUP: "convergence"
 
   - label: ":owl: documentation"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
       - "julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
       - "julia --color=yes --project=docs/ docs/make.jl"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,11 +6,15 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(verbose=true)'"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.precompile()'"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.status()'"
+      # force the initialization of the CUDA runtime as it is lazily loaded by default
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using CUDA; CUDA.versioninfo()'"
 
   - wait
 
-  - label: ":rabbit2: unit tests"
+  - label: "🐇 unit tests"
     env:
       TEST_GROUP: "unit"
     commands:
@@ -21,7 +25,7 @@ steps:
       queue: tartarus
 
 
-  - label: ":dolphin: model tests"
+  - label: "🐬 model tests"
     env:
       TEST_GROUP: "model"
     commands:
@@ -31,7 +35,7 @@ steps:
     agents:
       queue: tartarus
 
-  - label: ":whale: simulation tests"
+  - label: "🐳 simulation tests"
     env:
       TEST_GROUP: "simulation"
     commands:
@@ -41,7 +45,7 @@ steps:
     agents:
       queue: tartarus
  
-  - label: ":camel: regression tests"
+  - label: "🐫 regression tests"
     env:
       TEST_GROUP: "regression"
     commands:
@@ -51,7 +55,7 @@ steps:
     agents:
       queue: tartarus
 
-  - label: ":gorilla: scripts"
+  - label: "🦍 scripts"
     env:
       TEST_GROUP: "scripts"
     commands:
@@ -61,7 +65,7 @@ steps:
     agents:
       queue: tartarus
 
-  # - label: ":sauropod: convergence tests"
+  # - label: "🦕 convergence tests"
   #   env:
   #     TEST_GROUP: "convergence"
   #   commands:
@@ -72,7 +76,7 @@ steps:
   #   agents:
   #     queue: tartarus
 
-  - label: ":owl: documentation"
+  - label: "🦉 documentation"
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,4 @@
 env:
-  JULIA_VERSION: 1.4
   CUDA_VISIBLE_DEVICES: 3
 
 steps:
@@ -8,7 +7,7 @@ steps:
       TEST_GROUP: "unit"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -20,7 +19,7 @@ steps:
       TEST_GROUP: "model"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -31,7 +30,7 @@ steps:
       TEST_GROUP: "simulation"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -42,7 +41,7 @@ steps:
       TEST_GROUP: "regression"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -53,7 +52,7 @@ steps:
       TEST_GROUP: "scripts"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -64,7 +63,7 @@ steps:
   #     TEST_GROUP: "convergence"
   #   commands:
   #     - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-  #     - "eval $$(bash install_julia.sh $JULIA_VERSION)"
+  #     - "eval $$(bash install_julia.sh 1.4)"
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
   #   agents:
@@ -73,7 +72,7 @@ steps:
   - label: ":owl: documentation"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
       - "julia --color=yes --project=docs/ docs/make.jl"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,7 @@
 env:
   JULIA_DEPOT_PATH: "$HOME/.julia"
   CUDA_VISIBLE_DEVICES: 3
+  JULIA_CUDA_MEMORY_LIMIT: 2147483648  # 2 GiB
 
 steps:
   - label: "🏕️ initialize environment"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     env:
       TEST_GROUP: "unit"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
       - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
@@ -18,7 +18,7 @@ steps:
     env:
       TEST_GROUP: "model"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
       - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
@@ -29,7 +29,7 @@ steps:
     env:
       TEST_GROUP: "simulation"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
       - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
@@ -40,7 +40,7 @@ steps:
     env:
       TEST_GROUP: "regression"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
       - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
@@ -51,7 +51,7 @@ steps:
     env:
       TEST_GROUP: "scripts"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
       - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
@@ -62,7 +62,7 @@ steps:
   #   env:
   #     TEST_GROUP: "convergence"
   #   commands:
-  #     - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+  #     - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
   #     - "eval $$(bash install_julia.sh 1.4)"
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
@@ -71,7 +71,7 @@ steps:
 
   - label: ":owl: documentation"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
       - "eval $$(bash install_julia.sh 1.4)"
       - "julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
       - "julia --color=yes --project=docs/ docs/make.jl"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
       TEST_GROUP: "unit"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -20,7 +20,7 @@ steps:
       TEST_GROUP: "model"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -31,7 +31,7 @@ steps:
       TEST_GROUP: "simulation"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -42,7 +42,7 @@ steps:
       TEST_GROUP: "regression"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -53,7 +53,7 @@ steps:
       TEST_GROUP: "scripts"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -64,7 +64,7 @@ steps:
   #     TEST_GROUP: "convergence"
   #   commands:
   #     - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-  #     - "eval \$(bash install_julia.sh $JULIA_VERSION)"
+  #     - "eval $$(bash install_julia.sh $JULIA_VERSION)"
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
   #   agents:
@@ -73,7 +73,7 @@ steps:
   - label: ":owl: documentation"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
-      - "eval \$(bash install_julia.sh $JULIA_VERSION)"
+      - "eval $$(bash install_julia.sh $JULIA_VERSION)"
       - "julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
       - "julia --color=yes --project=docs/ docs/make.jl"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  JULIA_DEPOT_PATH: "$PWD/.julia"
+  JULIA_DEPOT_PATH: "$HOME/.julia"
   CUDA_VISIBLE_DEVICES: 3
 
 steps:
@@ -23,7 +23,6 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -35,7 +34,6 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -46,7 +44,6 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -57,7 +54,6 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -68,7 +64,6 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -79,7 +74,6 @@ steps:
   #   commands:
   #     - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
   #     - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-  #     - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
   #     - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
   #   agents:
   #     queue: tartarus

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,8 @@ steps:
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.status()'"
       # force the initialization of the CUDA runtime as it is lazily loaded by default
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using CUDA; CUDA.versioninfo()'"
+    agents:
+      queue: tartarus
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(verbose=true)'"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.precompile()'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.status()'"
       # force the initialization of the CUDA runtime as it is lazily loaded by default

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,5 @@
 env:
+  JULIA_DEPOT_PATH: "$PWD/.julia"
   CUDA_VISIBLE_DEVICES: 3
 
 steps:
@@ -22,6 +23,7 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -33,6 +35,7 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -43,6 +46,7 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -53,6 +57,7 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -63,6 +68,7 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,65 +1,80 @@
 env:
-  JULIA_PATH: "/home/alir/julia-1.4.2/bin/julia"
+  JULIA_VERSION: 1.4
   CUDA_VISIBLE_DEVICES: 3
 
 steps:
   - label: ":rabbit2: unit tests"
-    commands:
-      - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.test()'"
-    agents:
-      queue: tartarus
     env:
       TEST_GROUP: "unit"
+    commands:
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: tartarus
+
 
   - label: ":dolphin: model tests"
-    commands:
-      - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.test()'"
-    agents:
-      queue: tartarus
     env:
       TEST_GROUP: "model"
+    commands:
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: tartarus
 
   - label: ":whale: simulation tests"
-    commands:
-      - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.test()'"
-    agents:
-      queue: tartarus
     env:
       TEST_GROUP: "simulation"
+    commands:
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: tartarus
  
   - label: ":camel: regression tests"
-    commands:
-      - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.test()'"
-    agents:
-      queue: tartarus
     env:
       TEST_GROUP: "regression"
-
-  - label: ":gorilla: scripts"
     commands:
-      - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
+
+  - label: ":gorilla: scripts"
     env:
       TEST_GROUP: "scripts"
+    commands:
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: tartarus
 
-# - label: ":sauropod: convergence tests"
-#   commands:
-#     - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-#     - "$JULIA_PATH --color=yes --project -e 'using Pkg; Pkg.test()'"
-#   agents:
-#     queue: tartarus
-#   env:
-#     TEST_GROUP: "convergence"
+  # - label: ":sauropod: convergence tests"
+  #   env:
+  #     TEST_GROUP: "convergence"
+  #   commands:
+  #     - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+  #     - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+  #     - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+  #     - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+  #   agents:
+  #     queue: tartarus
 
   - label: ":owl: documentation"
     commands:
-      - "$JULIA_PATH --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
-      - "$JULIA_PATH --color=yes --project=docs/ docs/make.jl"
+      - "wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh"
+      - "eval "$(bash install_julia.sh $JULIA_VERSION)"
+      - "julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
+      - "julia --color=yes --project=docs/ docs/make.jl"
     agents:
       queue: tartarus

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  JULIA_DEPOT_PATH: "$HOME/.julia"
+  JULIA_DEPOT_PATH: "$HOME/.julia-$BUILDKITE_BUILD_NUMBER"
   CUDA_VISIBLE_DEVICES: 3
   JULIA_CUDA_MEMORY_LIMIT: 2147483648  # 2 GiB
 
@@ -77,3 +77,10 @@ steps:
       - "$HOME/julia-1.4.2/bin/julia --color=yes --project=docs/ docs/make.jl"
     agents:
       queue: tartarus
+
+  - wait: ~
+    continue_on_failure: true
+
+  - label: "🧹 clean up environment"
+    commands:
+      - "rm -rf $JULIA_DEPOT_PATH"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,10 +6,10 @@ steps:
     env:
       TEST_GROUP: "unit"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install-julia.sh 1.4)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
 
@@ -18,10 +18,10 @@ steps:
     env:
       TEST_GROUP: "model"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install-julia.sh 1.4)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
 
@@ -29,10 +29,10 @@ steps:
     env:
       TEST_GROUP: "simulation"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install-julia.sh 1.4)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
  
@@ -40,10 +40,10 @@ steps:
     env:
       TEST_GROUP: "regression"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install-julia.sh 1.4)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
 
@@ -51,10 +51,10 @@ steps:
     env:
       TEST_GROUP: "scripts"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install-julia.sh 1.4)"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-      - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
 
@@ -62,18 +62,18 @@ steps:
   #   env:
   #     TEST_GROUP: "convergence"
   #   commands:
-  #     - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-  #     - "eval $$(bash install-julia.sh 1.4)"
-  #     - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
-  #     - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+  #     - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+  #     - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+  #     - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+  #     - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
   #   agents:
   #     queue: tartarus
 
   - label: ":owl: documentation"
     commands:
-      - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install-julia.sh 1.4)"
-      - "julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
-      - "julia --color=yes --project=docs/ docs/make.jl"
+      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
+      - "./julia-1.4.2/bin/julia --color=yes --project=docs/ docs/make.jl"
     agents:
       queue: tartarus

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ steps:
       TEST_GROUP: "unit"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install_julia.sh 1.4)"
+      - "eval $$(bash install-julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -19,7 +19,7 @@ steps:
       TEST_GROUP: "model"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install_julia.sh 1.4)"
+      - "eval $$(bash install-julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -30,7 +30,7 @@ steps:
       TEST_GROUP: "simulation"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install_julia.sh 1.4)"
+      - "eval $$(bash install-julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -41,7 +41,7 @@ steps:
       TEST_GROUP: "regression"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install_julia.sh 1.4)"
+      - "eval $$(bash install-julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -52,7 +52,7 @@ steps:
       TEST_GROUP: "scripts"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install_julia.sh 1.4)"
+      - "eval $$(bash install-julia.sh 1.4)"
       - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
@@ -63,7 +63,7 @@ steps:
   #     TEST_GROUP: "convergence"
   #   commands:
   #     - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-  #     - "eval $$(bash install_julia.sh 1.4)"
+  #     - "eval $$(bash install-julia.sh 1.4)"
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
   #     - "julia --color=yes --project -e 'using Pkg; Pkg.test()'"
   #   agents:
@@ -72,7 +72,7 @@ steps:
   - label: ":owl: documentation"
     commands:
       - "wget -nv https://raw.githubusercontent.com/JuliaCI/install-julia/master/install-julia.sh"
-      - "eval $$(bash install_julia.sh 1.4)"
+      - "eval $$(bash install-julia.sh 1.4)"
       - "julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
       - "julia --color=yes --project=docs/ docs/make.jl"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,7 @@ env:
 steps:
   - label: "🏕️ initialize environment"
     commands:
+      - "rm -rf $JULIA_DEPOT_PATH"
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,13 +6,13 @@ steps:
   - label: "🏕️ initialize environment"
     commands:
       - "rm -rf $JULIA_DEPOT_PATH"
-      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
-      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.precompile()'"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.status()'"
+      - "wget -P $HOME https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+      - "tar xf $HOME/julia-1.4.2-linux-x86_64.tar.gz -C $HOME"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.precompile()'"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.status()'"
       # force the initialization of the CUDA runtime as it is lazily loaded by default
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using CUDA; CUDA.versioninfo()'"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using CUDA; CUDA.versioninfo()'"
     agents:
       queue: tartarus
 
@@ -22,9 +22,7 @@ steps:
     env:
       TEST_GROUP: "unit"
     commands:
-      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
-      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
 
@@ -33,9 +31,7 @@ steps:
     env:
       TEST_GROUP: "model"
     commands:
-      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
-      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
 
@@ -43,9 +39,7 @@ steps:
     env:
       TEST_GROUP: "simulation"
     commands:
-      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
-      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
  
@@ -53,9 +47,7 @@ steps:
     env:
       TEST_GROUP: "regression"
     commands:
-      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
-      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
 
@@ -63,9 +55,7 @@ steps:
     env:
       TEST_GROUP: "scripts"
     commands:
-      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
-      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
 
@@ -73,17 +63,13 @@ steps:
   #   env:
   #     TEST_GROUP: "convergence"
   #   commands:
-  #     - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
-  #     - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-  #     - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
+  #     - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
   #   agents:
   #     queue: tartarus
 
   - label: "🦉 documentation"
     commands:
-      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
-      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
-      - "./julia-1.4.2/bin/julia --color=yes --project=docs/ docs/make.jl"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project=docs/ docs/make.jl"
     agents:
       queue: tartarus

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,13 +2,20 @@ env:
   CUDA_VISIBLE_DEVICES: 3
 
 steps:
+  - label: "🏕️ initialize environment"
+    commands:
+      - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+      - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
+      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
+
+  - wait
+
   - label: ":rabbit2: unit tests"
     env:
       TEST_GROUP: "unit"
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -20,7 +27,6 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -31,7 +37,6 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -42,7 +47,6 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
@@ -53,7 +57,6 @@ steps:
     commands:
       - "wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf julia-1.4.2-linux-x86_64.tar.gz"
-      - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "./julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,8 @@ env:
 
 steps:
   - label: "🏕️ initialize environment"
+    env:
+      TEST_GROUP: "init"
     commands:
       - "rm -rf $JULIA_DEPOT_PATH"
       - "wget -P $HOME https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
@@ -14,6 +16,7 @@ steps:
       - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.status()'"
       # force the initialization of the CUDA runtime as it is lazily loaded by default
       - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using CUDA; CUDA.versioninfo()'"
+      - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
       queue: tartarus
 


### PR DESCRIPTION
Kind of a work-in-progress but would be good to merge as PR #997 depends on these changes.

Not the final form of the Buildkite pipeline as I'm still working on improving and expanding it but so far there's an initial job/stage that downloads Julia and instantiates, precompiles, etc. Then all the other jobs can use this new Julia environment to run their tests.

Past behavior was just to reuse my Julia environment. I think it's important that CI always creates a fresh environment from scratch as this is how users will install the code usually, and it will help us catch issues like #991 early.