### PR TITLE
Run Buildkite cleanup step on Tartarus

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
       TEST_GROUP: "init"
     commands:
       - "rm -rf $JULIA_DEPOT_PATH"
-      - "wget -P $HOME https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+      - "wget -N -P $HOME https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
       - "tar xf $HOME/julia-1.4.2-linux-x86_64.tar.gz -C $HOME"
       - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "$HOME/julia-1.4.2/bin/julia --color=yes --project -e 'using Pkg; Pkg.precompile()'"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -84,3 +84,6 @@ steps:
   - label: "🧹 clean up environment"
     commands:
       - "rm -rf $JULIA_DEPOT_PATH"
+    agents:
+      queue: tartarus
+


### PR DESCRIPTION
Was accidently running on the Caltech cluster. Also, now it only downloads Julia if the server version is newer than an existing local file (`wget -N`).