### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,11 @@
 
 <!-- CI/CD badges -->
 <p align="center">
+  <a href="https://buildkite.com/clima/oceananigans">
+    <img alt="Buildkite CPU+GPU build status" src="https://img.shields.io/buildkite/4d921fc17b95341ea5477fb62df0e6d9364b61b154e050a123/master?label=Buildkite%20CPU%2BGPU&style=flat-square">
+  </a>
   <a href="https://travis-ci.com/clima/Oceananigans.jl">
-    <img alt="CPU build status" src="https://img.shields.io/travis/com/clima/Oceananigans.jl/master?label=CPU&logo=travis&logoColor=white&style=flat-square">
-  </a>
-  <a href="https://gitlab.com/JuliaGPU/Oceananigans-jl/commits/master">
-    <img alt="GPU build status" src="https://img.shields.io/gitlab/pipeline/JuliaGPU/Oceananigans-jl/master?label=GPU&logo=gitlab&logoColor=white&style=flat-square">
-  </a>
-  <a href="https://ci.appveyor.com/project/ali-ramadhan/oceananigans-jl">
-    <img alt="Windows build status" src="https://img.shields.io/appveyor/ci/ali-ramadhan/oceananigans-jl/master?label=Window&logo=appveyor&logoColor=white&style=flat-square">
+    <img alt="CPU build status" src="https://img.shields.io/travis/com/clima/Oceananigans.jl/master?label=Travis&logo=travis&logoColor=white&style=flat-square">
   </a>
   <a href="https://hub.docker.com/r/aliramadhan/oceananigans">
     <img alt="Docker build status" src="https://img.shields.io/docker/cloud/build/aliramadhan/oceananigans?label=Docker&logo=docker&logoColor=white&style=flat-square">


### PR DESCRIPTION
Just removing the GitLab CI and Appveyor badges and adding a Buildkite one.