### PR TITLE
Compressible model

### DIFF
--- a/compressible/.appveyor.yml
+++ b/compressible/.appveyor.yml
@@ -1,0 +1,29 @@
+# Documentation: https://github.com/JuliaCI/Appveyor.jl
+environment:
+  matrix:
+  - julia_version: 1.5
+
+platform:
+  - x64
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
+
+build_script:
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
+
+test_script:
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/compressible/.gitignore
+++ b/compressible/.gitignore
@@ -1,0 +1,36 @@
+# Julia stuff
+*.jl.cov
+*.jl.*.cov
+*.jl.*.mem
+deps/deps.jl
+
+# Swap files.
+*.swp
+*~
+
+# Documenter.jl and MkDocs
+docs/build
+docs/site
+
+# Jupyter Lab stuff and notebooks
+*.ipynb
+.ipynb_checkpoints
+
+# MacOS stuff
+*.DS_Store
+
+# Latex compiler output
+notes/*.aux
+notes/*.log
+notes/*.gz
+
+# Various output
+frames
+*.png
+*.gif
+*.mp4
+*.nc
+*.jld2
+
+# Local development packages
+dev

--- a/compressible/.travis.yml
+++ b/compressible/.travis.yml
@@ -1,0 +1,15 @@
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+
+os:
+  - linux
+  - osx
+
+julia:
+  - 1.5
+
+notifications:
+  email: false
+
+after_success:
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/compressible/LICENSE
+++ b/compressible/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Tristan Abbott, Ali Ramadhan, and Raphael Rousseau-Rizzi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/compressible/Manifest.toml
+++ b/compressible/Manifest.toml
@@ -1,0 +1,654 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[AbstractFFTs]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "051c95d6836228d120f5f4b984dd5aba1624f716"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "0.5.0"
+
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "42c42f2221906892ceb765dbcb1a51deeffd86d7"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "2.3.0"
+
+[[Artifacts]]
+deps = ["Pkg"]
+git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.3.0"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinDeps]]
+deps = ["Libdl", "Pkg", "SHA", "URIParser", "Unicode"]
+git-tree-sha1 = "46cf2c1668ad07aba5a9d331bdeea994a1f13856"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "1.0.1"
+
+[[BinaryProvider]]
+deps = ["Libdl", "Logging", "SHA"]
+git-tree-sha1 = "ecdec412a9abc8db54c0efc5548c64dfce072058"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.5.10"
+
+[[Bzip2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c3598e525718abcc440f69cc6d5f60dda0a1b61e"
+uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
+version = "1.0.6+5"
+
+[[CEnum]]
+git-tree-sha1 = "215a9aa4a1f23fbd05b92769fdd62559488d70e9"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.4.1"
+
+[[CFTime]]
+deps = ["Dates", "Printf"]
+git-tree-sha1 = "143ef231a14c2ab1ac7e838c559ee1e45c0d1b57"
+uuid = "179af706-886a-5703-950a-314cd64e0468"
+version = "0.1.0"
+
+[[CUDA]]
+deps = ["AbstractFFTs", "Adapt", "BinaryProvider", "CEnum", "DataStructures", "ExprTools", "GPUArrays", "GPUCompiler", "LLVM", "Libdl", "LinearAlgebra", "Logging", "MacroTools", "NNlib", "Pkg", "Printf", "Random", "Reexport", "Requires", "SparseArrays", "Statistics", "TimerOutputs"]
+git-tree-sha1 = "83bfd180e2f842f6d4ee315a6db8665e9aa0c19b"
+uuid = "052768ef-5323-5732-b1bb-66c8b64840ba"
+version = "1.3.3"
+
+[[Cassette]]
+git-tree-sha1 = "ff6f5109371926beb67ec3101be17d2c211e497d"
+uuid = "7057c7e9-c182-5462-911a-8362d720325c"
+version = "0.3.3"
+
+[[CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.0"
+
+[[ColorSchemes]]
+deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random", "StaticArrays"]
+git-tree-sha1 = "5d472aa8908568bc198564db06983913a6c2c8e7"
+uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+version = "3.10.1"
+
+[[ColorTypes]]
+deps = ["FixedPointNumbers", "Random"]
+git-tree-sha1 = "4bffea7ed1a9f0f3d1a131bbcd4b925548d75288"
+uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+version = "0.10.9"
+
+[[Colors]]
+deps = ["ColorTypes", "FixedPointNumbers", "InteractiveUtils", "Reexport"]
+git-tree-sha1 = "008d6bc68dea6beb6303fdc37188cb557391ebf2"
+uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
+version = "0.12.4"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "f76e41cf110de7176a657c72409e722cfc86fbb6"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.20.0"
+
+[[CompilerSupportLibraries_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "7c4f882c41faa72118841185afc58a2eb00ef612"
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "0.3.3+0"
+
+[[Conda]]
+deps = ["JSON", "VersionParsing"]
+git-tree-sha1 = "7a58bb32ce5d85f8bf7559aa7c2842f9aecf52fc"
+uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+version = "1.4.1"
+
+[[CondaBinDeps]]
+deps = ["BinDeps", "Conda"]
+git-tree-sha1 = "25f750df2893991f2c9b18425bfac6f2ce855154"
+uuid = "a9693cdc-2bc8-5703-a9cd-1da358117377"
+version = "0.2.0"
+
+[[Contour]]
+deps = ["StaticArrays"]
+git-tree-sha1 = "d05a3a25b762720d40246d5bedf518c9c2614ef5"
+uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
+version = "0.5.5"
+
+[[Crayons]]
+git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.0.4"
+
+[[DataAPI]]
+git-tree-sha1 = "176e23402d80e7743fc26c19c681bfb11246af32"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.3.0"
+
+[[DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "db07bb22795762895b60e44d62b34b16c982a687"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.7"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[EarCut_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "eabac56550a7d7e0be499125673fbff560eb8b20"
+uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
+version = "2.1.5+0"
+
+[[ExprTools]]
+git-tree-sha1 = "10407a39b87f29d47ebaca8edbc75d7c302ff93e"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.3"
+
+[[FFMPEG]]
+deps = ["FFMPEG_jll", "x264_jll"]
+git-tree-sha1 = "9a73ffdc375be61b0e4516d83d880b265366fe1f"
+uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
+version = "0.4.0"
+
+[[FFMPEG_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "LibVPX_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "Pkg", "Zlib_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "3cc57ad0a213808473eafef4845a74766242e05f"
+uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
+version = "4.3.1+4"
+
+[[FFTW]]
+deps = ["AbstractFFTs", "FFTW_jll", "IntelOpenMP_jll", "Libdl", "LinearAlgebra", "MKL_jll", "Reexport"]
+git-tree-sha1 = "8b7c16b56936047ca41bf25effa137ae0b381ae8"
+uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+version = "1.2.4"
+
+[[FFTW_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "6c975cd606128d45d1df432fb812d6eb10fee00b"
+uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
+version = "3.3.9+5"
+
+[[FixedPointNumbers]]
+deps = ["Statistics"]
+git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
+uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+version = "0.8.4"
+
+[[Formatting]]
+deps = ["Printf"]
+git-tree-sha1 = "a0c901c29c0e7c763342751c0a94211d56c0de5c"
+uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
+version = "0.4.1"
+
+[[FreeType2_jll]]
+deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "cbd58c9deb1d304f5a245a0b7eb841a2560cfec6"
+uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
+version = "2.10.1+5"
+
+[[FriBidi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "0d20aed5b14dd4c9a2453c1b601d08e1149679cc"
+uuid = "559328eb-81f9-559d-9380-de523a88c83c"
+version = "1.0.5+6"
+
+[[GPUArrays]]
+deps = ["AbstractFFTs", "Adapt", "LinearAlgebra", "Printf", "Random", "Serialization"]
+git-tree-sha1 = "da6398282abd2a8c0dc3e55b49d984fcc2c582e5"
+uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+version = "5.2.1"
+
+[[GPUCompiler]]
+deps = ["DataStructures", "InteractiveUtils", "LLVM", "Libdl", "TimerOutputs", "UUIDs"]
+git-tree-sha1 = "05097d81898c527e3bf218bb083ad0ead4378e5f"
+uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
+version = "0.6.1"
+
+[[GR]]
+deps = ["Base64", "DelimitedFiles", "HTTP", "JSON", "LinearAlgebra", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
+git-tree-sha1 = "cd0f34bd097d4d5eb6bbe01778cf8a7ed35f29d9"
+uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
+version = "0.52.0"
+
+[[GeometryBasics]]
+deps = ["EarCut_jll", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
+git-tree-sha1 = "876a906eab3be990fdcbfe1e43bb3a76f4776f72"
+uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+version = "0.3.3"
+
+[[GeometryTypes]]
+deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "StaticArrays"]
+git-tree-sha1 = "34bfa994967e893ab2f17b864eec221b3521ba4d"
+uuid = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
+version = "0.8.3"
+
+[[Grisu]]
+git-tree-sha1 = "03d381f65183cb2d0af8b3425fde97263ce9a995"
+uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
+version = "1.0.0"
+
+[[HTTP]]
+deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
+git-tree-sha1 = "c7ec02c4c6a039a98a15f955462cd7aea5df4508"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.8.19"
+
+[[IniFile]]
+deps = ["Test"]
+git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.0"
+
+[[IntelOpenMP_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "fb8e1c7a5594ba56f9011310790e03b5384998d6"
+uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
+version = "2018.0.3+0"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IterTools]]
+git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.3.0"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JLD2]]
+deps = ["CodecZlib", "DataStructures", "MacroTools", "Mmap", "Pkg", "Printf", "Requires", "UUIDs"]
+git-tree-sha1 = "1b8168c14939e43c7c4d2c9e8f0ddd8718965430"
+uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+version = "0.2.4"
+
+[[JLLWrappers]]
+git-tree-sha1 = "7cec881362e5b4e367ff0279dd99a06526d51a55"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.1.2"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.1"
+
+[[KernelAbstractions]]
+deps = ["Adapt", "CUDA", "Cassette", "InteractiveUtils", "MacroTools", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "9262c704a2897c7e4837e75638ec4fc522a0cc19"
+uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+version = "0.4.3"
+
+[[LAME_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "df381151e871f41ee86cee4f5f6fd598b8a68826"
+uuid = "c1c5ebd0-6772-5130-a774-d5fcae4a789d"
+version = "3.100.0+3"
+
+[[LLVM]]
+deps = ["CEnum", "Libdl", "Printf", "Unicode"]
+git-tree-sha1 = "a662366a5d485dee882077e8da3e1a95a86d097f"
+uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
+version = "2.0.0"
+
+[[LaTeXStrings]]
+git-tree-sha1 = "c7aebfecb1a60d59c0fe023a68ec947a208b1e6b"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.2.0"
+
+[[Latexify]]
+deps = ["Formatting", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "Printf", "Requires"]
+git-tree-sha1 = "829b033e31573b8ffdd14e0d47154fd3ddc7abbf"
+uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+version = "0.14.0"
+
+[[LibGit2]]
+deps = ["Printf"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibVPX_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "85fcc80c3052be96619affa2fe2e6d2da3908e11"
+uuid = "dd192d2f-8180-539f-9fb4-cc70b1dcf69a"
+version = "1.9.0+1"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MKL_jll]]
+deps = ["IntelOpenMP_jll", "Libdl", "Pkg"]
+git-tree-sha1 = "eb540ede3aabb8284cb482aa41d00d6ca850b1f8"
+uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
+version = "2020.2.254+0"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "f7d2e3f654af75f01ec49be82c231c382214223a"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.5"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
+git-tree-sha1 = "426a6978b03a97ceb7ead77775a1da066343ec6e"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.0.2"
+
+[[MbedTLS_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "c0b1286883cac4e2b617539de41111e0776d02e8"
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.16.8+0"
+
+[[Measures]]
+git-tree-sha1 = "e498ddeee6f9fdb4551ce855a46f54dbd900245f"
+uuid = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
+version = "0.3.1"
+
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "ed61674a0864832495ffe0a7e889c0da76b0f4c8"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "0.4.4"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[NCDatasets]]
+deps = ["BinDeps", "CFTime", "CondaBinDeps", "DataStructures", "Dates", "Libdl", "Printf"]
+git-tree-sha1 = "31ce6711bc8fa173d97c59066e78caa2846ed200"
+uuid = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
+version = "0.10.4"
+
+[[NNlib]]
+deps = ["Libdl", "LinearAlgebra", "Pkg", "Requires", "Statistics"]
+git-tree-sha1 = "1ef04283efe283be08e2d0de842f5e5286dd0b7a"
+uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+version = "0.7.5"
+
+[[NaNMath]]
+git-tree-sha1 = "c84c576296d0e2fbb3fc134d3e09086b3ea617cd"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.4"
+
+[[Oceananigans]]
+deps = ["Adapt", "CUDA", "Crayons", "Dates", "FFTW", "InteractiveUtils", "JLD2", "KernelAbstractions", "LinearAlgebra", "Logging", "NCDatasets", "OffsetArrays", "OrderedCollections", "Pkg", "Printf", "Random", "SafeTestsets", "SeawaterPolynomials", "StaticArrays", "Statistics"]
+git-tree-sha1 = "610ea28446158cdd3220a51af013683441436d28"
+uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
+version = "0.42.0"
+
+[[OffsetArrays]]
+git-tree-sha1 = "3fdfca8a532507d65f39ff0ad34fe81097a55337"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.3.0"
+
+[[Ogg_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "a42c0f138b9ebe8b58eba2271c5053773bde52d0"
+uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
+version = "1.3.4+2"
+
+[[OpenSSL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "71bbbc616a1d710879f5a1021bcba65ffba6ce58"
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "1.1.1+6"
+
+[[OpenSpecFun_jll]]
+deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
+git-tree-sha1 = "d51c416559217d974a1113522d5919235ae67a87"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.3+3"
+
+[[Opus_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f9d57f4126c39565e05a2b0264df99f497fc6f37"
+uuid = "91d4177d-7536-5919-b921-800302f37372"
+version = "1.3.1+3"
+
+[[OrderedCollections]]
+git-tree-sha1 = "16c08bf5dba06609fe45e30860092d6fa41fde7b"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.3.1"
+
+[[Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "6fa4202675c05ba0f8268a6ddf07606350eda3ce"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.0.11"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PlotThemes]]
+deps = ["PlotUtils", "Requires", "Statistics"]
+git-tree-sha1 = "c6f5ea535551b3b16835134697f0c65d06c94b91"
+uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
+version = "2.0.0"
+
+[[PlotUtils]]
+deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
+git-tree-sha1 = "4e098f88dad9a2b518b83124a116be1c49e2b2bf"
+uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
+version = "1.0.7"
+
+[[Plots]]
+deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "GeometryTypes", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
+git-tree-sha1 = "9376c978098b85a001870ad0270569b6e445f154"
+uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+version = "1.6.10"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[RecipesBase]]
+git-tree-sha1 = "6ee6c35fe69e79e17c455a386c1ccdc66d9f7da4"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.1.0"
+
+[[RecipesPipeline]]
+deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
+git-tree-sha1 = "4a325c9bcc2d8e62a8f975b9666d0251d53b63b9"
+uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
+version = "0.1.13"
+
+[[Reexport]]
+deps = ["Pkg"]
+git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "0.2.0"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "28faf1c963ca1dc3ec87f166d92982e3c4a1f66d"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.1.0"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[SafeTestsets]]
+deps = ["Test"]
+git-tree-sha1 = "36ebc5622c82eb9324005cc75e7e2cc51181d181"
+uuid = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+version = "0.0.1"
+
+[[SeawaterPolynomials]]
+deps = ["Test"]
+git-tree-sha1 = "6db1b6004791962cb12d425cd12691506ad7d2b6"
+uuid = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
+version = "0.2.0"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Showoff]]
+deps = ["Dates", "Grisu"]
+git-tree-sha1 = "ee010d8f103468309b8afac4abb9be2e18ff1182"
+uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
+version = "0.3.2"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures", "Random", "Test"]
+git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "0.3.1"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SpecialFunctions]]
+deps = ["OpenSpecFun_jll"]
+git-tree-sha1 = "d8d8b8a9f4119829410ecd706da4cc8594a1e020"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "0.10.3"
+
+[[StaticArrays]]
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "016d1e1a00fabc556473b07161da3d39726ded35"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.12.4"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics"]
+git-tree-sha1 = "7bab7d4eb46b225b35179632852b595a3162cb61"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.33.2"
+
+[[StructArrays]]
+deps = ["Adapt", "DataAPI", "Tables"]
+git-tree-sha1 = "8099ed9fb90b6e754d6ba8c6ed8670f010eadca0"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.4.4"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "b1ad568ba658d8cbb3b892ed5380a6f3e781a81e"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.0"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "24a584cf65e2cfabdadc21694fb69d2e74c82b44"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.1.0"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TimerOutputs]]
+deps = ["Printf"]
+git-tree-sha1 = "f458ca23ff80e46a630922c555d838303e4b9603"
+uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+version = "0.5.6"
+
+[[TranscodingStreams]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "7c53c35547de1c5b9d46a4797cf6d8253807108c"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.9.5"
+
+[[URIParser]]
+deps = ["Unicode"]
+git-tree-sha1 = "53a9f49546b8d2dd2e688d216421d050c9a31d0d"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.1"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[VersionParsing]]
+git-tree-sha1 = "80229be1f670524750d905f8fc8148e5a8c4537f"
+uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
+version = "1.2.0"
+
+[[Zlib_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "ded43825988ace7a311ee7e1d0f09571822509c4"
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.11+17"
+
+[[libass_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "acc685bcf777b2202a904cdcb49ad34c2fa1880c"
+uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
+version = "0.14.0+4"
+
+[[libfdk_aac_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "7a5780a0d9c6864184b3a2eeeb833a0c871f00ab"
+uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
+version = "0.1.6+4"
+
+[[libvorbis_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll", "Pkg"]
+git-tree-sha1 = "fa14ac25af7a4b8a7f61b287a124df7aab601bcd"
+uuid = "f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
+version = "1.3.6+6"
+
+[[x264_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "d713c1ce4deac133e3334ee12f4adff07f81778f"
+uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
+version = "2020.7.14+2"
+
+[[x265_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "487da2f8f2f0c8ee0e83f39d13037d6bbf0a45ab"
+uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
+version = "3.0.0+3"

--- a/compressible/Project.toml
+++ b/compressible/Project.toml
@@ -1,0 +1,26 @@
+name = "JULES"
+uuid = "216628ba-da5e-11e9-0e9d-731cbc3ee0ea"
+authors = ["Tristan Abbott", "Ali Ramadhan", "Raphael Rousseau-Rizzi"]
+version = "0.1.0"
+
+[deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
+Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/compressible/README.md
+++ b/compressible/README.md
@@ -1,0 +1,12 @@
+# JULES.jl
+
+[![travis][travis-img]][travis-url] [![appveyor][appveyor-img]][appveyor-url] [![codecov][codecov-img]][codecov-url]
+
+[travis-img]: https://travis-ci.com/thabbott/JULES.jl.svg?branch=master
+[travis-url]: https://travis-ci.com/thabbott/JULES.jl
+
+[appveyor-img]: https://ci.appveyor.com/api/projects/status/ni5ifxwqjkbcofsk/branch/master?svg=true
+[appveyor-url]: https://ci.appveyor.com/project/thabbott/jules-jl
+
+[codecov-img]: https://codecov.io/gh/thabbott/JULES.jl/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/thabbott/JULES.jl

--- a/compressible/benchmarks/benchmark_cfl.jl
+++ b/compressible/benchmarks/benchmark_cfl.jl
@@ -1,0 +1,117 @@
+using Printf
+
+using BenchmarkTools
+using CUDA
+using DataFrames
+using PrettyTables
+
+using Oceananigans
+using Oceananigans.Architectures
+using JULES
+
+using BenchmarkTools: prettytime, prettymemory
+
+Archs = [CPU]
+@hascuda Archs = [CPU, GPU]
+
+Ns = [32, 128]
+Tvars = [Energy, Entropy]
+Gases = [DryEarth, DryEarth3]
+
+tags = ["arch", "N", "gases", "tvar"]
+
+suite = BenchmarkGroup(
+    "cfl" => BenchmarkGroup(),
+    "acoustic_cfl" => BenchmarkGroup()
+)
+
+_cfl(model) = cfl(model, 1)
+_cfl(model::CompressibleModel{GPU}) = CUDA.@sync cfl(model, 1)
+_acoustic_cfl(model) = acoustic_cfl(model, 1)
+_acoustic_cfl(model::CompressibleModel{GPU}) = CUDA.@sync acoustic_cfl(model, 1)
+
+for Arch in Archs, N in Ns, Gas in Gases, Tvar in Tvars
+    @info "Running CFL benchmark [$Arch, N=$N, $Tvar, $Gas]..."
+
+    grid = RegularCartesianGrid(size=(N, N, N), extent=(1, 1, 1))
+    model = CompressibleModel(architecture=Arch(), grid=grid, thermodynamic_variable=Tvar(),
+                              gases=Gas())
+
+    # warmup
+    _cfl(model)
+    _acoustic_cfl(model)
+
+    b_cfl = @benchmark _cfl($model) samples=10
+    display(b_cfl)
+
+    b_acfl = @benchmark _acoustic_cfl($model) samples=10
+    display(b_acfl)
+
+    key = (Arch, N, Gas, Tvar)
+    suite["cfl"][key] = b_cfl
+    suite["acoustic_cfl"][key] = b_acfl
+end
+
+function benchmarks_to_dataframe(suite)
+    df = DataFrame(architecture=[], size=[], gases=[],
+                   thermodynamic_variable=[], min=[], median=[],
+                   mean=[], max=[], memory=[], allocs=[])
+    
+    for Arch in Archs, N in Ns, Gas in Gases, Tvar in Tvars
+        b = suite[Arch, N, Gas, Tvar]
+
+        d = Dict(
+            "architecture" => Arch,
+            "size" => "$(N)³",
+            "gases" => Gas,
+            "thermodynamic_variable" => Tvar,
+            "min" => minimum(b.times) |> prettytime,
+            "median" => median(b.times) |> prettytime,
+            "mean" => mean(b.times) |> prettytime,
+            "max" => maximum(b.times) |> prettytime,
+            "memory" => prettymemory(b.memory),
+            "allocs" => b.allocs
+        )
+
+        push!(df, d)
+    end
+
+    return df
+end
+
+header = ["Arch" "Size" "Gases" "ThermoVar" "min" "median" "mean" "max" "memory" "allocs"]
+
+df = benchmarks_to_dataframe(suite["cfl"])
+pretty_table(df, header, title="CFL benchmarks", nosubheader=true)
+
+df = benchmarks_to_dataframe(suite["acoustic_cfl"])
+pretty_table(df, header, title="Acoustic CFL benchmarks", nosubheader=true)
+
+function gpu_speedups(suite)
+    df = DataFrame(size=[], gases=[], thermodynamic_variable=[], speedup=[])
+
+    for N in Ns, Gas in Gases, Tvar in Tvars
+        b_cpu = suite[CPU, N, Gas, Tvar] |> median
+        b_gpu = suite[GPU, N, Gas, Tvar] |> median
+        b_ratio = ratio(b_cpu, b_gpu)
+
+        d = Dict(
+            "size" => "$(N)³",
+            "gases" => Gas,
+            "thermodynamic_variable" => Tvar,
+            "speedup" => @sprintf("%.3fx", b_ratio.time)
+        )
+
+        push!(df, d)
+    end
+
+    return df
+end
+
+header = ["Size" "Gases" "ThermoVar" "speedup"]
+
+df = gpu_speedups(suite["cfl"])
+pretty_table(df, header, title="CFL speedups", nosubheader=true)
+
+df = gpu_speedups(suite["acoustic_cfl"])
+pretty_table(df, header, title="Acoustic CFL speedups", nosubheader=true)

--- a/compressible/benchmarks/benchmark_compressible_model.jl
+++ b/compressible/benchmarks/benchmark_compressible_model.jl
@@ -1,0 +1,97 @@
+using Printf
+
+using BenchmarkTools
+using CUDA
+using DataFrames
+using PrettyTables
+
+using Oceananigans
+using Oceananigans.Architectures
+using JULES
+
+using BenchmarkTools: prettytime, prettymemory
+
+Archs = [CPU]
+@hascuda Archs = [CPU, GPU]
+
+Ns = [32, 192]
+Tvars = [Energy, Entropy]
+Gases = [DryEarth, DryEarth3]
+
+suite = BenchmarkGroup()
+
+sync_step!(model) = time_step!(model, 1)
+sync_step!(model::CompressibleModel{GPU}) = CUDA.@sync time_step!(model, 1)
+
+for Arch in Archs, N in Ns, Gas in Gases, Tvar in Tvars
+    @info "Running static atmosphere benchmark [$Arch, N=$N, $Tvar, $Gas]..."
+
+    grid = RegularCartesianGrid(size=(N, N, N), halo=(2, 2, 2), extent=(1, 1, 1))
+    model = CompressibleModel(architecture=Arch(), grid=grid, thermodynamic_variable=Tvar(), gases=Gas())
+
+    sync_step!(model) # warmup
+
+    b = @benchmark sync_step!($model) samples=10
+    display(b)
+
+    key = (Arch, N, Gas, Tvar)
+    suite[key] = b
+end
+
+function benchmarks_to_dataframe(suite)
+    df = DataFrame(architecture=[], size=[], gases=[],
+                   thermodynamic_variable=[], min=[], median=[],
+                   mean=[], max=[], memory=[], allocs=[])
+    
+    for Arch in Archs, N in Ns, Gas in Gases, Tvar in Tvars
+        b = suite[Arch, N, Gas, Tvar]
+
+        d = Dict(
+            "architecture" => Arch,
+            "size" => "$(N)³",
+            "gases" => Gas,
+            "thermodynamic_variable" => Tvar,
+            "min" => minimum(b.times) |> prettytime,
+            "median" => median(b.times) |> prettytime,
+            "mean" => mean(b.times) |> prettytime,
+            "max" => maximum(b.times) |> prettytime,
+            "memory" => prettymemory(b.memory),
+            "allocs" => b.allocs
+        )
+
+        push!(df, d)
+    end
+
+    return df
+end
+
+header = ["Arch" "Size" "Gases" "ThermoVar" "min" "median" "mean" "max" "memory" "allocs"]
+
+df = benchmarks_to_dataframe(suite)
+pretty_table(df, header, title="Static atmosphere benchmarks", nosubheader=true)
+
+function gpu_speedups(suite)
+    df = DataFrame(size=[], gases=[], thermodynamic_variable=[], speedup=[])
+
+    for N in Ns, Gas in Gases, Tvar in Tvars
+        b_cpu = suite[CPU, N, Gas, Tvar] |> median
+        b_gpu = suite[GPU, N, Gas, Tvar] |> median
+        b_ratio = ratio(b_cpu, b_gpu)
+
+        d = Dict(
+            "size" => "$(N)³",
+            "gases" => Gas,
+            "thermodynamic_variable" => Tvar,
+            "speedup" => @sprintf("%.3fx", b_ratio.time)
+        )
+
+        push!(df, d)
+    end
+
+    return df
+end
+
+header = ["Size" "Gases" "ThermoVar" "speedup"]
+
+df = gpu_speedups(suite)
+pretty_table(df, header, title="Static atmosphere speedups", nosubheader=true)

--- a/compressible/benchmarks/benchmark_diagnosis.jl
+++ b/compressible/benchmarks/benchmark_diagnosis.jl
@@ -1,0 +1,103 @@
+using BenchmarkTools
+using DataFrames
+using PrettyTables
+using CUDA
+
+using Oceananigans
+using Oceananigans.Architectures
+using JULES
+
+using BenchmarkTools: prettytime, prettymemory
+using JULES: intermediate_thermodynamic_field, compute_temperature!
+
+Archs = [CPU]
+@hascuda Archs = [CPU, GPU]
+
+Ns = [32, 64]
+@hascuda Ns = [32, 192]
+
+Tvars = [Energy, Entropy]
+Gases = [DryEarth, DryEarth3]
+
+tags = ["arch", "N", "gases", "tvar"]
+
+suite = BenchmarkGroup(
+    "temperature" => BenchmarkGroup(),
+    "pressure" => BenchmarkGroup()
+)
+
+_compute_temperature!(model) = compute_temperature!(model)
+_compute_temperature!(model::CompressibleModel{GPU}) = CUDA.@sync compute_temperature!(model)
+
+for Arch in Archs, N in Ns, Gases in Gases, Tvar in Tvars
+    @info "Running temperature computation benchmark [$Arch, N=$N, $Tvar, $Gases]..."
+
+    grid = RegularCartesianGrid(size=(N, N, N), extent=(1, 1, 1))
+    model = CompressibleModel(architecture=Arch(), grid=grid, thermodynamic_variable=Tvar(),
+                              gases=Gases())
+
+    _compute_temperature!(model) # warmup
+
+    b = @benchmark _compute_temperature!($model) samples=10
+
+    key = (Arch, N, Gases, Tvar)
+    suite["temperature"][key] = b
+end
+
+function benchmarks_to_dataframe(suite)
+    df = DataFrame(architecture=[], size=[], gases=[],
+                   thermodynamic_variable=[], min=[], median=[],
+                   mean=[], max=[], memory=[], allocs=[])
+    
+    for (key, b) in suite
+        Arch, N, Gases, Tvar = key
+
+        d = Dict(
+            "architecture" => Arch,
+            "size" => "$(N)³",
+            "gases" => Gases,
+            "thermodynamic_variable" => Tvar,
+            "min" => minimum(b.times) |> prettytime,
+            "median" => median(b.times) |> prettytime,
+            "mean" => mean(b.times) |> prettytime,
+            "max" => maximum(b.times) |> prettytime,
+            "memory" => prettymemory(b.memory),
+            "allocs" => b.allocs
+        )
+
+        push!(df, d)
+    end
+
+    return df
+end
+
+header = ["Arch" "Size" "Gases" "ThermoVar" "min" "median" "mean" "max" "memory" "allocs"]
+
+df = benchmarks_to_dataframe(suite["temperature"])
+pretty_table(df, header, title="Temperature computation benchmarks", nosubheader=true)
+
+function gpu_speedups(suite)
+    df = DataFrame(size=[], gases=[], thermodynamic_variable=[], speedup=[])
+
+    for N in Ns, Gas in Gases, Tvar in Tvars
+        b_cpu = suite[CPU, N, Gas, Tvar] |> median
+        b_gpu = suite[GPU, N, Gas, Tvar] |> median
+        b_ratio = ratio(b_cpu, b_gpu)
+
+        d = Dict(
+            "size" => "$(N)³",
+            "gases" => Gas,
+            "thermodynamic_variable" => Tvar,
+            "speedup" => @sprintf("%.3fx", b_ratio.time)
+        )
+
+        push!(df, d)
+    end
+
+    return df
+end
+
+header = ["Size" "Gases" "ThermoVar" "speedup"]
+
+df = gpu_speedups(suite["temperature"])
+pretty_table(df, header, title="Temperature computation speedups", nosubheader=true)

--- a/compressible/codecov.yml
+++ b/compressible/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  range: 50..90
+  round: down
+  precision: 2
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: auto
+        threshold: 20%

--- a/compressible/sandbox/dry_adiabatic_atmosphere.jl
+++ b/compressible/sandbox/dry_adiabatic_atmosphere.jl
@@ -1,0 +1,99 @@
+using JULES, Oceananigans
+using Plots
+using Printf
+
+Nx = Ny = 1
+Nz = 32
+L = 10e3
+
+grid = RegularCartesianGrid(size=(Nx, Ny, Nz), halo=(2, 2, 2),
+                            x=(0, L), y=(0, L), z=(0, L))
+#####
+##### Dry adiabatic atmosphere
+#####
+
+gas = IdealGas()
+Rᵈ, cₚ, cᵥ = gas.Rᵈ, gas.cₚ, gas.cᵥ
+
+g  = 9.80665
+pₛ = 100000
+θₛ = 300
+πₛ = 1
+
+θ(x, y, z) = θₛ
+π(x, y, z) = πₛ - g*z / (cₚ*θₛ)
+p(x, y, z) = pₛ * π(x, y, z)^(cₚ/Rᵈ)
+ρ(x, y, z) = pₛ / (Rᵈ * θ(x, y, z)) * π(x, y, z)^(cᵥ/Rᵈ)
+Θ(x, y, z) = ρ(x, y, z) * θ(x, y, z)
+
+#####
+##### Create model
+#####
+
+model = CompressibleModel(grid=grid, buoyancy=gas, reference_pressure=pₛ,
+                          thermodynamic_variable=ModifiedPotentialTemperature(),
+                          tracers=(:Θᵐ,))
+
+#####
+##### Set initial conditions
+#####
+
+set!(model.density, ρ)
+set!(model.tracers.Θᵐ, θ)
+
+# Initial profiles
+Θ₀_prof = model.tracers.Θᵐ[1, 1, 1:Nz]
+ρ₀_prof = model.density[1, 1, 1:Nz]
+
+# Arrays we will use to store a time series of ρw(z = L/2).
+times = [model.clock.time]
+ρw_ts = [model.momenta.ρw[1, 1, Int(Nz/2)]]
+
+#####
+##### Time step and keep plotting vertical profiles of ρθ′, ρw, and ρ′.
+#####
+
+# @animate for i=1:100
+while model.clock.time < 500
+    time_step!(model; Δt=0.5, Nt=10)
+
+    @show model.clock.time
+    Θ_prof = model.tracers.Θᵐ[1, 1, 1:Nz] .- Θ₀_prof
+    W_prof = model.momenta.ρw[1, 1, 1:Nz+1]
+    ρ_prof = model.density[1, 1, 1:Nz] .- ρ₀_prof
+
+    Θ_plot = plot(Θ_prof, grid.zC, xlim=(-2.5, 2.5), xlabel="Theta_prime", ylabel="z (m)", label="")
+    W_plot = plot(W_prof, grid.zF, xlim=(-1.2, 1.2), xlabel="rho*w", label="")
+    ρ_plot = plot(ρ_prof, grid.zC, xlim=(-0.01, 0.01), xlabel="rho", label="")
+
+    t_str = @sprintf("t = %d s", model.clock.time)
+    display(plot(Θ_plot, W_plot, ρ_plot, title=["" "$t_str" ""], layout=(1, 3), show=true))
+
+    push!(times, model.clock.time)
+    push!(ρw_ts, model.momenta.ρw[1, 1, Int(Nz/2)])
+end
+
+#####
+##### Plot the initial profile and the hydrostatically balanced profile.
+#####
+
+ρ∞_prof = model.density[1, 1, 1:Nz]
+
+θ₀_prof = Θ₀_prof ./ ρ₀_prof
+θ∞_prof = model.tracers.Θᵐ[1, 1, 1:Nz] ./ ρ∞_prof
+
+θ_plot = plot(θ₀_prof, grid.zC, xlabel="theta (K)", ylabel="z (m)", label="initial", legend=:topleft)
+plot!(θ_plot, θ∞_prof, grid.zC, label="balanced")
+
+ρ_plot = plot(ρ₀_prof, grid.zC, xlabel="rho (kg/m³)", ylabel="z (m)", label="initial")
+plot!(ρ_plot, ρ∞_prof, grid.zC, label="balanced")
+
+display(plot(θ_plot, ρ_plot, show=true))
+
+
+#####
+##### Plot timeseries of maximum ρw
+#####
+
+plot(times, ρw_ts, linewidth=2, xlabel="time (s)", ylabel="rho*w(z=$(Int(L/2)) m)", label="", show=true)
+

--- a/compressible/sandbox/dry_convection.jl
+++ b/compressible/sandbox/dry_convection.jl
@@ -1,0 +1,132 @@
+using Logging
+using Printf
+using Statistics
+using NCDatasets
+using CUDA
+
+using Oceananigans
+using Oceananigans.Grids
+using Oceananigans.Advection
+using Oceananigans.OutputWriters
+using Oceananigans.Utils
+using JULES
+
+using Oceananigans.Fields: cpudata
+
+Logging.global_logger(OceananigansLogger())
+
+const km = kilometers
+const hPa = 100.0
+
+#####
+##### Hydrostatic base state
+#####
+
+pₛ = 1000hPa
+Tₛ = 300.0
+
+θ₀(x, y, z) = Tₛ
+p₀(x, y, z) = pₛ * (1 - g*z / (cₚ*Tₛ))^(cₚ/R)
+T₀(x, y, z) = Tₛ * (p₀(x, y, z)/pₛ)^(R/cₚ)
+ρ₀(x, y, z) = p₀(x, y, z) / (R*T₀(x, y, z))
+
+#####
+##### Model setup
+#####
+
+L = 2.56km
+Δ = 40meters
+N = Int(L/Δ)
+
+topo = (Periodic, Periodic, Bounded)
+domain = (x=(0, L), y=(0, L), z=(0, L))
+grid = RegularCartesianGrid(topology=topo, size=(N, N, N), halo=(3, 3, 3); domain...)
+
+gas = DryEarth()
+
+# Sponge layer at the top with exponential decay length scale γ.
+@inline damping_profile(z, L, γ) = exp(- (L - z) / γ)
+
+forcing_params = (λ = 1/(10seconds), L=grid.Lz, γ=0.2grid.Lz)
+
+@inline rayleigh_damping_ρu(i, j, k, grid, clock, fields, p) =
+    @inbounds - p.λ * damping_profile(grid.zC[k], p.L, p.γ) * fields.ρu[i, j, k]
+
+@inline rayleigh_damping_ρv(i, j, k, grid, clock, fields, p) =
+    @inbounds - p.λ * damping_profile(grid.zC[k], p.L, p.γ) * fields.ρv[i, j, k]
+
+@inline rayleigh_damping_ρw(i, j, k, grid, clock, fields, p) =
+    @inbounds - p.λ * damping_profile(grid.zC[k], p.L, p.γ) * fields.ρw[i, j, k]
+
+ρu_forcing = Forcing(rayleigh_damping_ρu, discrete_form=true, parameters=forcing_params)
+ρv_forcing = Forcing(rayleigh_damping_ρv, discrete_form=true, parameters=forcing_params)
+ρw_forcing = Forcing(rayleigh_damping_ρw, discrete_form=true, parameters=forcing_params)
+
+# Exponentially decaying radiative forcing
+@inline radiative_profile(z, Q₀, ℓ) = Q₀ * exp(-z/ℓ)
+
+radiative_params = (Q₀=100.0, ℓ=100.0)
+
+@inline radiative_forcing_ρe(i, j, k, grid, clock, fields, p) =
+    @inbounds (radiative_profile(grid.zC[k], p.Q₀, p.ℓ) - radiative_profile(grid.zC[k+1], p.Q₀, p.ℓ)) / grid.Δz
+
+ρe_forcing = Forcing(radiative_forcing_ρe, discrete_form=true, parameters=radiative_params)
+
+model = CompressibleModel(
+              architecture = GPU(),
+                      grid = grid,
+                 advection = WENO5(),
+                     gases = gas,
+    thermodynamic_variable = Energy(),
+                   closure = IsotropicDiffusivity(ν=1e-2, κ=1e-2),
+                   forcing = (ρu=ρu_forcing, ρv=ρv_forcing, ρw=ρw_forcing, ρe=ρe_forcing)
+)
+
+g  = model.gravity
+R, cₚ, cᵥ = gas.ρ.R, gas.ρ.cₚ, gas.ρ.cᵥ
+uᵣ, Tᵣ, ρᵣ, sᵣ = gas.ρ.u₀, gas.ρ.T₀, gas.ρ.ρ₀, gas.ρ.s₀
+ρe₀(x, y, z) = ρ₀(x, y, z) * (uᵣ + cᵥ * (T₀(x, y, z) - Tᵣ) + g*z) + randn()
+
+# Set initial state
+set!(model.tracers.ρ, ρ₀)
+set!(model.tracers.ρe, ρe₀)
+update_total_density!(model)
+
+function print_progress(simulation)
+    model, Δt = simulation.model, simulation.Δt
+    tvar = model.thermodynamic_variable
+
+    progress = 100 * model.clock.time / simulation.stop_time
+    message = @sprintf("[%05.2f%%] iteration = %d, time = %s, CFL = %.4e, acoustic CFL = %.4e",
+                       progress, model.clock.iteration, prettytime(model.clock.time), cfl(model, Δt),
+                       acoustic_cfl(model, Δt))
+
+    @info message
+
+    return nothing
+end
+
+simulation = Simulation(model, Δt=0.02second, stop_time=1hour, iteration_interval=20,
+                        progress=print_progress)
+
+fields = Dict(
+    "ρ"  => model.total_density,
+    "ρu" => model.momenta.ρu,
+    "ρv" => model.momenta.ρv,
+    "ρw" => model.momenta.ρw,
+    "ρe" => model.tracers.ρe
+)
+    
+simulation.output_writers[:fields] =
+    NetCDFOutputWriter(model, fields, filepath="dry_convection.nc", time_interval=10seconds)
+
+# Save base state to NetCDF.
+ds = simulation.output_writers[:fields].dataset
+ds_ρ = defVar(ds, "ρ₀", Float32, ("xC", "yC", "zC"))
+ds_ρe = defVar(ds, "ρe₀", Float32, ("xC", "yC", "zC"))
+
+x, y, z = nodes((Cell, Cell, Cell), grid, reshape=true)
+ds_ρ[:, :, :] = ρ₀.(x, y, z)
+ds_ρe[:, :, :] = ρe₀.(x, y, z)
+
+run!(simulation)

--- a/compressible/sandbox/plot_dry_convection_makie.jl
+++ b/compressible/sandbox/plot_dry_convection_makie.jl
@@ -1,0 +1,77 @@
+using NCDatasets
+using Interpolations
+using Makie
+
+#####
+##### Read data
+#####
+
+ds = NCDataset("dry_convection.nc")
+
+nx, ny, nz, nt = size(ds["ρe"])
+
+ρe₀ = Array(ds["ρe₀"]);
+ρe  = Array(ds["ρe"]);
+ρe′ = similar(ρe);
+
+for n in 1:length(ds["time"])
+    @. ρe′[:, :, :, n] = ρe[:, :, :, n] - ρe₀;
+end
+
+#####
+##### Interpolate to a finer grid with S::Int > 1
+#####
+
+function get_data(n, S=1)
+    if S == 1
+        return ρe′[:, :, :, n]
+    else
+        itp = interpolate(ρe′[:, :, :, n], BSpline(Cubic(Periodic(OnCell()))));
+        n = size(ρe′[:, :, :, n])
+        N = S .* n
+        ℑρe′ = zeros(N)
+
+        i_inds = range(1, n[1], length=N[1])
+        j_inds = range(1, n[2], length=N[2])
+        k_inds = range(1, n[3], length=N[3])
+
+        i_inds = reshape(i_inds, (N[1], 1, 1))
+        j_inds = reshape(j_inds, (1, N[2], 1))
+        k_inds = reshape(k_inds, (1, 1, N[3]))
+
+        @. ℑρe′ = itp(i_inds, j_inds, k_inds)
+
+        return ℑρe′
+    end
+end
+
+#####
+##### Plot!
+#####
+
+α(ξ) = ξ  # Opacity/alpha along the cmap (0 <= ξ <= 1)
+
+cmap_rgb = to_colormap(:ice)
+A = α.(range(0, 1, length=length(cmap_rgb)))
+cmap_rgba = RGBAf0.(cmap_rgb, A)
+
+time_index = Node(1)
+data = @lift get_data($time_index, 3)
+
+function make_movie(scene)
+    n_frames = nt
+    θ = 2π / 360
+
+    record(scene, "dry_convection_oceananigans_makie.mp4", 1:n_frames, framerate=30) do n
+        @info "frame $n/$n_frames"
+        time_index[] = n
+        n == 1 && zoom!(scene, (0, 0, 0), -1.25, false)
+        rotate_cam!(scene, (θ, 0, 0))
+    end
+end
+
+scene = volume(0..nx, 0..ny, 0..nz, data, colorrange=(0, 400), colormap=cmap_rgba, algorithm=:absorption, absorption=10.0f0,
+               backgroundcolor=cmap_rgb[2], show_axis=false, resolution = (1920, 1080))
+
+make_movie(scene)
+

--- a/compressible/sandbox/solve_for_hydrostatic_profiles.jl
+++ b/compressible/sandbox/solve_for_hydrostatic_profiles.jl
@@ -1,0 +1,110 @@
+using JULES, Oceananigans
+using Printf
+using Plots
+using NLsolve
+
+Nx = Ny = 1
+Nz = 32
+L = 10e3
+
+grid = RegularCartesianGrid(size=(Nx, Ny, Nz), halo=(2, 2, 2),
+                            x=(0, L), y=(0, L), z=(0, L))
+Δz = grid.Δz
+
+pₛ = 100000
+Tₐ = 293.15
+g  = 9.80665
+
+buoyancy = IdealGas()
+Rᵈ, cₚ, γ = buoyancy.Rᵈ, buoyancy.cₚ, buoyancy.γ
+
+####
+#### Isothermal atmosphere
+####
+
+H = Rᵈ * Tₐ / g    # Scale height [m]
+ρₛ = pₛ / (Rᵈ*Tₐ)  # Surface density [kg/m³]
+
+p₀(x, y, z) = pₛ * exp(-z/H)
+ρ₀(x, y, z) = ρₛ * exp(-z/H)
+
+θ₀(x, y, z) = Tₐ * exp(z/H * Rᵈ/cₚ)
+Θ₀(x, y, z) = ρ₀(x, y, z) * θ₀(x, y, z)
+
+θ₀_prof = θ₀.(0, 0, grid.zC)
+p₀_prof = p₀.(0, 0, grid.zC)
+ρ₀_prof = ρ₀.(0, 0, grid.zC)
+
+####
+#### Objective function describing the ideal gas equation of state and hydrostatic balance
+#### Set up a nonlinear system of equations F(x) = 0 and solve for pₖ and ρₖ.
+####
+
+# First Nz variables are pressure values pₖ, k = 1, 2, …, Nz
+# Second Nz variables are density values ρₖ
+function f!(F, x)
+    @inbounds begin
+        p₁, ρ₁, θ₁ = x[1], x[Nz+1], θ₀_prof[1]
+        F[1] = p₁ - pₛ * (Rᵈ*ρ₁*θ₁ / pₛ)^γ
+        F[Nz+1] = p₁ - pₛ + ρ₁*g*(Δz/2)
+
+        for k in 2:Nz
+            pₖ, pₖ₋₁, ρₖ, θₖ = x[k], x[k-1], x[Nz+k], θ₀_prof[k]
+            F[k] = pₖ - pₛ * (Rᵈ*ρₖ*θₖ / pₛ)^γ
+            F[Nz+k] = pₖ - pₖ₋₁ + ρₖ*g*Δz
+        end
+    end
+end
+
+guess = [p₀_prof; ρ₀_prof]
+sol = nlsolve(f!, guess, show_trace=true)
+
+####
+#### Plot difference between initial condition and solution.
+####
+
+p∞_prof = sol.zero[1:Nz]
+ρ∞_prof = sol.zero[Nz+1:2Nz]
+
+p_plot = plot(p₀_prof, grid.zC, xlabel="pressure (Pa)", ylabel="z (m)", label="initial")
+plot!(p_plot, p∞_prof, grid.zC, label="balanced")
+
+ρ_plot = plot(ρ₀_prof, grid.zC, xlabel="rho (kg/m³)", ylabel="z (m)", label="initial")
+plot!(ρ_plot, ρ∞_prof, grid.zC, label="balanced")
+
+display(plot(p_plot, ρ_plot, show=true))
+
+####
+#### Set up compressible model
+####
+
+model = CompressibleModel(grid=grid, buoyancy=buoyancy, reference_pressure=pₛ,
+                          thermodynamic_variable=ModifiedPotentialTemperature(),
+                          tracers=(:Θᵐ,))
+
+Θ∞_prof = ρ∞_prof .* θ₀_prof
+
+set!(model.density, reshape(ρ∞_prof, (Nx, Ny, Nz)))
+set!(model.tracers.Θᵐ, reshape(Θ∞_prof, (Nx, Ny, Nz)))
+
+times = [model.clock.time]
+ρw_ts = [model.momenta.W[1, 1, Int(Nz/2)]]
+
+while model.clock.time < 50
+    time_step!(model; Δt=0.5, Nt=10)
+
+    @show model.clock.time
+    Θ_prof = model.tracers.Θᵐ[1, 1, 1:Nz] .- Θ∞_prof
+    W_prof = model.momenta.W[1, 1, 1:Nz+1]
+    ρ_prof = model.density[1, 1, 1:Nz] .- ρ∞_prof
+
+    Θ_plot = plot(Θ_prof, grid.zC, xlim=(-2.5, 2.5), xlabel="Theta_prime", ylabel="z (m)", label="")
+    W_plot = plot(W_prof, grid.zF, xlim=(-1.2, 1.2), xlabel="rho*w", label="")
+    ρ_plot = plot(ρ_prof, grid.zC, xlim=(-0.01, 0.01), xlabel="rho", label="")
+
+    t_str = @sprintf("t = %d s", model.clock.time)
+    display(plot(Θ_plot, W_plot, ρ_plot, title=["" "$t_str" ""], layout=(1, 3), show=true))
+
+    push!(times, model.clock.time)
+    push!(ρw_ts, model.momenta.W[1, 1, Int(Nz/2)])
+end

--- a/compressible/src/JULES.jl
+++ b/compressible/src/JULES.jl
@@ -1,0 +1,30 @@
+module JULES
+
+using Oceananigans
+using Oceananigans: AbstractGrid
+
+using Oceananigans.TurbulenceClosures:
+    IsotropicDiffusivity, DiffusivityFields, with_tracers
+
+export
+    Entropy, Energy,
+    DryEarth, DryEarth3,
+    CompressibleModel,
+    update_total_density!,
+    time_step!,
+    cfl, acoustic_cfl
+
+include("Operators/Operators.jl")
+
+include("lazy_fields.jl")
+include("thermodynamics.jl")
+include("pressure_gradients.jl")
+include("time_steppers.jl")
+include("compressible_model.jl")
+
+include("source_terms.jl")
+include("time_stepping_kernels.jl")
+include("time_stepping.jl")
+include("utils.jl")
+
+end # module

--- a/compressible/src/Operators/Operators.jl
+++ b/compressible/src/Operators/Operators.jl
@@ -1,0 +1,19 @@
+module Operators
+
+using Oceananigans
+using Oceananigans.Grids
+using Oceananigans.Operators
+
+using Oceananigans: AbstractGrid
+using Oceananigans.TurbulenceClosures: IsotropicDiffusivity
+
+export
+    kinetic_energy,
+    hdivᶜᶜᵃ, divᶜᶜᶜ, ∇²,
+    div_ρuũ, div_ρvũ, div_ρwũ, div_ρUc,
+    ∂ⱼpuⱼ, ∂ⱼDᶜⱼ, ∂ⱼtᶜDᶜⱼ, ∂ⱼDᵖⱼ,
+    ∂ⱼτ₁ⱼ, ∂ⱼτ₂ⱼ, ∂ⱼτ₃ⱼ, Q_dissipation
+
+include("compressible_operators.jl")
+
+end

--- a/compressible/src/Operators/compressible_operators.jl
+++ b/compressible/src/Operators/compressible_operators.jl
@@ -1,0 +1,225 @@
+using Oceananigans.Advection
+
+#####
+##### Legend:
+##### ρ  -> density fields
+##### ρũ -> momentum fields
+#####  ũ -> velocity fields
+##### ρc̃ -> conservative tracer fields
+#####  c̃ -> tracer fields
+#####  K̃ -> diffusivity fields
+#####
+
+#####
+##### Convert conservative variables to primitive variables
+#####
+
+@inline U_over_ρ(i, j, k, grid, ρ, ρu) = @inbounds ρu[i, j, k] / ℑxᶠᵃᵃ(i, j, k, grid, ρ)
+@inline V_over_ρ(i, j, k, grid, ρ, ρv) = @inbounds ρv[i, j, k] / ℑyᵃᶠᵃ(i, j, k, grid, ρ)
+@inline W_over_ρ(i, j, k, grid, ρ, ρw) = @inbounds ρw[i, j, k] / ℑzᵃᵃᶠ(i, j, k, grid, ρ)
+@inline C_over_ρ(i, j, k, grid, ρ, ρc) = @inbounds ρc[i, j, k] / ρ[i, j, k]
+
+#####
+##### Kinetic energy
+#####
+
+@inline kinetic_energy(i, j, k, grid::AbstractGrid{FT}, ρ, ρũ) where FT =
+    @inbounds FT(0.5) * (  (ℑxᶜᵃᵃ(i, j, k, grid, ρũ.ρu) / ρ[i, j, k])^2
+                         + (ℑyᵃᶜᵃ(i, j, k, grid, ρũ.ρv) / ρ[i, j, k])^2
+                         + (ℑzᵃᵃᶜ(i, j, k, grid, ρũ.ρw) / ρ[i, j, k])^2)
+
+#####
+##### Pressure work
+#####
+
+@inline p∂u∂x(i, j, k, grid, diagnose_p, tvar, gases, gravity, ρ, ρũ, ρc̃) =
+       (  ℑxᶠᵃᵃ(i, j, k, grid, diagnose_p, tvar, gases, gravity, ρ, ρũ, ρc̃)
+        * Axᵃᵃᶠ(i, j, k, grid) * U_over_ρ(i, j, k, grid, ρ, ρũ.ρu))
+
+@inline p∂v∂y(i, j, k, grid, diagnose_p, tvar, gases, gravity, ρ, ρũ, ρc̃) =
+       (  ℑyᵃᶠᵃ(i, j, k, grid, diagnose_p, tvar, gases, gravity, ρ, ρũ, ρc̃)
+        * Ayᵃᵃᶠ(i, j, k, grid) * V_over_ρ(i, j, k, grid, ρ, ρũ.ρv))
+
+@inline p∂w∂z(i, j, k, grid, diagnose_p, tvar, gases, gravity, ρ, ρũ, ρc̃) =
+       (  ℑzᵃᵃᶠ(i, j, k, grid, diagnose_p, tvar, gases, gravity, ρ, ρũ, ρc̃)
+        * Azᵃᵃᵃ(i, j, k, grid) * W_over_ρ(i, j, k, grid, ρ, ρũ.ρw))
+
+@inline ∂ⱼpuⱼ(i, j, k, grid, diagnose_p, tvar, gases, gravity, ρ, ρũ, ρc̃) =
+    (1/Vᵃᵃᶜ(i, j, k, grid)
+        * (  δxᶜᵃᵃ(i, j, k, grid, p∂u∂x, diagnose_p, tvar, gases, gravity, ρ, ρũ, ρc̃)
+           + δyᵃᶜᵃ(i, j, k, grid, p∂v∂y, diagnose_p, tvar, gases, gravity, ρ, ρũ, ρc̃)
+           + δzᵃᵃᶜ(i, j, k, grid, p∂w∂z, diagnose_p, tvar, gases, gravity, ρ, ρũ, ρc̃)))
+
+#####
+##### Tracer advection
+#####
+
+@inline tracer_flux_ρuc(i, j, k, grid, scheme, ρ, ρu, ρc) = advective_tracer_flux_x(i, j, k, grid, scheme, ρu, ρc) / ℑxᶠᵃᵃ(i, j, k, grid, ρ)
+@inline tracer_flux_ρvc(i, j, k, grid, scheme, ρ, ρv, ρc) = advective_tracer_flux_y(i, j, k, grid, scheme, ρv, ρc) / ℑyᵃᶠᵃ(i, j, k, grid, ρ)
+@inline tracer_flux_ρwc(i, j, k, grid, scheme, ρ, ρw, ρc) = advective_tracer_flux_z(i, j, k, grid, scheme, ρw, ρc) / ℑzᵃᵃᶠ(i, j, k, grid, ρ)
+
+@inline div_ρUc(i, j, k, grid, scheme, density, momenta, ρc) =
+    (1/Vᵃᵃᶜ(i, j, k, grid)
+        * (  δxᶜᵃᵃ(i, j, k, grid, tracer_flux_ρuc, scheme, density, momenta.ρu, ρc)
+           + δyᵃᶜᵃ(i, j, k, grid, tracer_flux_ρvc, scheme, density, momenta.ρv, ρc)
+           + δzᵃᵃᶜ(i, j, k, grid, tracer_flux_ρwc, scheme, density, momenta.ρw, ρc)))
+
+#####
+##### Diffusion
+##### FIXME: need a better way to enforce boundary conditions on diffusive fluxes at rigid boundaries
+#####
+
+@inline diffusive_flux_x(i, j, k, grid, κᶠᶜᶜ, ρ, ρc) =
+    ℑxᶠᵃᵃ(i, j, k, grid, ρ) * κᶠᶜᶜ * Axᵃᵃᶠ(i, j, k, grid) * ∂xᶠᵃᵃ(i, j, k, grid, C_over_ρ, ρ, ρc)
+
+@inline diffusive_flux_y(i, j, k, grid, κᶜᶠᶜ, ρ, ρc) =
+    ℑyᵃᶠᵃ(i, j, k, grid, ρ) * κᶜᶠᶜ * Ayᵃᵃᶠ(i, j, k, grid) * ∂yᵃᶠᵃ(i, j, k, grid, C_over_ρ, ρ, ρc)
+
+@inline diffusive_flux_z(i, j, k, grid, κᶜᶜᶠ, ρ, ρc) =
+    ℑzᵃᵃᶠ(i, j, k, grid, ρ) * κᶜᶜᶠ * Azᵃᵃᵃ(i, j, k, grid) * ∂zᵃᵃᶠ(i, j, k, grid, C_over_ρ, ρ, ρc)
+
+@inline diffusive_tvar_flux_x(i, j, k, grid, κᶠᶜᶜ, tvar_diag, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃, ρc) =
+    (ℑxᶠᵃᵃ(i, j, k, grid, tvar_diag, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃)
+     * κᶠᶜᶜ * Axᵃᵃᶠ(i, j, k, grid) * ∂xᶠᵃᵃ(i, j, k, grid, C_over_ρ, ρ, ρc))
+
+@inline diffusive_tvar_flux_y(i, j, k, grid, κᶜᶠᶜ, tvar_diag, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃, ρc) =
+    (ℑyᵃᶠᵃ(i, j, k, grid, tvar_diag, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃)
+     * κᶜᶠᶜ * Ayᵃᵃᶠ(i, j, k, grid) * ∂yᵃᶠᵃ(i, j, k, grid, C_over_ρ, ρ, ρc))
+
+@inline diffusive_tvar_flux_z(i, j, k, grid, κᶜᶜᶠ, tvar_diag, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃, ρc) =
+    (ℑzᵃᵃᶠ(i, j, k, grid, tvar_diag, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃)
+     * κᶜᶜᶠ * Azᵃᵃᵃ(i, j, k, grid) * ∂zᵃᵃᶠ(i, j, k, grid, C_over_ρ, ρ, ρc))
+
+@inline diffusive_pressure_flux_x(i, j, k, grid, κᶠᶜᶜ, p_over_ρ_diag, tvar, gases, gravity, ρ, ρũ, ρc̃) =
+    (ℑxᶠᵃᵃ(i, j, k, grid, ρ) * κᶠᶜᶜ * Axᵃᵃᶠ(i, j, k, grid)
+     * ∂xᶠᵃᵃ(i, j, k, grid, p_over_ρ_diag, tvar, gases, gravity, ρ, ρũ, ρc̃))
+
+@inline diffusive_pressure_flux_y(i, j, k, grid, κᶜᶠᶜ, p_over_ρ_diag, tvar, gases, gravity, ρ, ρũ, ρc̃) =
+    (ℑyᵃᶠᵃ(i, j, k, grid, ρ) * κᶜᶠᶜ * Ayᵃᵃᶠ(i, j, k, grid)
+     * ∂yᵃᶠᵃ(i, j, k, grid, p_over_ρ_diag, tvar, gases, gravity, ρ, ρũ, ρc̃))
+
+@inline function diffusive_pressure_flux_z(i, j, k, grid::AbstractGrid{FT}, κᶜᶜᶠ, p_over_ρ_diag, tvar, gases, gravity, ρ, ρũ, ρc̃) where FT
+    (k <= 1 || k > grid.Nz) && return zero(FT)
+    return (ℑzᵃᵃᶠ(i, j, k, grid, ρ) * κᶜᶜᶠ * Azᵃᵃᵃ(i, j, k, grid)
+            * ∂zᵃᵃᶠ(i, j, k, grid, p_over_ρ_diag, tvar, gases, gravity, ρ, ρũ, ρc̃))
+end
+
+@inline function ∂ⱼDᶜⱼ(i, j, k, grid, closure::IsotropicDiffusivity, tracer_index, ρ, ρc, args...)
+    @inbounds κ = closure.κ[tracer_index]
+    return (1/Vᵃᵃᶜ(i, j, k, grid)
+            * (  δxᶜᵃᵃ(i, j, k, grid, diffusive_flux_x, κ, ρ, ρc)
+               + δyᵃᶜᵃ(i, j, k, grid, diffusive_flux_y, κ, ρ, ρc)
+               + δzᵃᵃᶜ(i, j, k, grid, diffusive_flux_z, κ, ρ, ρc)))
+end
+
+@inline function ∂ⱼtᶜDᶜⱼ(i, j, k, grid, closure::IsotropicDiffusivity, tvar_diag,
+                         tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃, ρc, args...)
+
+    @inbounds κ = closure.κ[tracer_index]
+    return (1/Vᵃᵃᶜ(i, j, k, grid)
+               * (  δxᶜᵃᵃ(i, j, k, grid, diffusive_tvar_flux_x, κ, tvar_diag, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃, ρc)
+                  + δyᵃᶜᵃ(i, j, k, grid, diffusive_tvar_flux_y, κ, tvar_diag, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃, ρc)
+                  + δzᵃᵃᶜ(i, j, k, grid, diffusive_tvar_flux_z, κ, tvar_diag, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃, ρc)))
+end
+
+@inline function ∂ⱼDᵖⱼ(i, j, k, grid, closure::IsotropicDiffusivity, tracer_index,
+                       p_over_ρ_diag, tvar, gases, gravity, ρ, ρũ, ρc̃, args ...)
+
+    @inbounds κ = closure.κ[tracer_index]
+    return (1/Vᵃᵃᶜ(i, j, k, grid)
+               * (  δxᶜᵃᵃ(i, j, k, grid, diffusive_pressure_flux_x, κ, p_over_ρ_diag, tvar, gases, gravity, ρ, ρũ, ρc̃)
+                  + δyᵃᶜᵃ(i, j, k, grid, diffusive_pressure_flux_y, κ, p_over_ρ_diag, tvar, gases, gravity, ρ, ρũ, ρc̃)
+                  + δzᵃᵃᶜ(i, j, k, grid, diffusive_pressure_flux_z, κ, p_over_ρ_diag, tvar, gases, gravity, ρ, ρũ, ρc̃)))
+end
+
+#####
+##### Momentum advection
+##### Note the convention "momentum_flux_Ua" corresponds to the advection _of_ a _by_ U.
+#####
+
+@inline momentum_flux_ρuu(i, j, k, grid, scheme, ρ, ρu) = @inbounds momentum_flux_uu(i, j, k, grid, scheme, ρu, ρu) / ρ[i, j, k]
+@inline momentum_flux_ρvv(i, j, k, grid, scheme, ρ, ρv) = @inbounds momentum_flux_vv(i, j, k, grid, scheme, ρv, ρv) / ρ[i, j, k]
+@inline momentum_flux_ρww(i, j, k, grid, scheme, ρ, ρw) = @inbounds momentum_flux_ww(i, j, k, grid, scheme, ρw, ρw) / ρ[i, j, k]
+
+@inline momentum_flux_ρuv(i, j, k, grid, scheme, ρ, ρu, ρv) = momentum_flux_uv(i, j, k, grid, scheme, ρv, ρu) / ℑxyᶠᶠᵃ(i, j, k, grid, ρ)
+@inline momentum_flux_ρuw(i, j, k, grid, scheme, ρ, ρu, ρw) = momentum_flux_uw(i, j, k, grid, scheme, ρw, ρu) / ℑxzᶠᵃᶠ(i, j, k, grid, ρ)
+@inline momentum_flux_ρvu(i, j, k, grid, scheme, ρ, ρu, ρv) = momentum_flux_vu(i, j, k, grid, scheme, ρu, ρv) / ℑxyᶠᶠᵃ(i, j, k, grid, ρ)
+@inline momentum_flux_ρvw(i, j, k, grid, scheme, ρ, ρv, ρw) = momentum_flux_vw(i, j, k, grid, scheme, ρw, ρv) / ℑyzᵃᶠᶠ(i, j, k, grid, ρ)
+@inline momentum_flux_ρwu(i, j, k, grid, scheme, ρ, ρu, ρw) = momentum_flux_wu(i, j, k, grid, scheme, ρu, ρw) / ℑxzᶠᵃᶠ(i, j, k, grid, ρ)
+@inline momentum_flux_ρwv(i, j, k, grid, scheme, ρ, ρv, ρw) = momentum_flux_wv(i, j, k, grid, scheme, ρv, ρw) / ℑyzᵃᶠᶠ(i, j, k, grid, ρ)
+
+@inline div_ρuũ(i, j, k, grid, scheme, ρ, ρũ) =
+    (1/Vᵃᵃᶜ(i, j, k, grid)
+        * (  δxᶠᵃᵃ(i, j, k, grid, momentum_flux_ρuu, scheme, ρ, ρũ.ρu)
+           + δyᵃᶜᵃ(i, j, k, grid, momentum_flux_ρuv, scheme, ρ, ρũ.ρu, ρũ.ρv)
+           + δzᵃᵃᶜ(i, j, k, grid, momentum_flux_ρuw, scheme, ρ, ρũ.ρu, ρũ.ρw)))
+
+@inline div_ρvũ(i, j, k, grid, scheme, ρ, ρũ) =
+    (1/Vᵃᵃᶜ(i, j, k, grid)
+        * (  δxᶜᵃᵃ(i, j, k, grid, momentum_flux_ρvu, scheme, ρ, ρũ.ρu, ρũ.ρv)
+           + δyᵃᶠᵃ(i, j, k, grid, momentum_flux_ρvv, scheme, ρ, ρũ.ρv)
+           + δzᵃᵃᶜ(i, j, k, grid, momentum_flux_ρvw, scheme, ρ, ρũ.ρv, ρũ.ρw)))
+
+@inline div_ρwũ(i, j, k, grid, scheme, ρ, ρũ) =
+    (1/Vᵃᵃᶠ(i, j, k, grid)
+        * (  δxᶜᵃᵃ(i, j, k, grid, momentum_flux_ρwu, scheme, ρ, ρũ.ρu, ρũ.ρw)
+           + δyᵃᶜᵃ(i, j, k, grid, momentum_flux_ρwv, scheme, ρ, ρũ.ρv, ρũ.ρw)
+           + δzᵃᵃᶠ(i, j, k, grid, momentum_flux_ρww, scheme, ρ, ρũ.ρw)))
+
+#####
+##### Viscous dissipation
+#####
+
+@inline strain_rate_tensor_ux(i, j, k, grid::AbstractGrid{FT}, ρ, ρu) where FT = FT(1/3) * ∂xᶜᵃᵃ(i, j, k, grid, U_over_ρ, ρ, ρu)
+@inline strain_rate_tensor_vy(i, j, k, grid::AbstractGrid{FT}, ρ, ρv) where FT = FT(1/3) * ∂yᵃᶜᵃ(i, j, k, grid, V_over_ρ, ρ, ρv)
+@inline strain_rate_tensor_wz(i, j, k, grid::AbstractGrid{FT}, ρ, ρw) where FT = FT(1/3) * ∂zᵃᵃᶜ(i, j, k, grid, W_over_ρ, ρ, ρw)
+
+@inline strain_rate_tensor_uy(i, j, k, grid, ρ, ρu, ρv) = ∂yᵃᶠᵃ(i, j, k, grid, U_over_ρ, ρ, ρu) + ∂xᶠᵃᵃ(i, j, k, grid, V_over_ρ, ρ, ρv)
+@inline strain_rate_tensor_uz(i, j, k, grid, ρ, ρu, ρw) = ∂zᵃᵃᶠ(i, j, k, grid, U_over_ρ, ρ, ρu) + ∂xᶠᵃᵃ(i, j, k, grid, W_over_ρ, ρ, ρw)
+@inline strain_rate_tensor_vx(i, j, k, grid, ρ, ρv, ρu) = ∂xᶠᵃᵃ(i, j, k, grid, V_over_ρ, ρ, ρv) + ∂yᵃᶠᵃ(i, j, k, grid, U_over_ρ, ρ, ρu)
+@inline strain_rate_tensor_vz(i, j, k, grid, ρ, ρv, ρw) = ∂zᵃᵃᶠ(i, j, k, grid, V_over_ρ, ρ, ρv) + ∂yᵃᶠᵃ(i, j, k, grid, W_over_ρ, ρ, ρw)
+@inline strain_rate_tensor_wx(i, j, k, grid, ρ, ρw, ρu) = ∂xᶠᵃᵃ(i, j, k, grid, W_over_ρ, ρ, ρw) + ∂zᵃᵃᶠ(i, j, k, grid, U_over_ρ, ρ, ρu)
+@inline strain_rate_tensor_wy(i, j, k, grid, ρ, ρw, ρv) = ∂yᵃᶠᵃ(i, j, k, grid, W_over_ρ, ρ, ρw) + ∂zᵃᵃᶠ(i, j, k, grid, V_over_ρ, ρ, ρv)
+
+@inline viscous_flux_ux(i, j, k, grid, νᶜᶜᶜ, ρ, ρu) = @inbounds ρ[i, j, k] * νᶜᶜᶜ * Axᵃᵃᶜ(i, j, k, grid) * strain_rate_tensor_ux(i, j, k, grid, ρ, ρu)
+@inline viscous_flux_vy(i, j, k, grid, νᶜᶜᶜ, ρ, ρv) = @inbounds ρ[i, j, k] * νᶜᶜᶜ * Ayᵃᵃᶜ(i, j, k, grid) * strain_rate_tensor_vy(i, j, k, grid, ρ, ρv)
+@inline viscous_flux_wz(i, j, k, grid, νᶜᶜᶜ, ρ, ρw) = @inbounds ρ[i, j, k] * νᶜᶜᶜ * Azᵃᵃᵃ(i, j, k, grid) * strain_rate_tensor_wz(i, j, k, grid, ρ, ρw)
+
+@inline viscous_flux_uy(i, j, k, grid, νᶠᶠᶜ, ρ, ρu, ρv) = ℑxyᶠᶠᵃ(i, j, k, grid, ρ) * νᶠᶠᶜ * Ayᵃᵃᶜ(i, j, k, grid) * strain_rate_tensor_uy(i, j, k, grid, ρ, ρu, ρv)
+@inline viscous_flux_uz(i, j, k, grid, νᶠᶜᶠ, ρ, ρu, ρw) = ℑxzᶠᵃᶠ(i, j, k, grid, ρ) * νᶠᶜᶠ * Azᵃᵃᵃ(i, j, k, grid) * strain_rate_tensor_uz(i, j, k, grid, ρ, ρu, ρw)
+@inline viscous_flux_vx(i, j, k, grid, νᶠᶠᶜ, ρ, ρv, ρu) = ℑxyᶠᶠᵃ(i, j, k, grid, ρ) * νᶠᶠᶜ * Axᵃᵃᶜ(i, j, k, grid) * strain_rate_tensor_vx(i, j, k, grid, ρ, ρv, ρu)
+@inline viscous_flux_vz(i, j, k, grid, νᶜᶠᶠ, ρ, ρv, ρw) = ℑyzᵃᶠᶠ(i, j, k, grid, ρ) * νᶜᶠᶠ * Azᵃᵃᵃ(i, j, k, grid) * strain_rate_tensor_vz(i, j, k, grid, ρ, ρv, ρw)
+@inline viscous_flux_wx(i, j, k, grid, νᶠᶜᶠ, ρ, ρw, ρu) = ℑxzᶠᵃᶠ(i, j, k, grid, ρ) * νᶠᶜᶠ * Axᵃᵃᶠ(i, j, k, grid) * strain_rate_tensor_wx(i, j, k, grid, ρ, ρw, ρu)
+@inline viscous_flux_wy(i, j, k, grid, νᶜᶠᶠ, ρ, ρw, ρv) = ℑyzᵃᶠᶠ(i, j, k, grid, ρ) * νᶜᶠᶠ * Ayᵃᵃᶠ(i, j, k, grid) * strain_rate_tensor_wy(i, j, k, grid, ρ, ρw, ρv)
+
+@inline ∂ⱼτ₁ⱼ(i, j, k, grid, closure::IsotropicDiffusivity, ρ, ρũ, args...) =
+    (1/Vᵃᵃᶜ(i, j, k, grid)
+        * (  δxᶠᵃᵃ(i, j, k, grid, viscous_flux_ux, closure.ν, ρ, ρũ.ρu)
+           + δyᵃᶜᵃ(i, j, k, grid, viscous_flux_uy, closure.ν, ρ, ρũ.ρu, ρũ.ρv)
+           + δzᵃᵃᶜ(i, j, k, grid, viscous_flux_uz, closure.ν, ρ, ρũ.ρu, ρũ.ρw)))
+
+@inline ∂ⱼτ₂ⱼ(i, j, k, grid, closure::IsotropicDiffusivity, ρ, ρũ, args...) =
+    (1/Vᵃᵃᶜ(i, j, k, grid)
+        * (  δxᶜᵃᵃ(i, j, k, grid, viscous_flux_vx, closure.ν, ρ, ρũ.ρv, ρũ.ρu)
+           + δyᵃᶠᵃ(i, j, k, grid, viscous_flux_vy, closure.ν, ρ, ρũ.ρv)
+           + δzᵃᵃᶜ(i, j, k, grid, viscous_flux_vz, closure.ν, ρ, ρũ.ρv, ρũ.ρw)))
+
+@inline ∂ⱼτ₃ⱼ(i, j, k, grid, closure::IsotropicDiffusivity, ρ, ρũ, args...) =
+    (1/Vᵃᵃᶠ(i, j, k, grid)
+        * (  δxᶜᵃᵃ(i, j, k, grid, viscous_flux_wx, closure.ν, ρ, ρũ.ρw, ρũ.ρu)
+           + δyᵃᶜᵃ(i, j, k, grid, viscous_flux_wy, closure.ν, ρ, ρũ.ρw, ρũ.ρv)
+           + δzᵃᵃᶠ(i, j, k, grid, viscous_flux_wz, closure.ν, ρ, ρũ.ρw)))
+
+@inline u₁∂ⱼτ₁ⱼ(i, j, k, grid, closure::IsotropicDiffusivity, ρ, ρũ, args...) =
+    U_over_ρ(i, j, k, grid, ρ, ρũ.ρu) * ∂ⱼτ₁ⱼ(i, j, k, grid, closure, ρ, ρũ, args...)
+
+@inline u₂∂ⱼτ₂ⱼ(i, j, k, grid, closure::IsotropicDiffusivity, ρ, ρũ, args...) =
+    V_over_ρ(i, j, k, grid, ρ, ρũ.ρv) * ∂ⱼτ₂ⱼ(i, j, k, grid, closure, ρ, ρũ, args...)
+
+@inline u₃∂ⱼτ₃ⱼ(i, j, k, grid, closure::IsotropicDiffusivity, ρ, ρũ, args...) =
+    W_over_ρ(i, j, k, grid, ρ, ρũ.ρw) * ∂ⱼτ₃ⱼ(i, j, k, grid, closure, ρ, ρũ, args...)
+
+@inline Q_dissipation(i, j, k, grid, closure::IsotropicDiffusivity, ρ, ρũ, args...) =
+    (  ℑxᶜᵃᵃ(i, j, k, grid, u₁∂ⱼτ₁ⱼ, closure, ρ, ρũ, args...)
+     + ℑyᵃᶜᵃ(i, j, k, grid, u₂∂ⱼτ₂ⱼ, closure, ρ, ρũ, args...)
+     + ℑzᵃᵃᶜ(i, j, k, grid, u₃∂ⱼτ₃ⱼ, closure, ρ, ρũ, args...))

--- a/compressible/src/compressible_model.jl
+++ b/compressible/src/compressible_model.jl
@@ -1,0 +1,167 @@
+using Oceananigans
+using Oceananigans.Advection: CenteredSecondOrder
+using Oceananigans.Models: AbstractModel, Clock, tracernames
+using Oceananigans.Forcings: zeroforcing, ContinuousForcing
+
+#####
+##### Definition of a compressible model
+#####
+
+mutable struct CompressibleModel{A, FT, Ω, ∇, D, M, V, T, L, K, Θ, G, X, C, F, S} <: AbstractModel
+              architecture :: A
+                      grid :: Ω
+                     clock :: Clock{FT}
+                 advection :: ∇
+             total_density :: D
+                   momenta :: M
+                velocities :: V
+                   tracers :: T
+              lazy_tracers :: L
+             diffusivities :: K
+    thermodynamic_variable :: Θ
+                     gases :: G
+                   gravity :: FT
+                  coriolis :: X
+                   closure :: C
+                   forcing :: F
+              time_stepper :: S
+end
+
+#####
+##### Constructor for compressible models
+#####
+
+const pₛ_Earth = 100000
+const  g_Earth = 9.80665
+
+function CompressibleModel(;
+                      grid,
+              architecture = CPU(),
+                float_type = Float64,
+                     clock = Clock{float_type}(0, 0),
+                 advection = CenteredSecondOrder(),
+                     gases = DryEarth(float_type),
+    thermodynamic_variable = Energy(),
+               tracernames = collect_tracers(thermodynamic_variable, gases),
+                  coriolis = nothing,
+                   closure = IsotropicDiffusivity(float_type, ν=0.5, κ=0.5),
+       boundary_conditions = NamedTuple(),
+                   momenta = MomentumFields(architecture, grid, boundary_conditions),
+             diffusivities = DiffusivityFields(architecture, grid, tracernames, boundary_conditions, closure),
+                   forcing = NamedTuple(),
+                   gravity = g_Earth,
+              time_stepper = WickerSkamarockTimeStepper(architecture, grid, tracernames))
+
+    total_density = CellField(architecture, grid)
+
+    gravity = float_type(gravity)
+    tracers = TracerFields(tracernames, architecture, grid, boundary_conditions)
+    closure = with_tracers(tracernames, closure)
+    forcing = model_forcing(tracernames; forcing...)
+
+    velocities = LazyVelocityFields(architecture, grid, total_density, momenta)
+    lazy_tracers = LazyTracerFields(architecture, grid, total_density, tracers)
+
+    return CompressibleModel(
+        architecture, grid, clock, advection, total_density, momenta, velocities, tracers,
+        lazy_tracers, diffusivities, thermodynamic_variable, gases, gravity,
+        coriolis, closure, forcing, time_stepper)
+end
+
+using Oceananigans.Grids: short_show
+
+Base.show(io::IO, model::CompressibleModel{A, FT}) where {A, FT} =
+    print(io, "CompressibleModel{$A, $FT} with $(length(model.gases)) gas(es) ",
+        "(time = $(prettytime(model.clock.time)), iteration = $(model.clock.iteration)) \n",
+        "├── grid: $(short_show(model.grid))\n",
+        "├── tracers: $(tracernames(model.tracers))\n",
+        "├── closure: $(typeof(model.closure))\n",
+        "└── coriolis: $(typeof(model.coriolis))\n")
+
+#####
+##### Utilities for constructing compressible models
+#####
+
+generate_key(::Entropy) = :ρs
+generate_key(::Energy) = :ρe
+
+function collect_tracers(thermodynamic_variable, args...)
+    list = [generate_key(thermodynamic_variable)]
+    for arg in args
+        if arg !== nothing
+            for name in keys(arg)
+                push!(list, name)
+            end
+        end
+    end
+    return Tuple(list)
+end
+
+function DryEarth(FT = Float64)
+    return (ρ = EarthN₂O₂(FT),)
+end
+
+function DryEarth3(FT = Float64)
+    return (ρ₁ = EarthN₂O₂(FT), ρ₂ = EarthN₂O₂(FT), ρ₃ = EarthN₂O₂(FT))
+end
+
+function MomentumFields(arch, grid, bcs::NamedTuple)
+    ρu_bcs = :ρu ∈ keys(bcs) ? bcs[:ρu] : UVelocityBoundaryConditions(grid)
+    ρv_bcs = :ρv ∈ keys(bcs) ? bcs[:ρv] : VVelocityBoundaryConditions(grid)
+    ρw_bcs = :ρw ∈ keys(bcs) ? bcs[:ρw] : WVelocityBoundaryConditions(grid)
+
+    ρu = XFaceField(arch, grid, ρu_bcs)
+    ρv = YFaceField(arch, grid, ρv_bcs)
+    ρw = ZFaceField(arch, grid, ρw_bcs)
+
+    return (ρu=ρu, ρv=ρv, ρw=ρw)
+end
+
+function TracerFields(names, arch, grid, bcs)
+    tracer_names = tracernames(names) # filter `names` if it contains velocity fields
+    tracer_fields =
+        Tuple(c ∈ keys(bcs) ?
+              CellField(arch, grid, bcs[c]) :
+              CellField(arch, grid, TracerBoundaryConditions(grid))
+              for c in tracer_names)
+    return NamedTuple{tracer_names}(tracer_fields)
+end
+
+#####
+##### Utilities for constructing model forcing
+##### Should merge with incompressible version
+#####
+
+assumed_field_location(name) = name === :ρu ? (Face, Cell, Cell) :
+                               name === :ρv ? (Cell, Face, Cell) :
+                               name === :ρw ? (Cell, Cell, Face) :
+                                              (Cell, Cell, Cell)
+
+regularize_forcing(forcing, field_name, model_field_names) = forcing # fallback
+
+function regularize_forcing(forcing::Function, field_name, model_field_names)
+    X, Y, Z = assumed_field_location(field_name)
+    return ContinuousForcing{X, Y, Z}(forcing)
+end
+
+regularize_forcing(::Nothing, field_name, model_field_names) = zeroforcing
+
+function model_forcing(tracer_names; ρu=nothing, ρv=nothing, ρw=nothing, tracer_forcings...)
+
+    model_field_names = tuple(:ρu, :ρv, :ρw, tracer_names...)
+
+    ρu = regularize_forcing(ρu, :ρu, model_field_names)
+    ρv = regularize_forcing(ρv, :ρv, model_field_names)
+    ρw = regularize_forcing(ρw, :ρw, model_field_names)
+
+    # Build tuple of user-specified tracer forcings
+    specified_tracer_forcings_tuple = Tuple(regularize_forcing(f.second, f.first, model_field_names) for f in tracer_forcings)
+    specified_tracer_names = Tuple(f.first for f in tracer_forcings)
+
+    specified_forcings = NamedTuple{specified_tracer_names}(specified_tracer_forcings_tuple)
+
+    # Re-build with defaults for unspecified tracer forcing
+    tracer_forcings = with_tracers(tracer_names, specified_forcings, (name, initial_tuple) -> zeroforcing)
+
+    return merge((ρu=ρu, ρv=ρv, ρw=ρw), tracer_forcings)
+end

--- a/compressible/src/lazy_fields.jl
+++ b/compressible/src/lazy_fields.jl
@@ -1,0 +1,56 @@
+import Base: getindex
+import Oceananigans.Fields: interior, interiorparent
+
+using Base: @propagate_inbounds
+
+using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
+using Oceananigans.Fields
+
+struct LazyPrimitiveField{X, Y, Z, A, G, C, D} <: AbstractField{X, Y, Z, A, G}
+          architecture :: A
+                  grid :: G
+    conservative_field :: C
+               density :: D
+end
+
+LazyPrimitiveField(LX, LY, LZ, arch, grid, ρϕ, ρ) =
+    LazyPrimitiveField{LX, LY, LZ, typeof(arch), typeof(grid), typeof(ρϕ), typeof(ρ)}(arch, grid, ρϕ, ρ)
+
+@inline @propagate_inbounds getindex(f::LazyPrimitiveField{Cell, Cell, Cell}, I...) =
+    @inbounds f.conservative_field[I...] / f.density[I...]
+
+@inline @propagate_inbounds getindex(f::LazyPrimitiveField{Face, Cell, Cell}, I...) =
+    @inbounds f.conservative_field[I...] / ℑxᶠᵃᵃ(I..., f.grid, f.density)
+
+@inline @propagate_inbounds getindex(f::LazyPrimitiveField{Cell, Face, Cell}, I...) =
+    @inbounds f.conservative_field[I...] / ℑyᵃᶠᵃ(I..., f.grid, f.density)
+
+@inline @propagate_inbounds getindex(f::LazyPrimitiveField{Cell, Cell, Face}, I...) =
+    @inbounds f.conservative_field[I...] / ℑzᵃᵃᶠ(I..., f.grid, f.density)
+
+LazyVelocityFields(arch, grid, ρ, ρũ) =
+    (u = LazyPrimitiveField(Face, Cell, Cell, arch, grid, ρũ.ρu, ρ),
+     v = LazyPrimitiveField(Cell, Face, Cell, arch, grid, ρũ.ρv, ρ),
+     w = LazyPrimitiveField(Cell, Cell, Face, arch, grid, ρũ.ρw, ρ))
+
+function LazyTracerFields(arch, grid, ρ, ρc̃)
+    c_names = [filter(c -> c != 'ρ', string(c)) for c in keys(ρc̃)]
+    c_names = filter(s -> s != "", c_names) .|> Symbol |> Tuple  # Don't include the ρ tracer.
+
+    c_fields = Tuple(
+        LazyPrimitiveField(Cell, Cell, Cell, arch, grid, getproperty(ρc̃, Symbol(:ρ, c)), ρ)
+        for c in c_names
+    )
+
+    return NamedTuple{c_names}(c_fields)
+end
+
+function interior(f::LazyPrimitiveField)
+    data = zeros(size(f.conservative_field))
+    for k in 1:f.grid.Nz, j in 1:f.grid.Ny, i in 1:f.grid.Nx
+        data[i, j, k] = f[i, j, k]
+    end
+    return data
+end
+
+interiorparent(lf::LazyPrimitiveField) = interior(lf)

--- a/compressible/src/pressure_gradients.jl
+++ b/compressible/src/pressure_gradients.jl
@@ -1,0 +1,9 @@
+using JULES.Operators: ∂xᶠᵃᵃ, ∂yᵃᶠᵃ, ∂zᵃᵃᶠ
+
+####
+#### Pressure gradient ∇p terms for entropy S = ρs
+####
+
+@inline ∂p∂x(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃) = ∂xᶠᵃᵃ(i, j, k, grid, diagnose_pressure, tvar, gases, gravity, ρ, ρũ, ρc̃)
+@inline ∂p∂y(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃) = ∂yᵃᶠᵃ(i, j, k, grid, diagnose_pressure, tvar, gases, gravity, ρ, ρũ, ρc̃)
+@inline ∂p∂z(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃) = ∂zᵃᵃᶠ(i, j, k, grid, diagnose_pressure, tvar, gases, gravity, ρ, ρũ, ρc̃)

--- a/compressible/src/source_terms.jl
+++ b/compressible/src/source_terms.jl
@@ -1,0 +1,75 @@
+using Oceananigans.Operators: ℑzᵃᵃᶠ
+using Oceananigans.Coriolis
+
+####
+#### Element-wise forcing and right-hand-side calculations
+####
+
+@inline ρu_slow_source_term(i, j, k, grid, coriolis, closure, ρ, ρũ, K̃) =
+    (- x_f_cross_U(i, j, k, grid, coriolis, ρũ)
+     + ∂ⱼτ₁ⱼ(i, j, k, grid, closure, ρ, ρũ, K̃))
+
+
+@inline ρv_slow_source_term(i, j, k, grid, coriolis, closure, ρ, ρũ, K̃) =
+    (- y_f_cross_U(i, j, k, grid, coriolis, ρũ)
+     + ∂ⱼτ₂ⱼ(i, j, k, grid, closure, ρ, ρũ, K̃))
+
+@inline ρw_slow_source_term(i, j, k, grid, coriolis, closure, ρ, ρũ, K̃) =
+    (- z_f_cross_U(i, j, k, grid, coriolis, ρũ)
+     + ∂ⱼτ₃ⱼ(i, j, k, grid, closure, ρ, ρũ, K̃))
+
+@inline ρc_slow_source_term(i, j, k, grid, closure, tracer_index, ρ, ρc, K̃) =
+    ∂ⱼDᶜⱼ(i, j, k, grid, closure, tracer_index, ρ, ρc, K̃)
+
+@inline ρt_slow_source_term(i, j, k, grid, closure, tvar::Energy, gases, gravity, ρ, ρũ, ρc̃, K̃) =
+    ∂ⱼDᵖⱼ(i, j, k, grid, closure, 1, diagnose_p_over_ρ, tvar, gases, gravity, ρ, ρũ, ρc̃, K̃)
+
+@inline function ρt_slow_source_term(i, j, k, grid, closure, tvar::Entropy, gases, gravity, ρ, ρũ, ρc̃, K̃)
+    @inbounds begin
+        Ṡ = 0.0
+        for gas_index = 1:length(gases)
+            tracer_index = gas_index + 1
+            ρc = ρc̃[tracer_index]
+            Ṡ += ∂ⱼtᶜDᶜⱼ(i, j, k, grid, closure, diagnose_ρs, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃, ρc)
+        end
+        T = diagnose_temperature(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃)
+        Ṡ += Q_dissipation(i, j, k, grid, closure, ρ, ρũ) / T
+        return Ṡ
+    end
+end
+
+@inline function ρu_fast_source_term(i, j, k, grid, tvar, gases, gravity, advection_scheme, ρ, ρũ, ρc̃, FU)
+    @inbounds begin
+        return (- div_ρuũ(i, j, k, grid, advection_scheme, ρ, ρũ)
+                - ∂p∂x(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃)
+                + FU[i, j, k])
+    end
+end
+
+@inline function ρv_fast_source_term(i, j, k, grid, tvar, gases, gravity, advection_scheme, ρ, ρũ, ρc̃, FV)
+    @inbounds begin
+        return (- div_ρvũ(i, j, k, grid, advection_scheme, ρ, ρũ)
+                - ∂p∂y(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃)
+                + FV[i, j, k])
+    end
+end
+
+@inline function ρw_fast_source_term(i, j, k, grid, tvar, gases, gravity, advection_scheme, ρ, ρũ, ρc̃, FW)
+    @inbounds begin
+        return (- div_ρwũ(i, j, k, grid, advection_scheme, ρ, ρũ)
+                - ∂p∂z(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃)
+                - gravity * ℑzᵃᵃᶠ(i, j, k, grid, ρ)
+                + FW[i, j, k])
+    end
+end
+
+@inline function ρc_fast_source_term(i, j, k, grid, advection_scheme, ρ, ρũ, ρc, FC)
+    @inbounds begin
+        return -div_ρUc(i, j, k, grid, advection_scheme, ρ, ρũ, ρc) + FC[i, j, k]
+    end
+end
+
+@inline ρt_fast_source_term(i, j, k, grid::AbstractGrid{T}, tvar::Entropy, gases, gravity, ρ, ρũ, ρc̃) where T = zero(T)
+
+@inline ρt_fast_source_term(i, j, k, grid, tvar::Energy, gases, gravity, ρ, ρũ, ρc̃) =
+    -∂ⱼpuⱼ(i, j, k, grid, diagnose_pressure, tvar, gases, gravity, ρ, ρũ, ρc̃)

--- a/compressible/src/thermodynamics.jl
+++ b/compressible/src/thermodynamics.jl
@@ -1,0 +1,139 @@
+using JULES.Operators
+using Oceananigans.Buoyancy: AbstractEquationOfState
+
+#####
+##### Universal gas constant and default reference states
+#####
+
+const atm = 101325.0         # 1 atmosphere in Pa
+const R⁰ = 8.31446261815324  # Universal gas constant [J/mol/K]
+const T₀ = 273.16            # Reference temperature [K]
+const p₀ = 1atm              # Reference pressure [Pa]
+const s₀ = 0.0               # Reference entropy [J/kg/K]
+const u₀ = 0.0               # Reference internal energy [J/kg]
+
+#####
+##### Molar masses and degrees of freedom for common gases
+#####
+
+const M_N₂ = 28e-3           # Molar mass of diatomic nitrogen (kg/mol)
+const dof_N₂ = 5.0           # DOF of diatomic nitrogren (nondim)
+const M_O₂ = 32e-3           # Molar mass of diatomic nitrogen (kg/mol)
+const dof_O₂ = 5.0           # DOF of diatomic nitrogren (nondim)
+
+#####
+##### Composition information for common atmospheres
+#####
+
+const η_N₂_earth = 0.7809    # Molar mixing ratio of N₂ on earth (nondim)
+const η_O₂_earth = 0.2095    # Molar mixing ratio of O₂ on earth (nondim)
+
+#####
+##### Non-condensible ideal gas
+#####
+
+struct IdealGas{FT} <: AbstractEquationOfState
+     R :: FT
+    cₚ :: FT
+    cᵥ :: FT
+    T₀ :: FT
+    p₀ :: FT
+    ρ₀ :: FT
+    s₀ :: FT
+    u₀ :: FT
+end
+
+function EarthN₂O₂(FT=Float64; T₀=T₀, p₀=p₀, s₀=s₀, u₀=u₀)
+    # Calculate abundance-weighted molar masses and DOFs
+    M = (η_N₂_earth * M_N₂ + η_O₂_earth * M_O₂)/(η_N₂_earth + η_O₂_earth)
+    dof = (η_N₂_earth * dof_N₂ + η_O₂_earth * dof_O₂)/(η_N₂_earth + η_O₂_earth)
+    return IdealGas(FT, M, dof; T₀=T₀, p₀=p₀, s₀=s₀, u₀=u₀)
+end
+
+function IdealGas(FT, M, dof; T₀=T₀, p₀=p₀, s₀=s₀, u₀=u₀)
+    R = R⁰/M
+    cᵥ = R*dof/2
+    cₚ = cᵥ + R
+    ρ₀ = p₀/(R*T₀)
+    return IdealGas{FT}(R, cₚ, cᵥ, T₀, p₀, ρ₀, s₀, u₀)
+end
+
+#####
+##### Thermodynamic variables
+#####
+
+abstract type AbstractThermodynamicVariable end
+
+struct Entropy <: AbstractThermodynamicVariable end
+struct Energy  <: AbstractThermodynamicVariable end
+
+#####
+##### Thermodynamic state diagnostics
+#####
+
+@inline function diagnose_ρs(i, j, k, grid::AbstractGrid{FT}, tracer_index, tvar, gases, gravity, ρ, ρũ, ρc̃) where FT
+    @inbounds begin
+        T = diagnose_temperature(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃)
+        ρᵅ = ρc̃[tracer_index][i, j, k]
+        gas = gases[tracer_index-1]
+        return ρᵅ > zero(FT) ? ρᵅ*(gas.s₀ + gas.cᵥ*log(T/gas.T₀) - gas.R*log(ρᵅ/gas.ρ₀)) : zero(FT)
+    end
+end
+
+@inline function diagnose_temperature(i, j, k, grid::AbstractGrid{FT}, tvar::Entropy, gases, gravity, ρ, ρũ, ρc̃) where FT
+    @inbounds begin
+        numerator = ρc̃.ρs[i, j, k]
+        denominator = zero(FT)
+        for (gas_index, gas) in enumerate(gases)
+            ρᵅ = ρc̃[gas_index+1][i, j, k]
+            numerator += ρᵅ > 0 ? (ρᵅ*gas.R*log(ρᵅ/gas.ρ₀) - ρᵅ*gas.s₀) : zero(FT)
+            denominator += ρᵅ*gas.cᵥ
+        end
+        return T₀*exp(numerator/denominator)
+    end
+end
+
+@inline function diagnose_temperature(i, j, k, grid::AbstractGrid{FT}, tvar::Energy, gases, gravity, ρ, ρũ, ρc̃) where FT
+    @inbounds begin
+        numerator = ρc̃.ρe[i,j,k]
+        denominator = zero(FT)
+        KE = kinetic_energy(i, j, k, grid, ρ, ρũ)
+        Φ = gravity * grid.zC[clamp(k, 1, grid.Nz)]
+        for (gas_index, gas) in enumerate(gases)
+            ρᵅ = ρc̃[gas_index+1][i,j,k]
+            numerator += -ρᵅ*(gas.u₀ + Φ + KE - gas.cᵥ*gas.T₀)
+            denominator += ρᵅ*gas.cᵥ
+        end
+        return numerator/denominator
+    end
+end
+
+@inline function diagnose_pressure(i, j, k, grid::AbstractGrid{FT}, tvar, gases, gravity, ρ, ρũ, ρc̃) where FT
+    @inbounds begin
+        T = diagnose_temperature(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃)
+        p = zero(FT)
+        for gas_index in 1:length(gases)
+            R = gases[gas_index].R
+            ρᵅ = ρc̃[gas_index+1][i, j, k]
+            p += ρᵅ*R*T
+        end
+        return p
+    end
+end
+
+@inline function diagnose_density(i, j, k, grid::AbstractGrid{FT}, gases, ρc̃) where FT
+    @inbounds begin
+        ρ = zero(FT)
+        for gas_index in 1:length(gases)
+            ρ += ρc̃[gas_index+1][i, j, k]
+        end
+        return ρ
+    end
+end
+
+@inline function diagnose_p_over_ρ(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃)
+    @inbounds begin
+        p = diagnose_pressure(i, j, k, grid, tvar, gases, gravity, ρ, ρũ, ρc̃)
+        return p / ρ[i, j, k]
+    end
+end

--- a/compressible/src/time_steppers.jl
+++ b/compressible/src/time_steppers.jl
@@ -1,0 +1,32 @@
+using Oceananigans.TimeSteppers: AbstractTimeStepper
+
+struct WickerSkamarockTimeStepper{S, F, I} <: AbstractTimeStepper
+      slow_source_terms :: S
+      fast_source_terms :: F
+    intermediate_fields :: I
+
+    function WickerSkamarockTimeStepper(arch, grid, tracers;
+        slow_source_terms = SlowSourceTermFields(arch, grid, tracers),
+        fast_source_terms = FastSourceTermFields(arch, grid, tracers),
+      intermediate_fields = FastSourceTermFields(arch, grid, tracers))
+  
+      return new{typeof(slow_source_terms), typeof(fast_source_terms),
+        typeof(intermediate_fields)}(slow_source_terms, fast_source_terms, intermediate_fields)
+  end
+end
+
+function SlowSourceTermFields(arch, grid, tracernames)
+    ρu = XFaceField(arch, grid)
+    ρv = YFaceField(arch, grid)
+    ρw = ZFaceField(arch, grid)
+    tracers = TracerFields(tracernames, arch, grid, ())
+    return (ρu = ρu, ρv = ρv, ρw = ρw, tracers = tracers)
+end
+
+function FastSourceTermFields(arch, grid, tracernames)
+    ρu = XFaceField(arch, grid)
+    ρv = YFaceField(arch, grid)
+    ρw = ZFaceField(arch, grid)
+    tracers = TracerFields(tracernames, arch, grid, ())
+    return (ρu = ρu, ρv = ρv, ρw = ρw, tracers = tracers)
+end

--- a/compressible/src/time_stepping.jl
+++ b/compressible/src/time_stepping.jl
@@ -1,0 +1,137 @@
+using JULES.Operators
+
+using Oceananigans.BoundaryConditions
+
+using Oceananigans.Fields: datatuple
+using Oceananigans.TimeSteppers: tick!
+
+import Oceananigans.TimeSteppers: time_step!
+import Oceananigans.Simulations: ab2_or_rk3_time_step!
+
+ab2_or_rk3_time_step!(model::CompressibleModel, Δt; euler) = time_step!(model, Δt)
+
+function time_step!(model::CompressibleModel, Δt)
+    arch = model.architecture
+    total_density  = model.total_density
+    momenta = model.momenta
+    tracers = model.tracers
+    diffusivities  = model.diffusivities
+
+    slow_source_terms   = model.time_stepper.slow_source_terms
+    fast_source_terms   = model.time_stepper.fast_source_terms
+    intermediate_fields = model.time_stepper.intermediate_fields
+
+    momenta_names = propertynames(momenta)
+    tracers_names = propertynames(tracers)
+
+    intermediate_momenta_fields = [getproperty(intermediate_fields, ρu)         for ρu in momenta_names]
+    intermediate_tracers_fields = [getproperty(intermediate_fields.tracers, ρc) for ρc in tracers_names]
+
+    intermediate_momenta = NamedTuple{momenta_names}(intermediate_momenta_fields)
+    intermediate_tracers = NamedTuple{tracers_names}(intermediate_tracers_fields)
+
+    first_stage_Δt  = Δt / 3
+    second_stage_Δt = Δt / 2
+    third_stage_Δt  = Δt
+
+    #####
+    ##### Compute slow source terms
+    #####
+
+    density_update_event =
+        launch!(arch, model.grid, :xyz, update_total_density!,
+                datatuple(total_density), model.grid, model.gases, datatuple(tracers),
+                dependencies=Event(device(arch)))
+
+    wait(device(arch), density_update_event)
+    
+    fill_halo_regions!(merge((Σρ=total_density,), momenta, tracers), model.architecture, model.clock, nothing)
+    fill_halo_regions!(momenta.ρw, model.architecture, model.clock, nothing)
+    fill_halo_regions!(intermediate_momenta.ρw, model.architecture, model.clock, nothing)
+
+    compute_slow_source_terms!(
+        slow_source_terms, arch, model.grid, model.thermodynamic_variable, model.gases, model.gravity,
+        model.coriolis, model.closure, total_density, momenta, tracers, diffusivities, model.forcing, model.clock)
+
+    fill_halo_regions!(slow_source_terms.ρw, model.architecture, model.clock, nothing)
+
+    #####
+    ##### Stage 1
+    #####
+
+    density_update_event =
+        launch!(arch, model.grid, :xyz, update_total_density!,
+                datatuple(total_density), model.grid, model.gases, datatuple(tracers),
+                dependencies=Event(device(arch)))
+
+    wait(device(arch), density_update_event)
+
+    fill_halo_regions!(merge((Σρ=total_density,), momenta, tracers), model.architecture, model.clock, nothing)    
+    fill_halo_regions!(momenta.ρw, model.architecture, model.clock, nothing)
+    fill_halo_regions!(intermediate_momenta.ρw, model.architecture, model.clock, nothing)
+
+    compute_fast_source_terms!(
+        fast_source_terms, arch, model.grid, model.thermodynamic_variable, model.gases, model.gravity,
+        model.advection, total_density, momenta, tracers, slow_source_terms)
+
+    calculate_boundary_tendency_contributions!(fast_source_terms, arch, momenta, tracers, model.clock, nothing)
+
+    advance_state_variables!(intermediate_fields, arch, model.grid, momenta, tracers, fast_source_terms, Δt=first_stage_Δt)
+
+    tick!(model.clock, 0, stage=true)
+
+    #####
+    ##### Stage 2
+    #####
+
+    density_update_event =
+        launch!(arch, model.grid, :xyz, update_total_density!,
+                datatuple(total_density), model.grid, model.gases, datatuple(intermediate_tracers),
+                dependencies=Event(device(arch)))
+
+    wait(device(arch), density_update_event)
+
+    fill_halo_regions!(merge((Σρ=total_density,), intermediate_momenta, intermediate_tracers), model.architecture, model.clock, nothing)
+    fill_halo_regions!(momenta.ρw, model.architecture, model.clock, nothing)
+    fill_halo_regions!(intermediate_momenta.ρw, model.architecture, model.clock, nothing)
+
+    compute_fast_source_terms!(
+        fast_source_terms, arch, model.grid, model.thermodynamic_variable, model.gases, model.gravity,
+        model.advection, total_density, intermediate_momenta, intermediate_tracers, slow_source_terms)
+
+    calculate_boundary_tendency_contributions!(fast_source_terms, arch, intermediate_momenta,
+                                               intermediate_tracers, model.clock, nothing)
+
+    advance_state_variables!(intermediate_fields, arch, model.grid, momenta, tracers, fast_source_terms, Δt=second_stage_Δt)
+
+    tick!(model.clock, 0, stage=true)
+
+    #####
+    ##### Stage 3
+    #####
+
+    density_update_event =
+        launch!(arch, model.grid, :xyz, update_total_density!,
+                datatuple(total_density), model.grid, model.gases, datatuple(intermediate_tracers),
+                dependencies=Event(device(arch)))
+
+    wait(device(arch), density_update_event)
+
+    fill_halo_regions!(merge((Σρ=total_density,), intermediate_momenta, intermediate_tracers), model.architecture, model.clock, nothing)
+    fill_halo_regions!(momenta.ρw, model.architecture, model.clock, nothing)
+    fill_halo_regions!(intermediate_momenta.ρw, model.architecture, model.clock, nothing)
+
+    compute_fast_source_terms!(
+        fast_source_terms, arch, model.grid, model.thermodynamic_variable, model.gases, model.gravity,
+        model.advection, total_density, intermediate_momenta, intermediate_tracers, slow_source_terms)
+
+    calculate_boundary_tendency_contributions!(fast_source_terms, arch, intermediate_momenta,
+                                               intermediate_tracers, model.clock, nothing)
+
+    state_variables = (momenta..., tracers = tracers)
+    advance_state_variables!(state_variables, arch, model.grid, momenta, tracers, fast_source_terms, Δt=third_stage_Δt)
+
+    tick!(model.clock, Δt)
+
+    return nothing
+end

--- a/compressible/src/time_stepping_kernels.jl
+++ b/compressible/src/time_stepping_kernels.jl
@@ -1,0 +1,222 @@
+using KernelAbstractions
+using Oceananigans.Utils
+using Oceananigans.Architectures: device, @hascuda, CPU, GPU, array_type
+using Oceananigans.Fields: datatuple
+using Oceananigans.BoundaryConditions: apply_x_bcs!, apply_y_bcs!, apply_z_bcs!
+
+@kernel function update_total_density!(total_density, grid, gases, tracers)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds total_density[i, j, k] = diagnose_density(i, j, k, grid, gases, tracers)
+end
+
+# This is for users. Do not use in time_stepping.jl as it doesn't make use of intermediate fields.
+function update_total_density!(model)
+
+    density_update_event =
+        launch!(model.architecture, model.grid, :xyz, update_total_density!,
+                datatuple(model.total_density), model.grid, model.gases, datatuple(model.tracers),
+                dependencies=Event(device(model.architecture)))
+
+    wait(device(model.architecture), density_update_event)
+
+    return nothing
+end
+
+#####
+##### Computing slow source terms (viscous dissipation, diffusion, and Coriolis terms).
+#####
+
+function compute_slow_source_terms!(slow_source_terms, arch, grid, thermodynamic_variable, gases, gravity, coriolis, closure, total_density, momenta, tracers, diffusivities, forcing, clock)
+
+    slow_source_terms, total_density, momenta, tracers, diffusivities =
+        datatuples(slow_source_terms, total_density, momenta, tracers, diffusivities)
+
+    workgroup, worksize = work_layout(grid, :xyz)
+    barrier = Event(device(arch))
+
+    momentum_kernel! = compute_slow_momentum_source_terms!(device(arch), workgroup, worksize)
+    tracer_kernel! = compute_slow_tracer_source_terms!(device(arch), workgroup, worksize)
+    thermodynamic_variable_kernel! = compute_slow_thermodynamic_variable_source_terms!(device(arch), workgroup, worksize)
+
+    momentum_event = momentum_kernel!(slow_source_terms, grid, coriolis, closure, total_density, momenta, tracers, diffusivities, forcing, clock, dependencies=barrier)
+
+    events = [momentum_event]
+
+    for (tracer_index, ρc_name) in enumerate(propertynames(tracers))
+        ρc   = getproperty(tracers, ρc_name)
+        S_ρc = getproperty(slow_source_terms.tracers, ρc_name)
+        forcing_ρc = getproperty(forcing, ρc_name)
+
+        tracer_event = tracer_kernel!(S_ρc, grid, closure, tracer_index, total_density, ρc, momenta, tracers, diffusivities, forcing_ρc, clock, dependencies=barrier)
+        push!(events, tracer_event)
+    end
+
+    thermodynamic_variable_event = thermodynamic_variable_kernel!(slow_source_terms.tracers[1], grid, thermodynamic_variable, gases, gravity, closure, total_density, momenta, tracers, diffusivities, dependencies=barrier)
+    push!(events, thermodynamic_variable_event)
+
+    wait(device(arch), MultiEvent(Tuple(events)))
+
+    return nothing
+end
+
+@kernel function compute_slow_momentum_source_terms!(slow_source_terms, grid, coriolis, closure, total_density, momenta, tracers, diffusivities, forcing, clock)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds slow_source_terms.ρu[i, j, k] = ρu_slow_source_term(i, j, k, grid, coriolis, closure, total_density, momenta, diffusivities) + forcing.ρu(i, j, k, grid, clock, merge(momenta, tracers))
+    @inbounds slow_source_terms.ρv[i, j, k] = ρv_slow_source_term(i, j, k, grid, coriolis, closure, total_density, momenta, diffusivities) + forcing.ρv(i, j, k, grid, clock, merge(momenta, tracers))
+    @inbounds slow_source_terms.ρw[i, j, k] = ρw_slow_source_term(i, j, k, grid, coriolis, closure, total_density, momenta, diffusivities) + forcing.ρw(i, j, k, grid, clock, merge(momenta, tracers))
+end
+
+@kernel function compute_slow_tracer_source_terms!(S_ρc, grid, closure, tracer_index, total_density, ρc, momenta, tracers, diffusivities, forcing, clock)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds S_ρc[i, j, k] = ρc_slow_source_term(i, j, k, grid, closure, tracer_index, total_density, ρc, diffusivities) + forcing(i, j, k, grid, clock, merge(momenta, tracers))
+end
+
+@kernel function compute_slow_thermodynamic_variable_source_terms!(S_ρt, grid, thermodynamic_variable, gases, gravity, closure, total_density, momenta, tracers, diffusivities)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds S_ρt[i, j, k] += ρt_slow_source_term(i, j, k, grid, closure, thermodynamic_variable, gases, gravity, total_density, momenta, tracers, diffusivities)
+end
+
+#####
+##### Computing fast source terms (advection, pressure gradient, and buoyancy terms).
+#####
+
+function compute_fast_source_terms!(fast_source_terms, arch, grid, thermodynamic_variable, gases, gravity, advection_scheme, total_density, momenta, tracers, slow_source_terms)
+
+    fast_source_terms, total_density, momenta, tracers, slow_source_terms =
+        datatuples(fast_source_terms, total_density, momenta, tracers, slow_source_terms)
+
+    workgroup, worksize = work_layout(grid, :xyz)
+    barrier = Event(device(arch))
+
+    momentum_kernel! = compute_fast_momentum_source_terms!(device(arch), workgroup, worksize)
+    tracer_kernel! = compute_fast_tracer_source_terms!(device(arch), workgroup, worksize)
+    thermodynamic_variable_kernel! = compute_fast_thermodynamic_variable_source_terms!(device(arch), workgroup, worksize)
+
+    momentum_event = momentum_kernel!(fast_source_terms, grid, thermodynamic_variable, gases, gravity, advection_scheme, total_density, momenta, tracers, slow_source_terms, dependencies=barrier)
+
+    events = [momentum_event]
+
+    for ρc_name in propertynames(tracers)
+        ρc   = getproperty(tracers, ρc_name)
+        F_ρc = getproperty(fast_source_terms.tracers, ρc_name)
+        S_ρc = getproperty(slow_source_terms.tracers, ρc_name)
+
+        tracer_event = tracer_kernel!(F_ρc, grid, advection_scheme, total_density, momenta, ρc, S_ρc, dependencies=barrier)
+        push!(events, tracer_event)
+    end
+    
+    thermodynamic_variable_event = thermodynamic_variable_kernel!(fast_source_terms.tracers[1], grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers, dependencies=barrier)
+    push!(events, thermodynamic_variable_event)
+
+    wait(device(arch), MultiEvent(Tuple(events)))
+
+    return nothing
+end
+
+@kernel function compute_fast_momentum_source_terms!(fast_source_terms, grid, thermodynamic_variable, gases, gravity, advection_scheme, total_density, momenta, tracers, slow_source_terms)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds fast_source_terms.ρu[i, j, k] = ρu_fast_source_term(i, j, k, grid, thermodynamic_variable, gases, gravity, advection_scheme, total_density, momenta, tracers, slow_source_terms.ρu)
+    @inbounds fast_source_terms.ρv[i, j, k] = ρv_fast_source_term(i, j, k, grid, thermodynamic_variable, gases, gravity, advection_scheme, total_density, momenta, tracers, slow_source_terms.ρv)
+    @inbounds fast_source_terms.ρw[i, j, k] = ρw_fast_source_term(i, j, k, grid, thermodynamic_variable, gases, gravity, advection_scheme, total_density, momenta, tracers, slow_source_terms.ρw)
+end
+
+@kernel function compute_fast_tracer_source_terms!(F_ρc, grid, advection_scheme, total_density, momenta, ρc, S_ρc)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds F_ρc[i, j, k] = ρc_fast_source_term(i, j, k, grid, advection_scheme, total_density, momenta, ρc, S_ρc)
+end
+
+@kernel function compute_fast_thermodynamic_variable_source_terms!(F_ρt, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds F_ρt[i, j, k] += ρt_fast_source_term(i, j, k, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
+end
+
+#####
+##### Calculating boundary tendency contributions
+#####
+
+function calculate_boundary_tendency_contributions!(source_terms, arch, momenta, tracers, clock, model_fields)
+
+    barrier = Event(device(arch))
+
+    events = []
+
+    # Momentum fields
+    momentum_source_terms = (source_terms.ρu, source_terms.ρv, source_terms.ρw)
+
+    for (ρϕ_source_term, ρϕ) in zip(momentum_source_terms, momenta)
+        x_bcs_event = apply_x_bcs!(ρϕ_source_term, ρϕ, arch, barrier, clock, model_fields)
+        y_bcs_event = apply_y_bcs!(ρϕ_source_term, ρϕ, arch, barrier, clock, model_fields)
+        z_bcs_event = apply_z_bcs!(ρϕ_source_term, ρϕ, arch, barrier, clock, model_fields)
+
+        push!(events, x_bcs_event, y_bcs_event, z_bcs_event)
+    end
+
+    # Tracer fields
+    for (ρϕ_source_term, ρϕ) in zip(source_terms.tracers, tracers)
+        x_bcs_event = apply_x_bcs!(ρϕ_source_term, ρϕ, arch, barrier, clock, model_fields)
+        y_bcs_event = apply_y_bcs!(ρϕ_source_term, ρϕ, arch, barrier, clock, model_fields)
+        z_bcs_event = apply_z_bcs!(ρϕ_source_term, ρϕ, arch, barrier, clock, model_fields)
+
+        push!(events, x_bcs_event, y_bcs_event, z_bcs_event)
+    end
+
+    events = filter(e -> typeof(e) <: Event, events)
+
+    wait(device(arch), MultiEvent(Tuple(events)))
+
+    return nothing
+end
+
+#####
+##### Advancing state variables
+#####
+
+function advance_state_variables!(state_variables, arch, grid, momenta, tracers, fast_source_terms; Δt)
+    
+    state_variables, momenta, tracers, fast_source_terms =
+        datatuples(state_variables, momenta, tracers, fast_source_terms )
+
+    workgroup, worksize = work_layout(grid, :xyz)
+    barrier = Event(device(arch))
+
+    momentum_kernel! = advance_momentum!(device(arch), workgroup, worksize)
+    tracer_kernel! = advance_tracer!(device(arch), workgroup, worksize)
+
+    momentum_event = momentum_kernel!(state_variables, grid, momenta, fast_source_terms, Δt, dependencies=barrier)
+
+    events = [momentum_event]
+
+    for ρc_name in propertynames(tracers)
+        ρc   = getproperty(tracers, ρc_name)
+        ρc⁺  = getproperty(state_variables.tracers, ρc_name)
+        F_ρc = getproperty(fast_source_terms.tracers, ρc_name)
+        
+        tracer_event = tracer_kernel!(ρc⁺, grid, ρc, F_ρc, Δt, dependencies=barrier)
+        push!(events, tracer_event)
+    end
+
+    wait(device(arch), MultiEvent(Tuple(events)))
+
+    return nothing
+end
+
+@kernel function advance_momentum!(momenta⁺, grid, momenta, fast_source_terms, Δt)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds momenta⁺.ρu[i, j, k] = momenta.ρu[i, j, k] + Δt * fast_source_terms.ρu[i, j, k]
+    @inbounds momenta⁺.ρv[i, j, k] = momenta.ρv[i, j, k] + Δt * fast_source_terms.ρv[i, j, k]
+    @inbounds momenta⁺.ρw[i, j, k] = momenta.ρw[i, j, k] + Δt * fast_source_terms.ρw[i, j, k]
+end
+
+@kernel function advance_tracer!(ρc⁺, grid, ρc, F_ρc, Δt)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds ρc⁺[i, j, k] = ρc[i, j, k] + Δt * F_ρc[i, j, k]
+end

--- a/compressible/src/utils.jl
+++ b/compressible/src/utils.jl
@@ -1,0 +1,116 @@
+#####
+##### Grabbing properties for thermodynamic variables
+#####
+
+function thermodynamic_field(model)
+    model.thermodynamic_variable isa Energy  && return model.tracers.ρe
+    model.thermodynamic_variable isa Entropy && return model.tracers.ρs
+end
+
+function intermediate_thermodynamic_field(model)
+    model.thermodynamic_variable isa Energy  && return model.time_stepper.intermediate_fields.tracers.ρe
+    model.thermodynamic_variable isa Entropy && return model.time_stepper.intermediate_fields.tracers.ρs
+end
+
+#####
+##### Kernels for diagnosing thermodynamic variables
+#####
+
+@kernel function compute_velocities!(velocities, grid, momenta, total_density)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds velocities.u[i, j, k] = momenta.ρu[i, j, k] / ℑxᶠᵃᵃ(i, j, k, grid, total_density)
+    @inbounds velocities.v[i, j, k] = momenta.ρv[i, j, k] / ℑyᵃᶠᵃ(i, j, k, grid, total_density)
+    @inbounds velocities.w[i, j, k] = momenta.ρw[i, j, k] / ℑzᵃᵃᶠ(i, j, k, grid, total_density)
+end
+
+@kernel function compute_p_over_ρ!(p_over_ρ, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds p_over_ρ[i, j, k] = diagnose_p_over_ρ(i, j, k, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
+end
+
+@kernel function compute_temperature!(temperature, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
+    i, j, k = @index(Global, NTuple)
+
+    @inbounds temperature[i, j, k] = diagnose_temperature(i, j, k, grid, thermodynamic_variable, gases, gravity, total_density, momenta, tracers)
+end
+
+function compute_temperature!(model)
+    temperature = intermediate_thermodynamic_field(model)
+
+    temperature, total_density, momenta, tracers =
+        datatuples(temperature, model.total_density, model.momenta, model.tracers)
+
+    compute_temperature_event =
+        launch!(model.architecture, model.grid, :xyz, compute_temperature!,
+                temperature, model.grid, model.thermodynamic_variable, model.gases,
+                model.gravity, total_density, momenta, tracers,
+                dependencies=Event(device(model.architecture)))
+
+    wait(device(model.architecture), compute_temperature_event)
+
+    return temperature
+end
+
+#####
+##### CFL
+#####
+
+function cfl(model, Δt)
+    # We will store the velocities in the time stepper's intermediate fields.
+    velocities = (
+        u = model.time_stepper.intermediate_fields.ρu,
+        v = model.time_stepper.intermediate_fields.ρv,
+        w = model.time_stepper.intermediate_fields.ρw
+    )
+
+    velocities, momenta, total_density =
+        datatuples(velocities, model.momenta, model.total_density)
+
+    velocity_event =
+        launch!(model.architecture, model.grid, :xyz, compute_velocities!,
+                velocities, model.grid, momenta, total_density,
+                dependencies=Event(device(model.architecture)))
+    
+    wait(device(model.architecture), velocity_event)
+
+    u_max = maximum(velocities.u.parent)
+    v_max = maximum(velocities.v.parent)
+    w_max = maximum(velocities.w.parent)
+
+    Δx, Δy, Δz = model.grid.Δx, model.grid.Δy, model.grid.Δz
+    CFL = Δt / min(Δx/u_max, Δy/v_max, Δz/w_max)
+
+    return CFL
+end
+
+#####
+##### Acoustic CFL
+#####
+
+function acoustic_cfl(model, Δt)
+    # We will store p/ρ in the time stepper's intermediate field for the thermodynamic variable.
+    p_over_ρ = intermediate_thermodynamic_field(model)
+
+    p_over_ρ, total_density, momenta, tracers =
+        datatuples(p_over_ρ, model.total_density, model.momenta, model.tracers)
+
+    compute_p_over_ρ_event =
+        launch!(model.architecture, model.grid, :xyz, compute_p_over_ρ!,
+                p_over_ρ, model.grid, model.thermodynamic_variable, model.gases,
+                model.gravity, total_density, momenta, tracers,
+                dependencies=Event(device(model.architecture)))
+
+    wait(device(model.architecture), compute_p_over_ρ_event)
+
+    p_over_ρ_max = maximum(p_over_ρ.parent)
+
+    γ_max = maximum(gas.cₚ / gas.cᵥ for gas in model.gases)
+    c_max = √(γ_max * p_over_ρ_max)
+
+    Δx, Δy, Δz = model.grid.Δx, model.grid.Δy, model.grid.Δz
+    acoustic_CFL = Δt / min(Δx/c_max, Δy/c_max, Δz/c_max)
+
+    return acoustic_CFL
+end

--- a/compressible/test/runtests.jl
+++ b/compressible/test/runtests.jl
@@ -1,0 +1,26 @@
+using Test
+using Logging
+using Statistics
+using Printf
+using JLD2
+using CUDA
+
+using Oceananigans
+using Oceananigans.Architectures
+using JULES
+
+Logging.global_logger(OceananigansLogger())
+
+         Archs = [CPU]
+@hascuda Archs = [GPU]
+
+
+CUDA.allowscalar(true)
+
+@testset "JULES" begin
+    include("test_models.jl")
+    include("test_lazy_fields.jl")
+    include("test_time_stepping.jl")
+    include("test_regression.jl")
+end
+

--- a/compressible/test/test_lazy_fields.jl
+++ b/compressible/test/test_lazy_fields.jl
@@ -1,0 +1,46 @@
+using JULES: LazyVelocityFields, LazyTracerFields
+
+@testset "Lazy fields" begin
+    @info "Testing lazy fields..."
+
+    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    model = CompressibleModel(grid=grid, gases=DryEarth(),
+                              thermodynamic_variable=Energy())
+
+    model.total_density.data .= π
+    model.momenta.ρu.data .= 1.0
+    model.momenta.ρv.data .= 2.0
+    model.momenta.ρw.data .= 3.0
+    model.tracers.ρe.data .= 4.0
+
+    velocities = LazyVelocityFields(model.architecture, model.grid, model.total_density, model.momenta)
+    primitive_tracers = LazyTracerFields(model.architecture, model.grid, model.total_density, model.tracers)
+
+    @test velocities.u[1, 2, 3] == 1/π
+    @test velocities.v[4, 5, 6] == 2/π
+    @test velocities.w[7, 8, 9] == 3/π
+
+    @test primitive_tracers.e[10, 11, 12] == 4/π
+
+    grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+    model = CompressibleModel(grid=grid, gases=DryEarth(),
+                              thermodynamic_variable=Entropy())
+
+    @. model.total_density.data = randn()
+    @. model.momenta.ρu.data = randn()
+    @. model.momenta.ρv.data = randn()
+    @. model.momenta.ρw.data = randn()
+    @. model.tracers.ρs.data = randn()
+
+    velocities = LazyVelocityFields(model.architecture, model.grid, model.total_density, model.momenta)
+    primitive_tracers = LazyTracerFields(model.architecture, model.grid, model.total_density, model.tracers)
+
+    ρ = model.total_density
+    ρu, ρv, ρw = model.momenta
+    @test velocities.u[1, 2, 3] == ρu[1, 2, 3] / ((ρ[0, 2, 3] + ρ[1, 2, 3]) / 2)
+    @test velocities.v[4, 5, 6] == ρv[4, 5, 6] / ((ρ[4, 4, 6] + ρ[4, 5, 6]) / 2)
+    @test velocities.w[7, 8, 9] == ρw[7, 8, 9] / ((ρ[7, 8, 8] + ρ[7, 8, 9]) / 2)
+
+    ρs = model.tracers.ρs
+    @test primitive_tracers.s[10, 11, 12] == ρs[10, 11, 12] / ρ[10, 11, 12]
+end

--- a/compressible/test/test_models.jl
+++ b/compressible/test/test_models.jl
@@ -1,0 +1,25 @@
+for Arch in Archs
+    @testset "Models [$Arch]" begin
+        @info "Testing models [$Arch]..."
+
+        @testset "Energy thermodynamic variable" begin
+            @info "  Testing model construction with energy thermodynamic variable..."
+
+            grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+            model = CompressibleModel(architecture=Arch(), grid = grid, gases = DryEarth(),
+                                      thermodynamic_variable = Energy())
+            
+            @test model isa CompressibleModel
+        end
+
+        @testset "Entropy thermodynamic variable" begin
+            @info "  Testing model construction with entropy thermodynamic variable..."
+
+            grid = RegularCartesianGrid(size=(16, 16, 16), extent=(1, 1, 1))
+            model = CompressibleModel(architecture=Arch(), grid = grid, gases = DryEarth(),
+                                      thermodynamic_variable = Entropy())
+            
+            @test model isa CompressibleModel
+        end
+    end
+end

--- a/compressible/test/test_regression.jl
+++ b/compressible/test/test_regression.jl
@@ -1,0 +1,167 @@
+using Oceananigans.Fields: interiorparent
+
+function summarize_regression_test(fields, correct_fields)
+    for (field_name, φ, φ_c) in zip(keys(fields), fields, correct_fields)
+        Δ = φ .- φ_c
+
+        Δ_min      = minimum(Δ)
+        Δ_max      = maximum(Δ)
+        Δ_mean     = mean(Δ)
+        Δ_abs_mean = mean(abs, Δ)
+        Δ_std      = std(Δ)
+
+        matching    = sum(φ .≈ φ_c)
+        grid_points = length(φ_c)
+
+        @info @sprintf("Δ%s: min=%+.6e, max=%+.6e, mean=%+.6e, absmean=%+.6e, std=%+.6e (%d/%d matching grid points)",
+                       field_name, Δ_min, Δ_max, Δ_mean, Δ_abs_mean, Δ_std, matching, grid_points)
+    end
+end
+
+for Arch in Archs
+    @testset "Regression [$Arch]" begin
+        @info "Testing regression [$Arch]..."
+
+        include("../verification/dry_rising_thermal_bubble/dry_rising_thermal_bubble.jl")
+
+        for Tvar in (Energy, Entropy)
+            @testset "Dry rising thermal bubble [$Tvar, $Arch]" begin
+                @info "  Testing dry rising thermal bubble regression [$Tvar, $Arch]..."
+
+                simulation = simulate_dry_rising_thermal_bubble(architecture = Arch(),
+                    end_time=4.999, thermodynamic_variable=Tvar())
+
+                model = simulation.model
+                regression_filepath = "thermal_bubble_regression_$Tvar.jld2"
+
+                # UNCOMMENT TO GENERATE REGRESSION DATA!
+                # jldopen(regression_filepath, "w") do file
+                #     file["ρ"]  = interiorparent(model.total_density)
+                #     file["ρu"] = interiorparent(model.momenta.ρu)
+                #     file["ρv"] = interiorparent(model.momenta.ρv)
+                #     file["ρw"] = interiorparent(model.momenta.ρw)
+                #
+                #     if Tvar == Energy
+                #         file["ρe"] = interiorparent(model.tracers.ρe)
+                #     elseif Tvar == Entropy
+                #         file["ρs"] = interiorparent(model.tracers.ρs)
+                #     end
+                # end
+
+                file = jldopen(regression_filepath, "r")
+
+                field_names = [:ρ, :ρu, :ρv, :ρw]
+
+                test_fields = [Array(interior(model.total_density)),
+                               Array(interior(model.momenta.ρu)),
+                               Array(interior(model.momenta.ρv)),
+                               Array(interior(model.momenta.ρw)[:, :, 1:end-1])]
+
+                correct_fields = [file["ρ"], file["ρu"], file["ρv"], file["ρw"]]
+
+                if Tvar == Energy
+                    push!(field_names, :ρe)
+                    push!(test_fields, Array(interior(model.tracers.ρe)))
+                    push!(correct_fields, file["ρe"])
+                elseif Tvar == Entropy
+                    push!(field_names, :ρs)
+                    push!(test_fields, Array(interior(model.tracers.ρs)))
+                    push!(correct_fields, file["ρs"])
+                end
+
+                test_fields = NamedTuple{Tuple(field_names)}(Tuple(test_fields))
+                correct_fields = NamedTuple{Tuple(field_names)}(Tuple(correct_fields))
+                summarize_regression_test(test_fields, correct_fields)
+
+                # https://github.com/thabbott/JULES.jl/pull/91#issuecomment-707666010
+                @test all(isapprox.(test_fields.ρu, correct_fields.ρu, atol=1e-12))
+                @test all(isapprox.(test_fields.ρw, correct_fields.ρw, atol=1e-12))
+
+                @test all(test_fields.ρ  .≈ correct_fields.ρ)
+                @test all(test_fields.ρv .≈ correct_fields.ρv)
+
+                if Tvar == Energy
+                    @test all(test_fields.ρe .≈ correct_fields.ρe)
+                elseif Tvar == Entropy
+                    @test all(test_fields.ρs .≈ correct_fields.ρs)
+                end
+            end
+        end
+
+        include("../verification/three_gas_dry_rising_thermal_bubble/three_gas_dry_rising_thermal_bubble.jl")
+
+        for Tvar in (Energy, Entropy)
+            @testset "Three gas thermal bubble [$Tvar, $Arch]" begin
+                @info "  Testing three gas thermal bubble regression [$Tvar, $Arch]..."
+
+                simulation = simulate_three_gas_dry_rising_thermal_bubble(architecture = Arch(),
+                    end_time=4.999, thermodynamic_variable=Tvar())
+
+                model = simulation.model
+                regression_filepath = "three_gas_thermal_bubble_regression_$Tvar.jld2"
+
+                # UNCOMMENT TO GENERATE REGRESSION DATA!
+                # jldopen(regression_filepath, "w") do file
+                #     file["ρ"]  = interiorparent(model.total_density)
+                #     file["ρu"] = interiorparent(model.momenta.ρu)
+                #     file["ρv"] = interiorparent(model.momenta.ρv)
+                #     file["ρw"] = interiorparent(model.momenta.ρw)
+                #     file["ρ₁"] = interiorparent(model.tracers.ρ₁)
+                #     file["ρ₂"] = interiorparent(model.tracers.ρ₂)
+                #     file["ρ₃"] = interiorparent(model.tracers.ρ₃)
+                #
+                #     if Tvar == Energy
+                #         file["ρe"] = interiorparent(model.tracers.ρe)
+                #     elseif Tvar == Entropy
+                #         file["ρs"] = interiorparent(model.tracers.ρs)
+                #     end
+                # end
+
+                file = jldopen(regression_filepath, "r")
+
+                field_names = [:ρ, :ρu, :ρv, :ρw, :ρ₁, :ρ₂, :ρ₃]
+                
+                test_fields = [Array(interior(model.total_density)),
+                               Array(interior(model.momenta.ρu)),
+                               Array(interior(model.momenta.ρv)),
+                               Array(interior(model.momenta.ρw)[:, :, 1:end-1]),
+                               Array(interior(model.tracers.ρ₁)),
+                               Array(interior(model.tracers.ρ₂)),
+                               Array(interior(model.tracers.ρ₃))]
+                
+                correct_fields = [file["ρ"], file["ρu"], file["ρv"], file["ρw"],
+                                  file["ρ₁"], file["ρ₂"], file["ρ₃"]]
+
+                if Tvar == Energy
+                    push!(field_names, :ρe)
+                    push!(test_fields, Array(interior(model.tracers.ρe)))
+                    push!(correct_fields, file["ρe"])
+                elseif Tvar == Entropy
+                    push!(field_names, :ρs)
+                    push!(test_fields, Array(interior(model.tracers.ρs)))
+                    push!(correct_fields, file["ρs"])
+                end
+
+                test_fields = NamedTuple{Tuple(field_names)}(Tuple(test_fields))
+                correct_fields = NamedTuple{Tuple(field_names)}(Tuple(correct_fields))
+                summarize_regression_test(test_fields, correct_fields)
+
+                # https://github.com/thabbott/JULES.jl/pull/91#issuecomment-707666010
+                @test all(isapprox.(test_fields.ρu, correct_fields.ρu, atol=1e-12))
+                @test all(isapprox.(test_fields.ρw, correct_fields.ρw, atol=1e-12))
+
+                @test all(test_fields.ρ  .≈ correct_fields.ρ)
+                @test all(test_fields.ρv .≈ correct_fields.ρv)
+                @test all(test_fields.ρ₁ .≈ correct_fields.ρ₁)
+                @test all(test_fields.ρ₂ .≈ correct_fields.ρ₂)
+                @test all(test_fields.ρ₃ .≈ correct_fields.ρ₃)
+
+                if Tvar == Energy
+                    @test all(test_fields.ρe .≈ correct_fields.ρe)
+                elseif Tvar == Entropy
+                    @test all(test_fields.ρs .≈ correct_fields.ρs)
+                end
+            end
+        end
+    end
+end

--- a/compressible/test/test_time_stepping.jl
+++ b/compressible/test/test_time_stepping.jl
@@ -1,0 +1,27 @@
+for Arch in Archs
+    @testset "Time stepping [$Arch]" begin
+        @info "Testing time stepping [$Arch]..."
+
+        @testset "Energy thermodynamic variable" begin
+            @info "  Testing time stepping with energy thermodynamic variable..."
+
+            grid = RegularCartesianGrid(size=(16, 16, 16), halo=(2, 2, 2), extent=(1, 1, 1))
+            model = CompressibleModel(architecture = Arch(), grid = grid, gases = DryEarth(),
+                                      thermodynamic_variable = Energy())
+            time_step!(model, 1)
+            
+            @test model isa CompressibleModel
+        end
+
+        @testset "Entropy thermodynamic variable" begin
+            @info "  Testing time stepping with entropy thermodynamic variable..."
+
+            grid = RegularCartesianGrid(size=(16, 16, 16), halo=(2, 2, 2), extent=(1, 1, 1))
+            model = CompressibleModel(architecture = Arch(), grid = grid, gases = DryEarth(),
+                                    thermodynamic_variable = Entropy())
+            time_step!(model, 1)
+
+            @test model isa CompressibleModel
+        end
+    end
+end

--- a/compressible/verification/burgers_equation/burgers_equation.jl
+++ b/compressible/verification/burgers_equation/burgers_equation.jl
@@ -1,0 +1,66 @@
+using Printf
+using Plots
+
+using Oceananigans
+using Oceananigans.Advection
+using JULES
+
+using JULES: IdealGas
+using Oceananigans.Grids: Cell, xnodes
+
+ENV["GKSwstype"] = "100"
+
+N = 512
+L = 1
+T = 1e-1
+Δt = 2e-4
+Nt = Int(T/Δt)
+
+ideal_gas = IdealGas(Float64, JULES.R⁰, 1; T₀=1, p₀=1, s₀=1, u₀=0)
+
+topo = (Periodic, Periodic, Periodic)
+domain = (x=(0, L), y=(0, 1), z=(0, 1))
+grid = RegularCartesianGrid(topology=topo, size=(N, 1, 1), halo=(4, 4, 4); domain...)
+
+model = CompressibleModel(
+                      grid = grid,
+                 advection = WENO5(),
+                     gases = (ρ=ideal_gas,),
+    thermodynamic_variable = Energy(),
+                   closure = IsotropicDiffusivity(ν=0, κ=0),
+                   gravity = 0.0
+)
+
+g  = model.gravity
+gas = model.gases.ρ
+R, cₚ, cᵥ = gas.R, gas.cₚ, gas.cᵥ
+u₀₀, T₀₀, ρ₀₀, s₀₀ = gas.u₀, gas.T₀, gas.ρ₀, gas.s₀
+
+ρ₀(x, y, z) = 1
+p₀(x, y, z) = 1
+T₀(x, y, z) = p₀(x, y, z) / (R*ρ₀(x, y, z))
+ρe₀(x, y, z) = ρ₀(x, y, z) * (u₀₀ + cᵥ * (T₀(x, y, z) - T₀₀) + g*z)
+
+@inline x′(x, t, L, U) = mod(x + L/2 - U * t, L) - L/2
+@inline ϕ_Gaussian(x, t; L, U, a=1, c=1/8) = a * exp(-x′(x, t, L, U)^2 / (2c^2))
+@inline ϕ_Square(x, t; L, U, w=0.15) = -w <= x′(x, t, L, U) <= w ? 1.0 : 0.0
+@inline ϕ_Sine(x, t; L, U) = sin(2π * x)
+ρu₀(x, y, z) = ϕ_Sine(x, 0, L=L, U=1)
+
+set!(model.tracers.ρ, ρ₀)
+set!(model.tracers.ρe, ρe₀)
+set!(model.momenta.ρu, ρu₀)
+update_total_density!(model)
+
+anim = @animate for n in 1:Nt
+    @info "iteration $n/$Nt"
+    time_step!(model, Δt)
+
+    title = @sprintf("Burgers equation t=%.3f", model.clock.time)
+
+    x = xnodes(Cell, grid)
+    ρu = interior(model.momenta.ρu)[:]
+    plot(x, ρu, lw=2, label="", title=title, xlims=(0, L), ylims=(-2, 2), dpi=200)
+end
+
+mp4(anim, "burgers_equation.mp4", fps=60)

--- a/compressible/verification/dry_rising_thermal_bubble/animate_dry_rising_thermal_bubble.jl
+++ b/compressible/verification/dry_rising_thermal_bubble/animate_dry_rising_thermal_bubble.jl
@@ -1,0 +1,71 @@
+using Printf
+using NCDatasets
+using PyCall
+using PyPlot
+
+using Oceananigans
+using Oceananigans.Utils
+using JULES
+
+cmocean = pyimport("cmocean")
+
+const plt = PyPlot
+plt.ioff()
+
+km = kilometers
+Tvar = Energy
+
+ds = NCDataset("dry_rising_thermal_bubble_$(Tvar).nc")
+
+for n in 1:length(ds["time"])
+    fig, axes = plt.subplots(nrows=2, ncols=2, sharex=true, sharey=true, figsize=(16, 9), dpi=200)
+
+    xC, xF = ds["xC"] / km, ds["xF"] / km
+    zC, zF = ds["zC"] / km, ds["zF"] / km
+
+    ρ₀ = ds["ρ₀"][:, 1, :]'
+    ρe₀ = ds["ρe₀"][:, 1, :]'
+
+    ρ  = ds["ρ"][:, 1, :, n]'
+    ρw = ds["ρw"][:, 1, 2:end, n]'
+    ρu = ds["ρu"][:, 1, :, n]'
+    ρe = ds["ρe"][:, 1, :, n]'
+
+    fig.suptitle("Dry rising thermal bubble: time = $(prettytime(ds["time"][n]))")
+
+    ax_u = axes[1, 1]
+    im = ax_u.pcolormesh(xF, zC, ρu ./ ρ, cmap=cmocean.cm.balance, vmin=-10, vmax=10)
+    ax_u.set_title("u(x, z)")
+    ax_u.set_ylabel("z (km)")
+    fig.colorbar(im, ax=ax_u, label="m/s")
+
+    ax_w = axes[1, 2]
+    im = ax_w.pcolormesh(xC, zC, ρw ./ ρ, cmap=cmocean.cm.balance, vmin=-10, vmax=10)
+    ax_w.set_title("w(x, z)")
+    fig.colorbar(im, ax=ax_w, label="m/s")
+
+    ax_ρ = axes[2, 1]
+    im = ax_ρ.pcolormesh(xC, zC, ρ - ρ₀, cmap=cmocean.cm.dense, vmin=-0.007, vmax=0)
+    ax_ρ.set_xlabel("x (km)")
+    ax_ρ.set_ylabel("z (km)")
+    ax_ρ.set_title("ρ′(x, z)")
+    fig.colorbar(im, ax=ax_ρ, label="kg/m³")
+
+    ax_e = axes[2, 2]
+    im = ax_e.pcolormesh(xC, zC, (ρe .- ρe₀) ./ ρ, cmap=cmocean.cm.thermal, vmin=0, vmax=600)
+    ax_e.set_xlabel("x (km)")
+    ax_e.set_title("e′(x, z)")
+    fig.colorbar(im, ax=ax_e, extend="max", label="J/kg")
+
+    plt.xlim(-10, 10)
+    plt.ylim(0, 10)
+
+    filename = @sprintf("dry_rising_thermal_bubble_%s_%03d.png", Tvar, n)
+    @info "Saving $filename..."
+    plt.savefig(filename)
+    plt.close(fig)
+end
+
+close(ds)
+
+run(`ffmpeg -r 15 -f image2 -i dry_rising_thermal_bubble_$(Tvar)_%03d.png -vcodec libx264 -crf 22 -pix_fmt yuv420p dry_rising_thermal_bubble_$Tvar.mp4`)

--- a/compressible/verification/dry_rising_thermal_bubble/dry_rising_thermal_bubble.jl
+++ b/compressible/verification/dry_rising_thermal_bubble/dry_rising_thermal_bubble.jl
@@ -1,0 +1,142 @@
+using Logging
+using Printf
+using Statistics
+using NCDatasets
+using CUDA
+
+using Oceananigans
+using Oceananigans.Grids
+using Oceananigans.Advection
+using Oceananigans.OutputWriters
+using Oceananigans.Utils
+using JULES
+
+using Oceananigans.Fields: cpudata
+
+Logging.global_logger(OceananigansLogger())
+
+const km = kilometers
+const hPa = 100.0
+
+function simulate_dry_rising_thermal_bubble(; architecture=CPU(), thermodynamic_variable, end_time=1000.0)
+    tvar = thermodynamic_variable
+
+    Lx = 20km
+    Lz = 10km
+    Δ  = 200meters
+
+    Nx = Int(Lx/Δ)
+    Ny = 1
+    Nz = Int(Lz/Δ)
+
+    topo = (Periodic, Periodic, Bounded)
+    domain = (x=(-Lx/2, Lx/2), y=(-Lx/2, Lx/2), z=(0, Lz))
+    grid = RegularCartesianGrid(topology=topo, size=(Nx, Ny, Nz), halo=(3, 3, 3); domain...)
+
+    model = CompressibleModel(
+                  architecture = architecture,
+                          grid = grid,
+                         gases = DryEarth(),
+        thermodynamic_variable = tvar,
+                       closure = IsotropicDiffusivity(ν=75.0, κ=75.0)
+    )
+
+    gas = model.gases.ρ
+    R, cₚ, cᵥ = gas.R, gas.cₚ, gas.cᵥ
+    g  = model.gravity
+    pₛ = 1000hPa
+    Tₛ = 300.0
+
+    # Define an approximately hydrostatic background state
+    θ₀(x, y, z) = Tₛ
+    p₀(x, y, z) = pₛ * (1 - g*z / (cₚ*Tₛ))^(cₚ/R)
+    T₀(x, y, z) = Tₛ * (p₀(x, y, z)/pₛ)^(R/cₚ)
+    ρ₀(x, y, z) = p₀(x, y, z) / (R*T₀(x, y, z))
+
+    # Define both energy and entropy
+    uᵣ, Tᵣ, ρᵣ, sᵣ = gas.u₀, gas.T₀, gas.ρ₀, gas.s₀  # Reference values
+    ρe₀(x, y, z) = ρ₀(x, y, z) * (uᵣ + cᵥ * (T₀(x, y, z) - Tᵣ) + g*z)
+    ρs₀(x, y, z) = ρ₀(x, y, z) * (sᵣ + cᵥ * log(T₀(x, y, z)/Tᵣ) - R * log(ρ₀(x, y, z)/ρᵣ))
+
+    # Define the initial density perturbation
+    θᶜ′ = 2.0
+    xᶜ, zᶜ = 0km, 2km
+    xʳ, zʳ = 2km, 2km
+
+    L(x, y, z) = sqrt(((x - xᶜ)/xʳ)^2 + ((z - zᶜ)/zʳ)^2)
+    θ′(x, y, z) = (L(x, y, z) <= 1) * θᶜ′ * cos(π/2 * L(x, y, z))^2
+    ρ′(x, y, z) = -ρ₀(x, y, z) * θ′(x, y, z) / θ₀(x, y, z)
+
+    # Define initial state
+    ρᵢ(x, y, z) = ρ₀(x, y, z) + ρ′(x, y, z)
+    pᵢ(x, y, z) = p₀(x, y, z)
+    Tᵢ(x, y, z) = pᵢ(x, y, z) / (R * ρᵢ(x, y, z))
+
+    ρeᵢ(x, y, z) = ρᵢ(x, y, z) * (uᵣ + cᵥ * (Tᵢ(x, y, z) - Tᵣ) + g*z)
+    ρsᵢ(x, y, z) = ρᵢ(x, y, z) * (sᵣ + cᵥ * log(Tᵢ(x, y, z)/Tᵣ) - R * log(ρᵢ(x, y, z)/ρᵣ))
+
+    # Set initial state
+    set!(model.tracers.ρ, ρᵢ)
+    tvar isa Energy  && set!(model.tracers.ρe, ρeᵢ)
+    tvar isa Entropy && set!(model.tracers.ρs, ρsᵢ)
+    update_total_density!(model)
+
+    simulation = Simulation(model, Δt=0.1, stop_time=end_time, iteration_interval=50,
+                            progress=print_progress, parameters=(ρᵢ, ρeᵢ, ρsᵢ))
+
+    fields = Dict(
+        "ρ"  => model.total_density,
+        "ρu" => model.momenta.ρu,
+        "ρw" => model.momenta.ρw
+    )
+
+    tvar isa Energy  && push!(fields, "ρe" => model.tracers.ρe)
+    tvar isa Entropy && push!(fields, "ρs" => model.tracers.ρs)
+    
+    simulation.output_writers[:fields] =
+        NetCDFOutputWriter(model, fields, filepath="dry_rising_thermal_bubble_$(typeof(tvar)).nc",
+                           time_interval=10seconds)
+
+
+    # Save base state to NetCDF.
+    ds = simulation.output_writers[:fields].dataset
+    ds_ρ = defVar(ds, "ρ₀", Float32, ("xC", "yC", "zC"))
+    ds_ρe = defVar(ds, "ρe₀", Float32, ("xC", "yC", "zC"))
+
+    x, y, z = nodes((Cell, Cell, Cell), grid, reshape=true)
+    ds_ρ[:, :, :] = ρ₀.(x, y, z)
+    ds_ρe[:, :, :] = ρe₀.(x, y, z)
+
+    run!(simulation)
+
+    return simulation
+end
+
+function print_progress(simulation)
+    model, Δt = simulation.model, simulation.Δt
+    tvar = model.thermodynamic_variable
+    ρᵢ, ρeᵢ, ρsᵢ = simulation.parameters
+
+    zC = znodes(Cell, model.grid)
+    ρ̄ᵢ = mean(ρᵢ.(0, 0, zC))
+    ρ̄ = mean(cpudata(model.total_density))
+
+    progress = 100 * model.clock.time / simulation.stop_time
+    message = @sprintf("[%05.2f%%] iteration = %d, time = %s, CFL = %.4e, acoustic CFL = %.4e, ρ̄ = %.4e (relΔ = %.4e)",
+                       progress, model.clock.iteration, prettytime(model.clock.time), cfl(model, Δt),
+                       acoustic_cfl(model, Δt), ρ̄, (ρ̄ - ρ̄ᵢ) / ρ̄)
+
+    if tvar isa Energy
+        ρ̄ēᵢ = mean(ρeᵢ.(0, 0, zC))
+        ρ̄ē = mean(cpudata(model.tracers.ρe))
+        message *= @sprintf(", ρ̄ē = %.4e (relΔ = %.4e)", ρ̄ē, (ρ̄ē - ρ̄ēᵢ)/ρ̄ē)
+    elseif tvar isa Entropy
+        ρ̄s̄ᵢ = mean(ρsᵢ.(0, 0, zC))
+        ρ̄s̄ = mean(cpudata(model.tracers.ρs))
+        message *= @sprintf(", ρ̄s̄ = %.4e (relΔ = %.4e)", ρ̄s̄, (ρ̄s̄ - ρ̄s̄ᵢ)/ρ̄s̄)
+    end
+
+    @info message
+
+    return nothing
+end

--- a/compressible/verification/intertia_gravity_waves/intertia_gravity_waves.jl
+++ b/compressible/verification/intertia_gravity_waves/intertia_gravity_waves.jl
@@ -1,0 +1,82 @@
+using Printf
+using PyPlot
+
+using Oceananigans
+using Oceananigans.Advection
+using JULES
+
+const km = 1000.0
+const hPa = 100.0
+
+L= 300km
+H = 10km
+Δ = 0.5km  # grid spacing [m]
+
+Nx = Int(L/Δ)
+Ny = 1
+Nz = Int(H/Δ)
+
+grid = RegularCartesianGrid(size=(Nx, Ny, Nz), halo=(4, 4, 4),
+                            x=(0, L), y=(0, L), z=(0, H))
+
+model = CompressibleModel(
+                      grid = grid,
+                     gases = DryEarth(),
+    thermodynamic_variable = Entropy(),
+                   closure = IsotropicDiffusivity(ν=75.0, κ=75.0)
+)
+
+#####
+##### Dry thermal bubble perturbation
+#####
+
+gas = model.gases.ρ
+R, cₚ, cᵥ = gas.R, gas.cₚ, gas.cᵥ
+g  = model.gravity
+pₛ = 1000hPa
+θₛ = 300.0
+N² = 1e-4
+Γ  = - N² * θₛ / g
+U  = 0
+
+# Define an approximately hydrostatic background state
+θ₀(x, y, z) = θₛ + Γ * z
+p₀(x, y, z) = pₛ * (1 - g / (cₚ*Γ) * log(θ₀(x, y, z)/θₛ))^(cₚ/R)
+T₀(x, y, z) = θₛ * (p₀(x, y, z)/pₛ)^(R/cₚ)
+ρ₀(x, y, z) = p₀(x, y, z) / (R*T₀(x, y, z))
+
+# Define both energy and entropy
+uᵣ, Tᵣ, ρᵣ, sᵣ = gas.u₀, gas.T₀, gas.ρ₀, gas.s₀  # Reference values
+ρe₀(x, y, z) = ρ₀(x, y, z) * (uᵣ + cᵥ * (T₀(x, y, z) - Tᵣ) + g*z)
+ρs₀(x, y, z) = ρ₀(x, y, z) * (sᵣ + cᵥ * log(T₀(x, y, z)/Tᵣ) - R * log(ρ₀(x, y, z)/ρᵣ))
+
+# Define the initial density perturbation
+Δθ₀ = 1e-2
+xᶜ = 100km
+a = 5km
+
+θ′(x, y, z) = Δθ₀ * sin(π*z/H) / (1 + (x-xᶜ)^2/a^2)
+ρ′(x, y, z) = ρ₀(x, y, z) * θ′(x, y, z) / θ₀(x, y, z)
+
+# Define initial state
+ρᵢ(x, y, z) = ρ₀(x, y, z) + ρ′(x, y, z)
+pᵢ(x, y, z) = p₀(x, y, z)
+Tᵢ(x, y, z) = pᵢ(x, y, z) / (R * ρᵢ(x, y, z))
+
+ρuᵢ(x, y, z) = ρᵢ(x, y, z) * U
+ρeᵢ(x, y, z) = ρᵢ(x, y, z) * (uᵣ + cᵥ * (Tᵢ(x, y, z) - Tᵣ) + g*z)
+ρsᵢ(x, y, z) = ρᵢ(x, y, z) * (sᵣ + cᵥ * log(Tᵢ(x, y, z)/Tᵣ) - R * log(ρᵢ(x, y, z)/ρᵣ))
+
+# Set initial state (which includes the thermal perturbation)
+set!(model.tracers.ρ, ρᵢ)
+set!(model.momenta.ρu, ρuᵢ)
+set!(model.tracers.ρs, ρsᵢ)
+update_total_density!(model)
+
+T = 1000
+Δt = 0.1
+Nt = Int(T/Δt)
+for n in 1:Nt
+    @info "iteration = $n/$Nt, ρ=$(model.total_density[200, 1, 10])"
+    time_step!(model, Δt)
+end

--- a/compressible/verification/isothermal_atmosphere_hydrostatic_adjustment/isothermal_atmosphere_hydrostatic_adjustment.jl
+++ b/compressible/verification/isothermal_atmosphere_hydrostatic_adjustment/isothermal_atmosphere_hydrostatic_adjustment.jl
@@ -1,0 +1,117 @@
+using JULES, Oceananigans
+using Plots
+using Printf
+
+Nx = Ny = 1
+Nz = 32
+L = 10e3
+
+grid = RegularCartesianGrid(size=(Nx, Ny, Nz), halo=(2, 2, 2),
+                            x=(0, L), y=(0, L), z=(0, L))
+
+pₛ = 100000
+Tₐ = 293.15
+g  = 9.80665
+
+buoyancy = IdealGas()
+Rᵈ, cₚ = buoyancy.Rᵈ, buoyancy.cₚ
+
+####
+#### Isothermal atmosphere
+####
+
+H = Rᵈ * Tₐ / g    # Scale height [m]
+ρₛ = pₛ / (Rᵈ*Tₐ)  # Surface density [kg/m³]
+
+p₀(x, y, z) = pₛ * exp(-z/H)
+ρ₀(x, y, z) = ρₛ * exp(-z/H)
+
+θ₀(x, y, z) = Tₐ * exp(z/H * Rᵈ/cₚ)
+Θ₀(x, y, z) = ρ₀(x, y, z) * θ₀(x, y, z)
+
+####
+#### Sponge layer forcing to damp vertically propagating acoustic waves at the top.
+####
+
+const τ⁻¹ = 1    # Damping/relaxation time scale [s⁻¹]. This is very strong damping.
+const Δμ = 0.1L  # Sponge layer width [m] set to 10% of the domain height.
+@inline μ(z, Lz) = τ⁻¹ * exp(-(Lz-z) / Δμ)
+
+@inline Fw(i, j, k, grid, t, Ũ, C̃, p) = @inbounds -μ(grid.zF[k], grid.Lz) * Ũ.ρw[i, j, k]
+forcing = ModelForcing(w=Fw)
+
+####
+#### Create model
+####
+
+model = CompressibleModel(
+                      grid = grid,
+                  buoyancy = buoyancy,
+        reference_pressure = pₛ,
+    thermodynamic_variable = ModifiedPotentialTemperature(),
+                   tracers = (:Θᵐ,),
+                   forcing = forcing
+)
+
+####
+#### Set initial conditions
+####
+
+set!(model.density, ρ₀)
+set!(model.tracers.Θᵐ, Θ₀)
+
+# Initial profiles
+Θ₀_prof = model.tracers.Θᵐ[1, 1, 1:Nz]
+ρ₀_prof = model.density[1, 1, 1:Nz]
+
+# Arrays we will use to store a time series of ρw(z = L/2).
+times = [model.clock.time]
+ρw_ts = [model.momenta.ρw[1, 1, Int(Nz/2)]]
+
+####
+#### Time step and keep plotting vertical profiles of ρθ′, ρw, and ρ′.
+####
+
+# @animate for i=1:100
+while model.clock.time < 500
+    time_step!(model; Δt=0.5, Nt=10)
+
+    @show model.clock.time
+    Θ_prof = model.tracers.Θᵐ[1, 1, 1:Nz] .- Θ₀_prof
+    W_prof = model.momenta.ρw[1, 1, 1:Nz+1]
+    ρ_prof = model.density[1, 1, 1:Nz] .- ρ₀_prof
+
+    Θ_plot = plot(Θ_prof, grid.zC, xlim=(-2.5, 2.5), xlabel="Theta_prime", ylabel="z (m)", label="")
+    W_plot = plot(W_prof, grid.zF, xlim=(-1.2, 1.2), xlabel="rho*w", label="")
+    ρ_plot = plot(ρ_prof, grid.zC, xlim=(-0.01, 0.01), xlabel="rho", label="")
+
+    t_str = @sprintf("t = %d s", model.clock.time)
+    display(plot(Θ_plot, W_plot, ρ_plot, title=["" "$t_str" ""], layout=(1, 3), show=true))
+
+    push!(times, model.clock.time)
+    push!(ρw_ts, model.momenta.ρw[1, 1, Int(Nz/2)])
+end
+
+####
+#### Plot the initial profile and the hydrostatically balanced profile.
+####
+
+ρ∞_prof = model.density[1, 1, 1:Nz]
+
+θ₀_prof = Θ₀_prof ./ ρ₀_prof
+θ∞_prof = model.tracers.Θᵐ[1, 1, 1:Nz] ./ ρ∞_prof
+
+θ_plot = plot(θ₀_prof, grid.zC, xlabel="theta (K)", ylabel="z (m)", label="initial", legend=:topleft)
+plot!(θ_plot, θ∞_prof, grid.zC, label="balanced")
+
+ρ_plot = plot(ρ₀_prof, grid.zC, xlabel="rho (kg/m³)", ylabel="z (m)", label="initial")
+plot!(ρ_plot, ρ∞_prof, grid.zC, label="balanced")
+
+display(plot(θ_plot, ρ_plot, show=true))
+
+
+####
+#### Plot timeseries of maximum ρw
+####
+
+plot(times, ρw_ts, linewidth=2, xlabel="time (s)", ylabel="rho*w(z=$(Int(L/2)) m)", label="", show=true)

--- a/compressible/verification/nonlinear_density_current/animate_nonlinear_density_current.jl
+++ b/compressible/verification/nonlinear_density_current/animate_nonlinear_density_current.jl
@@ -1,0 +1,73 @@
+using Printf
+using NCDatasets
+using PyCall
+using PyPlot
+
+using Oceananigans
+using Oceananigans.Utils
+using JULES
+
+cmocean = pyimport("cmocean")
+
+const plt = PyPlot
+plt.ioff()
+
+km = kilometers
+Tvar = Energy
+
+ds = NCDataset("nonlinear_density_current_$(Tvar).nc")
+
+for n in 1:length(ds["time"])
+    fig, axes = plt.subplots(nrows=4, ncols=1, sharex=true, sharey=true, figsize=(12, 12), dpi=200)
+
+    xC, xF = ds["xC"] / km, ds["xF"] / km
+    zC, zF = ds["zC"] / km, ds["zF"] / km
+
+    ρ₀ = ds["ρ₀"][:, 1, :]'
+    ρe₀ = ds["ρe₀"][:, 1, :]'
+
+    ρ  = ds["ρ"][:, 1, :, n]'
+    ρw = ds["ρw"][:, 1, 2:end, n]'
+    ρu = ds["ρu"][:, 1, :, n]'
+    ρe = ds["ρe"][:, 1, :, n]'
+
+    fig.suptitle("Nonlinear density current: time = $(prettytime(ds["time"][n]))")
+
+    ax_u = axes[1, 1]
+    im = ax_u.pcolormesh(xF, zC, ρu ./ ρ, cmap=cmocean.cm.balance, vmin=-10, vmax=10)
+    ax_u.set_title("u(x, z)")
+    ax_u.set_ylabel("z (km)")
+    fig.colorbar(im, ax=ax_u, label="m/s")
+
+    ax_w = axes[2, 1]
+    im = ax_w.pcolormesh(xC, zC, ρw ./ ρ, cmap=cmocean.cm.balance, vmin=-10, vmax=10)
+    ax_w.set_title("w(x, z)")
+    ax_w.set_ylabel("z (km)")
+    fig.colorbar(im, ax=ax_w, label="m/s")
+
+    ax_ρ = axes[3, 1]
+    im = ax_ρ.pcolormesh(xC, zC, ρ - ρ₀, cmap=cmocean.cm.dense, vmin=0, vmax=0.04)
+    ax_ρ.set_xlabel("x (km)")
+    ax_ρ.set_title("ρ′(x, z)")
+    fig.colorbar(im, ax=ax_ρ, label="kg/m³")
+
+    ax_e = axes[4, 1]
+    im = ax_e.pcolormesh(xC, zC, (ρe .- ρe₀) ./ ρ, cmap=cmocean.cm.thermal, vmin=-5000, vmax=0)
+    ax_e.set_xlabel("x (km)")
+    ax_e.set_ylabel("z (km)")
+    ax_e.set_title("e′(x, z)")
+    fig.colorbar(im, ax=ax_e, label="J/kg")
+
+    plt.xlim(-25.6, 25.6)
+    plt.ylim(0, 6.4)
+
+    filename = @sprintf("nonlinear_density_current_%s_%03d.png", Tvar, n)
+    @info "Saving $filename..."
+    plt.savefig(filename)
+    plt.close(fig)
+end
+
+close(ds)
+
+run(`ffmpeg -r 15 -f image2 -i nonlinear_density_current_$(Tvar)_%03d.png -vcodec libx264 -crf 22 -pix_fmt yuv420p nonlinear_density_current_$Tvar.mp4`)
+

--- a/compressible/verification/nonlinear_density_current/nonlinear_density_current.jl
+++ b/compressible/verification/nonlinear_density_current/nonlinear_density_current.jl
@@ -1,0 +1,148 @@
+"""
+This example sets up a cold bubble perturbation which develops into a non-linear
+density current. This numerical test case is described by Straka et al. (1993).
+Also see: http://www2.mmm.ucar.edu/projects/srnwp_tests/density/density.html
+
+Straka et al. (1993). "Numerical Solutions of a Nonlinear Density-Current -
+    A Benchmark Solution and Comparisons." International Journal for Numerical
+    Methods in Fluids 17, pp. 1-22.
+"""
+
+using Logging
+using Printf
+using Statistics
+using NCDatasets
+using CUDA
+
+using Oceananigans
+using Oceananigans.Grids
+using Oceananigans.Advection
+using Oceananigans.OutputWriters
+using Oceananigans.Utils
+using JULES
+
+using Oceananigans.Fields: cpudata
+
+Logging.global_logger(OceananigansLogger())
+
+const km = kilometers
+const hPa = 100.0
+
+Lx = 51.2km
+Lz = 6.4km
+
+Δ = 20.0  # grid spacing [m]
+
+Nx = Int(Lx/Δ)
+Ny = 1
+Nz = Int(Lz/Δ)
+
+topo = (Periodic, Periodic, Bounded)
+domain = (x=(-Lx/2, Lx/2), y=(-Lx/2, Lx/2), z=(0, Lz))
+grid = RegularCartesianGrid(topology=topo, size=(Nx, Ny, Nz), halo=(3, 3, 3); domain...)
+
+tvar = Energy()
+
+model = CompressibleModel(
+                      grid = grid,
+                     gases = DryEarth(),
+ 	         advection = WENO5(),
+    thermodynamic_variable = tvar,
+                   closure = IsotropicDiffusivity(ν=75.0, κ=75.0)
+)
+
+gas = model.gases.ρ
+R, cₚ, cᵥ = gas.R, gas.cₚ, gas.cᵥ
+g  = model.gravity
+pₛ = 1000hPa
+Tₛ = 300.0
+
+# Define an approximately hydrostatic background state
+θ₀(x, y, z) = Tₛ
+p₀(x, y, z) = pₛ * (1 - g*z / (cₚ*Tₛ))^(cₚ/R)
+T₀(x, y, z) = Tₛ * (p₀(x, y, z)/pₛ)^(R/cₚ)
+ρ₀(x, y, z) = p₀(x, y, z) / (R*T₀(x, y, z))
+
+# Define both energy and entropy
+uᵣ, Tᵣ, ρᵣ, sᵣ = gas.u₀, gas.T₀, gas.ρ₀, gas.s₀  # Reference values
+ρe₀(x, y, z) = ρ₀(x, y, z) * (uᵣ + cᵥ * (T₀(x, y, z) - Tᵣ) + g*z)
+ρs₀(x, y, z) = ρ₀(x, y, z) * (sᵣ + cᵥ * log(T₀(x, y, z)/Tᵣ) - R * log(ρ₀(x, y, z)/ρᵣ))
+
+# Define the initial density perturbation
+θᶜ′ = -15.0
+xᶜ, zᶜ = 0km, 2km
+xʳ, zʳ = 2km, 2km
+L(x, y, z) = sqrt(((x - xᶜ)/xʳ)^2 + ((z - zᶜ)/zʳ)^2)
+θ′(x, y, z) = (L(x, y, z) <= 1) * θᶜ′ * (1 + cos(π*L(x, y, z))) / 2
+ρ′(x, y, z) = -ρ₀(x, y, z) * θ′(x, y, z) / θ₀(x, y, z)
+
+# Define initial state
+ρᵢ(x, y, z) = ρ₀(x, y, z) + ρ′(x, y, z)
+pᵢ(x, y, z) = p₀(x, y, z)
+Tᵢ(x, y, z) = pᵢ(x, y, z) / (R * ρᵢ(x, y, z))
+
+ρeᵢ(x, y, z) = ρᵢ(x, y, z) * (uᵣ + cᵥ * (Tᵢ(x, y, z) - Tᵣ) + g*z)
+ρsᵢ(x, y, z) = ρᵢ(x, y, z) * (sᵣ + cᵥ * log(Tᵢ(x, y, z)/Tᵣ) - R * log(ρᵢ(x, y, z)/ρᵣ))
+
+# Set initial state (which includes the thermal perturbation)
+set!(model.tracers.ρ, ρᵢ)
+tvar isa Energy  && set!(model.tracers.ρe, ρeᵢ)
+tvar isa Entropy && set!(model.tracers.ρs, ρsᵢ)
+update_total_density!(model)
+
+function print_progress(simulation)
+    model, Δt = simulation.model, simulation.Δt
+    tvar = model.thermodynamic_variable
+    ρᵢ, ρeᵢ, ρsᵢ = simulation.parameters
+
+    zC = znodes(Cell, model.grid)
+    ρ̄ᵢ = mean(ρᵢ.(0, 0, zC))
+    ρ̄ = mean(cpudata(model.total_density))
+
+    progress = 100 * model.clock.time / simulation.stop_time
+    message = @sprintf("[%05.2f%%] iteration = %d, time = %s, CFL = %.4e, acoustic CFL = %.4e, ρ̄ = %.4e (relΔ = %.4e)",
+                       progress, model.clock.iteration, prettytime(model.clock.time), cfl(model, Δt),
+                       acoustic_cfl(model, Δt), ρ̄, (ρ̄ - ρ̄ᵢ) / ρ̄)
+
+    if tvar isa Energy
+        ρ̄ēᵢ = mean(ρeᵢ.(0, 0, zC))
+        ρ̄ē = mean(cpudata(model.tracers.ρe))
+        message *= @sprintf(", ρ̄ē = %.4e (relΔ = %.4e)", ρ̄ē, (ρ̄ē - ρ̄ēᵢ)/ρ̄ē)
+    elseif tvar isa Entropy
+        ρ̄s̄ᵢ = mean(ρsᵢ.(0, 0, zC))
+        ρ̄s̄ = mean(cpudata(model.tracers.ρs))
+        message *= @sprintf(", ρ̄s̄ = %.4e (relΔ = %.4e)", ρ̄s̄, (ρ̄s̄ - ρ̄s̄ᵢ)/ρ̄s̄)
+    end
+
+    @info message
+
+    return nothing
+end
+
+simulation = Simulation(model, Δt=0.02, stop_time=1000, iteration_interval=50,
+                        progress=print_progress, parameters=(ρᵢ, ρeᵢ, ρsᵢ))
+
+fields = Dict(
+    "ρ"  => model.total_density,
+    "ρu" => model.momenta.ρu,
+    "ρw" => model.momenta.ρw
+)
+
+tvar isa Energy  && push!(fields, "ρe" => model.tracers.ρe)
+tvar isa Entropy && push!(fields, "ρs" => model.tracers.ρs)
+
+simulation.output_writers[:fields] =
+NetCDFOutputWriter(model, fields, filepath="nonlinear_density_current_$(typeof(tvar)).nc",
+                   time_interval=10seconds)
+
+
+# Save base state to NetCDF.
+ds = simulation.output_writers[:fields].dataset
+ds_ρ = defVar(ds, "ρ₀", Float32, ("xC", "yC", "zC"))
+ds_ρe = defVar(ds, "ρe₀", Float32, ("xC", "yC", "zC"))
+
+x, y, z = nodes((Cell, Cell, Cell), grid, reshape=true)
+ds_ρ[:, :, :] = ρ₀.(x, y, z)
+ds_ρe[:, :, :] = ρe₀.(x, y, z)
+
+run!(simulation)

--- a/compressible/verification/periodic_advection/periodic_advection.jl
+++ b/compressible/verification/periodic_advection/periodic_advection.jl
@@ -1,0 +1,97 @@
+using Printf
+using Plots
+
+using Oceananigans
+using Oceananigans.Advection
+using JULES
+
+using JULES: IdealGas
+using Oceananigans.Grids: Cell, xnodes
+
+ENV["GKSwstype"] = "100"
+
+@inline x′(x, t, L, U) = mod(x + L/2 - U * t, L) - L/2
+@inline ϕ_Square(x, t; L, U, w=0.15) = -w <= x′(x, t, L, U) <= w ? 1.0 : 0.0
+
+function every(n)
+      0 < n <= 128 && return 1
+    128 < n <= 256 && return 2
+    256 < n <= 512 && return 4
+    512 < n        && return 8
+end
+
+function periodic_advection_verification(N, L, T, U, CFL, advection, solution)
+    ideal_gas = IdealGas(Float64, JULES.R⁰, 1; T₀=1, p₀=1, s₀=1, u₀=0)
+
+    topo = (Periodic, Periodic, Periodic)
+    domain = (x=(-L/2, L/2), y=(0, 1), z=(0, 1))
+    grid = RegularCartesianGrid(topology=topo, size=(N, 1, 1), halo=(4, 4, 4); domain...)
+
+    Δt = CFL * grid.Δx / abs(U)
+    Nt = ceil(Int, T/Δt)
+
+    model = CompressibleModel(
+                      grid = grid,
+                 advection = advection,
+                     gases = (ρ=ideal_gas,),
+    thermodynamic_variable = Entropy(),
+                   closure = IsotropicDiffusivity(ν=0, κ=0),
+                   gravity = 0.0,
+               tracernames = (:ρ, :ρs, :ρc)
+    )
+
+    gas = model.gases.ρ
+    R, cₚ, cᵥ = gas.R, gas.cₚ, gas.cᵥ
+    u₀₀, T₀₀, ρ₀₀, s₀₀ = gas.u₀, gas.T₀, gas.ρ₀, gas.s₀
+    
+    ρ₀(x, y, z) = 1
+    p₀(x, y, z) = 1
+    T₀(x, y, z) = p₀(x, y, z) / (R*ρ₀(x, y, z))
+    ρs₀(x, y, z) = ρ₀(x, y, z) * (s₀₀ + cᵥ * log(T₀(x, y, z)/T₀₀) - R * log(ρ₀(x, y, z)/ρ₀₀))
+
+    set!(model.tracers.ρ, ρ₀)
+    set!(model.momenta.ρu, U)
+    set!(model.tracers.ρs, ρs₀)
+    update_total_density!(model)
+
+    initial_condition(x, y, z) = solution(x, 0)
+    set!(model.tracers.ρc, initial_condition)
+    set!(model.momenta.ρv, initial_condition)
+    set!(model.momenta.ρw, initial_condition)
+
+    anim = @animate for n in 1:Nt
+        @info "Running periodic advection [N=$N, CFL=$CFL, $(typeof(advection)), U=$U]... iteration $n/$Nt"
+        
+        time_step!(model, Δt)
+
+        x = xnodes(Cell, grid)
+        analytic_solution = solution.(x, model.clock.time)
+        ρc = interior(model.tracers.ρc)[:]
+        ρv = interior(model.momenta.ρv)[:]
+        ρw = interior(model.momenta.ρv)[:]
+
+        title = @sprintf("N=%d, CFL=%.2f %s", N, CFL, typeof(advection))
+        plot(x, analytic_solution, lw=2, label="analytic", title=title, xlims=(-L/2, L/2), ylims=(-0.2, 1.2), dpi=200)
+        plot!(x, ρc, lw=2, ls=:solid, label="Oceananigans ρc")
+        plot!(x, ρv, lw=2, ls=:dash,  label="Oceananigans ρv")
+        plot!(x, ρw, lw=2, ls=:dot,   label="Oceananigans ρw")
+
+    end every every(Nt)
+
+    filename = @sprintf("periodic_advection_N%d_CFL%.2f_%s_U%+d.mp4", N, CFL, typeof(advection), U)
+    mp4(anim, filename, fps=15)
+end
+
+T = 2
+L = 1
+
+Ns = [64]
+Us = [+1, -1]
+CFLs = [0.1]
+advection_schemes = [CenteredSecondOrder(), CenteredFourthOrder(), UpwindBiasedThirdOrder(), UpwindBiasedFifthOrder(), WENO5()]
+
+for N in Ns, CFL in CFLs, scheme in advection_schemes, U in Us
+    @info "Running periodic advection [N=$N, CFL=$CFL, $(typeof(scheme)), U=$U]..."
+    solution(x, t) = ϕ_Square(x, t, L=L, U=U)
+    periodic_advection_verification(N, L, T, U, CFL, scheme, solution)
+end

--- a/compressible/verification/shock_tube/shock_tube.jl
+++ b/compressible/verification/shock_tube/shock_tube.jl
@@ -1,0 +1,60 @@
+using Printf
+using Plots
+using JULES
+using Oceananigans
+using Oceananigans.Advection
+
+using Oceananigans.Grids: Cell, xnodes
+
+ENV["GKSwstype"] = "100"
+
+N = 512
+L = 1
+T = 0.25
+Δt = 1e-3
+Nt = Int(T/Δt)
+
+topo = (Bounded, Periodic, Periodic)
+domain = (x=(0, L), y=(0, 1), z=(0, 1))
+grid = RegularCartesianGrid(topology=topo, size=(N, 1, 1), halo=(4, 4, 4); domain...)
+
+model = CompressibleModel(
+                      grid = grid,
+                 advection = WENO5(),
+                     gases = DryEarth(),
+    thermodynamic_variable = Entropy(),
+                   closure = IsotropicDiffusivity(ν=0, κ=0)
+)
+
+gas = model.gases.ρ
+R, cₚ, cᵥ = gas.R, gas.cₚ, gas.cᵥ
+u₀₀, T₀₀, ρ₀₀, s₀₀ = gas.u₀, gas.T₀, gas.ρ₀, gas.s₀
+g  = model.gravity
+
+ρₗ, ρᵣ = 1.0, 0.125
+pₗ, pᵣ = 1.0, 0.1
+uₗ, uᵣ = 0.0, 0.0
+
+ρ₀(x, y, z) = x < 0.5 ? ρₗ : ρᵣ
+p₀(x, y, z) = x < 0.5 ? pₗ : pᵣ
+u₀(x, y, z) = x < 0.5 ? uₗ : uᵣ
+
+T₀(x, y, z) = p₀(x, y, z) / (R*ρ₀(x, y, z))
+ρs₀(x, y, z) = ρ₀(x, y, z) * (s₀₀ + cᵥ * log(T₀(x, y, z)/T₀₀) - R * log(ρ₀(x, y, z)/ρ₀₀))
+
+set!(model.tracers.ρ, ρ₀)
+set!(model.tracers.ρs, ρs₀)
+update_total_density!(model)
+
+anim = @animate for n in 1:Nt
+    @info "iteration $n/$Nt"
+    time_step!(model, Δt)
+
+    title = @sprintf("Shock tube t=%.3f", model.clock.time)
+
+    x = xnodes(Cell, grid)
+    ρ = interior(model.total_density)[:]
+    plot(x, ρ, lw=2, label="", title=title, xlims=(0, 1), ylims=(0, 1), dpi=200)
+end
+
+mp4(anim, "shock_tube.mp4", fps=60)

--- a/compressible/verification/three_gas_dry_rising_thermal_bubble/animate_three_gas_dry_rising_thermal_bubble.jl
+++ b/compressible/verification/three_gas_dry_rising_thermal_bubble/animate_three_gas_dry_rising_thermal_bubble.jl
@@ -1,0 +1,88 @@
+using Printf
+using NCDatasets
+using PyCall
+using PyPlot
+
+using Oceananigans
+using Oceananigans.Utils
+using JULES
+
+cmocean = pyimport("cmocean")
+
+const plt = PyPlot
+plt.ioff()
+
+km = kilometers
+Tvar = Energy
+
+ds = NCDataset("three_gas_dry_rising_thermal_bubble_$(Tvar).nc")
+
+for n in 1:length(ds["time"])
+    fig, axes = plt.subplots(nrows=2, ncols=3, sharex=true, sharey=true, figsize=(16, 9), dpi=200)
+
+    xC, xF = ds["xC"] / km, ds["xF"] / km
+    zC, zF = ds["zC"] / km, ds["zF"] / km
+
+    ρ₀ = ds["ρ₀"][:, 1, :]'
+    ρ₁₀ = ds["ρ₁₀"][:, 1, :]'
+    ρ₂₀ = ds["ρ₂₀"][:, 1, :]'
+    ρ₃₀ = ds["ρ₃₀"][:, 1, :]'
+    ρe₀ = ds["ρe₀"][:, 1, :]'
+
+    ρ = ds["ρ"][:, 1, :, n]'
+    ρ₁ = ds["ρ₁"][:, 1, :, n]'
+    ρ₂ = ds["ρ₂"][:, 1, :, n]'
+    ρ₃ = ds["ρ₃"][:, 1, :, n]'
+    ρw = ds["ρw"][:, 1, 2:end, n]'
+    ρu = ds["ρu"][:, 1, :, n]'
+    ρe = ds["ρe"][:, 1, :, n]'
+
+    fig.suptitle("Three gas dry rising thermal bubble: time = $(prettytime(ds["time"][n]))")
+
+    ax_ρ₁ = axes[1, 1]
+    im = ax_ρ₁.pcolormesh(xC, zC, ρ₁, cmap=cmocean.cm.dense, vmin=0, vmax=1)
+    ax_ρ₁.set_title("ρ₁(x, z)")
+    ax_ρ₁.set_ylabel("z (km)")
+    fig.colorbar(im, ax=ax_ρ₁, label="kg/m³")
+
+    ax_ρ₂ = axes[1, 2]
+    im = ax_ρ₂.pcolormesh(xC, zC, ρ₂, cmap=cmocean.cm.dense, vmin=0, vmax=1)
+    ax_ρ₂.set_title("ρ₂(x, z)")
+    fig.colorbar(im, ax=ax_ρ₂, label="kg/m³")
+
+    ax_ρ₃ = axes[1, 3]
+    im = ax_ρ₃.pcolormesh(xC, zC, ρ₃, cmap=cmocean.cm.dense, vmin=0, vmax=1)
+    ax_ρ₃.set_title("ρ₃(x, z)")
+    fig.colorbar(im, ax=ax_ρ₃, label="kg/m³")
+
+    ax_u = axes[2, 1]
+    im = ax_u.pcolormesh(xF, zC, ρu ./ ρ, cmap=cmocean.cm.balance, vmin=-10, vmax=10)
+    ax_u.set_title("u(x, z)")
+    ax_u.set_xlabel("x (km)")
+    ax_u.set_ylabel("z (km)")
+    fig.colorbar(im, ax=ax_u, label="m/s")
+
+    ax_w = axes[2, 2]
+    im = ax_w.pcolormesh(xC, zC, ρw ./ ρ, cmap=cmocean.cm.balance, vmin=-10, vmax=10)
+    ax_w.set_title("w(x, z)")
+    ax_w.set_xlabel("x (km)")
+    fig.colorbar(im, ax=ax_w, label="m/s")
+
+    ax_e = axes[2, 3]
+    im = ax_e.pcolormesh(xC, zC, (ρe .- ρe₀) ./ ρ, cmap=cmocean.cm.thermal, vmin=0, vmax=600)
+    ax_e.set_title("e′(x, z)")
+    ax_e.set_xlabel("x (km)")
+    fig.colorbar(im, ax=ax_e, extend="max", label="J/kg")
+
+    plt.xlim(-10, 10)
+    plt.ylim(0, 10)
+
+    filename = @sprintf("three_gas_dry_rising_thermal_bubble_%s_%03d.png", Tvar, n)
+    @info "Saving $filename..."
+    plt.savefig(filename)
+    plt.close(fig)
+end
+
+close(ds)
+
+run(`ffmpeg -r 15 -f image2 -i three_gas_dry_rising_thermal_bubble_$(Tvar)_%03d.png -vcodec libx264 -crf 22 -pix_fmt yuv420p three_gas_dry_rising_thermal_bubble_$Tvar.mp4`)

--- a/compressible/verification/three_gas_dry_rising_thermal_bubble/three_gas_dry_rising_thermal_bubble.jl
+++ b/compressible/verification/three_gas_dry_rising_thermal_bubble/three_gas_dry_rising_thermal_bubble.jl
@@ -1,0 +1,189 @@
+using Logging
+using Printf
+using Statistics
+using NCDatasets
+using CUDA
+
+using Oceananigans
+using Oceananigans.Grids
+using Oceananigans.Advection
+using Oceananigans.OutputWriters
+using Oceananigans.Utils
+using JULES
+
+using Oceananigans.Fields: cpudata
+
+Logging.global_logger(OceananigansLogger())
+
+const km = kilometers
+const hPa = 100.0
+
+function simulate_three_gas_dry_rising_thermal_bubble(; architecture=CPU(), thermodynamic_variable, end_time=1000.0)
+    tvar = thermodynamic_variable
+
+    Lx = 20km
+    Lz = 10km
+    Δ  = 200meters
+
+    Nx = Int(Lx/Δ)
+    Ny = 1
+    Nz = Int(Lz/Δ)
+
+    topo = (Periodic, Periodic, Bounded)
+    domain = (x=(-Lx/2, Lx/2), y=(-Lx/2, Lx/2), z=(0, Lz))
+    grid = RegularCartesianGrid(topology=topo, size=(Nx, Ny, Nz), halo=(3, 3, 3); domain...)
+
+    model = CompressibleModel(
+                  architecture = architecture,
+                          grid = grid,
+                         gases = DryEarth3(),
+        thermodynamic_variable = tvar,
+                       closure = IsotropicDiffusivity(ν=75.0, κ=75.0)
+    )
+
+    gas = model.gases.ρ₁
+    R, cₚ, cᵥ = gas.R, gas.cₚ, gas.cᵥ
+    g  = model.gravity
+    pₛ = 1000hPa
+    Tₛ = 300.0
+
+    # Define initial mixing ratios
+    q₁(z) = exp(-(4z/Lz)^2)
+    q₃(z) = exp(-(4*(z - Lz)/Lz)^2)
+    q₂(z) = 1 - q₁(z) - q₃(z)
+
+    # Define an approximately hydrostatic background state
+    θ₀(x, y, z) = Tₛ
+    p₀(x, y, z) = pₛ * (1 - g*z / (cₚ*Tₛ))^(cₚ/R)
+    T₀(x, y, z) = Tₛ * (p₀(x, y, z)/pₛ)^(R/cₚ)
+    ρ₀(x, y, z) = p₀(x, y, z) / (R*T₀(x, y, z))
+
+    ρ₁₀(x, y, z) = q₁(z) * ρ₀(x, y, z)
+    ρ₂₀(x, y, z) = q₂(z) * ρ₀(x, y, z)
+    ρ₃₀(x, y, z) = q₃(z) * ρ₀(x, y, z)
+
+    uᵣ, Tᵣ, ρᵣ, sᵣ = gas.u₀, gas.T₀, gas.ρ₀, gas.s₀  # Reference values
+    ρe₀(x, y, z) = sum(ρ₀(x, y, z) * (uᵣ + cᵥ * (T₀(x, y, z) - Tᵣ) + g*z)
+                       for ρ₀ in (ρ₁₀, ρ₂₀, ρ₃₀))
+
+    function ρs₀(x, y, z)
+       ρs = 0.0
+       T = T₀(x, y, z)
+       for ρ in (ρ₁₀(x, y, z), ρ₂₀(x, y, z), ρ₃₀(x, y, z))
+           ρs += ρ > 0 ?  ρ * (sᵣ + cᵥ*log(T/Tᵣ) - R*log(ρ/ρᵣ)) : 0.0
+       end
+       return ρs
+    end
+
+    # Define the initial density perturbation
+    θᶜ′ = 2.0
+    xᶜ, zᶜ = 0km, 2km
+    xʳ, zʳ = 2km, 2km
+
+    L(x, y, z) = sqrt(((x - xᶜ)/xʳ)^2 + ((z - zᶜ)/zʳ)^2)
+    θ′(x, y, z) = (L(x, y, z) <= 1) * θᶜ′ * cos(π/2 * L(x, y, z))^2
+    ρ′(x, y, z) = -ρ₀(x, y, z) * θ′(x, y, z) / θ₀(x, y, z)
+
+    # Define initial state
+    ρᵢ(x, y, z) = ρ₀(x, y, z) + ρ′(x, y, z)
+    pᵢ(x, y, z) = p₀(x, y, z)
+    Tᵢ(x, y, z) = pᵢ(x, y, z) / (R * ρᵢ(x, y, z))
+
+    ρ₁ᵢ(x, y, z) = q₁(z) * ρᵢ(x, y, z)
+    ρ₂ᵢ(x, y, z) = q₂(z) * ρᵢ(x, y, z)
+    ρ₃ᵢ(x, y, z) = q₃(z) * ρᵢ(x, y, z)
+
+    ρeᵢ(x, y, z) = sum(ρᵢ(x, y, z) * (uᵣ + cᵥ * (Tᵢ(x, y, z) - Tᵣ) + g*z)
+                       for ρᵢ in (ρ₁ᵢ, ρ₂ᵢ, ρ₃ᵢ))
+
+    function ρsᵢ(x, y, z)
+        ρs = 0.0
+        T = Tᵢ(x, y, z)
+        for ρ in (ρ₁ᵢ(x, y, z), ρ₂ᵢ(x, y, z), ρ₃ᵢ(x, y, z))
+            ρs += ρ > 0 ?  ρ * (sᵣ + cᵥ*log(T/Tᵣ) - R*log(ρ/ρᵣ)) : 0.0
+        end
+        return ρs
+    end
+
+    # Set initial state (which includes the thermal perturbation)
+    set!(model.tracers.ρ₁, ρ₁ᵢ)
+    set!(model.tracers.ρ₂, ρ₂ᵢ)
+    set!(model.tracers.ρ₃, ρ₃ᵢ)
+    tvar isa Energy  && set!(model.tracers.ρe, ρeᵢ)
+    tvar isa Entropy && set!(model.tracers.ρs, ρsᵢ)
+    update_total_density!(model)
+
+    simulation = Simulation(model, Δt=0.1, stop_time=end_time, iteration_interval=50,
+                            progress=print_progress, parameters=(ρᵢ, ρeᵢ, ρsᵢ))
+
+    fields = Dict(
+        "ρ"  => model.total_density,
+        "ρu" => model.momenta.ρu,
+        "ρw" => model.momenta.ρw,
+        "ρ₁" => model.tracers.ρ₁,
+        "ρ₂" => model.tracers.ρ₂,
+        "ρ₃" => model.tracers.ρ₃
+    )
+
+    tvar isa Energy  && push!(fields, "ρe" => model.tracers.ρe)
+    tvar isa Entropy && push!(fields, "ρs" => model.tracers.ρs)
+    
+    simulation.output_writers[:fields] =
+        NetCDFOutputWriter(model, fields, filepath="three_gas_dry_rising_thermal_bubble_$(typeof(tvar)).nc",
+                           time_interval=10seconds)
+
+    # Save base state to NetCDF.
+    ds = simulation.output_writers[:fields].dataset
+    ds_ρ = defVar(ds, "ρ₀", Float32, ("xC", "yC", "zC"))
+    ds_ρ₁ = defVar(ds, "ρ₁₀", Float32, ("xC", "yC", "zC"))
+    ds_ρ₂ = defVar(ds, "ρ₂₀", Float32, ("xC", "yC", "zC"))
+    ds_ρ₃ = defVar(ds, "ρ₃₀", Float32, ("xC", "yC", "zC"))
+    ds_ρe = defVar(ds, "ρe₀", Float32, ("xC", "yC", "zC"))
+
+    x, y, z = nodes((Cell, Cell, Cell), grid, reshape=true)
+    ds_ρ[:, :, :] = ρ₀.(x, y, z)
+    ds_ρ₁[:, :, :] = ρ₁₀.(x, y, z)
+    ds_ρ₂[:, :, :] = ρ₂₀.(x, y, z)
+    ds_ρ₃[:, :, :] = ρ₃₀.(x, y, z)
+    ds_ρe[:, :, :] = ρe₀.(x, y, z)
+
+    run!(simulation)
+
+    return simulation
+end
+
+function print_progress(simulation)
+    model, Δt = simulation.model, simulation.Δt
+    tvar = model.thermodynamic_variable
+    ρᵢ, ρeᵢ, ρsᵢ = simulation.parameters
+
+    zC = znodes(Cell, model.grid)
+    ρ̄ᵢ = mean(ρᵢ.(0, 0, zC))
+    ρ̄ = mean(cpudata(model.total_density))
+
+    progress = 100 * model.clock.time / simulation.stop_time
+    message = @sprintf("[%05.2f%%] iteration = %d, time = %s, CFL = %.4e, acoustic CFL = %.4e, ρ̄ = %.4e (relΔ = %.4e)",
+                       progress, model.clock.iteration, prettytime(model.clock.time), cfl(model, Δt),
+                       acoustic_cfl(model, Δt), ρ̄, (ρ̄ - ρ̄ᵢ) / ρ̄)
+
+    if tvar isa Energy
+        ρ̄ēᵢ = mean(ρeᵢ.(0, 0, zC))
+        ρ̄ē = mean(cpudata(model.tracers.ρe))
+        message *= @sprintf(", ρ̄ē = %.4e (relΔ = %.4e)", ρ̄ē, (ρ̄ē - ρ̄ēᵢ) / ρ̄ē)
+    elseif tvar isa Entropy
+        ρ̄s̄ᵢ = mean(ρsᵢ.(0, 0, zC))
+        ρ̄s̄ = mean(cpudata(model.tracers.ρs))
+        message *= @sprintf(", ρ̄s̄ = %.4e (relΔ = %.4e)", ρ̄s̄, (ρ̄s̄ - ρ̄s̄ᵢ) / ρ̄s̄)
+    end
+
+    @info message
+
+    ∂tρ₁ = maximum(model.time_stepper.slow_source_terms.tracers.ρ₁.data.parent)
+    ∂tρ₂ = maximum(model.time_stepper.slow_source_terms.tracers.ρ₂.data.parent)
+    ∂tρ₃ = maximum(model.time_stepper.slow_source_terms.tracers.ρ₃.data.parent)
+
+    @info @sprintf("[%05.2f%%] Maximum mass tendencies from diffusion: ∂tρ₁ = %.4e, ∂tρ₂ = %.4e, ∂tρ₃ = %.4e",
+                   progress, ∂tρ₁, ∂tρ₂, ∂tρ₃)
+
+    return nothing
+end


### PR DESCRIPTION
This PR adds a GPU-enabled `CompressibleModel`, developed with @thabbott and @RaphaelRR in a separate repository (https://github.com/ali-ramadhan/Atmosfoolery.jl). This is a large PR and I'm not even sure if it makes sense to merge it into Oceananigans.jl. The main purpose of opening this PR is to document progress made and ultimately decide on what to do with this feature. I don't think I can continue working on it.

# Description

The compressible model implements the conservative Scheme by Satoh (2003), suitable for compressible non-hydrostatic models with moist processes, and is valid in the limit of a condensable gas/atmosphere with multiple moist species. Two choices of prognostic thermodynamic variables are available, internal energy and entropy, although in the Oceananigans spirit adding new thermodynamic variables is pretty easy!

@thabbott implemented the Satoh (2003) equation set. I initially implemented the Klemp et al. (2007) equation set which is only valid in the limit of a dry atmosphere with trace amounts of moist species.

An RK3 time-stepper is used that is apparently 3rd-order accurate for linear terms but only 2nd-order accurate for non-linear terms. This is because it's developed to allow for acoustic time stepping between RK stages. This split-explicit time-stepping scheme is described by Wicker & Skamarock (2002), Klemp et al. (2007), and Satoh (2003). It's essentially the same one used by the NCAR WRF model (Skamarock et al., 2019). No acoustic time stepper is implemented yet. Explicit acoustic time stepping could make sense for regular Cartesian grids while a vertically implicit acoustic time stepper would make sense for vertically stretched grids (possible with `Oceananigans.Solver.BatchedTridiagonalSolver`).

Building the compressible model on top of Oceananigans.jl has allowed it to run on GPUs and make use of the same operators, grids, Coriolis terms, forcing function and boundary conditions, diagnostics, output writers, higher-order advection schemes, and user-interface niceties. Turbulent diffusivity closures may take more work to integrate and not all of them can be shared as the stress tensor is not traceless when the fluid is compressible (see #654 for more discussion).

# Reasons why we may consider adding a compressible model to the Oceananigans.jl ecosystem

1. I see Oceananigans.jl as a general-purpose package for fluid dynamics even though we mostly apply it to ocean problems. With both incompressible and compressible models, Oceananigans.jl would appeal to a larger audience and may be used to investigate a greater range of problems.
2. One potential use of the `CompressibleModel` is to simulate a compressible ocean (with pressure as a prognostic variable) in which sound waves artificially slowed down for practical purposes. There were some discussions around this idea and @johncmarshall54 might still be interested.
3. With PR #590, Oceananigans.jl will support distributed parallelism via MPI. While incompressible models (and anelastic models) don't scale that well to many nodes due to the need to solve an elliptic Poission equation globally across all ranks, a compressible model is completely local and might easily scale well on many GPUs. So even if the scalability of incompressible models on many GPUs is dissapointing, we may get a very scalable compressible model almost for free. Actually, the efficiency of the Oceananigans MPI algorithm might be best tested using a compressible model.
4. Since distributed FFTs aren't generally available on GPUs (CuFFT only goes up to 16 GPUs), CUDA-aware MPI for incompressible models might take some time and effort to support once PR #590 is merged. However, CUDA-aware MPI should work out of the box for compressible models as there are no FFTs to worry about.
5. Due to the need for a fast pressure solver for incompressible models, we are not considering more general grids beyond the vertically stretched Cartesian grid. The compressible model does not have this limitation and can easily make use of a more general Cartesian grid (stretching in all dimensions).
6. The incompressible model is limited to a certain number of topologies, particularly on the GPU, due to the pressure solver. A compressible model would work with all possible topologies out of the box.
7. Since `CompressibleModel` and `IncompressibleModel` share so much common infrastructure they also share a common user interface by construction which makes it easy to switch between the two. I think this is a valueble feature. Most existing packages do not have compressible/incompressible or ocean/atmosphere capabilities within the same package.
8. Under a shared package and user interface, Oceananigans.jl will allow users to easily switch between simulating compressible and incompressible fluids and might also allow for _fast and friendly_ coupled large-eddy simulation (although the amount of work needed to reach this would be non-trivial).

# Mono-repo vs. multiple packages

I think merging this PR puts the Oceananigans.jl repo in danger of becoming a mono-repo so we should be careful.

One big reason why we haven't kept the compressible model in a separate repo is because we just don't have a good name for it yet.

A potential pathway to multiple packages would be to split out the Oceananigans.jl package into four packages: OceananigansBase.jl, OceananigansIncompressible.jl, OceananigansCompressible.jl, and Oceananigans.jl. I'm not sure which modules would go where but the idea is that users will only have to keep interfacing with Oceananigans.jl.

An added advantage of keeping everything under some Oceananigans.jl umbrella is that the name is getting more well-known (and we have a JOSS paper) so I don't think it makes sense to start a second package with a new name that nobody knows (unless it's a good name!).

That said, I would not be opposed to a mono-repo with a well-defined scope. I actually think that this is a better approach. For example, Oceananigans.jl could provide the `CompressibleModel` and `IncompressibleModel` but ocean-specific modules could live in separate packages. We did this with SeawaterPolynomials.jl and could probably do it with other modules to further limit scope if we decide to pursue this approach. So this is still a multiple packages approach but for ancillary features.

# Tests and validation experiments

We spent quite some time ensuring the `CompressibleModel` can simulate some known atmospheric test cases. Following recent trials and tribulations I also decided to add some simple 1D tests. Here I list the tests but will post a followup comment for each test with a figure or animation. Hopefully together these tests act as a starting point to start believing that the `CompressibleModel` indeed does work as expected.

1. Periodic advection of a square waveform
2. Inviscid Burgers equation developing a shock
3. Shock tube problem (Sod, 1978)
4. Rising thermal bubble with entropy and energy (Wicker & Skamarock, 1998)
5. Rising thermal bubble with 3 different gas species (entropy and energy)
6. Density current (Straka et al., 1993)
7. Dry convection

See comments below for movies and eyeball norms.

The four dry rising thermal bubble simulations are used for regression testing.

# GPU performance benchmarks

Preliminary benchmarks show a 75~80x speedup for large models when comparing a single CPU core to a single Titan V GPU on Tartarus. Not as good as the incompressible model as some of the functions that diagnose temperature and pressure need some optimizing, especially in the case of multiple gases.

```
Compressible model benchmarks                                                                                                                                                                                     
┌──────┬──────┬───────────┬───────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────┐
│ Arch │ Size │     Gases │ ThermoVar │        min │     median │       mean │        max │     memory │ allocs │
├──────┼──────┼───────────┼───────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────┤
│  CPU │  32³ │  DryEarth │    Energy │  37.682 ms │  38.012 ms │  37.982 ms │  38.199 ms │ 646.33 KiB │   4499 │
│  CPU │  32³ │  DryEarth │   Entropy │  32.325 ms │  32.920 ms │  32.928 ms │  33.628 ms │ 646.33 KiB │   4499 │
│  CPU │  32³ │ DryEarth3 │    Energy │  52.473 ms │  52.815 ms │  52.896 ms │  53.413 ms │ 816.50 KiB │   5635 │
│  CPU │  32³ │ DryEarth3 │   Entropy │  69.928 ms │  70.388 ms │  70.402 ms │  71.224 ms │ 816.50 KiB │   5635 │
│  CPU │ 192³ │  DryEarth │    Energy │    7.438 s │    7.438 s │    7.438 s │    7.438 s │ 646.33 KiB │   4499 │
│  CPU │ 192³ │  DryEarth │   Entropy │    6.501 s │    6.501 s │    6.501 s │    6.501 s │ 646.58 KiB │   4512 │
│  CPU │ 192³ │ DryEarth3 │    Energy │   11.265 s │   11.265 s │   11.265 s │   11.265 s │ 816.75 KiB │   5648 │
│  CPU │ 192³ │ DryEarth3 │   Entropy │   15.038 s │   15.038 s │   15.038 s │   15.038 s │ 816.50 KiB │   5635 │
│  GPU │  32³ │  DryEarth │    Energy │   8.328 ms │   8.513 ms │   8.608 ms │   9.676 ms │   2.00 MiB │  30129 │
│  GPU │  32³ │  DryEarth │   Entropy │   7.863 ms │   8.500 ms │   8.529 ms │   9.515 ms │   2.00 MiB │  30129 │
│  GPU │  32³ │ DryEarth3 │    Energy │  10.133 ms │  10.754 ms │  10.751 ms │  11.281 ms │   2.54 MiB │  37805 │
│  GPU │  32³ │ DryEarth3 │   Entropy │   9.992 ms │  10.572 ms │  10.542 ms │  10.836 ms │   2.54 MiB │  37839 │
│  GPU │ 192³ │  DryEarth │    Energy │ 101.341 ms │ 101.612 ms │ 101.589 ms │ 101.709 ms │   2.01 MiB │  30270 │
│  GPU │ 192³ │  DryEarth │   Entropy │  86.051 ms │  86.195 ms │  86.226 ms │  86.710 ms │   2.01 MiB │  30270 │
│  GPU │ 192³ │ DryEarth3 │    Energy │ 139.732 ms │ 140.009 ms │ 139.957 ms │ 140.079 ms │   2.54 MiB │  37983 │
│  GPU │ 192³ │ DryEarth3 │   Entropy │ 375.725 ms │ 376.142 ms │ 376.123 ms │ 376.399 ms │   2.54 MiB │  37983 │
└──────┴──────┴───────────┴───────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────┘
```

```
Compressible model speedups                                                                                                                                                                                       
┌──────┬───────────┬───────────┬─────────┐
│ Size │     Gases │ ThermoVar │ speedup │
├──────┼───────────┼───────────┼─────────┤
│  32³ │  DryEarth │    Energy │  4.465x │
│  32³ │  DryEarth │   Entropy │  3.873x │
│  32³ │ DryEarth3 │    Energy │  4.911x │
│  32³ │ DryEarth3 │   Entropy │  6.658x │
│ 192³ │  DryEarth │    Energy │ 73.203x │
│ 192³ │  DryEarth │   Entropy │ 75.421x │
│ 192³ │ DryEarth3 │    Energy │ 80.457x │
│ 192³ │ DryEarth3 │   Entropy │ 39.981x │
└──────┴───────────┴───────────┴─────────┘
```

# TODO

Right now everything lives in a `compressible` directory to keep it separate.

There are many improvements that could be made to the `CompressibleModel`, starting first with how reference states are initialized and how initial conditions are set (see verification scripts), but this is a list of TODO items in case we decide to merge this PR.

- [ ] Add some documentation, especially for the numerical methods. I should probably LaTeX some notes first [@thabbot has some but might be for the Klemp et al. (2007) equations?].
- [ ] Transfer issues from JULES.jl to Oceananigans.jl to preserve useful discussions and action items.
- [ ] Merge modules, tests, and verification experiments from `compressible` directory.

# References

Jahn et al. (2015): https://doi.org/10.5194/gmd-8-317-2015
Klemp et al. (2007): https://doi.org/10.1175/MWR3440.1
Satoh (2003): https://doi.org/10.1175/1520-0493(2003)131%3C1033:CSFACN%3E2.0.CO;2
Skamarock et al. (2019): https://opensky.ucar.edu/islandora/object/opensky%3A2898
Sod (1978): https://doi.org/10.1016/0021-9991(78)90023-2
Straka et al. (1993): https://doi.org/10.1002/fld.1650170103
Wicker and Skamarock (1998): https://doi.org/10.1175/1520-0493(1998)126%3C1992:ATSSFT%3E2.0.CO;2