### PR TITLE
Bump v0.43.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.42.0"
+version = "0.43.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
In the spirit of getting closer to continuous delivery (see https://www.oxinabox.net/2019/09/28/Continuous-Delivery-For-Julia-Packages.html#what-if-i-dont-want-to-release-right-now--dev-versions) we should probably tag and release v0.43.0 soon since PRs #1070, #1057, and #1061 + couple of bug fix PRs would be useful to have.

Release notes:

* Fixes a bug in `TwoDimensionalLeith` (PR #1073, issue #1034). Previously tests were being skipped due to extreme slowness. Now we run tests on GPU (but not CPU, where the closure is much slower to compile).

* Rewrites the interface for "scheduling" output and diagnostics (PR #1070). Previously output and diagnostics were usually scheduled by specifying either `time_interval` or `iteration_interval` kwargs in the constrcutor for the object in question. Now, the relevant kwarg is called `schedule` and takes a callable `AbstractSchedule` object (or any user-defined function `func` that returns `true` or `false` depending on the single argument `func(model)`). This design is more flexible and extensible, and also simplifies underlying code. Four schedules are provided:

    - `TimeInterval(interval)`
    - `IterationInterval(interval)`
    - `WallTimeInterval(interval)`
    - `AveragedTimeInterval(interval; window=interval, stride=1)` (for time-averaging output).

Breaking changes:

* Output writers and diagnostics no longer have the keyword arguments `time_interval` or `iteration_interval`. The most commonly-used features that are affected are `JLD2OutputWriter`, `NetCDFOutputWriter`, and `Checkpointer`. `JLD2OutputWriter` and `NetCDFOutputWriter` no longer have the kwargs `time_averaging_window` and `time_averaging_stride`. The specific syntax changes are:

    * `time_interval=T` becomes `schedule=TimeInterval(T)`
    * `iteration_interval=I` becomes `schedule=IterationInterval(I)`
    * `time_interval=T, time_averaging_window=W` becomes `schedule=AveragedTimeInterval(T, window=W)`.

