### PR TITLE
Field slicing with floats and other numbers

### DIFF
--- a/src/OutputWriters/field_slicer.jl
+++ b/src/OutputWriters/field_slicer.jl
@@ -35,6 +35,9 @@ FieldSlicer(; i=Colon(), j=Colon(), k=Colon(), with_halos=false) =
 # Integer slice
 parent_slice_indices(loc, topo, N, H, i::Int, with_halos) = UnitRange(i + H, i + H)
 
+# If it looks like an integer, slice anyway
+parent_slice_indices(loc, topo, N, H, i::Number, with_halos) = parent_slice_indices(loc, topo, N, H, Int(i), with_halos)
+
 # Colon slicing
 parent_slice_indices(loc, topo, N, H, 
                      ::Colon, with_halos) = with_halos ? UnitRange(1, N+2H) : UnitRange(H+1, H+N)

--- a/src/OutputWriters/field_slicer.jl
+++ b/src/OutputWriters/field_slicer.jl
@@ -26,7 +26,12 @@ The keyword `with_halos` denotes whether halo data is saved or not. Halo regions
 sliced off output for `UnitRange` and `Colon` index specifications.
 """
 FieldSlicer(; i=Colon(), j=Colon(), k=Colon(), with_halos=false) =
-    FieldSlicer(i, j, k, with_halos)
+    FieldSlicer(num2int(i), num2int(j), num2int(k), with_halos)
+
+# To support FieldSlicer construction with all number types (but we always want to
+# index with an integer).
+num2int(i) = i
+num2int(i::Number) = Int(i)
 
 #####
 ##### Slice of life, err... data
@@ -34,9 +39,6 @@ FieldSlicer(; i=Colon(), j=Colon(), k=Colon(), with_halos=false) =
 
 # Integer slice
 parent_slice_indices(loc, topo, N, H, i::Int, with_halos) = UnitRange(i + H, i + H)
-
-# If it looks like an integer, slice anyway
-parent_slice_indices(loc, topo, N, H, i::Number, with_halos) = parent_slice_indices(loc, topo, N, H, Int(i), with_halos)
 
 # Colon slicing
 parent_slice_indices(loc, topo, N, H, 


### PR DESCRIPTION
Would be nice if things like `FieldSlicer(k=grid.Nz/2)` worked out of the box. This PR makes this possible.

cc @suyashbire1 