### PR TITLE
Bump v0.42.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.41.0"
+version = "0.42.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Release notes:

This release adds support for time averaging and field slicing to `NetCDFOutputWriter`.

**Breaking changes**:
* `NetCDFOutputWriter` constructor: The `filename` keyword argument is now `filepath`.
* `NetCDFOutputWriter` constructor: To specify slices, pass a `FieldSlicer(i, j, k; with_halos)` instead of using the `xC`, `xF`, `yC`, `yF`, `zC`, and `zF` keyword arguments.