### PR TITLE
Remove dollar signs used for latexing in Docs

### DIFF
--- a/docs/src/appendix/fractional_step.md
+++ b/docs/src/appendix/fractional_step.md
@@ -3,8 +3,8 @@
 Solving the momentum equation \eqref{eq:momentumFV} coupled with the continuity equation \eqref{eq:continuityFV} can be
 cumbersome so instead we employ a fractional step method. To approximate the solution of the coupled system we first
 solve an approximation to the discretized momentum equation \eqref{eq:momentumFV} for an intermediate velocity field
-$\bm{u}^\star$ without worrying about satisfying the incompressibility constraint. We then project $\bm{u}^\star$ onto
-the space of divergence-free velocity fields to obtain a value for $\bm{u}^{n+1}$ that satisfies
+``\bm{u}^\star`` without worrying about satisfying the incompressibility constraint. We then project ``\bm{u}^\star`` onto
+the space of divergence-free velocity fields to obtain a value for ``\bm{u}^{n+1}`` that satisfies
 \eqref{eq:continuityFV}.
 
 We thus discretize the momentum equation as
@@ -16,15 +16,15 @@ We thus discretize the momentum equation as
   + \div{\nu\nabla\bm{u}^{n+\frac{1}{2}}}
   + \bm{F}^{n+\frac{1}{2}}
 ```
-where the superscript $n + \frac{1}{2}$ indicates that these terms are evaluated at time step $n + \frac{1}{2}$, which
+where the superscript ``n + \frac{1}{2}`` indicates that these terms are evaluated at time step ``n + \frac{1}{2}``, which
 we compute explicitly (see \S\ref{sec:time-stepping}).
 
 The projection is then performed
 ```math
    \bm{u}^{n+1} = \bm{u}^\star - \Delta t \nabla \phi^{n+1}
 ```
-to obtain a divergence-free velocity field $\bm{u}^{n+1}$. Here the projection is performed by solving an elliptic
-problem for the pressure $\phi^{n+1}$ with the boundary condition
+to obtain a divergence-free velocity field ``\bm{u}^{n+1}``. Here the projection is performed by solving an elliptic
+problem for the pressure ``\phi^{n+1}`` with the boundary condition
 ```math
 \newcommand{\uvec}[1]{\boldsymbol{\hat{\textbf{#1}}}}
   \bm{\hat{n}} \cdotp \nabla\phi^{n+1} |_{\partial\Omega} = 0
@@ -32,13 +32,13 @@ problem for the pressure $\phi^{n+1}$ with the boundary condition
 
 [Orszag86](@cite) and [Brown01](@cite) raise an important issue regarding these fractional step methods, which is that
 "while the velocity can be reliably computed to second-order accuracy in time and space, the pressure is typically only
-first-order accurate in the $L_\infty$-norm." The numerical boundary conditions must be carefully accounted for to
+first-order accurate in the ``L_\infty``-norm." The numerical boundary conditions must be carefully accounted for to
 ensure the second-order accuracy promised by the fractional step methods.
 
 We are currently investigating whether our projection method is indeed second-order accurate in both velocity and
 pressure (see \S\ref{sec:forced-flow}). However, it may not matter too much for simulating high Reynolds number
 geophysical fluids as [Brown01](@cite) conclude that "Quite often, semi-implicit projection methods are applied to
-problems in which the viscosity is small. Since the predicted first-order errors in the pressure are scaled by $\nu$,
+problems in which the viscosity is small. Since the predicted first-order errors in the pressure are scaled by ``\nu``,
 it is not clear whether the improved pressure-update formula is beneficial in such situations. ... Finally, in some
 applications of projection methods, second-order accuracy in the pressure may not be relevant or in some cases even
 possible due to the treatment of other terms in the equations."

--- a/docs/src/appendix/fractional_step.md
+++ b/docs/src/appendix/fractional_step.md
@@ -26,7 +26,7 @@ The projection is then performed
 to obtain a divergence-free velocity field ``\bm{u}^{n+1}``. Here the projection is performed by solving an elliptic
 problem for the pressure ``\phi^{n+1}`` with the boundary condition
 ```math
-\newcommand{\uvec}[1]{\boldsymbol{\hat{\textbf{#1}}}}
+\newcommand{\uvec}[1]{\bm{\hat{\textbf{#1}}}}
   \bm{\hat{n}} \cdotp \nabla\phi^{n+1} |_{\partial\Omega} = 0
 ```
 

--- a/docs/src/appendix/staggered_grid.md
+++ b/docs/src/appendix/staggered_grid.md
@@ -1,24 +1,24 @@
 # Staggered grid
 
-Velocities $u$, $v$, and $w$ are defined on the faces of the cells, which are coincident with three orthogonal
-coordinate axes (the Cartesian axes in the case of Oceananigans). Pressure $p$ and tracers $c$ are stored at
+Velocities ``u``, ``v``, and ``w`` are defined on the faces of the cells, which are coincident with three orthogonal
+coordinate axes (the Cartesian axes in the case of Oceananigans). Pressure ``p`` and tracers ``c`` are stored at
 the cell  centers as cell averages. See figure \ref{fig:staggered_grid} for a schematic of the different control
-volumes. Other quantities may be defined at other locations. For example, vorticity $\bm{\omega} = \nabla\times\bm{u}$
+volumes. Other quantities may be defined at other locations. For example, vorticity ``\bm{\omega} = \nabla\times\bm{u}``
 is defined at the cell edges.[^1]
 
 [^1]: In 2D it would more correct to say the cell corners. In 3D, variables like vorticity lie at the same vertical
     levels as the cell-centered variables and so they really lie at the cell edges.
 
 ![Schematic of control volumes](assets/staggered_grid_control_volumes.png)
-*Figure 1: A schematic of the control volumes in a two-dimensional staggered grid. Note that pressure $p$
-(and tracers) is defined at the center of the control volume. The $u$ control volumes are centered on the
-left and right edges of the pressure control volume while the $v$ control volumes are centered on the top
+*Figure 1: A schematic of the control volumes in a two-dimensional staggered grid. Note that pressure ``p``
+(and tracers) is defined at the center of the control volume. The ``u`` control volumes are centered on the
+left and right edges of the pressure control volume while the ``v`` control volumes are centered on the top
 and bottom edges of the pressure control volumes. Figure credit: [Kumar16](@cite)*
 
 This staggered arrangement of variables is more complicated than the collocated grid arrangement but is greatly
 beneficial as it avoids the odd-even decoupling between the pressure and velocity if they are stored at the same
 positions. §6.1 of [Patankar80](@cite) discusses this problem in the presence of a zigzag pressure field: on a 1D
-collocated grid the velocity at the point $i$ is influenced by the pressure at points $i-1$ and $i+1$, and a zigzag
+collocated grid the velocity at the point ``i`` is influenced by the pressure at points ``i-1`` and ``i+1``, and a zigzag
 pressure field will be felt as a uniform pressure, which is obviously wrong and would reduce the accuracy of the
 solution. The pressure is effectively taken from a coarser grid than what is actually used. The basic problem is that
 the momentum equations will use the pressure difference between two alternate points when it should be using two
@@ -32,30 +32,30 @@ The staggered grid was first introduced by [Harlow65](@cite) with their *marker 
 and oceanography, the staggered grid is usually referred to as the Arakawa C-grid after [Arakawa77](@cite), who
 investigated four different staggered grids and the unstaggered A-grid for use in an atmospheric model.
 
-[Arakawa77](@cite) investigated the dispersion relation of inertia-gravity waves[^2] traveling in the $x$-direction
+[Arakawa77](@cite) investigated the dispersion relation of inertia-gravity waves[^2] traveling in the ``x``-direction
 ```math
   \omega^2 = f^2 + gHk^2
 ```
-in the linearized rotating shallow-water equations for five grids. Here $\omega$ is the angular frequency, $H$ is the
-height of the fluid and $k$ is the wavenumber in the $x$-direction. Looking at the effect of spatial discretization
+in the linearized rotating shallow-water equations for five grids. Here ``\omega`` is the angular frequency, ``H`` is the
+height of the fluid and ``k`` is the wavenumber in the ``x``-direction. Looking at the effect of spatial discretization
 error on the frequency of these waves they find that the B and C-grids reproduce the dispersion relation most closely
 out of the five [Arakawa77](@cite) (Figure 5). In particular, the dispersion relation for the C-grid is given by
 ```math
   \omega^2 = f^2 \left[ \cos^2 \left( \frac{k\Delta}{2} \right)
              + 4 \left( \frac{\lambda}{\Delta} \right)^2 \sin^2 \left( \frac{k\Delta}{2} \right) \right]
 ```
-where $\lambda$ is the wavelength and $\Delta$ is the grid spacing. Paraphrasing p. 184 of [Arakawa77](@cite): The
-wavelength of the shortest resolvable wave is $2\Delta$ with corresponding wavenumber $k = \pi/\Delta$ so it is
-sufficient to evaluate the dispersion relation over the range $0 < k\Delta < \pi$. The frequency is monotonically
-increasing for $\lambda/\Delta > \frac{1}{2}$ and monotonically decreasing for $\lambda/\Delta < \frac{1}{2}$. For the
-fourth smallest wave $\lambda/\Delta = \frac{1}{2}$ we get $\omega^2 = f^2$ which matches the $k = 0$ wave. Furthermore,
-the group velocity is zero for all $k$. On the other grids, waves with $k\Delta = \pi$ can behave like pure inertial
+where ``\lambda`` is the wavelength and ``\Delta`` is the grid spacing. Paraphrasing p. 184 of [Arakawa77](@cite): The
+wavelength of the shortest resolvable wave is ``2\Delta`` with corresponding wavenumber ``k = \pi/\Delta`` so it is
+sufficient to evaluate the dispersion relation over the range ``0 < k\Delta < \pi``. The frequency is monotonically
+increasing for ``\lambda/\Delta > \frac{1}{2}`` and monotonically decreasing for ``\lambda/\Delta < \frac{1}{2}``. For the
+fourth smallest wave ``\lambda/\Delta = \frac{1}{2}`` we get ``\omega^2 = f^2`` which matches the ``k = 0`` wave. Furthermore,
+the group velocity is zero for all ``k``. On the other grids, waves with ``k\Delta = \pi`` can behave like pure inertial
 oscillations or stationary waves, which is bad.
 
 The B and C-grids are less oscillatory than the others and quite faithfully simulate geostrophic adjustment. However,
-the C-grid is the only one that faithfully reproduces the two-dimensional dispersion relation $\omega^2(k, \ell)$, all
+the C-grid is the only one that faithfully reproduces the two-dimensional dispersion relation ``\omega^2(k, \ell)``, all
 the other grids have false maxima, and so [Arakawa77](@cite) conclude that the C-grid is best for simulating geostrophic
-adjustment except for abnormal situations in which $\lambda/\Delta$ is less than or close to 1. This seems to have held
+adjustment except for abnormal situations in which ``\lambda/\Delta`` is less than or close to 1. This seems to have held
 true for most atmospheric and oceanographic simulations as the C-grid is popular and widely used.
 
 [^2]: Apparently also called Poincaré waves, Sverdrup waves, and *rotational gravity waves* §13.9 of [Kundu15](@cite).

--- a/docs/src/appendix/staggered_grid.md
+++ b/docs/src/appendix/staggered_grid.md
@@ -9,7 +9,7 @@ is defined at the cell edges.[^1]
 [^1]: In 2D it would more correct to say the cell corners. In 3D, variables like vorticity lie at the same vertical
     levels as the cell-centered variables and so they really lie at the cell edges.
 
-![Schematic of control volumes](../numerical_implementation/assets/staggered_grid_control_volumes.png)
+![Schematic of control volumes](assets/staggered_grid_control_volumes.png)
 *Figure 1: A schematic of the control volumes in a two-dimensional staggered grid. Note that pressure ``p``
 (and tracers) is defined at the center of the control volume. The ``u`` control volumes are centered on the
 left and right edges of the pressure control volume while the ``v`` control volumes are centered on the top

--- a/docs/src/appendix/staggered_grid.md
+++ b/docs/src/appendix/staggered_grid.md
@@ -9,7 +9,7 @@ is defined at the cell edges.[^1]
 [^1]: In 2D it would more correct to say the cell corners. In 3D, variables like vorticity lie at the same vertical
     levels as the cell-centered variables and so they really lie at the cell edges.
 
-![Schematic of control volumes](assets/staggered_grid_control_volumes.png)
+![Schematic of control volumes](../numerical_implementation/assets/staggered_grid_control_volumes.png)
 *Figure 1: A schematic of the control volumes in a two-dimensional staggered grid. Note that pressure ``p``
 (and tracers) is defined at the center of the control volume. The ``u`` control volumes are centered on the
 left and right edges of the pressure control volume while the ``v`` control volumes are centered on the top

--- a/docs/src/model_setup/background_fields.md
+++ b/docs/src/model_setup/background_fields.md
@@ -9,23 +9,23 @@ For example, tracer advection is described by
 \nabla \cdot \left ( \bm{u} c \right )
 ```
 
-where $\bm{u}$ is the resolved velocity field and $c$ is the resolved
+where ``\bm{u}`` is the resolved velocity field and ``c`` is the resolved
 tracer field corresponding to `model.tracers.c`.
-When a background field $C$ is provided, the tracer advection term becomes
+When a background field ``C`` is provided, the tracer advection term becomes
 
 ```math
-\nabla \cdot \left ( \bm{u} c \right ) + \nabla \cdot \left ( \bm{u} C \right )
+\nabla \cdot \left ( \bm{u} c \right ) + \nabla \cdot \left ( \bm{u} C \right ) \, .
 ```
 
-When both a background field velocity field `\bm{U}` and a background tracer field $C$
+When both a background field velocity field `\bm{U}` and a background tracer field ``C``
 are provided, then the tracer advection term becomes
 
 ```math
 \nabla \cdot \left ( \bm{u} c \right ) + \nabla \cdot \left ( \bm{u} C \right )
-    + \nabla \cdot \left ( \bm{U} c \right )
+    + \nabla \cdot \left ( \bm{U} c \right ) \, .
 ```
 
-Notice that the term $\nabla \cdot \left ( \bm{U} C \right )$ is neglected:
+Notice that the term ``\nabla \cdot \left ( \bm{U} C \right )`` is neglected:
 only the terms describing the advection of resolved tracer by the background velocity field
 and the advection of background tracer by the resolved velocity field are included.
 An analgous statement holds for the advection of background momentum by the resolved

--- a/docs/src/model_setup/background_fields.md
+++ b/docs/src/model_setup/background_fields.md
@@ -6,7 +6,7 @@ associated with the interaction between background and resolved fields are inclu
 For example, tracer advection is described by
 
 ```math
-\nabla \cdot \left ( \bm{u} c \right )
+\nabla \cdot \left ( \bm{u} c \right ) \, ,
 ```
 
 where ``\bm{u}`` is the resolved velocity field and ``c`` is the resolved

--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -33,14 +33,14 @@ Oceananigans uses a hierarchical structure to express boundary conditions.
 1. A [`BoundaryCondition`](@ref) is associated with every field, dimension, and endpoint.
 2. Boundary conditions specifying the condition at the left and right endpoints are
    grouped into [`CoordinateBoundaryConditions`](@ref).
-3. A set of three `CoordinateBoundaryConditions` specifying the boundary conditions along the $x$-, $y$-,
-   and $z$-dimensions.
+3. A set of three `CoordinateBoundaryConditions` specifying the boundary conditions along the ``x``-, ``y``-,
+   and ``z``-dimensions.
    for a single field are grouped into a [`FieldBoundaryConditions`](@ref) `NamedTuple`.
 4. A set of `FieldBoundaryConditions`, up to one for each field, are grouped into a `NamedTuple` and passed
    to the model constructor.
 
 Boundary conditions are defined at model construction time by passing a `NamedTuple` of `FieldBoundaryConditions`
-specifying non-default boundary conditions for fields such as velocities ($u$, $v$, $w$) and tracers.
+specifying non-default boundary conditions for fields such as velocities (``u``, ``v``, ``w``) and tracers.
 Fields for which boundary conditions are not specified are assigned a default boundary conditions.
 Note that default boundary conditions depend on the grid topology.
 
@@ -91,7 +91,7 @@ can can be used, for example, to specify cooling, heating, evaporation, or wind 
 
 !!! info "The flux convention in Oceananigans"
     `Oceananigans` uses the convention that positive fluxes produce transport in the
-    _positive_ direction (east, north, and up for $x$, $y$, $z$).
+    _positive_ direction (east, north, and up for ``x``, ``y``, ``z``).
     This means, for example, that a _negative_ flux of momentum or velocity at a _top_
     boundary, such as in the above example, produces currents in the _positive_ direction,
     because it prescribes a downwards flux of momentum into the domain from the top.
@@ -162,7 +162,7 @@ BoundaryCondition: type=Flux, condition=linear_drag(i, j, grid, clock, model_fie
     where `i, j` are grid indices that vary along the boundary, `grid` is `model.grid`,
     `clock` is the `model.clock`, and `model_fields` is a `NamedTuple`
     containing `u, v, w` and the fields in `model.tracers`.
-    The signature is similar for $x$ and $y$ boundary conditions expect that `i, j` is replaced
+    The signature is similar for ``x`` and ``y`` boundary conditions expect that `i, j` is replaced
     with `j, k` and `i, k` respectively.
 
 ##### 6. Discrete-form boundary condition with parameters
@@ -215,9 +215,9 @@ Oceananigans.FieldBoundaryConditions (NamedTuple{(:x, :y, :z)}), with boundary c
 
 `T_bcs` is a [`FieldBoundaryConditions`](@ref) object for temperature `T` appropriate
 for horizontally periodic grid topologies.
-The default `Periodic` boundary conditions in $x$ and $y$ are inferred from the `topology` of `grid`.
+The default `Periodic` boundary conditions in ``x`` and ``y`` are inferred from the `topology` of `grid`.
 
-For $u$, $v$, and $w$, use the 
+For ``u``, ``v``, and ``w``, use the 
 `UVelocityBoundaryConditions`
 `VVelocityBoundaryConditions`, and 
 `WVelocityBoundaryConditions` constructors, respectively.
@@ -227,7 +227,7 @@ For $u$, $v$, and $w$, use the
 To specify non-default boundary conditions, a named tuple of [`FieldBoundaryConditions`](@ref) objects is
 passed to the keyword argument `boundary_conditions` in the [`IncompressibleModel`](@ref) constructor.
 The keys of `boundary_conditions` indicate the field to which the boundary condition is applied.
-Below, non-default boundary conditions are imposed on the $u$-velocity and temperature.
+Below, non-default boundary conditions are imposed on the ``u``-velocity and temperature.
 
 ```jldoctest
 julia> topology = (Periodic, Periodic, Bounded);

--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -4,8 +4,8 @@ The buoyancy option selects how buoyancy is treated. There are currently three o
 
 1. No buoyancy (and no gravity).
 2. Evolve buoyancy as a tracer.
-3. _Seawater buoyancy_: evolve temperature $T$ and salinity $S$ as tracers with a value for the gravitational
-   acceleration $g$ and an equation of state of your choosing. This is the default setting.
+3. _Seawater buoyancy_: evolve temperature ``T`` and salinity ``S`` as tracers with a value for the gravitational
+   acceleration ``g`` and an equation of state of your choosing. This is the default setting.
 
 ## No buoyancy
 
@@ -60,7 +60,7 @@ IncompressibleModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 
 ## Seawater buoyancy
 
-To evolve temperature $T$ and salinity $S$ and diagnose the buoyancy, you can pass
+To evolve temperature ``T`` and salinity ``S`` and diagnose the buoyancy, you can pass
 `buoyancy = SeawaterBuoyancy()` which is the default.
 
 ```jldoctest buoyancy
@@ -73,11 +73,11 @@ IncompressibleModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 └── coriolis: Nothing
 ```
 
-Without any options specified, a value of $g = 9.80665 \; \text{m/s}^2$ is used for the gravitational
+Without any options specified, a value of ``g = 9.80665 \, \text{m}\,\text{s}^{-2}`` is used for the gravitational
 acceleration (corresponding to [standard gravity](https://en.wikipedia.org/wiki/Standard_gravity)) along
 with a linear equation of state with thermal expansion and haline contraction coefficients suitable for seawater.
 
-If, for example, you wanted to simulate fluids on another planet such as Europa where $g = 1.3 \; \text{m/s}^2$,
+If, for example, you wanted to simulate fluids on another planet such as Europa where ``g = 1.3 \, \text{m}\,\text{s}^{-2}``,
 then use
 
 ```jldoctest buoyancy
@@ -100,7 +100,7 @@ can be accomplished by passing `tracers = (:T, :S)` to a model constructor.
 ### Linear equation of state
 
 To use non-default thermal expansion and haline contraction coefficients, say
-$\alpha = 2 \times 10^{-3} \; \text{K}^{-1}$ and $\beta = 5 \times 10^{-4} \text{ppt}^{-1}$ corresponding to some other
+``\alpha = 2 \times 10^{-3} \; \text{K}^{-1}`` and ``\beta = 5 \times 10^{-4} \text{ppt}^{-1}`` corresponding to some other
 fluid, then use
 
 ```jldoctest

--- a/docs/src/model_setup/clock.md
+++ b/docs/src/model_setup/clock.md
@@ -25,7 +25,7 @@ Clock{Float64}: time = 1 hour, iteration = 0, stage = 1
 ```
 
 to the constructor for `IncompressibleModel` causes the simulation
-time to start at $t = 3600$ seconds.
+time to start at ``t = 3600`` seconds.
 
 The type of the keyword argument `time` should be a float or date type.
 To use the date type `TimeDate` from the `TimesDates.jl` package,

--- a/docs/src/model_setup/coriolis.md
+++ b/docs/src/model_setup/coriolis.md
@@ -1,7 +1,7 @@
 # Coriolis
 
 The Coriolis option determines whether the fluid experiences the effect of the Coriolis force, or rotation. Currently
-three options are available: no rotation, $f$-plane, and $\beta$-plane.
+three options are available: no rotation, ``f``-plane, and ``\beta``-plane.
 
 !!! info "Coriolis vs. rotation"
     If you are wondering why this option is called "Coriolis" it is because rotational effects could include the
@@ -12,9 +12,9 @@ three options are available: no rotation, $f$-plane, and $\beta$-plane.
 
 By default there is no rotation. This can be made explicit by passing `coriolis = nothing` to a model constructor.
 
-## Traditional $f$-plane
+## Traditional ``f``-plane
 
-To set up an $f$-plane with, for example, Coriolis parameter $f = 10^{-4} \text{s}^{-1}$
+To set up an ``f``-plane with, for example, Coriolis parameter ``f = 10^{-4} \text{s}^{-1}``
 
 ```@meta
 DocTestSetup = quote
@@ -27,42 +27,42 @@ julia> coriolis = FPlane(f=1e-4)
 FPlane{Float64}: f = 1.00e-04
 ```
 
-An $f$-plane can also be specified at some latitude on a spherical planet with a planetary rotation rate. For example,
-to specify an $f$-plane at a latitude of $\varphi = 45°\text{N}$ on Earth which has a rotation rate of
-$\Omega = 7.292115 \times 10^{-5} \text{s}^{-1}$
+An ``f``-plane can also be specified at some latitude on a spherical planet with a planetary rotation rate. For example,
+to specify an ``f``-plane at a latitude of ``\varphi = 45°\text{N}`` on Earth which has a rotation rate of
+``\Omega = 7.292115 \times 10^{-5} \text{s}^{-1}``
 
 ```jldoctest
 julia> coriolis = FPlane(rotation_rate=7.292115e-5, latitude=45)
 FPlane{Float64}: f = 1.03e-04
 ```
 
-in which case the value of $f$ is given by $2\Omega\sin\varphi$.
+in which case the value of ``f`` is given by ``2\Omega\sin\varphi``.
 
-## Non-traditional $f$-plane
+## Non-traditional ``f``-plane
 
-To set up an $f$-plane with non-traditional Coriolis terms, for example, with
-$\bm{f} = (0, f_y, f_z) = (0, 2, 1) \times 10^{-4} \text{s}^{-1}$,
+To set up an ``f``-plane with non-traditional Coriolis terms, for example, with
+``\bm{f} = (0, f_y, f_z) = (0, 2, 1) \times 10^{-4} \text{s}^{-1}``,
 
 ```jldoctest
 julia> coriolis = NonTraditionalFPlane(fz=1e-4, fy=2e-4)
 NonTraditionalFPlane{Float64}: fz = 1.00e-04, fy = 2.00e-04
 ```
 
-An $f$-plane with non-traditional Coriolis terms can also be specified at some latitude on a spherical planet
-with a planetary rotation rate. For example, to specify an $f$-plane at a latitude of $\varphi = 45°\text{N}$
-on Earth which has a rotation rate of $\Omega = 7.292115 \times 10^{-5} \text{s}^{-1}$
+An ``f``-plane with non-traditional Coriolis terms can also be specified at some latitude on a spherical planet
+with a planetary rotation rate. For example, to specify an ``f``-plane at a latitude of ``\varphi = 45°\text{N}``
+on Earth which has a rotation rate of ``\Omega = 7.292115 \times 10^{-5} \text{s}^{-1}``
 
 ```jldoctest
 julia> coriolis = NonTraditionalFPlane(rotation_rate=7.292115e-5, latitude=45)
 NonTraditionalFPlane{Float64}: fz = 1.03e-04, fy = 1.03e-04
 ```
 
-in which case $f_z = 2\Omega\sin\varphi$ and $f_y = 2\Omega\cos\varphi$.
+in which case ``f_z = 2\Omega\sin\varphi`` and ``f_y = 2\Omega\cos\varphi``.
 
-## Traditional $\beta$-plane
+## Traditional ``\beta``-plane
 
-To set up a $\beta$-plane the background rotation rate $f_0$ and the $\beta$ parameter must be specified. For example,
-a $\beta$-plane with $f_0 = 10^{-4} \text{s}^{-1}$ and $\beta = 1.5 \times 10^{-11} \text{s}^{-1}\text{m}^{-1}$ can be
+To set up a ``\beta``-plane the background rotation rate ``f_0`` and the ``\beta`` parameter must be specified. For example,
+a ``\beta``-plane with ``f_0 = 10^{-4} \text{s}^{-1}`` and ``\beta = 1.5 \times 10^{-11} \text{s}^{-1}\text{m}^{-1}`` can be
 set up with
 
 ```jldoctest
@@ -70,20 +70,20 @@ julia> coriolis = BetaPlane(f₀=1e-4, β=1.5e-11)
 BetaPlane{Float64}: f₀ = 1.00e-04, β = 1.50e-11
 ```
 
-Alternatively, a $\beta$-plane can also be set up at some latitude on a spherical planet with a planetary rotation rate
-and planetary radius. For example, to specify a $\beta$-plane at a latitude of $\varphi = 10\degree{S}$ on Earth
-which has a rotation rate of $\Omega = 7.292115 \times 10^{-5} \text{s}^{-1}$ and a radius of $R = 6,371 \text{km}$
+Alternatively, a ``\beta``-plane can also be set up at some latitude on a spherical planet with a planetary rotation rate
+and planetary radius. For example, to specify a ``\beta``-plane at a latitude of ``\varphi = 10\degree{S}`` on Earth
+which has a rotation rate of ``\Omega = 7.292115 \times 10^{-5} \text{s}^{-1}`` and a radius of ``R = 6,371 \text{km}``
 
 ```jldoctest
 julia> coriolis = BetaPlane(rotation_rate=7.292115e-5, latitude=-10, radius=6371e3)
 BetaPlane{Float64}: f₀ = -2.53e-05, β = 2.25e-11
 ```
 
-in which case $f_0 = 2\Omega\sin\varphi$ and $\beta = 2\Omega\cos\varphi / R$.
+in which case ``f_0 = 2\Omega\sin\varphi`` and ``\beta = 2\Omega\cos\varphi / R``.
 
-## Non-traditional $\beta$-plane
+## Non-traditional ``\beta``-plane
 
-A non-traditional $\beta$-plane requires either 5 parameters (by default Earth's radius and
+A non-traditional ``\beta``-plane requires either 5 parameters (by default Earth's radius and
 rotation rate are used):
 
 ```jldoctest

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -7,8 +7,8 @@ A `RegularCartesianGrid` is constructed by specifying the `size` of the grid (a 
 grid points in each direction) and either the `extent` (a `Tuple` specifying the physical extent of the grid in
 each direction), or 2-`Tuple`s `x`, `y`, and `z` (for a 3D grid) that defines the the _end points_ in each direction.
 
-A regular Cartesian grid with $N_x \times N_y \times N_z = 32 \times 64 \times 256$ grid points and an `extent` of
-$L_x = 128$ meters, $L_y = 256$ meters, and $L_z = 512$ meters is constructed using
+A regular Cartesian grid with ``N_x \times N_y \times N_z = 32 \times 64 \times 256`` grid points and an `extent` of
+``L_x = 128`` meters, ``L_y = 256`` meters, and ``L_z = 512`` meters is constructed using
 
 ```@meta
 DocTestSetup = quote
@@ -27,7 +27,7 @@ grid spacing (Δx, Δy, Δz): (4.0, 4.0, 2.0)
 ```
 
 !!! info "Default domain"
-    When using the `extent` keyword, the domain is $x \in [0, L_x]$, $y \in [0, L_y]$, and $z \in [-L_z, 0]$
+    When using the `extent` keyword, the domain is ``x \in [0, L_x]``, ``y \in [0, L_y]``, and ``z \in [-L_z, 0]``
     --- a sensible choice for oceanographic applications.
 
 ## Specifying the grid's topology
@@ -64,7 +64,7 @@ grid spacing (Δx, Δy, Δz): (156.25, 156.25, 0.0)
 ```
 
 Grid spacing in `Flat` directions is `0`. Notice that two-dimensional domains accept 2-`Tuple`s
-for `size` and `extent`. To specify a one-dimensional "column" model that varies only in $z$, write
+for `size` and `extent`. To specify a one-dimensional "column" model that varies only in ``z``, write
 
 ```jldoctest
 julia> grid = RegularCartesianGrid(topology=(Flat, Flat, Bounded), size=128, extent=256)
@@ -81,7 +81,7 @@ For one-dimensional domains, `size` and `extent` may either be scalars or 1-`Tup
 ## Specifying domain end points
 
 To specify a domain with a different origin than the default, the `x`, `y`, and `z` keyword arguments must be used.
-For example, a grid with $x \in [-100, 100]$ meters, $y \in [0, 12.5]$ meters, and $z \in [0, \pi]$ meters
+For example, a grid with ``x \in [-100, 100]`` meters, ``y \in [0, 12.5]`` meters, and ``z \in [0, \pi]`` meters
 is constructed via
 
 ```jldoctest

--- a/docs/src/model_setup/output_writers.md
+++ b/docs/src/model_setup/output_writers.md
@@ -222,9 +222,9 @@ With `AveragedTimeInterval`, the time-average of ``a`` is taken as a left Rieman
 ```math
 \langle a \rangle = \frac{1}{T} \int_{t_i-T}^{t_i} a \, \mathrm{d} t \, ,
 ```
-where $\langle a \rangle$ is the time-average of $a$, $T$ is the time-`window` for averaging specified by
-the `window` keyword argument to `AveragedTimeInterval`, and the $t_i$ are discrete times separated by the
-time `interval`. The $t_i$ specify both the end of the averaging window and the time at which output is written.
+where ``\langle a \rangle`` is the time-average of ``a``, ``T`` is the time-`window` for averaging specified by
+the `window` keyword argument to `AveragedTimeInterval`, and the ``t_i`` are discrete times separated by the
+time `interval`. The ``t_i`` specify both the end of the averaging window and the time at which output is written.
 
 ### Example
 

--- a/docs/src/model_setup/tracers.md
+++ b/docs/src/model_setup/tracers.md
@@ -39,7 +39,7 @@ Field located at (Cell, Cell, Cell)
 ```
 
 Any number of arbitrary tracers can be appended to this list and passed to a model constructor. For example, to evolve
-quantities $C_1$, CO₂, and nitrogen as additional passive tracers you could set them up as
+quantities ``C_1``, CO₂, and nitrogen as additional passive tracers you could set them up as
 
 ```jldoctest tracers
 julia> model = IncompressibleModel(grid=grid, tracers=(:T, :S, :C₁, :CO₂, :nitrogen))

--- a/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
+++ b/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
@@ -19,8 +19,8 @@ IsotropicDiffusivity: ν=0.01, κ=0.01
 
 ## Constant anisotropic diffusivity
 
-To specify constant values for the horizontal and vertical viscosities, $\nu_h$ and $\nu_v$, and horizontal and vertical
-diffusivities, $\kappa_h$ and $\kappa_v$, you can use [`AnisotropicDiffusivity`](@ref)
+To specify constant values for the horizontal and vertical viscosities, ``\nu_h`` and ``\nu_v``, and horizontal and vertical
+diffusivities, ``\kappa_h`` and ``\kappa_v``, you can use [`AnisotropicDiffusivity`](@ref)
 
 ```jldoctest
 julia> using Oceananigans.TurbulenceClosures

--- a/docs/src/numerical_implementation/boundary_conditions.md
+++ b/docs/src/numerical_implementation/boundary_conditions.md
@@ -10,27 +10,27 @@ boundary conditions in Oceananigans.
 
 ## Gradient boundary conditions
 
-Users impose gradient boundary conditions by prescribing the gradient $\gamma$ of a field $c$ across a
-*external boundary* $\partial \Omega_b$.
-The prescribed gradient $\gamma$ may be a constant, discrete array of values, or an arbitrary function.
+Users impose gradient boundary conditions by prescribing the gradient ``\gamma`` of a field ``c`` across a
+*external boundary* ``\partial \Omega_b``.
+The prescribed gradient ``\gamma`` may be a constant, discrete array of values, or an arbitrary function.
 The gradient boundary condition is enforced setting the value of halo points located outside the domain interior such that
 ```math
     \tag{eq:gradient-bc}
     \hat{\bm{n}} \bm{\cdot} \bm{\nabla} c |_{\partial \Omega_b} = \gamma \, .
 ```
-where $\hat{\bm{n}}$ is the vector normal to $\partial \Omega_b$.
+where ``\hat{\bm{n}}`` is the vector normal to ``\partial \Omega_b``.
 
-Across the bottom boundary in $z$, for example, this requires that
+Across the bottom boundary in ``z``, for example, this requires that
 ```math
     \tag{eq:linear-extrapolation}
     c_{i, j, 0} = c_{i, j, 1} + \gamma_{i, j, 1} \tfrac{1}{2} \left ( \Delta z_{i, j, 1} + \Delta z_{i, j, 0} \right ) \, ,
 ```
-where $\Delta z_{i, j, 1} = \Delta z_{i, j, 0}$ are the heights of the finite volume at $i, j$ and $k=1$ and $k=0$.
-This prescription implies that the $z$-derivative of $c$ across the boundary at $k=1$ is
+where ``\Delta z_{i, j, 1} = \Delta z_{i, j, 0}`` are the heights of the finite volume at ``i, j`` and ``k=1`` and ``k=0``.
+This prescription implies that the ``z``-derivative of ``c`` across the boundary at ``k=1`` is
 ```math
     \partial_z c \, |_{i, j, 1} \equiv
         \frac{c_{i, j, 1} - c_{i, j, 0}}{\tfrac{1}{2} \left ( \Delta z_{i, j, 1} + \Delta z_{i, j, 0} \right )}
-            = \gamma_{i, j, 1} , ,
+            = \gamma_{i, j, 1} \, ,
 ```
 as prescribed by the user.
 
@@ -38,57 +38,59 @@ Gradient boundary conditions are represented by the [`Gradient`](@ref) type.
 
 ## Value boundary conditions
 
-Users impose value boundary conditions by prescribing $c^b$, the value of $c$ on the external
-boundary $\partial \Omega_b$.
-The value $c^b$ may be a constant, array of discrete values, or an arbitrary function.
+Users impose value boundary conditions by prescribing ``c^b``, the value of ``c`` on the external
+boundary ``\partial \Omega_b``.
+The value ``c^b`` may be a constant, array of discrete values, or an arbitrary function.
 To enforce a value boundary condition, the gradient associated with the difference between
-$c^b$ and $c$ at boundary-adjacent nodes is diagnosed and used to set the value of the $c$ halo point
+``c^b`` and ``c`` at boundary-adjacent nodes is diagnosed and used to set the value of the ``c`` halo point
 located outside the boundary.
 
-At the bottom boundary in $z$, for example, this means that the gradient of $c$ is determined by
+At the bottom boundary in ``z``, for example, this means that the gradient of ``c`` is determined by
 ```math
 \gamma = \frac{c_{i, j, 1} - c^b_{i, j, 1}}{\tfrac{1}{2} \Delta z_{i, j, 1}} \, ,
 ```
-which is then used to set the halo point $c_{i, j, 0}$ via linear extrapolation.
+which is then used to set the halo point ``c_{i, j, 0}`` via linear extrapolation.
 
 Value boundary conditions are represented by the [`Value`](@ref) type.
 
 ## Flux boundary conditions
 
-Users impose flux boundary conditions by prescribing the flux $q_c \, |_b$ of $c$ across
-the external boundary $\partial \Omega_b$.
-The flux $q_c \, |_b$ may be a constant, array of discrete values, or arbitrary function.
+Users impose flux boundary conditions by prescribing the flux ``q_c \, |_b`` of ``c`` across
+the external boundary ``\partial \Omega_b``.
+The flux ``q_c \, |_b`` may be a constant, array of discrete values, or arbitrary function.
 To explain how flux boundary conditions are imposed in `Oceananigans.jl`, we note that
 the average of the tracer conservation equation over a finite volume yields
 ```math
     \partial_t c_{i, j, k} = \underbrace{ - \frac{1}{V_{i, j, k}} \oint_{\partial \Omega_{i, j, k}} \bm{u} c + \bm{q}_c \, \rm{d} S
                                           + \frac{1}{V_{i, j, k}} \int_{V_{i, j, k}} F_c \, \rm{d} V }_{\equiv G_c |_{i, j, k}} \, ,
 ```
-where the surface integral over $\partial \Omega_{i, j, k}$ averages the flux of $c$ across the six faces of the finite volume.
+where the surface integral over ``\partial \Omega_{i, j, k}`` averages the flux of ``c`` across the six faces of the finite volume.
 
 An external boundary of a finite volume is associated with a no-penetration condition such that
-$\hat{\bm{n}} \bm{\cdot} \bm{u} \, |_{\partial \Omega_b} = 0$, where $\hat{\bm{n}}$ is the vector normal to $\partial \Omega_b$.
-Furthermore, the closures currently available in \texttt{Oceananigans.jl} have the property that $\bm{q}_c \propto \bm{\nabla} c$.
-Thus setting $\hat{\bm{n}} \bm{\cdot} \bm{\nabla} c \, |_{\partial \Omega_b} = 0$ on the external boundary implies that the total
-flux of $c$ across the external boundary is
+``\hat{\bm{n}} \bm{\cdot} \bm{u} \, |_{\partial \Omega_b} = 0``, where ``\hat{\bm{n}}`` is the vector normal to ``\partial \Omega_b``.
+Furthermore, the closures currently available in \texttt{Oceananigans.jl} have the property that ``\bm{q}_c \propto \bm{\nabla} c``.
+Thus setting ``\hat{\bm{n}} \bm{\cdot} \bm{\nabla} c \, |_{\partial \Omega_b} = 0`` on the external boundary implies that the total
+flux of ``c`` across the external boundary is
 ```math
 \hat{\bm{n}} \bm{\cdot} \left ( \bm{u} c + \bm{q}_c \right ) |_{\partial \Omega_b} = 0 \, .
 ```
-`Oceananigans.jl` exploits this fact to define algorithm that prescribe fluxes across external boundaries $\partial \Omega_b$:
+`Oceananigans.jl` exploits this fact to define algorithm that prescribe fluxes across external boundaries ``\partial \Omega_b``:
 
-1. Impose a constant gradient $\hat{\bm{n}} \bm{\cdot} \bm{\nabla} c \, |_{\partial \Omega_b} = 0$ across external boundaries
-    via using halo points (similar to \eqref{eq:gradient-bc}), which ensures that the evaluation of $G_c$ in boundary-adjacent
+1. Impose a constant gradient ``\hat{\bm{n}} \bm{\cdot} \bm{\nabla} c \, |_{\partial \Omega_b} = 0`` across external boundaries
+    via using halo points (similar to \eqref{eq:gradient-bc}), which ensures that the evaluation of ``G_c`` in boundary-adjacent
     cells does not include fluxes across the external boundary, and;
-2. Add the prescribed flux to the boundary-adjacent volumes prior to calculating $G_c$
+2. Add the prescribed flux to the boundary-adjacent volumes prior to calculating ``G_c``
 
-    $G_c \, |_b = G_c \, |_b - \frac{A_b}{V_b} q_c \, |_b \, \text{sign}(\hat{\bm{n}}) \, ,$
+    ```math
+    G_c \, |_b = G_c \, |_b - \frac{A_b}{V_b} q_c \, |_b \, \text{sign}(\hat{\bm{n}}) \, ,
+    ```
 
-    where $G_c \, |_b$ denotes values of $G_c$ in boundary-adjacent volumes, $q_c \, |_b$ is the flux prescribed along the boundary,
-    $V_b$ is the volume of the boundary-adjacent cell, and $A_b$ is the area of the external boundary of the boundary-adjacent cell.
+    where ``G_c \, |_b`` denotes values of ``G_c`` in boundary-adjacent volumes, ``q_c \, |_b`` is the flux prescribed along the boundary,
+    ``V_b`` is the volume of the boundary-adjacent cell, and ``A_b`` is the area of the external boundary of the boundary-adjacent cell.
 
-    The factor $\text{sign}(\hat{\bm{n}})$ is -1 and +1 on "left" and "right" boundaries, and accounts for the fact that a positive
-    flux on a left boundary where $\text{sign}(\hat{\bm{n}}) = -1$ implies an "inward" flux of $c$ that increases interior values of $c$,
-    whereas a positive flux on a right boundary where $\text{sign}(\hat{\bm{n}}) = 1$ implies an "outward" flux that decreases interior
-    values of $c$.
+    The factor ``\text{sign}(\hat{\bm{n}})`` is ``-``1 and ``+``1 on "left" and "right" boundaries, and accounts for the fact that a positive
+    flux on a left boundary where ``\text{sign}(\hat{\bm{n}}) = -1`` implies an "inward" flux of ``c`` that increases interior values of ``c``,
+    whereas a positive flux on a right boundary where ``\text{sign}(\hat{\bm{n}}) = 1`` implies an "outward" flux that decreases interior
+    values of ``c``.
 
 Flux boundary conditions are represented by the [`Flux`](@ref) type.

--- a/docs/src/numerical_implementation/boundary_conditions.md
+++ b/docs/src/numerical_implementation/boundary_conditions.md
@@ -81,9 +81,7 @@ flux of ``c`` across the external boundary is
     cells does not include fluxes across the external boundary, and;
 2. Add the prescribed flux to the boundary-adjacent volumes prior to calculating ``G_c``
 
-    ```math
-    G_c \, |_b = G_c \, |_b - \frac{A_b}{V_b} q_c \, |_b \, \text{sign}(\hat{\bm{n}}) \, ,
-    ```
+    `` G_c \, |_b = G_c \, |_b - \frac{A_b}{V_b} q_c \, |_b \, \text{sign}(\hat{\bm{n}}) \, , ``
 
     where ``G_c \, |_b`` denotes values of ``G_c`` in boundary-adjacent volumes, ``q_c \, |_b`` is the flux prescribed along the boundary,
     ``V_b`` is the volume of the boundary-adjacent cell, and ``A_b`` is the area of the external boundary of the boundary-adjacent cell.

--- a/docs/src/numerical_implementation/finite_volume.md
+++ b/docs/src/numerical_implementation/finite_volume.md
@@ -1,31 +1,31 @@
 # Finite volume method on a staggered grid
 
 The `Oceananigans.jl` staggered grid is defined by a Cartesian array of cuboids of horizontal dimensions 
-$\Delta x_{i, j, k}, \Delta y_{i, j, k}$ and vertical dimension 
-$\Delta z_{i, j, k}$, where $(i, j, k)$ index the location of each cell in the staggered grid.
-Note that the indices $(i, j, k)$ increase with increasing coordinate $(x, y, z)$.
+``\Delta x_{i, j, k}, \Delta y_{i, j, k}`` and vertical dimension 
+``\Delta z_{i, j, k}``, where ``(i, j, k)`` index the location of each cell in the staggered grid.
+Note that the indices ``(i, j, k)`` increase with increasing coordinate ``(x, y, z)``.
 
 ![Schematic of staggered grid](assets/staggered_grid.png)
-*A schematic of \texttt{Oceananigans.jl} finite volumes for a two-dimensional staggered grid in $(x, z)$.
-Tracers $c$ and pressure $p$ are defined at the center of the control volume. The $u$ control volumes are 
-centered on the left and right edges of the pressure control volume while the $w$ control volumes are centered 
-on the top and bottom edges of the pressure control volumes. The indexing convention places the $i^{\rm{th}}$ 
-$u$-node on cell $x$-faces to the left of the $i$ tracer point at cell centers.*
+*A schematic of \texttt{Oceananigans.jl} finite volumes for a two-dimensional staggered grid in ``(x, z)``.
+Tracers ``c`` and pressure ``p`` are defined at the center of the control volume. The ``u`` control volumes are 
+centered on the left and right edges of the pressure control volume while the ``w`` control volumes are centered 
+on the top and bottom edges of the pressure control volumes. The indexing convention places the ``i^{\rm{th}}`` 
+``u``-node on cell ``x``-faces to the left of the ``i`` tracer point at cell centers.*
 
 Dropping explicit indexing, the areas of cell faces are given by
 ```math
     A_x = \Delta y \Delta z, \quad A_y = \Delta x \Delta z, \quad A_z = \Delta x \Delta y
 ```
-so that each cell encloses a volume $V = \Delta x \Delta y \Delta z$.
+so that each cell encloses a volume ``V = \Delta x \Delta y \Delta z``.
 
-A finite volume method discretizes a continuous quantity $c$ by considering its average over a finite volume:
+A finite volume method discretizes a continuous quantity ``c`` by considering its average over a finite volume:
 ```math
     c_{i, j, k} \equiv \frac{1}{V_{i, j, k}} \int c(\bm{x}) \, \rm{d} V_{i, j, k} \, .
 ```
-The finite volumes that discretize each of $u$, $v$, and $w$ are located on a grid which is "staggered" 
+The finite volumes that discretize each of ``u``, ``v``, and ``w`` are located on a grid which is "staggered" 
 with respect to the grid that defines tracer finite volumes. 
 The nodes, or central points of the velocity finite volumes are co-located with the faces of the tracer 
 finite volume.
-In particular, the $u$-nodes are located in the center of the "$x$-face" (east of the tracer point), 
-$v$-nodes are located on $y$-faces south of the tracer point, and $w$-nodes are located on 
-$z$-faces downwards from the tracer point.
+In particular, the ``u``-nodes are located in the center of the "``x``-face" (east of the tracer point), 
+``v``-nodes are located on ``y``-faces south of the tracer point, and ``w``-nodes are located on 
+``z``-faces downwards from the tracer point.

--- a/docs/src/numerical_implementation/finite_volume.md
+++ b/docs/src/numerical_implementation/finite_volume.md
@@ -14,7 +14,7 @@ on the top and bottom edges of the pressure control volumes. The indexing conven
 
 Dropping explicit indexing, the areas of cell faces are given by
 ```math
-    A_x = \Delta y \Delta z, \quad A_y = \Delta x \Delta z, \quad A_z = \Delta x \Delta y
+    A_x = \Delta y \Delta z, \quad A_y = \Delta x \Delta z, \quad A_z = \Delta x \Delta y \, ,
 ```
 so that each cell encloses a volume ``V = \Delta x \Delta y \Delta z``.
 

--- a/docs/src/numerical_implementation/large_eddy_simulation.md
+++ b/docs/src/numerical_implementation/large_eddy_simulation.md
@@ -2,13 +2,13 @@
 
 The idea behind large eddy simulation (LES) is to resolve the "large eddies" while modeling the effect of unresolved
 sub-grid scale motions. This is done usually be assuming eddy viscosity and eddy diffusivity models and providing an
-estimate for the eddy viscosity $\nu_e$ and diffusivity $\kappa_e$.
+estimate for the eddy viscosity ``\nu_e`` and diffusivity ``\kappa_e``.
 
 Much of the early work on LES was motivated by the study of atmospheric boundary layer turbulence, being developed
 by [Smagorinsky63](@cite) and [Lilly66](@cite), then first implemented by [Deardorff70](@cite) and [Deardorff74](@cite).
 
 In the LES framework, the Navier-Stokes equations are averaged in the same way as [Reynolds1895](@cite) except that the
-mean field $\overline{\bm{u}}$ is obtained via convolution with a filter convolution kernel~$G$
+mean field ``\overline{\bm{u}}`` is obtained via convolution with a filter convolution kernel ``G``
 ```math
 \overline{\bm{u}(\bm{x}, t)} = G \star \bm{u} =
   \int_{-\infty}^\infty \int_{-\infty}^\infty
@@ -16,19 +16,19 @@ mean field $\overline{\bm{u}}$ is obtained via convolution with a filter convolu
 ```
 as described by [Leonard75](@cite) who introduced the general filtering formalism.
 
-The $\overline{u_i^\prime u_j^\prime}$ terms are now components of what is called the sub-grid scale (SGS) stress
-tensor $\tau^\text{SGS}_{ij}$, which looks the same as the Reynolds stress tensor so we will drop the SGS superscript.
+The ``\overline{u_i^\prime u_j^\prime}`` terms are now components of what is called the sub-grid scale (SGS) stress
+tensor ``\tau^\text{SGS}_{ij}``, which looks the same as the Reynolds stress tensor so we will drop the SGS superscript.
 
 It is probably important to note that the large eddy simulation filtering operation does not satisfy the properties
 of a Reynolds operator (§2.1)[sagaut06](@cite) and that in general, the filtered residual is not zero:
-$\overline{\bm{u}^\prime(\bm{x}, t)} \ne 0$.
+``\overline{\bm{u}^\prime(\bm{x}, t)} \ne 0``.
 
-§13.2 of [Pope00](@cite) lists a number of popular choices for the filter function $G$. For practical reasons we
+§13.2 of [Pope00](@cite) lists a number of popular choices for the filter function ``G``. For practical reasons we
 simply employ the box kernel
 ```math
   G_\Delta = G(\bm{x}, t) = \frac{1}{\Delta} H \left( \frac{1}{2}\Delta - |\bm{x}| \right) \delta(t - t_n)
 ```
-where $H$ is the Heaviside function, $\Delta$ is the grid spacing, and $t_n$ is the current time step. With
+where ``H`` is the Heaviside function, ``\Delta`` is the grid spacing, and ``t_n`` is the current time step. With
 \eqref{eq:box-kernel} we get back the averaging operator originally used by [Deardorff70](@cite)
 ```math
 \overline{\bm{u}(x, y, z, t)} =
@@ -43,26 +43,26 @@ which if evaluated at the cell centers just returns the cell averages we already
 
 ## Smagorinsky-Lilly model
 
-[Smagorinsky63](@cite) estimated the eddy viscosity $\nu_e$ via a characteristic length scale $\Delta$ times a velocity
-scale given by $\Delta |\overline{S}|$ where $|\overline{S}| = \sqrt{2\overline{S}_{ij}\overline{S}_{ij}}$. Thus the
+[Smagorinsky63](@cite) estimated the eddy viscosity ``\nu_e`` via a characteristic length scale ``\Delta`` times a velocity
+scale given by ``\Delta |\overline{S}|`` where ``|\overline{S}| = \sqrt{2\overline{S}_{ij}\overline{S}_{ij}}``. Thus the
 SGS stress tensor is given by
 ```math
 \tau_{ij} = -2\nu_e \overline{S}_{ij} = -2 (C_s \Delta)^2 |\overline{S}| \overline{S}_{ij}
 ```
-where $C_s$ is a dimensionless constant. The grid spacing is usually used for the characteristic length scale $\Delta$.
-The eddy diffusivities are calculated via $\kappa_e = \nu_e / \text{Pr}_t$ where the turbulent Prandtl number
-$\text{Pr}_t$ is usually chosen to be $\mathcal{O}(1)$ from experimental observations.
+where ``C_s`` is a dimensionless constant. The grid spacing is usually used for the characteristic length scale ``\Delta``.
+The eddy diffusivities are calculated via ``\kappa_e = \nu_e / \text{Pr}_t`` where the turbulent Prandtl number
+``\text{Pr}_t`` is usually chosen to be ``\mathcal{O}(1)`` from experimental observations.
 
-Assuming that the SGS energy cascade is equal to the overall dissipation rate $\varepsilon$ from the
+Assuming that the SGS energy cascade is equal to the overall dissipation rate ``\varepsilon`` from the
 [Kolmogorov41](@cite) theory, [Lilly66](@cite) was able to derive a value of
 ```math
 C_s = \left( \frac{3}{2}C_K\pi^\frac{4}{3} \right)^{-\frac{3}{4}} \approx 0.16
 ```
-using an empirical value of $C_K \approx 1.6$ for the Kolmogorov constant. This seems reasonable for isotropic
-turbulence if the grid spacing $\Delta$ falls in the inertial range. In practice, $C_s$ is a tunable parameter.
+using an empirical value of ``C_K \approx 1.6`` for the Kolmogorov constant. This seems reasonable for isotropic
+turbulence if the grid spacing ``\Delta`` falls in the inertial range. In practice, ``C_s`` is a tunable parameter.
 
-Due to the presence of the constant $C_s$, the model is sometimes referred to as the *constant Smagorinsky* model
-in contrast to *dynamic Smagorinsky* models that dynamically compute $C_s$ to account for effects such as buoyant
+Due to the presence of the constant ``C_s``, the model is sometimes referred to as the *constant Smagorinsky* model
+in contrast to *dynamic Smagorinsky* models that dynamically compute ``C_s`` to account for effects such as buoyant
 convection.
 
 ## Anisotropic minimum dissipation models
@@ -83,13 +83,13 @@ the resulting eddy dissipation properly counteracts the spurious kinetic energy 
 to derive a modified AMD model.
 
 The eddy viscosity and diffusivity are defined in terms of eddy viscosity and diffusivity *predictors*
-$\nu_e^\dagger$ and $\kappa_e^\dagger$, such that
+``\nu_e^\dagger`` and ``\kappa_e^\dagger``, such that
 ```math
 \nu_e = \text{max} \lbrace 0, \nu_e^\dagger \rbrace
 \quad \text{and} \quad
 \kappa_e = \text{max} \lbrace 0, \kappa_e^\dagger \rbrace
 ```
-to ensure that $\nu_e \ge 0$ and $\kappa_e \ge 0$. Leaving out the overlines and understanding that all variables
+to ensure that ``\nu_e \ge 0`` and ``\kappa_e \ge 0``. Leaving out the overlines and understanding that all variables
 represent the resolved/filtered variables, the eddy viscosity predictor is given by
 ```math
 \nu_e^\dagger = -(C\Delta)^2
@@ -118,13 +118,13 @@ so that the normalized rate of strain tensor is
   \frac{1}{2} \left[ \hat{\partial}_i \hat{u}_j(\hat{x}, t) + \hat{\partial}_j \hat{u}_i(\hat{x}, t) \right]
 ```
 
-In equations \eqref{eq:nu-dagger}--\eqref{eq:S-hat} $C$ is a modified Poincaré "constant" that is independent from
-the filter width $\Delta$ but does depend on the accuracy of the discretization method used. [Abkar16](@cite) cite
-$C^2 = \frac{1}{12}$ for a spectral method and $C^2 = \frac{1}{3}$ for a second-order accurate scheme. $\Delta_i$ is
-the filter width in the $x_i$-direction, and $\Delta$ is given by the square root of the harmonic mean of the squares
+In equations \eqref{eq:nu-dagger}--\eqref{eq:S-hat} ``C`` is a modified Poincaré "constant" that is independent from
+the filter width ``\Delta`` but does depend on the accuracy of the discretization method used. [Abkar16](@cite) cite
+``C^2 = \frac{1}{12}`` for a spectral method and ``C^2 = \frac{1}{3}`` for a second-order accurate scheme. ``\Delta_i`` is
+the filter width in the ``x_i``-direction, and ``\Delta`` is given by the square root of the harmonic mean of the squares
 of the filter widths in each direction
 ```math
     \frac{1}{\Delta^2} = \frac{1}{3} \left( \frac{1}{\Delta x^2} + \frac{1}{\Delta y^2} + \frac{1}{\Delta z^2} \right)
 ```
-The term multiplying $C_b$ is the buoyancy modification introduced by [Abkar17](@cite) and is small for weakly
-stratified flows. We have introduced the $C_b$ constant so that the buoyancy modification term may be turned on and off.
+The term multiplying ``C_b`` is the buoyancy modification introduced by [Abkar17](@cite) and is small for weakly
+stratified flows. We have introduced the ``C_b`` constant so that the buoyancy modification term may be turned on and off.

--- a/docs/src/numerical_implementation/large_eddy_simulation.md
+++ b/docs/src/numerical_implementation/large_eddy_simulation.md
@@ -12,7 +12,7 @@ mean field ``\overline{\bm{u}}`` is obtained via convolution with a filter convo
 ```math
 \overline{\bm{u}(\bm{x}, t)} = G \star \bm{u} =
   \int_{-\infty}^\infty \int_{-\infty}^\infty
-  \bm{u}(\bm{x}^\prime, t) G(\bm{x} - \bm{x}^\prime, t - \tau) \, d\bm{x}^\prime \, d\tau
+  \bm{u}(\bm{x}^\prime, t) G(\bm{x} - \bm{x}^\prime, t - \tau) \, d\bm{x}^\prime \, d\tau \, ,
 ```
 as described by [Leonard75](@cite) who introduced the general filtering formalism.
 
@@ -26,7 +26,7 @@ of a Reynolds operator (§2.1)[sagaut06](@cite) and that in general, the filtere
 §13.2 of [Pope00](@cite) lists a number of popular choices for the filter function ``G``. For practical reasons we
 simply employ the box kernel
 ```math
-  G_\Delta = G(\bm{x}, t) = \frac{1}{\Delta} H \left( \frac{1}{2}\Delta - |\bm{x}| \right) \delta(t - t_n)
+  G_\Delta = G(\bm{x}, t) = \frac{1}{\Delta} H \left( \frac{1}{2}\Delta - |\bm{x}| \right) \delta(t - t_n) \, ,
 ```
 where ``H`` is the Heaviside function, ``\Delta`` is the grid spacing, and ``t_n`` is the current time step. With
 \eqref{eq:box-kernel} we get back the averaging operator originally used by [Deardorff70](@cite)
@@ -36,7 +36,7 @@ where ``H`` is the Heaviside function, ``\Delta`` is the grid spacing, and ``t_n
   \int_{x - \frac{1}{2}\Delta x}^{x + \frac{1}{2}\Delta x}
   \int_{y - \frac{1}{2}\Delta y}^{y + \frac{1}{2}\Delta y}
   \int_{z - \frac{1}{2}\Delta z}^{z + \frac{1}{2}\Delta z}
-  \bm{u}(\xi, \eta, \zeta, t) \, d\xi \, d\eta \, d\zeta
+  \bm{u}(\xi, \eta, \zeta, t) \, d\xi \, d\eta \, d\zeta \, ,
 ```
 which if evaluated at the cell centers just returns the cell averages we already compute in the finite volume method.
 
@@ -47,7 +47,7 @@ which if evaluated at the cell centers just returns the cell averages we already
 scale given by ``\Delta |\overline{S}|`` where ``|\overline{S}| = \sqrt{2\overline{S}_{ij}\overline{S}_{ij}}``. Thus the
 SGS stress tensor is given by
 ```math
-\tau_{ij} = -2\nu_e \overline{S}_{ij} = -2 (C_s \Delta)^2 |\overline{S}| \overline{S}_{ij}
+\tau_{ij} = -2\nu_e \overline{S}_{ij} = -2 (C_s \Delta)^2 |\overline{S}| \overline{S}_{ij} \, ,
 ```
 where ``C_s`` is a dimensionless constant. The grid spacing is usually used for the characteristic length scale ``\Delta``.
 The eddy diffusivities are calculated via ``\kappa_e = \nu_e / \text{Pr}_t`` where the turbulent Prandtl number
@@ -56,7 +56,7 @@ The eddy diffusivities are calculated via ``\kappa_e = \nu_e / \text{Pr}_t`` whe
 Assuming that the SGS energy cascade is equal to the overall dissipation rate ``\varepsilon`` from the
 [Kolmogorov41](@cite) theory, [Lilly66](@cite) was able to derive a value of
 ```math
-C_s = \left( \frac{3}{2}C_K\pi^\frac{4}{3} \right)^{-\frac{3}{4}} \approx 0.16
+C_s = \left( \frac{3}{2}C_K\pi^\frac{4}{3} \right)^{-\frac{3}{4}} \approx 0.16 \, ,
 ```
 using an empirical value of ``C_K \approx 1.6`` for the Kolmogorov constant. This seems reasonable for isotropic
 turbulence if the grid spacing ``\Delta`` falls in the inertial range. In practice, ``C_s`` is a tunable parameter.
@@ -87,7 +87,7 @@ The eddy viscosity and diffusivity are defined in terms of eddy viscosity and di
 ```math
 \nu_e = \text{max} \lbrace 0, \nu_e^\dagger \rbrace
 \quad \text{and} \quad
-\kappa_e = \text{max} \lbrace 0, \kappa_e^\dagger \rbrace
+\kappa_e = \text{max} \lbrace 0, \kappa_e^\dagger \rbrace \, ,
 ```
 to ensure that ``\nu_e \ge 0`` and ``\kappa_e \ge 0``. Leaving out the overlines and understanding that all variables
 represent the resolved/filtered variables, the eddy viscosity predictor is given by
@@ -96,35 +96,35 @@ represent the resolved/filtered variables, the eddy viscosity predictor is given
   \frac
     {\left( \hat{\partial}_k \hat{u}_i \right) \left( \hat{\partial}_k \hat{u}_j \right) \hat{S}_{ij}
     + C_b\hat{\delta}_{i3} \alpha g \left( \hat{\partial}_k \hat{u_i} \right) \hat{\partial}_k \theta}
-    {\left( \hat{\partial}_l \hat{u}_m \right) \left( \hat{\partial}_l \hat{u}_m \right)}
+    {\left( \hat{\partial}_l \hat{u}_m \right) \left( \hat{\partial}_l \hat{u}_m \right)} \, ,
 ```
 and the eddy diffusivity predictor by
 ```math
 \kappa_e^\dagger = -(C\Delta)^2
 \frac
     {\left( \hat{\partial}_k \hat{u}_i \right) \left( \hat{\partial}_k \hat{\theta} \right) \hat{\partial}_i \theta}
-    {\left( \hat{\partial}_l \hat{\theta} \right) \left( \hat{\partial}_l \hat{\theta} \right)}
+    {\left( \hat{\partial}_l \hat{\theta} \right) \left( \hat{\partial}_l \hat{\theta} \right)} \, ,
 ```
 where
 ```math
   \hat{x}_i = \frac{x_i}{\Delta_i}, \quad
   \hat{u}_i(\hat{x}, t) = \frac{u_i(x, t)}{\Delta_i}, \quad
   \hat{\partial}_i \hat{u}_j(\hat{x}, t) = \frac{\Delta_i}{\Delta_j} \partial_i u_j(x, t), \quad
-  \hat{\delta}_{i3} = \frac{\delta_{i3}}{\Delta 3}
+  \hat{\delta}_{i3} = \frac{\delta_{i3}}{\Delta 3} \, ,
 ```
 so that the normalized rate of strain tensor is
 ```math
 \hat{S}_{ij} =
-  \frac{1}{2} \left[ \hat{\partial}_i \hat{u}_j(\hat{x}, t) + \hat{\partial}_j \hat{u}_i(\hat{x}, t) \right]
+  \frac{1}{2} \left[ \hat{\partial}_i \hat{u}_j(\hat{x}, t) + \hat{\partial}_j \hat{u}_i(\hat{x}, t) \right] \, .
 ```
 
-In equations \eqref{eq:nu-dagger}--\eqref{eq:S-hat} ``C`` is a modified Poincaré "constant" that is independent from
+In equations \eqref{eq:nu-dagger}--\eqref{eq:S-hat}, ``C`` is a modified Poincaré "constant" that is independent from
 the filter width ``\Delta`` but does depend on the accuracy of the discretization method used. [Abkar16](@cite) cite
 ``C^2 = \frac{1}{12}`` for a spectral method and ``C^2 = \frac{1}{3}`` for a second-order accurate scheme. ``\Delta_i`` is
 the filter width in the ``x_i``-direction, and ``\Delta`` is given by the square root of the harmonic mean of the squares
 of the filter widths in each direction
 ```math
-    \frac{1}{\Delta^2} = \frac{1}{3} \left( \frac{1}{\Delta x^2} + \frac{1}{\Delta y^2} + \frac{1}{\Delta z^2} \right)
+    \frac{1}{\Delta^2} = \frac{1}{3} \left( \frac{1}{\Delta x^2} + \frac{1}{\Delta y^2} + \frac{1}{\Delta z^2} \right) \, .
 ```
 The term multiplying ``C_b`` is the buoyancy modification introduced by [Abkar17](@cite) and is small for weakly
 stratified flows. We have introduced the ``C_b`` constant so that the buoyancy modification term may be turned on and off.

--- a/docs/src/numerical_implementation/poisson_solvers.md
+++ b/docs/src/numerical_implementation/poisson_solvers.md
@@ -6,7 +6,7 @@ The pressure field is obtained by taking the divergence of the horizontal compon
 \eqref{eq:momentumStar} and invoking the vertical component to yield an elliptic Poisson equation for the
 non-hydrostatic kinematic pressure
 ```math
-\nabla^2\phi_{NH} = \frac{\nabla \cdot \bm{u}^n}{\Delta t} + \nabla \cdot \bm{G}_{\bm{u}} \equiv \mathscr{F}
+\nabla^2\phi_{NH} = \frac{\nabla \cdot \bm{u}^n}{\Delta t} + \nabla \cdot \bm{G}_{\bm{u}} \equiv \mathscr{F} \, ,
 ```
 along with homogenous Neumann boundary conditions ``\bm{u} \cdot \bm{\hat{n}} = 0`` (Neumann on ``\phi`` for wall-bounded
 directions and periodic otherwise) and where ``\mathscr{F}`` denotes the source term for the Poisson equation.
@@ -25,7 +25,7 @@ The method can be explained easily by taking the Fourier transform of both sides
 ```math
 -(k_x^2 + k_y^2 + k_z^2) \widehat{\phi}_{NH} = \widehat{\mathscr{F}}
 \quad \implies \quad
-\widehat{\phi}_{NH} = - \frac{\widehat{\mathscr{F}}}{k_x^2 + k_y^2 + k_z^2}
+\widehat{\phi}_{NH} = - \frac{\widehat{\mathscr{F}}}{k_x^2 + k_y^2 + k_z^2} \, ,
 ```
 where ``\widehat{\cdot}`` denotes the Fourier component. Here ``k_x``, ``k_y``, and ``k_z`` are the wavenumbers. However, when
 solving the equation on a staggered grid we require a solution for ``\phi_{NH}`` that is second-order accurate such that
@@ -35,7 +35,7 @@ eigenvalues ``\lambda_x``, ``\lambda_y``, and ``\lambda_z`` satisfying the discr
 appropriate boundary conditions. Thus, Poisson's equation's is diagonalized in Fourier space and the Fourier
 coefficients of the solution are easily solved for
 ```math
-\widehat{\phi}_{NH}(i, j, k) = - \frac{\widehat{\mathscr{F}}(i, j, k)}{\lambda^x_i + \lambda^y_j + \lambda^z_k}
+\widehat{\phi}_{NH}(i, j, k) = - \frac{\widehat{\mathscr{F}}(i, j, k)}{\lambda^x_i + \lambda^y_j + \lambda^z_k} \, .
 ```
 
 The eigenvalues are given by [Schumann88](@cite) and can also be tediously derived by plugging in the definition of the
@@ -45,7 +45,7 @@ discrete Fourier transform into \eqref{eq:poisson-spectral}
     \lambda^x_i &= 4\frac{N_x^2}{L_x^2} \sin^2 \left [ \frac{(i-1)\pi}{N_x}  \right ], \quad i=0,1, \dots,N_x-1 \\
     \lambda^x_j &= 4\frac{N_y^2}{L_y^2} \sin^2 \left [ \frac{(j-1)\pi}{N_y}  \right ], \quad j=0,1, \dots,N_y-1 \\
     \lambda^x_k &= 4\frac{N_z^2}{L_z^2} \sin^2 \left [ \frac{(k-1)\pi}{2N_z} \right ], \quad k=0,1, \dots,N_z-1
-\end{aligned}
+\end{aligned} \, ,
 ```
 where ``\lambda_x`` and ``\lambda_y`` correspond to periodic boundary conditions in the horizontal and ``\lambda_z`` to
 Neumann boundary conditions in the vertical.
@@ -77,7 +77,7 @@ along the vertical dimension.
 
 Expanding ``\phi_{NH}`` and ``\mathscr{F}`` into Fourier modes along the ``x`` and ``y`` directions
 ```math
-\phi_{ijk} = \sum_{m=1}^{N_x} \sum_{n=1}^{N_y} \tilde{\phi}_{mnk} \; e^{-i2\pi im / N_x} \;  e^{-i2\pi jn / N_y}
+\phi_{ijk} = \sum_{m=1}^{N_x} \sum_{n=1}^{N_y} \tilde{\phi}_{mnk} \; e^{-i2\pi im / N_x} \;  e^{-i2\pi jn / N_y} \, ,
 ```
 and recalling that Fourier transforms do ``\partial_x \rightarrow ik_x`` and ``\partial_y \rightarrow ik_y`` we can write
 \eqref{eq:poisson-pressure} as
@@ -85,7 +85,7 @@ and recalling that Fourier transforms do ``\partial_x \rightarrow ik_x`` and ``\
 \sum_{m=1}^{N_x} \sum_{n=1}^{N_y}
 \left\lbrace
     \partial_z^2 \tilde{\phi}_{mnk} - (k_x^2 + k_y^2) \tilde{\phi}_{mnk} - \tilde{\mathscr{F}}_{mnk}
-\right\rbrace e^{-i2\pi im / N_x}  e^{-i2\pi jn / N_y} = 0
+\right\rbrace e^{-i2\pi im / N_x}  e^{-i2\pi jn / N_y} = 0 \, .
 ```
 Discretizing the ``\partial_z^2`` derivative and equating the term inside the brackets to zero we arrive at
 ``N_x\times N_y`` symmetric tridiagonal systems of ``N_z`` linear equations for the Fourier modes:
@@ -94,7 +94,7 @@ Discretizing the ``\partial_z^2`` derivative and equating the term inside the br
 - \left\lbrace \frac{1}{\Delta z^F_{k-1}} + \frac{1}{\Delta z^F_k} + \Delta z^C_k (k_x^2 + k_y^2) \right\rbrace
   \tilde{\phi}_{mnk}
 + \frac{\tilde{\phi}_{mn,k+1}}{\Delta z^F_k}
-= \Delta z^C_k \tilde{\mathscr{F}}_{mnk}
+= \Delta z^C_k \tilde{\mathscr{F}}_{mnk} \, .
 ```
 
 ## Cosine transforms on the GPU
@@ -106,11 +106,11 @@ regular Fourier transform to a permuted version of the array.
 In this section we will be using the DCT-II as the definition of the forward cosine transform for a real signal of
 length ``N``
 ```math
-  \text{DCT}(X): \quad Y_k = 2 \sum_{j=0}^{N-1} \cos \left[ \frac{\pi(j + \frac{1}{2})k}{N} \right] X_j
+  \text{DCT}(X): \quad Y_k = 2 \sum_{j=0}^{N-1} \cos \left[ \frac{\pi(j + \frac{1}{2})k}{N} \right] X_j \, ,
 ```
 and the DCT-III as the definition of the inverse cosine transform
 ```math
-  \text{IDCT}(X): \quad Y_k = X_0 + 2 \sum_{j=1}^{N-1} \cos \left[ \frac{\pi j (k + \frac{1}{2})}{N} \right] X_j
+  \text{IDCT}(X): \quad Y_k = X_0 + 2 \sum_{j=1}^{N-1} \cos \left[ \frac{\pi j (k + \frac{1}{2})}{N} \right] X_j \, ,
 ```
 and will use ``\omega_M = e^{-2\pi i/M}`` to denote the ``M^\text{th}`` root of unity, sometimes called the twiddle factors
 in the context of FFT algorithms.
@@ -121,17 +121,17 @@ dimension by ordering the odd elements first followed by the even elements to pr
 ```math
     X^\prime_n =
     \begin{cases}
-        \displaystyle X_{2N}, \quad 0 \le n \le \left[ \frac{N-1}{2} \right] \\
-        \displaystyle X_{2N - 2n - 1}, \quad \left[ \frac{N+1}{2} \right] \le n \le N-1
+        \displaystyle X_{2N}, \quad 0 \le n \le \left[ \frac{N-1}{2} \right] \, , \\
+        \displaystyle X_{2N - 2n - 1}, \quad \left[ \frac{N+1}{2} \right] \le n \le N-1 \, ,
     \end{cases}
 ```
 where ``[a]`` indicates the integer part of ``a``. This should produce, for example,
 ```math
-    (a, b, c, d, e, f, g, h) \quad \rightarrow \quad (a, c, e, g, h, f, d, b)
+    (a, b, c, d, e, f, g, h) \quad \rightarrow \quad (a, c, e, g, h, f, d, b) \, ,
 ```
 after which \eqref{eq:FCT} is computed using
 ```math
-  Y = \text{DCT}(X) = 2 \text{Re} \left\lbrace \omega_{4N}^k \text{FFT} \lbrace X^\prime \rbrace \right\rbrace
+  Y = \text{DCT}(X) = 2 \text{Re} \left\lbrace \omega_{4N}^k \text{FFT} \lbrace X^\prime \rbrace \right\rbrace \, .
 ```
 
 ### 1D fast inverse cosine transform

--- a/docs/src/numerical_implementation/poisson_solvers.md
+++ b/docs/src/numerical_implementation/poisson_solvers.md
@@ -8,13 +8,13 @@ non-hydrostatic kinematic pressure
 ```math
 \nabla^2\phi_{NH} = \frac{\nabla \cdot \bm{u}^n}{\Delta t} + \nabla \cdot \bm{G}_{\bm{u}} \equiv \mathscr{F}
 ```
-along with homogenous Neumann boundary conditions $\bm{u} \cdot \bm{\hat{n}} = 0$ (Neumann on $\phi$ for wall-bounded
-directions and periodic otherwise) and where $\mathscr{F}$ denotes the source term for the Poisson equation.
+along with homogenous Neumann boundary conditions ``\bm{u} \cdot \bm{\hat{n}} = 0`` (Neumann on ``\phi`` for wall-bounded
+directions and periodic otherwise) and where ``\mathscr{F}`` denotes the source term for the Poisson equation.
 
 ## Direct method
 
 Discretizing elliptic problems that can be solved via a classical separation-of-variables approach, such as Poisson's
-equation, results in a linear system of equations $M\bm{x} = \bm{y}$ where $M$ is a real symmetric matrix of block
+equation, results in a linear system of equations ``M\bm{x} = \bm{y}`` where ``M`` is a real symmetric matrix of block
 tridiagonal form. This allows for the matrix to be decomposed and solved efficiently, provided that the eigenvalues and
 eigenvectors of the blocks are known (§2) [Buzbee70](@cite). In the case of Poisson's equation on a rectangle,
 [Hockney65](@cite) has taken advantage of the fact that the fast Fourier transform can be used to perform the matrix
@@ -27,11 +27,11 @@ The method can be explained easily by taking the Fourier transform of both sides
 \quad \implies \quad
 \widehat{\phi}_{NH} = - \frac{\widehat{\mathscr{F}}}{k_x^2 + k_y^2 + k_z^2}
 ```
-where $\widehat{\cdot}$ denotes the Fourier component. Here $k_x$, $k_y$, and $k_z$ are the wavenumbers. However, when
-solving the equation on a staggered grid we require a solution for $\phi_{NH}$ that is second-order accurate such that
-when when its Laplacian is computed, $\nabla^2\phi_{NH}$ matches $\mathscr{F}$ to machine precision. This is crucial to
+where ``\widehat{\cdot}`` denotes the Fourier component. Here ``k_x``, ``k_y``, and ``k_z`` are the wavenumbers. However, when
+solving the equation on a staggered grid we require a solution for ``\phi_{NH}`` that is second-order accurate such that
+when when its Laplacian is computed, ``\nabla^2\phi_{NH}`` matches ``\mathscr{F}`` to machine precision. This is crucial to
 ensure that the projection step in \S\ref{sec:fractional-step} works. To do this, the wavenumbers are replaced by
-eigenvalues $\lambda_x$, $\lambda_y$, and $\lambda_z$ satisfying the discrete form of Poisson's equation with
+eigenvalues ``\lambda_x``, ``\lambda_y``, and ``\lambda_z`` satisfying the discrete form of Poisson's equation with
 appropriate boundary conditions. Thus, Poisson's equation's is diagonalized in Fourier space and the Fourier
 coefficients of the solution are easily solved for
 ```math
@@ -47,12 +47,12 @@ discrete Fourier transform into \eqref{eq:poisson-spectral}
     \lambda^x_k &= 4\frac{N_z^2}{L_z^2} \sin^2 \left [ \frac{(k-1)\pi}{2N_z} \right ], \quad k=0,1, \dots,N_z-1
 \end{aligned}
 ```
-where $\lambda_x$ and $\lambda_y$ correspond to periodic boundary conditions in the horizontal and $\lambda_z$ to
+where ``\lambda_x`` and ``\lambda_y`` correspond to periodic boundary conditions in the horizontal and ``\lambda_z`` to
 Neumann boundary conditions in the vertical.
 
 There is also an ambiguity in the solution to Poisson's equation as it's only defined up to a constant. To resolve this
-we choose the solution with zero mean by setting the zeroth Fourier coefficient $\phi_{000}$ (corresponding to
-$k_x = k_y = k_z = 0$) to zero. This also has the added benefit of discarding the zero eigenvalue so we don't divide by
+we choose the solution with zero mean by setting the zeroth Fourier coefficient ``\phi_{000}`` (corresponding to
+``k_x = k_y = k_z = 0``) to zero. This also has the added benefit of discarding the zero eigenvalue so we don't divide by
 it.
 
 The Fast Fourier transforms are computed using FFTW.jl [[Frigo98](@cite) and [Frigo05](@cite)] on the CPU and using the
@@ -62,12 +62,12 @@ are performed on a staggered grid, DCT-II (`REDFT10`) is used to perform the for
 
 ## Direct method with a vertically stretched grid
 
-Using Fourier transforms for all three dimensions results in a method requiring $\mathcal{O}(N \log_2 N)$ operations
-where $N$ is the total number of grid points. This algorithm can be made even more efficient by solving a tridiagonal
+Using Fourier transforms for all three dimensions results in a method requiring ``\mathcal{O}(N \log_2 N)`` operations
+where ``N`` is the total number of grid points. This algorithm can be made even more efficient by solving a tridiagonal
 system along one of the dimensions and utilizing cyclic reduction. This results in the *Fourier analysis cyclic
-reduction* or $\text{FACR}(\ell)$ algorithm (with $\ell$ cyclic reduction steps) which requires only
-$\mathcal{O}(N \log_2\log_2 N)$ operations provided the optimal number of cyclic reduction steps is taken, which is
-$\ell = \log_2 \log_2 n$ where $n$ is the number of grid points in the cyclic reduction dimension. The FACR algorithm
+reduction* or ``\text{FACR}(\ell)`` algorithm (with ``\ell`` cyclic reduction steps) which requires only
+``\mathcal{O}(N \log_2\log_2 N)`` operations provided the optimal number of cyclic reduction steps is taken, which is
+``\ell = \log_2 \log_2 n`` where ``n`` is the number of grid points in the cyclic reduction dimension. The FACR algorithm
 was first developed by [Hockney69](@cite) and is well reviewed by [Swarztrauber77](@cite) then further benchmarked and
 extended by [Temperton79](@cite) and [Temperton80](@cite).
 
@@ -75,11 +75,11 @@ Furthermore, the FACR algorithm removes the restriction that the grid is uniform
 be utilized to implement a fast Poisson solver for vertically stretched grids if the cyclic reduction is applied in the
 along the vertical dimension.
 
-Expanding $\phi_{NH}$ and $\mathscr{F}$ into Fourier modes along the $x$ and $y$ directions
+Expanding ``\phi_{NH}`` and ``\mathscr{F}`` into Fourier modes along the ``x`` and ``y`` directions
 ```math
 \phi_{ijk} = \sum_{m=1}^{N_x} \sum_{n=1}^{N_y} \tilde{\phi}_{mnk} \; e^{-i2\pi im / N_x} \;  e^{-i2\pi jn / N_y}
 ```
-and recalling that Fourier transforms do $\partial_x \rightarrow ik_x$ and $\partial_y \rightarrow ik_y$ we can write
+and recalling that Fourier transforms do ``\partial_x \rightarrow ik_x`` and ``\partial_y \rightarrow ik_y`` we can write
 \eqref{eq:poisson-pressure} as
 ```math
 \sum_{m=1}^{N_x} \sum_{n=1}^{N_y}
@@ -87,8 +87,8 @@ and recalling that Fourier transforms do $\partial_x \rightarrow ik_x$ and $\par
     \partial_z^2 \tilde{\phi}_{mnk} - (k_x^2 + k_y^2) \tilde{\phi}_{mnk} - \tilde{\mathscr{F}}_{mnk}
 \right\rbrace e^{-i2\pi im / N_x}  e^{-i2\pi jn / N_y} = 0
 ```
-Discretizing the $\partial_z^2$ derivative and equating the term inside the brackets to zero we arrive at
-$N_x\times N_y$ symmetric tridiagonal systems of $N_z$ linear equations for the Fourier modes:
+Discretizing the ``\partial_z^2`` derivative and equating the term inside the brackets to zero we arrive at
+``N_x\times N_y`` symmetric tridiagonal systems of ``N_z`` linear equations for the Fourier modes:
 ```math
 \frac{\tilde{\phi}_{mn,k-1}}{\Delta z^F_{k-1}}
 - \left\lbrace \frac{1}{\Delta z^F_{k-1}} + \frac{1}{\Delta z^F_k} + \Delta z^C_k (k_x^2 + k_y^2) \right\rbrace
@@ -104,7 +104,7 @@ We implemented the fast 1D and 2D cosine transforms described by [Makhoul80](@ci
 regular Fourier transform to a permuted version of the array.
 
 In this section we will be using the DCT-II as the definition of the forward cosine transform for a real signal of
-length $N$
+length ``N``
 ```math
   \text{DCT}(X): \quad Y_k = 2 \sum_{j=0}^{N-1} \cos \left[ \frac{\pi(j + \frac{1}{2})k}{N} \right] X_j
 ```
@@ -112,7 +112,7 @@ and the DCT-III as the definition of the inverse cosine transform
 ```math
   \text{IDCT}(X): \quad Y_k = X_0 + 2 \sum_{j=1}^{N-1} \cos \left[ \frac{\pi j (k + \frac{1}{2})}{N} \right] X_j
 ```
-and will use $\omega_M = e^{-2\pi i/M}$ to denote the $M^\text{th}$ root of unity, sometimes called the twiddle factors
+and will use ``\omega_M = e^{-2\pi i/M}`` to denote the ``M^\text{th}`` root of unity, sometimes called the twiddle factors
 in the context of FFT algorithms.
 
 ### 1D fast cosine transform
@@ -125,7 +125,7 @@ dimension by ordering the odd elements first followed by the even elements to pr
         \displaystyle X_{2N - 2n - 1}, \quad \left[ \frac{N+1}{2} \right] \le n \le N-1
     \end{cases}
 ```
-where $[a]$ indicates the integer part of $a$. This should produce, for example,
+where ``[a]`` indicates the integer part of ``a``. This should produce, for example,
 ```math
     (a, b, c, d, e, f, g, h) \quad \rightarrow \quad (a, c, e, g, h, f, d, b)
 ```
@@ -144,14 +144,14 @@ after which the inverse permutation of \eqref{eq:permutation} must be applied.
 ### 2D fast cosine transform
 Unfortunately, the 1D algorithm cannot be applied dimension-wise so the 2D algorithm is  more complicated. Thankfully
 though, the permutation \eqref{eq:permutation} can be applied dimension-wise. The forward cosine transform for a real
-signal of length $N_1 \times N_2$ is then given by
+signal of length ``N_1 \times N_2`` is then given by
 ```math
 Y_{k_1, k_2} = \text{DCT}(X_{n_1, n_2}) =
 2 \text{Re} \left\lbrace
     \omega_{4N_1}^k \left( \omega_{4N_2}^k \tilde{X} + \omega_{4N_2}^{-k} \tilde{X}^- \right)
 \right\rbrace
 ```
-where $\tilde{X} = \text{FFT}(X^\prime)$ and $\tilde{X}^-$ indicates that $\tilde{X}$ is indexed in reverse.
+where ``\tilde{X} = \text{FFT}(X^\prime)`` and ``\tilde{X}^-`` indicates that ``\tilde{X}`` is indexed in reverse.
 
 ### 2D fast inverse cosine transform
 The inverse can be computed using
@@ -163,9 +163,9 @@ Y_{k_1, k_2} = \text{IDCT}(X_{n_1, n_2}) =
     - i \left( M_1 \tilde{X}^{-+} + M_2 \tilde{X}^{+-} \right)
 \right\rbrace
 ```
-where $\tilde{X} = \text{IFFT}(X)$ here, $\tilde{X}^{-+}$ is indexed in reverse along the first dimension,
-$\tilde{X}^{-+}$ along the second dimension, and ``\tilde{X}^{--}`` along both. $M_1$ and $M_2$ are masks of lengths
-$N_1$ and $N_2$ respectively, both containing ones except at the first element where $M_0 = 0$. Afterwards, the inverse
+where ``\tilde{X} = \text{IFFT}(X)`` here, ``\tilde{X}^{-+}`` is indexed in reverse along the first dimension,
+``\tilde{X}^{-+}`` along the second dimension, and ``\tilde{X}^{--}`` along both. ``M_1`` and ``M_2`` are masks of lengths
+``N_1`` and ``N_2`` respectively, both containing ones except at the first element where ``M_0 = 0``. Afterwards, the inverse
 permutation of \eqref{eq:permutation} must be applied.
 
 Due to the extra steps involved in calculating the cosine transform in 2D, running with two wall-bounded dimensions

--- a/docs/src/numerical_implementation/pressure_decomposition.md
+++ b/docs/src/numerical_implementation/pressure_decomposition.md
@@ -1,6 +1,6 @@
 # Pressure decomposition
 
-In the numerical implementation of the momentum equations, the kinematic potential $\phi$ 
+In the numerical implementation of the momentum equations, the kinematic potential ``\phi`` 
 is split into "hydrostatic anomaly" and "non-hydrostatic" parts via
 ```math
     \tag{eq:pressure}
@@ -30,4 +30,4 @@ Under this pressure decomposition the momentum equation becomes
    \partial_t \bm{u} + \left ( \bm{u} \bm{\cdot} \bm{\nabla} \right ) \bm{u} + \bm{f} \times \bm{u} = 
     - \bm{\nabla} \phi_{\rm{non}} - \bm{\nabla}_h \phi_{\rm{hyd}} - \bm{\nabla} \bm{\cdot} \bm{\tau} + \bm{F_u} \, .
 ```
-Mathematically, the non-hydrostatic potential $\phi_{\rm{non}}$ enforces the incompressibility constraint.
+Mathematically, the non-hydrostatic potential ``\phi_{\rm{non}}`` enforces the incompressibility constraint.

--- a/docs/src/numerical_implementation/pressure_decomposition.md
+++ b/docs/src/numerical_implementation/pressure_decomposition.md
@@ -4,12 +4,12 @@ In the numerical implementation of the momentum equations, the kinematic potenti
 is split into "hydrostatic anomaly" and "non-hydrostatic" parts via
 ```math
     \tag{eq:pressure}
-    \phi(\bm{x}, t) = \phi_{\rm{hyd}}(\bm{x}, t) + \phi_{\rm{non}}(\bm{x}, t)
+    \phi(\bm{x}, t) = \phi_{\rm{hyd}}(\bm{x}, t) + \phi_{\rm{non}}(\bm{x}, t) \, .
 ```
 The anomalous hydrostatic component of the kinematic potential is defined by 
 ```math
     \tag{eq:hydrostaticpressure}
-    \partial_z \phi_{\rm{hyd}} \equiv -b
+    \partial_z \phi_{\rm{hyd}} \equiv -b \, ,
 ```
 such that the sum of the kinematic potential and buoyancy perturbation becomes
 ```math

--- a/docs/src/numerical_implementation/spatial_operators.md
+++ b/docs/src/numerical_implementation/spatial_operators.md
@@ -126,7 +126,7 @@ An isotropic viscosity operator acting on vertical momentum is discretized via
           \delta_x^{faa} \left( \nu_e \overline{A_x}^{caa} \delta_x^{caa} w \right)
         + \delta_y^{afa} \left( \nu_e \overline{A_y}^{aca} \delta_y^{aca} w \right)
         + \delta_z^{aaf} \left( \nu_e \overline{A_z}^{aac} \delta_z^{aac} w \right)
-    \right ]
+    \right ] \, ,
 ```
 where ``\nu`` is the kinematic viscosity.
 
@@ -137,20 +137,20 @@ An isotropic diffusion operator acting on a tracer ``c``, on the other hand, is 
         \delta_x^{caa} \left( \kappa_e A_x \delta_x^{faa} c \right)
       + \delta_y^{aca} \left( \kappa_e A_y \delta_y^{afa} c \right)
       + \delta_z^{aac} \left( \kappa_e A_z \delta_z^{aaf} c \right)
-    \right]
+    \right] \, .
 ```
 
 ## Vertical integrals
 Vertical integrals are converted into sums along each column. For example, the hydrostatic pressure anomaly is
 ```math
-    p_{HY}^\prime = \int_{-L_z}^0 b^\prime \; dz
+    p_{HY}^\prime = \int_{-L_z}^0 b^\prime \; dz \, ,
 ```
 where ``b^\prime`` is the buoyancy perturbation. Converting it into a sum that we compute from the top downwards we get
 ```math
     p_{HY}^\prime(k) =
         \begin{cases}
-            - \overline{b_{N_z}^\prime}^{aaf} \Delta z^F_{N_z},               & \quad k = N_z \\
-            p_{HY}^\prime(k+1) - \overline{b_{k+1}^\prime}^{aaf} \Delta z^F_k, & \quad 1 \le k \le N_z - 1
+            - \overline{b_{N_z}^\prime}^{aaf} \Delta z^F_{N_z},               & \quad k = N_z \, , \\
+            p_{HY}^\prime(k+1) - \overline{b_{k+1}^\prime}^{aaf} \Delta z^F_k, & \quad 1 \le k \le N_z - 1 \, ,
         \end{cases}
 ```
 where we converted the sum into a recursive definition for ``p_{HY}^\prime(k)`` in terms of ``p_{HY}^\prime(k+1)`` so that
@@ -158,7 +158,7 @@ the integral may be computed with ``\mathcal{O}(N_z)`` operations by a single th
 
 The vertical velocity ``w`` may be computed from ``u`` and ``v`` via the continuity equation
 ```math
-    w = - \int_{-L_z}^0 \left(\frac{\partial u}{\partial x} + \frac{\partial v}{\partial y} \right) \, dz
+    w = - \int_{-L_z}^0 \left(\frac{\partial u}{\partial x} + \frac{\partial v}{\partial y} \right) \, dz \, ,
 ```
 to satisfy the incompressibility condition ``\nabla\cdot\bm{u} = 0`` to numerical precision. This also involves computing
 a vertical integral, in this case evaluated from the bottom up

--- a/docs/src/numerical_implementation/spatial_operators.md
+++ b/docs/src/numerical_implementation/spatial_operators.md
@@ -7,7 +7,7 @@ material in this section is derived from [Marshall97FV](@cite).
 ## Differences
 
 Difference operators act as the discrete form of the derivative operator. Care must be taken when calculating
-differences on a staggered grid. For example, the the difference of a cell-centered variable such as temperature $T$
+differences on a staggered grid. For example, the the difference of a cell-centered variable such as temperature ``T``
 lies on the faces  in the direction of the difference, and vice versa. In principle, there are three difference
 operators, one for each  direction
 ```math
@@ -15,10 +15,10 @@ operators, one for each  direction
   \delta_y f = f_N - f_S , \quad
   \delta_z f = f_T - f_B ,
 ```
-where the $E$ and $W$ subscripts indicate that the value is evaluated the eastern or western wall of the cell, $N$ and
-$S$ indicate the northern and southern walls, and $T$ and $B$ indicate the top and bottom walls.
+where the ``E`` and ``W`` subscripts indicate that the value is evaluated the eastern or western wall of the cell, ``N`` and
+``S`` indicate the northern and southern walls, and ``T`` and ``B`` indicate the top and bottom walls.
 
-Additionally, two $\delta$ operators must be defined for each direction to account for the staggered nature of the grid.
+Additionally, two ``\delta`` operators must be defined for each direction to account for the staggered nature of the grid.
 One for taking the difference of a cell-centered variable and projecting it onto the cell faces
 ```math
 \begin{aligned}
@@ -73,11 +73,11 @@ The divergence of the flux of a cell-centered quantity over the cell can be calc
                    + \delta_y^{afa} (A_y f_y)
                    + \delta_z^{aaf} (A_z f_z) \right]
 ```
-where $\bm{f} = (f_x, f_y, f_z)$ is the flux with components defined normal to the faces, and $V$ is the volume of
+where ``\bm{f} = (f_x, f_y, f_z)`` is the flux with components defined normal to the faces, and ``V`` is the volume of
 the cell. The presence of a solid boundary is indicated by setting the appropriate flux normal to the boundary to zero.
 
-A similar divergence operator can be defined for a face-centered quantity. The divergence of the flux of $T$ over a
-cell,  $\nabla \cdot (\bm{u} T)$, required in the evaluation of $G_T$, for example, is then
+A similar divergence operator can be defined for a face-centered quantity. The divergence of the flux of ``T`` over a
+cell,  ``\nabla \cdot (\bm{u} T)``, required in the evaluation of ``G_T``, for example, is then
 ```math
 \renewcommand{\div}[1] {\nabla \cdot \left ( #1 \right )}
 \div{\bm{u} T}
@@ -85,13 +85,13 @@ cell,  $\nabla \cdot (\bm{u} T)$, required in the evaluation of $G_T$, for examp
                    + \delta_y^{aca} (A_y v \overline{T}^{afa})
                    + \delta_z^{aac} (A_z w \overline{T}^{aaf}) \right]
 ```
-where $T$ is interpolated onto the cell faces where it can be multiplied by the velocities, which are then differenced
-and  projected onto the cell centers where they added together and then added to $G_T$ which also lives at the cell
+where ``T`` is interpolated onto the cell faces where it can be multiplied by the velocities, which are then differenced
+and  projected onto the cell centers where they added together and then added to ``G_T`` which also lives at the cell
 centers.
 
 ## Momentum advection
 
-The advection terms that make up the $\mathbf{G}$ terms in equations \eqref{eq:horizontalMomentum} and
+The advection terms that make up the ``\mathbf{G}`` terms in equations \eqref{eq:horizontalMomentum} and
 \eqref{eq:verticalMomentum} can be mathematically written as, e.g,
 ```math
 \renewcommand{\div}[1] {\nabla \cdot \left ( #1 \right )}
@@ -102,7 +102,7 @@ The advection terms that make up the $\mathbf{G}$ terms in equations \eqref{eq:h
 which can then be discretized similarly to the flux divergence operator, however, they must be discretized differently
 for each direction.
 
-For example, the $x$-momentum advection operator is discretized as
+For example, the ``x``-momentum advection operator is discretized as
 ```math
 \bm{u} \cdot \nabla u
 = \frac{1}{\overline{V}^x} \left[
@@ -111,10 +111,10 @@ For example, the $x$-momentum advection operator is discretized as
   + \delta_z^{aaf} \left( \overline{A_z w}^{aac} \overline{u}^{aac} \right)
 \right]
 ```
-where $\overline{V}^x$ is the average of the volumes of the cells on either side of the face in question. Calculating
-$\partial(uu)/\partial x$ can be performed by interpolating $A_x u$ and $u$ onto the cell centers then multiplying them
-and differencing them back onto the faces. However, in the case of the the two other terms, $\partial(vu)/\partial y$
-and $\partial(wu)/\partial z$, the two variables must be interpolated onto the cell edges to be multiplied then
+where ``\overline{V}^x`` is the average of the volumes of the cells on either side of the face in question. Calculating
+``\partial(uu)/\partial x`` can be performed by interpolating ``A_x u`` and ``u`` onto the cell centers then multiplying them
+and differencing them back onto the faces. However, in the case of the the two other terms, ``\partial(vu)/\partial y``
+and ``\partial(wu)/\partial z``, the two variables must be interpolated onto the cell edges to be multiplied then
 differenced back onto the cell faces.
 
 ## Discretization of isotropic diffusion operators
@@ -128,9 +128,9 @@ An isotropic viscosity operator acting on vertical momentum is discretized via
         + \delta_z^{aaf} \left( \nu_e \overline{A_z}^{aac} \delta_z^{aac} w \right)
     \right ]
 ```
-where $\nu$ is the kinematic viscosity.
+where ``\nu`` is the kinematic viscosity.
 
-An isotropic diffusion operator acting on a tracer $c$, on the other hand, is discretized via
+An isotropic diffusion operator acting on a tracer ``c``, on the other hand, is discretized via
 ```math
    \bm{\nabla} \bm{\cdot} \left ( \kappa_e \bm{\nabla} c \right ) =
     = \frac{1}{V} \left[
@@ -145,7 +145,7 @@ Vertical integrals are converted into sums along each column. For example, the h
 ```math
     p_{HY}^\prime = \int_{-L_z}^0 b^\prime \; dz
 ```
-where $b^\prime$ is the buoyancy perturbation. Converting it into a sum that we compute from the top downwards we get
+where ``b^\prime`` is the buoyancy perturbation. Converting it into a sum that we compute from the top downwards we get
 ```math
     p_{HY}^\prime(k) =
         \begin{cases}
@@ -153,14 +153,14 @@ where $b^\prime$ is the buoyancy perturbation. Converting it into a sum that we 
             p_{HY}^\prime(k+1) - \overline{b_{k+1}^\prime}^{aaf} \Delta z^F_k, & \quad 1 \le k \le N_z - 1
         \end{cases}
 ```
-where we converted the sum into a recursive definition for $p_{HY}^\prime(k)$ in terms of $p_{HY}^\prime(k+1)$ so that
-the integral may be computed with $\mathcal{O}(N_z)$ operations by a single thread.
+where we converted the sum into a recursive definition for ``p_{HY}^\prime(k)`` in terms of ``p_{HY}^\prime(k+1)`` so that
+the integral may be computed with ``\mathcal{O}(N_z)`` operations by a single thread.
 
-The vertical velocity $w$ may be computed from $u$ and $v$ via the continuity equation
+The vertical velocity ``w`` may be computed from ``u`` and ``v`` via the continuity equation
 ```math
     w = - \int_{-L_z}^0 \left(\frac{\partial u}{\partial x} + \frac{\partial v}{\partial y} \right) \, dz
 ```
-to satisfy the incompressibility condition $\nabla\cdot\bm{u} = 0$ to numerical precision. This also involves computing
+to satisfy the incompressibility condition ``\nabla\cdot\bm{u} = 0`` to numerical precision. This also involves computing
 a vertical integral, in this case evaluated from the bottom up
 ```math
     w_k =

--- a/docs/src/numerical_implementation/spatial_operators.md
+++ b/docs/src/numerical_implementation/spatial_operators.md
@@ -165,7 +165,7 @@ a vertical integral, in this case evaluated from the bottom up
 ```math
     w_k =
         \begin{cases}
-            0, & \quad k = 1 \\
-            w_{k-1} - \left( \partial_x^{caa} u + \partial_y^{aca} v \right) \Delta z^C_k, & \quad 2 \le k \le N_z
+            0, & \quad k = 1 \, , \\
+            w_{k-1} - \left( \partial_x^{caa} u + \partial_y^{aca} v \right) \Delta z^C_k, & \quad 2 \le k \le N_z \, .
         \end{cases}
 ```

--- a/docs/src/numerical_implementation/time_stepping.md
+++ b/docs/src/numerical_implementation/time_stepping.md
@@ -1,7 +1,7 @@
 # Time-stepping and the fractional step method
 
-The time-integral of the momentum equation with the pressure decomposition from time step $n$ at $t = t_n$ 
-to time step $n+1$ at $t_{n+1}$ is
+The time-integral of the momentum equation with the pressure decomposition from time step ``n`` at ``t = t_n`` 
+to time step ``n+1`` at ``t_{n+1}`` is
 ```math
     \tag{eq:momentum-time-integral}
     \bm{u}^{n+1} - \bm{u}^n = 
@@ -12,18 +12,18 @@ to time step $n+1$ at $t_{n+1}$ is
                                     + \bm{\nabla} \bm{\cdot} \bm{\tau} 
                                     + \bm{F}_{\bm{u}} \Big ] \, \rm{d} t \, ,
 ```
-where the superscript $n$ and $n+1$ imply evaluation at $t_n$ and $t_{n+1}$, 
-such that $\bm{u}^n \equiv \bm{u}(t=t_n)$.
+where the superscript ``n`` and ``n+1`` imply evaluation at ``t_n`` and ``t_{n+1}``, 
+such that ``\bm{u}^n \equiv \bm{u}(t=t_n)``.
 The crux of the fractional step method is to treat the pressure term 
-$\bm{\nabla} \phi_{\rm{non}}$ implicitly using the approximation
+``\bm{\nabla} \phi_{\rm{non}}`` implicitly using the approximation
 ```math
 \int_{t_n}^{t_{n+1}} \bm{\nabla} \phi_{\rm{non}} \, \rm{d} t \approx 
     \Delta t \bm{\nabla} \phi_{\rm{non}}^{n+1} \, ,
 ```
 while treating the rest of the terms on the right hand side of \eqref{eq:momentum-time-integral} explicitly.
-The implicit treatment of pressure ensures that the velocity field obtained at time step $n+1$ is divergence-free.
+The implicit treatment of pressure ensures that the velocity field obtained at time step ``n+1`` is divergence-free.
 
-To effect such a fractional step method, we define an intermediate velocity field $\bm{u}^\star$ such that
+To effect such a fractional step method, we define an intermediate velocity field ``\bm{u}^\star`` such that
 ```math
     \tag{eq:intermediate-velocity-field}
     \bm{u}^\star - \bm{u}^n = \int_{t_n}^{t_{n+1}} \bm{G}_{\bm{u}} \, \rm{d} t \, ,
@@ -37,35 +37,35 @@ where
                        + \bm{F}_{\bm{u}}
 ```
 collects all terms on the right side of the time-integral of the momentum equation except the contribution 
-of non-hydrostatic pressure $\bm{\nabla} \phi_n$.
-The integral on the right of the equation for $\bm{u}^\star$ may be approximated by a variety of 
+of non-hydrostatic pressure ``\bm{\nabla} \phi_n``.
+The integral on the right of the equation for ``\bm{u}^\star`` may be approximated by a variety of 
 explicit methods: for example, a forward Euler method uses
 ```math
     \int_{t_n}^{t_{n+1}} G \, \rm{d} t \approx \Delta t G^n \, ,
     \tag{eq:forward-euler}
 ```
-for any time-dependent function $G(t)$, while a second-order Adams-Bashforth method uses the approximation
+for any time-dependent function ``G(t)``, while a second-order Adams-Bashforth method uses the approximation
 ```math
     \tag{eq:adams-bashforth}
     \int_{t_n}^{t_{n+1}} G \, \rm{d} t \approx 
         \Delta t \left [ \left ( \tfrac{3}{2} + \chi \right ) G^n 
         - \left ( \tfrac{1}{2} + \chi \right ) G^{n-1} \right ] \, ,
 ```
-where $\chi$ is a parameter. Ascher et al. (1995) claim that $\chi = \tfrac{1}{8}$ is optimal; 
-$\chi=-\tfrac{1}{2}$ yields the forward Euler scheme.
+where ``\chi`` is a parameter. Ascher et al. (1995) claim that ``\chi = \tfrac{1}{8}`` is optimal; 
+``\chi=-\tfrac{1}{2}`` yields the forward Euler scheme.
 
-Combining the equations for $\bm{u}^\star$ and the time integral of the momentum equation yields
+Combining the equations for ``\bm{u}^\star`` and the time integral of the momentum equation yields
 ```math
     \tag{eq:fractional-step}
     \bm{u}^{n+1} - \bm{u}^\star = - \Delta t \bm{\nabla} \phi_{\rm{non}}^{n+1} \, \rm{d} t \, .
 ```
 Taking the divergence of fractional step equation and requiring that 
-$\bm{\nabla} \bm{\cdot} \bm{u}^{n+1} = 0$ yields a Poisson equation for the potential 
-$\phi_{\rm{non}}$ at time-step $n+1$:
+``\bm{\nabla} \bm{\cdot} \bm{u}^{n+1} = 0`` yields a Poisson equation for the potential 
+``\phi_{\rm{non}}`` at time-step ``n+1``:
 ```math
     \bm{\nabla}^2 \phi_{\rm{non}}^{n+1} = \frac{\bm{\nabla} \bm{\cdot} \bm{u}^{\star}}{\Delta t} \, .
 ```
-With $\bm{u}^\star$ and $\phi_{\rm{non}}$, $\bm{u}^{n+1}$ is then computed via the fractional step equation.
+With ``\bm{u}^\star`` and ``\phi_{\rm{non}}``, ``\bm{u}^{n+1}`` is then computed via the fractional step equation.
 
 Tracers are stepped forward explicitly via
 ```math
@@ -77,4 +77,4 @@ where
     G_c \equiv - \bm{\nabla} \bm{\cdot} \left ( \bm{u} c \right ) - \bm{\nabla} \bm{\cdot} \bm{q}_c + F_c \, ,
 ```
 and the same forward Euler or Adams-Bashforth scheme as for the explicit evaluation of the time-integral of
-$\bm{G}_u$ is used to evaluate the integral of $G_c$.
+``\bm{G}_u`` is used to evaluate the integral of ``G_c``.

--- a/docs/src/numerical_implementation/turbulence_closures.md
+++ b/docs/src/numerical_implementation/turbulence_closures.md
@@ -1,17 +1,17 @@
 # [Turbulence closures](@id numerical_closures)
 
 To truly simulate and resolve turbulence at high Reynolds number (so basically all interesting flows) would require
-you resolve all motions down to the [Kolmogorov41](@cite) length scale $\eta = (\nu^3 / \varepsilon)^{1/4}$ where
-$\nu$ is the kinematic viscosity and $\varepsilon$ the average rate of dissipation of turbulence kinetic energy per
+you resolve all motions down to the [Kolmogorov41](@cite) length scale ``\eta = (\nu^3 / \varepsilon)^{1/4}`` where
+``\nu`` is the kinematic viscosity and ``\varepsilon`` the average rate of dissipation of turbulence kinetic energy per
 unit mass.
 
 As pointed out way back by [Corrsin61](@cite), to run a simulation on a horizontal domain about 10 times the size of an
-"average eddy" with 100 vertical levels and where the grid spacing is given by $\eta$ would require the computer to
-store on the order of $10^{14}$ variables.[^1] This is still impractical today, although may be within
+"average eddy" with 100 vertical levels and where the grid spacing is given by ``\eta`` would require the computer to
+store on the order of ``10^{14}`` variables.[^1] This is still impractical today, although may be within
 reach in less than a decade. He ends by suggesting the use of an analog rather digital computer---a tank of water.
 
-[^1]: And even then, $\eta$ gives the *maximum* allowable grid spacing. There is significant flow structure
-    smaller than $\eta$.
+[^1]: And even then, ``\eta`` gives the *maximum* allowable grid spacing. There is significant flow structure
+    smaller than ``\eta``.
 
 To have any hope of simulating high Reynolds number flows we need some way of resolving the sub-grid scale motions.[^2]
 
@@ -22,8 +22,8 @@ To have any hope of simulating high Reynolds number flows we need some way of re
 
 ## Reynolds-averaged Navier–Stokes equations
 
-Following [Reynolds1895](@cite) we can decompose flow variables such as velocity $\bm{u}$ into the mean component
-$\overline{\bm{u}}$ and the fluctuating component $\bm{u}^\prime$ so that $\bm{u} = \overline{\bm{u}} + \bm{u}^\prime$
+Following [Reynolds1895](@cite) we can decompose flow variables such as velocity ``\bm{u}`` into the mean component
+``\overline{\bm{u}}`` and the fluctuating component ``\bm{u}^\prime`` so that ``\bm{u} = \overline{\bm{u}} + \bm{u}^\prime``
 [see §4 of [Pope00](@cite) for a modern discussion].
 
 Expressing the Navier-Stokes equations in tensor notation
@@ -33,8 +33,8 @@ Expressing the Navier-Stokes equations in tensor notation
     \partial_t u_i + u_j \partial_j u_i &= f_i - \alpha\partial_i p + \nu \partial_j \partial_j u_i
 \end{aligned}
 ```
-where $\alpha = \rho^{-1}$ is the specific volume and $f_i$ represents external forces. We can plug in the Reynolds
-decomposition for $\bm{u}$ and after some manipulation arrive at the following form for the *Reynolds-averaged
+where ``\alpha = \rho^{-1}`` is the specific volume and ``f_i`` represents external forces. We can plug in the Reynolds
+decomposition for ``\bm{u}`` and after some manipulation arrive at the following form for the *Reynolds-averaged
 Navier-Stokes equations*
 ```math
 \begin{aligned}
@@ -55,7 +55,7 @@ terms which form the components of the *Reynolds stress tensor*
 \tau_{ij} = \rho \overline{u_i^\prime u_j^\prime}
 ```
 Attempting to close the equations leads to the *closure problem*: the time evolution of the Reynolds stresses
-depends on  triple covariances $\overline{u_i^\prime u_j^\prime u_k^\prime}$ and covariances with pressure, which depend
+depends on  triple covariances ``\overline{u_i^\prime u_j^\prime u_k^\prime}`` and covariances with pressure, which depend
 on quadruple covariances and so on [Chou45](@cite).
 
 This is kind of hopeless so we will have to find some way to model the Reynolds stresses.
@@ -63,8 +63,8 @@ This is kind of hopeless so we will have to find some way to model the Reynolds 
 ## Gradient-diffusion hypothesis and eddy viscosity models
 
 The *gradient-diffusion hypothesis*, due to [Boussinesq1877](@cite), assumes that the transport of scalar fluxes
-such as $\overline{\bm{u}^\prime c^\prime}$ and $\overline{u_i^\prime u_j^\prime}$ occurs down the mean scalar gradient
-$\grad c$ as if they are being diffused (§4.4) [Pope00](@cite). This is in analogy with how momentum transfer by
+such as ``\overline{\bm{u}^\prime c^\prime}`` and ``\overline{u_i^\prime u_j^\prime}`` occurs down the mean scalar gradient
+``\grad c`` as if they are being diffused (§4.4) [Pope00](@cite). This is in analogy with how momentum transfer by
 molecular motion in a gas can be described by a molecular viscosity.
 
 Taking this assumption we can express the Reynolds stresses and turbulent tracer fluxes in terms of the mean variables
@@ -74,7 +74,7 @@ and close the equations
 \quad \text{and} \quad
 \overline{u_i^\prime u_j^\prime} = -2\nu_e \overline{S}_{ij}
 ```
-where $\nu_e = \nu_e(\bm{x}, t)$ is the turbulent or *eddy viscosity* and $\kappa_e = \kappa_e(\bm{x}, t)$
+where ``\nu_e = \nu_e(\bm{x}, t)`` is the turbulent or *eddy viscosity* and ``\kappa_e = \kappa_e(\bm{x}, t)``
 is the *eddy diffusivity*.
 
 The effective diffusivity ends up being the sum of the molecular and eddy diffusivities. So just by using an elevated

--- a/docs/src/numerical_implementation/turbulence_closures.md
+++ b/docs/src/numerical_implementation/turbulence_closures.md
@@ -29,8 +29,8 @@ Following [Reynolds1895](@cite) we can decompose flow variables such as velocity
 Expressing the Navier-Stokes equations in tensor notation
 ```math
 \begin{aligned}
-    \partial_i u_i &= 0 \\
-    \partial_t u_i + u_j \partial_j u_i &= f_i - \alpha\partial_i p + \nu \partial_j \partial_j u_i
+    \partial_i u_i &= 0  \, ,\\
+    \partial_t u_i + u_j \partial_j u_i &= f_i - \alpha\partial_i p + \nu \partial_j \partial_j u_i \, ,
 \end{aligned}
 ```
 where ``\alpha = \rho^{-1}`` is the specific volume and ``f_i`` represents external forces. We can plug in the Reynolds
@@ -38,21 +38,21 @@ decomposition for ``\bm{u}`` and after some manipulation arrive at the following
 Navier-Stokes equations*
 ```math
 \begin{aligned}
-    \partial_i \overline{u}_i &= 0 \\
+    \partial_i \overline{u}_i &= 0  \, ,\\
     \partial_t \overline{u}_i + \overline{u}_j \partial_j \overline{u}_i &= \overline{f}_i -
-    \partial_j \left(-\alpha\overline{p}\delta_{ij} + 2\nu \overline{S}_{ij} - \overline{u_i^\prime u_j^\prime}\right)
+    \partial_j \left(-\alpha\overline{p}\delta_{ij} + 2\nu \overline{S}_{ij} - \overline{u_i^\prime u_j^\prime}\right) \, ,
 \end{aligned}
 ```
 where
 ```math
-\overline{S}_{ij} = \frac{1}{2} ( \partial_j \overline{u}_i + \partial_i \overline{u}_j )
+\overline{S}_{ij} = \frac{1}{2} ( \partial_j \overline{u}_i + \partial_i \overline{u}_j ) \, ,
 ```
 is the mean rate of strain tensor.
 
 Thanks to the non-linearity of the Navier-Stokes equations, even when averaged we are left with pesky fluctuation
 terms which form the components of the *Reynolds stress tensor*
 ```math
-\tau_{ij} = \rho \overline{u_i^\prime u_j^\prime}
+\tau_{ij} = \rho \overline{u_i^\prime u_j^\prime} \, .
 ```
 Attempting to close the equations leads to the *closure problem*: the time evolution of the Reynolds stresses
 depends on  triple covariances ``\overline{u_i^\prime u_j^\prime u_k^\prime}`` and covariances with pressure, which depend
@@ -72,7 +72,7 @@ and close the equations
 ```math
 \overline{\bm{u}^\prime c^\prime} = -\kappa_e \nabla \overline{c}
 \quad \text{and} \quad
-\overline{u_i^\prime u_j^\prime} = -2\nu_e \overline{S}_{ij}
+\overline{u_i^\prime u_j^\prime} = -2\nu_e \overline{S}_{ij} \, ,
 ```
 where ``\nu_e = \nu_e(\bm{x}, t)`` is the turbulent or *eddy viscosity* and ``\kappa_e = \kappa_e(\bm{x}, t)``
 is the *eddy diffusivity*.

--- a/docs/src/physics/boundary_conditions.md
+++ b/docs/src/physics/boundary_conditions.md
@@ -9,16 +9,16 @@ direction is \textit{no-penetration}.
 ## Flux boundary conditions
 
 A flux boundary condition prescribes flux of a quantity normal to the boundary.
-For a tracer $c$ this corresponds to prescribing
+  For a tracer ``c`` this corresponds to prescribing
 ```math
 q_c \, |_b \equiv \bm{q}_c \bm{\cdot} \hat{\bm{n}} \, |_{\partial \Omega_b} \, ,
 ```
-where $\partial \Omega_b$ is an external boundary.
+where ``\partial \Omega_b`` is an external boundary.
 
 ## Gradient (Neumann) boundary condition
 
 A gradient boundary condition prescribes the gradient of a field normal to the boundary.
-For a tracer $c$ this prescribes
+For a tracer ``c`` this prescribes
 ```math
 \gamma \equiv \bm{\nabla} c \bm{\cdot} \hat{\bm{n}} \, |_{\partial \Omega_b} \, .
 ```

--- a/docs/src/physics/buoyancy_and_equations_of_state.md
+++ b/docs/src/physics/buoyancy_and_equations_of_state.md
@@ -1,24 +1,24 @@
 # Buoyancy model and equations of state
 
-The buoyancy model determines the relationship between tracers and the buoyancy $b$ in the momentum equation.
+The buoyancy model determines the relationship between tracers and the buoyancy ``b`` in the momentum equation.
 
 ## Buoyancy tracer
 
-The simplest buoyancy model uses buoyancy $b$ itself as a tracer: $b$ obeys the tracer
+The simplest buoyancy model uses buoyancy ``b`` itself as a tracer: ``b`` obeys the tracer
 conservation equation and is used directly in the momentum equations in the momentum equation.
 
 ## Seawater buoyancy
 
 For seawater buoyancy is, in general, modeled as a function of conservative temperature
-$\theta$, absolute salinity $S$, and depth below the ocean surface $d$ via
+``\theta``, absolute salinity ``S``, and depth below the ocean surface ``d`` via
 ```math
     b = - \frac{g}{\rho_0} \rho' \left (\theta, S, d \right ) \, ,
     \tag{eq:seawater-buoyancy}
 ```
-where $g$ is gravitational acceleration, $\rho_0$ is the reference density.
-The function $\rho'(\theta, S, d)$ in the seawater buoyancy relationship that links conservative temperature,
+where ``g`` is gravitational acceleration, ``\rho_0`` is the reference density.
+The function ``\rho'(\theta, S, d)`` in the seawater buoyancy relationship that links conservative temperature,
 salinity, and depth to the density perturbation is called the *equation of state*.
-Both $\theta$ and $S$ obey the tracer conservation equation.
+Both ``\theta`` and ``S`` obey the tracer conservation equation.
 
 ### Linear equation of state
 
@@ -26,8 +26,8 @@ Buoyancy is determined from a linear equation of state via
 ```math
     b = g \left ( \alpha_\theta \theta - \beta_S S \right ) \, ,
 ```
-where $g$ is gravitational acceleration, $\alpha_\theta$ is the thermal expansion coefficient,
-and $\beta_S$ is the haline contraction coefficient.
+where ``g`` is gravitational acceleration, ``\alpha_\theta`` is the thermal expansion coefficient,
+and ``\beta_S`` is the haline contraction coefficient.
 
 ### Nonlinear equation of state
 

--- a/docs/src/physics/coriolis_forces.md
+++ b/docs/src/physics/coriolis_forces.md
@@ -57,6 +57,6 @@ The *non-traditional* ``\beta``-plane approximation accounts for the latitudinal
 the locally vertical and the locally horizontal components of the rotation vector
 ```math
     \bm{f} = \left[ 2\Omega\cos\varphi_0 \left( 1 -  \frac{z}{R} \right) + \gamma y \right] \bm{\hat y}
-           + \left[ 2\Omega\sin\varphi_0 \left( 1 + 2\frac{z}{R} \right) + \beta  y \right] \bm{\hat z}
+           + \left[ 2\Omega\sin\varphi_0 \left( 1 + 2\frac{z}{R} \right) + \beta  y \right] \bm{\hat z} \, ,
 ```
 where ``\beta = 2\Omega\cos\varphi_0 / R`` and ``\gamma = -4\Omega\varphi_0 / R``.

--- a/docs/src/physics/coriolis_forces.md
+++ b/docs/src/physics/coriolis_forces.md
@@ -1,62 +1,62 @@
 # Coriolis forces
 
-The Coriolis model controls the manifestation of the term $\bm{f} \times \bm{u}$ in the momentum equation.
+The Coriolis model controls the manifestation of the term ``\bm{f} \times \bm{u}`` in the momentum equation.
 
-## The $f$-plane approximation
+## The ``f``-plane approximation
 
-Under an $f$-plane approximation[^3] the reference frame in which
+Under an ``f``-plane approximation[^3] the reference frame in which
 the momentum and tracer equations are solved rotates at a constant rate.
 
-### The traditional $f$-plane approximation
+### The traditional ``f``-plane approximation
 
-In the *traditional* $f$-plane approximation, the coordinate system rotates around
+In the *traditional* ``f``-plane approximation, the coordinate system rotates around
 a vertical axis such that
 ```math
     \bm{f} = f \bm{\hat z}
 ```
-where $f$ is constant and determined by the user.
+where ``f`` is constant and determined by the user.
 
-### The non-traditional $f$-plane approximation
+### The non-traditional ``f``-plane approximation
 
-In the *non-traditional* $f$-plane approximation, the coordinate system rotates around
-an axis in the $y,z$-plane, such that
+In the *non-traditional* ``f``-plane approximation, the coordinate system rotates around
+an axis in the ``y,z``-plane, such that
 ```math
     \bm{f} = f_y \bm{\hat y} + f_z \bm{\hat z}
 ```
-where $f_y$ and $f_z$ are constant and determined by the user.
+where ``f_y`` and ``f_z`` are constant and determined by the user.
 
 
-[^3]: The $f$-plane approximation is used to model the effects of Earth's rotation on
+[^3]: The ``f``-plane approximation is used to model the effects of Earth's rotation on
       anisotropic fluid motion in a plane tangent to the Earth's surface. In this case, the projection of Earth's
-      rotation vector at latitude $\varphi$ and onto a coordinate system in which $x, y, z$ correspond to the
+      rotation vector at latitude ``\varphi`` and onto a coordinate system in which ``x, y, z`` correspond to the
       directions east, north, and up is
       ```math
-          \bm{f} \approx \frac{4 \pi}{\text{day}} \left ( \cos \varphi \bm{\hat y} + \sin \varphi \bm{\hat z} \right ) \, , $
+          \bm{f} \approx \frac{4 \pi}{\text{day}} \left ( \cos \varphi \bm{\hat y} + \sin \varphi \bm{\hat z} \right ) \, , ``
       ```
-      where the Earth's rotation rate is approximately $2 \pi / \text{day}$.
-      The *traditional* $f$-plane approximation neglects the $y$-component of this projection, which is appropriate for
+      where the Earth's rotation rate is approximately ``2 \pi / \text{day}``.
+      The *traditional* ``f``-plane approximation neglects the ``y``-component of this projection, which is appropriate for
       fluid motions with large horizontal-to-vertical aspect ratios.
 
-## The $\beta$-plane approximation
+## The ``\beta``-plane approximation
 
-### The traditional $\beta$-plane approximation
+### The traditional ``\beta``-plane approximation
 
-Under the *traditional* $\beta$-plane approximation, the rotation axis is vertical as for the
-$f$-plane approximation, but $f$ is expanded in a Taylor series around a central latitude such that
+Under the *traditional* ``\beta``-plane approximation, the rotation axis is vertical as for the
+``f``-plane approximation, but ``f`` is expanded in a Taylor series around a central latitude such that
 ```math
     \bm{f} = \left ( f_0 + \beta y \right ) \bm{\hat z} \, ,
 ```
-where $f_0$ is the planetary vorticity at some central latitude, and $\beta$ is the
+where ``f_0`` is the planetary vorticity at some central latitude, and ``\beta`` is the
 planetary vorticity gradient.
-The $\beta$-plane model is not periodic in $y$ and thus can be used only in domains that
-are bounded in the $y$-direction.
+The ``\beta``-plane model is not periodic in ``y`` and thus can be used only in domains that
+are bounded in the ``y``-direction.
 
-### The non-traditional $f$-plane approximation
+### The non-traditional ``f``-plane approximation
 
-The *non-traditional* $\beta$-plane approximation accounts for the latitudinal variation of both
+The *non-traditional* ``\beta``-plane approximation accounts for the latitudinal variation of both
 the locally vertical and the locally horizontal components of the rotation vector
 ```math
     \bm{f} = \left[ 2\Omega\cos\varphi_0 \left( 1 -  \frac{z}{R} \right) + \gamma y \right] \bm{\hat y}
            + \left[ 2\Omega\sin\varphi_0 \left( 1 + 2\frac{z}{R} \right) + \beta  y \right] \bm{\hat z}
 ```
-where $\beta = 2\Omega\cos\varphi_0 / R$ and $\gamma = -4\Omega\varphi_0 / R$.
+where ``\beta = 2\Omega\cos\varphi_0 / R`` and ``\gamma = -4\Omega\varphi_0 / R``.

--- a/docs/src/physics/navier_stokes_and_tracer_conservation.md
+++ b/docs/src/physics/navier_stokes_and_tracer_conservation.md
@@ -79,16 +79,16 @@ specified rate of rotation of the frame of reference.
 
 From left to right, the terms that appear on the right-hand side of the momentum conservation equation are:
 
-    * momentum advection, ``\left ( \bm{u} \bm{\cdot} \bm{\nabla} \right ) \bm{u}``,
-    * advection of resolved momentum by the background velocity field ``\bm{U}``, ``\left ( \bm{U} \bm{\cdot} \bm{\nabla} \right ) \bm{u}``,
-    * advection of background momentum by resolved velocity, ``\left ( \bm{u} \bm{\cdot} \bm{\nabla} \right ) \bm{U}``,
-    * coriolis, ``\bm{f} \times \bm{u}``
-    * the effective background rotation rate due to surface waves, ``\bm{\nabla} \times \bm{u}^S \right ) \times \bm{u}``
-    * pressure, ``\bm{\nabla} \phi``,
-    * buoyant acceleration, ``b \bm{\hat z}``
-    * molecular or turbulence viscous stress, ``\bm{\nabla} \bm{\cdot} \bm{\tau}``
-    * a source of momentum due to forcing or damping of surface waves, ``\partial_t \bm{u}^S``
-    * an arbitrary internal source of momentum, ``\bm{F_u}``
+* momentum advection, ``\left ( \bm{u} \bm{\cdot} \bm{\nabla} \right ) \bm{u}``,
+* advection of resolved momentum by the background velocity field ``\bm{U}``, ``\left ( \bm{U} \bm{\cdot} \bm{\nabla} \right ) \bm{u}``,
+* advection of background momentum by resolved velocity, ``\left ( \bm{u} \bm{\cdot} \bm{\nabla} \right ) \bm{U}``,
+* coriolis, ``\bm{f} \times \bm{u}``
+* the effective background rotation rate due to surface waves, ``\bm{\nabla} \times \bm{u}^S \right ) \times \bm{u}``
+* pressure, ``\bm{\nabla} \phi``,
+* buoyant acceleration, ``b \bm{\hat z}``
+* molecular or turbulence viscous stress, ``\bm{\nabla} \bm{\cdot} \bm{\tau}``
+* a source of momentum due to forcing or damping of surface waves, ``\partial_t \bm{u}^S``
+* an arbitrary internal source of momentum, ``\bm{F_u}``
 
 ## The tracer conservation equation
 
@@ -107,11 +107,11 @@ equations to be solved simultaneously with the momentum equations.
 
 From left to right, the terms that appear on the right-hand side of the tracer conservation equation are
 
-    * tracer advection, ``\bm{u} \bm{\cdot} \bm{\nabla} c``
-    * tracer advection by the background velocity field, ``U``, ``\bm{U} \bm{\cdot} \bm{\nabla} c``
-    * advection of the background tracer field, ``C``, by the resolved velocity field, ``\bm{u} \bm{\cdot} \bm{\nabla} C``
-    * molecular or turbulent diffusion, ``\bm{\nabla} \bm{\cdot} \bm{q}_c``
-    * an arbitrary internal source of tracer, ``F_c``
+* tracer advection, ``\bm{u} \bm{\cdot} \bm{\nabla} c``
+* tracer advection by the background velocity field, ``U``, ``\bm{U} \bm{\cdot} \bm{\nabla} c``
+* advection of the background tracer field, ``C``, by the resolved velocity field, ``\bm{u} \bm{\cdot} \bm{\nabla} C``
+* molecular or turbulent diffusion, ``\bm{\nabla} \bm{\cdot} \bm{q}_c``
+* an arbitrary internal source of tracer, ``F_c``
 
 The following subsections provide more details on the
 possible forms that each individual term in the momentum and tracer

--- a/docs/src/physics/navier_stokes_and_tracer_conservation.md
+++ b/docs/src/physics/navier_stokes_and_tracer_conservation.md
@@ -1,14 +1,14 @@
 # Coordinate system and notation
 
 Oceananigans.jl is formulated in a Cartesian coordinate system
-$\bm{x} = (x, y, z)$ with unit vectors $\bm{\hat x}$, $\bm{\hat y}$, and $\bm{\hat z}$,
-where $\bm{\hat x}$ points east, $\bm{\hat y}$ points north, and $\bm{\hat z}$ points 'upward',
+``\bm{x} = (x, y, z)`` with unit vectors ``\bm{\hat x}``, ``\bm{\hat y}``, and ``\bm{\hat z}``,
+where ``\bm{\hat x}`` points east, ``\bm{\hat y}`` points north, and ``\bm{\hat z}`` points 'upward',
 opposite the direction of gravitational acceleration.
-We denote time with $t$, partial derivatives with respect to time $t$ or a coordinate $x$
-with $\partial_t$ or $\partial_x$, and denote the gradient operator
-$\bm{\nabla} \equiv \partial_x \bm{\hat x} + \partial_y \bm{\hat y} + \partial_z \bm{\hat z}$.
-We use $u$, $v$, and $w$ to denote the east, north, and vertical velocity components,
-such that $\bm{u} = u \bm{\hat x} + v \bm{\hat y} + w \bm{\hat z}$.
+We denote time with ``t``, partial derivatives with respect to time ``t`` or a coordinate ``x``
+with ``\partial_t`` or ``\partial_x``, and denote the gradient operator
+``\bm{\nabla} \equiv \partial_x \bm{\hat x} + \partial_y \bm{\hat y} + \partial_z \bm{\hat z}``.
+We use ``u``, ``v``, and ``w`` to denote the east, north, and vertical velocity components,
+such that ``\bm{u} = u \bm{\hat x} + v \bm{\hat y} + w \bm{\hat z}``.
 
 # The Boussinesq Navier-Stokes equations and tracer conservation equations
 
@@ -29,23 +29,23 @@ user.
       for an asymptotic derivation. See Kundu (2015, Section 4.9) for an engineering
       introduction.
 
-The fluid density $\rho$ in Oceananigans.jl is, in general, decomposed into three
+The fluid density ``\rho`` in Oceananigans.jl is, in general, decomposed into three
 components:
 ```math
     \rho(\bm{x}, t) = \rho_0 + \rho_*(z) + \rho'(\bm{x}, t) \, ,
 ```
-where $\rho_0$ is a constant 'reference' density, $\rho_*(z)$ is a background density
+where ``\rho_0`` is a constant 'reference' density, ``\rho_*(z)`` is a background density
 profile which, when non-zero, is typically associated with the hydrostatic compression
-of seawater in the deep ocean, and $\rho'(\bm{x}, t)$ is the dynamic component of density
+of seawater in the deep ocean, and ``\rho'(\bm{x}, t)`` is the dynamic component of density
 corresponding to inhomogeneous distributions of a buoyant tracer such as temperature or salinity.
 The fluid *buoyancy*, associated with the buoyant acceleration of fluid, is
-defined in terms of $\rho'$ as
+defined in terms of ``\rho'`` as
 ```math
     b = - \frac{g \rho'}{\rho_0} \, ,
 ```
-where $g$ is gravitational acceleration.
+where ``g`` is gravitational acceleration.
 
-The Boussinesq approximation is valid when $\rho_* + \rho' \ll \rho_0$, which implies the
+The Boussinesq approximation is valid when ``\rho_* + \rho' \ll \rho_0``, which implies the
 fluid is _approximately_ incompressible, and thus does not support acoustic waves.
 In this case, the mass conservation equation reduces to the continuity equation
 ```math
@@ -70,11 +70,11 @@ at the top of the domain via the Craik-Leibovich approximation are
                         + \bm{F_u} \, ,
     \tag{eq:momentum}
 ```
-where $b$ is buoyancy, $\bm{\tau}$ is the kinematic stress tensor, $\bm{F_u}$
-denotes an internal forcing of the velocity field $\bm{u}$, $\phi$ is the potential
+where ``b`` is buoyancy, ``\bm{\tau}`` is the kinematic stress tensor, ``\bm{F_u}``
+denotes an internal forcing of the velocity field ``\bm{u}``, ``\phi`` is the potential
 associated with kinematic and constant hydrostatic contributions to pressure,
-$\bm{u}^S$ is the 'Stokes drift' velocity field associated with surface gravity waves,
-and $\bm{f}$ is *Coriolis parameter*, or the background vorticity associated with the
+``\bm{u}^S`` is the 'Stokes drift' velocity field associated with surface gravity waves,
+and ``\bm{f}`` is *Coriolis parameter*, or the background vorticity associated with the
 specified rate of rotation of the frame of reference.
 
 From left to right, the terms that appear on the right-hand side of the momentum conservation equation are:
@@ -101,7 +101,7 @@ The conservation law for tracers in Oceananigans.jl is
                    + F_c \, ,
     \tag{eq:tracer}
 ```
-where $\bm{q}_c$ is the diffusive flux of $c$ and $F_c$ is an arbitrary source term.
+where ``\bm{q}_c`` is the diffusive flux of ``c`` and ``F_c`` is an arbitrary source term.
 Oceananigans.jl permits arbitrary tracers and thus an arbitrary number of tracer
 equations to be solved simultaneously with the momentum equations.
 

--- a/docs/src/physics/surface_gravity_waves.md
+++ b/docs/src/physics/surface_gravity_waves.md
@@ -10,18 +10,18 @@ Surface waves are modeled in Oceananigans.jl by the Craik-Leibovich approximatio
 which governs interior motions under a surface gravity wave field that have been time- or
 phase-averaged over the rapid oscillations of the surface waves.
 The oscillatory vertical and horizontal motions associated with surface waves themselves,
-therefore, are not present in the resolved velocity field $\bm{u}$, and only the steady,
+therefore, are not present in the resolved velocity field ``\bm{u}``, and only the steady,
 averaged effect of surface waves that manifests over several or more wave oscillations are modeled.
 
-In Oceananigans.jl with surface waves, the resolved velocity field $\bm{u}$ is the Lagrangian-mean
+In Oceananigans.jl with surface waves, the resolved velocity field ``\bm{u}`` is the Lagrangian-mean
 velocity field.
-The Lagrangian-mean velocity field at a particular location $(x, y, z)$ is average velocity of a
-fluid particle whose average position is $(x, y, z)$ at time $t$.
-The average position of a fluid particle $\bm{\xi}(t) = (\xi, \eta, \zeta)$ is thus governed by
+The Lagrangian-mean velocity field at a particular location ``(x, y, z)`` is average velocity of a
+fluid particle whose average position is ``(x, y, z)`` at time ``t``.
+The average position of a fluid particle ``\bm{\xi}(t) = (\xi, \eta, \zeta)`` is thus governed by
 ```math
     \partial_t \bm{\xi} + \bm{u}(\bm{\xi}, t) \bm{\cdot} \bm{\nabla} \bm{\xi} = \bm{u}(\bm{\xi}, t) \, ,
 ```
-which is the same relationship that holds when surface waves are not present and $\bm{u}$ ceases
+which is the same relationship that holds when surface waves are not present and ``\bm{u}`` ceases
 to be an averaged velocity field.
 The simplicity of the governing equations for Lagrangian-mean momentum is the main reason we
 use a Lagrangian-mean formulation in Oceananigans.jl, rather than an Eulerian-mean formulation:
@@ -33,8 +33,8 @@ effects of surface waves in turbulence closures that model the effects of subgri
 More specifically, the effect of steady surface waves does not effect the conservation of
 Lagrangian-mean turbulent kinetic energy.
 
-The Lagrangian-mean velocity field $\bm{u}$ contrasts with the Eulerian-mean velocity field $\bm{u}^E$,
-which is the fluid velocity averaged at the fixed Eulerian position $(x, y, z)$.
+The Lagrangian-mean velocity field ``\bm{u}`` contrasts with the Eulerian-mean velocity field ``\bm{u}^E``,
+which is the fluid velocity averaged at the fixed Eulerian position ``(x, y, z)``.
 The surface wave Stokes drift field supplied by the user is, in fact, defined
 by the difference between the Eulerian- and Lagrangian-mean velocity:
 ```math

--- a/docs/src/physics/turbulence_closures.md
+++ b/docs/src/physics/turbulence_closures.md
@@ -1,8 +1,8 @@
 # Turbulence closures
 
 The turbulence closure selected by the user determines the form of stress divergence
-$\bm{\nabla} \bm{\cdot} \bm{\tau}$ and diffusive flux divergence
-$\bm{\nabla} \bm{\cdot} \bm{q}_c$ in the momentum and tracer conservation equations.
+``\bm{\nabla} \bm{\cdot} \bm{\tau}`` and diffusive flux divergence
+``\bm{\nabla} \bm{\cdot} \bm{q}_c`` in the momentum and tracer conservation equations.
 
 ## Constant isotropic diffusivity
 
@@ -10,24 +10,24 @@ In a constant isotropic diffusivity model, the kinematic stress tensor is define
 ```math
 \tau_{ij} = - \nu \Sigma_{ij} \, ,
 ```
-where $\nu$ is a constant viscosity and
-$\Sigma_{ij} \equiv \tfrac{1}{2} \left ( u_{i, j} + u_{j, i} \right )$ is the strain-rate
-tensor. The divergence of $\bm{\tau}$ is then
+where ``\nu`` is a constant viscosity and
+``\Sigma_{ij} \equiv \tfrac{1}{2} \left ( u_{i, j} + u_{j, i} \right )`` is the strain-rate
+tensor. The divergence of ``\bm{\tau}`` is then
 ```math
 \bm{\nabla} \bm{\cdot} \bm{\tau} = -\nu \bm{\nabla}^2 \bm{u} \, .
 ```
-Similarly, the diffusive tracer flux is $\bm{q}_c = - \kappa \bm{\nabla} c$ for tracer
-diffusivity $\kappa$, and the diffusive tracer flux divergence is
+Similarly, the diffusive tracer flux is ``\bm{q}_c = - \kappa \bm{\nabla} c`` for tracer
+diffusivity ``\kappa``, and the diffusive tracer flux divergence is
 ```math
 \bm{\nabla} \bm{\cdot} \bm{q}_c = - \kappa \bm{\nabla}^2 c \, .
 ```
-Each tracer may have a unique diffusivity $\kappa$.
+Each tracer may have a unique diffusivity ``\kappa``.
 
 ## Constant anisotropic diffusivity
 
 In Oceananigans.jl, a constant anisotropic diffusivity implies a constant tensor
-diffusivity $\nu_{j k}$ and stress $\bm{\tau}_{ij} = \nu_{j k} u_{i, k}$ with non-zero
-components $\nu_{11} = \nu_{22} = \nu_h$ and $\nu_{33} = \nu_v$.
+diffusivity ``\nu_{j k}`` and stress ``\bm{\tau}_{ij} = \nu_{j k} u_{i, k}`` with non-zero
+components ``\nu_{11} = \nu_{22} = \nu_h`` and ``\nu_{33} = \nu_v``.
 With this form the kinematic stress divergence becomes
 ```math
 \bm{\nabla} \bm{\cdot} \bm{\tau} = - \left [ \nu_h \left ( \partial_x^2 + \partial_y^2 \right )
@@ -38,15 +38,15 @@ and diffusive flux divergence
 \bm{\nabla} \bm{\cdot} \bm{q}_c = - \left [ \kappa_{h} \left ( \partial_x^2 + \partial_y^2 \right )
                                     + \kappa_{v} \partial_z^2 \right ] c \, .
 ```
-in terms of the horizontal viscosities and diffusivities $\nu_h$ and $\kappa_{h}$ and the
-vertical viscosity and diffusivities $\nu_v$ and $\kappa_{v}$.
-Each tracer may have a unique diffusivity components $\kappa_h$ and $\kappa_v$.
+in terms of the horizontal viscosities and diffusivities ``\nu_h`` and ``\kappa_{h}`` and the
+vertical viscosity and diffusivities ``\nu_v`` and ``\kappa_{v}``.
+Each tracer may have a unique diffusivity components ``\kappa_h`` and ``\kappa_v``.
 
 ## Constant anisotropic biharmonic diffusivity
 
 In Oceananigans.jl, a constant anisotropic biharmonic diffusivity implies a constant tensor
-diffusivity $\nu_{j k}$ and stress $\bm{\tau}_{ij} = \nu_{j k} \partial_k^3 u_i$ with non-zero
-components $\nu_{11} = \nu_{22} = \nu_h$ and $\nu_{33} = \nu_v$.
+diffusivity ``\nu_{j k}`` and stress ``\bm{\tau}_{ij} = \nu_{j k} \partial_k^3 u_i`` with non-zero
+components ``\nu_{11} = \nu_{22} = \nu_h`` and ``\nu_{33} = \nu_v``.
 With this form the kinematic stress divergence becomes
 ```math
 \bm{\nabla} \bm{\cdot} \bm{\tau} = - \left [ \nu_h \left ( \partial_x^2 + \partial_y^2 \right )^2
@@ -57,9 +57,9 @@ and diffusive flux divergence
 \bm{\nabla} \bm{\cdot} \bm{q}_c = - \left [ \kappa_{h} \left ( \partial_x^2 + \partial_y^2 \right )^2
                                     + \kappa_{v} \partial_z^4 \right ] c \, .
 ```
-in terms of the horizontal biharmonic viscosities and diffusivities $\nu_h$ and $\kappa_{h}$ and the
-vertical biharmonic viscosity and diffusivities $\nu_v$ and $\kappa_{v}$.
-Each tracer may have a unique diffusivity components $\kappa_h$ and $\kappa_v$.
+in terms of the horizontal biharmonic viscosities and diffusivities ``\nu_h`` and ``\kappa_{h}`` and the
+vertical biharmonic viscosity and diffusivities ``\nu_v`` and ``\kappa_{v}``.
+Each tracer may have a unique diffusivity components ``\kappa_h`` and ``\kappa_v``.
 
 ## Smagorinsky-Lilly turbulence closure
 
@@ -68,41 +68,41 @@ the subgrid stress associated with unresolved turbulent motions is modeled diffu
 ```math
 \tau_{ij} = \nu_e \Sigma_{ij} \, ,
 ```
-where $\Sigma_{ij} = \tfrac{1}{2} \left ( u_{i, j} + u_{j, i} \right )$ is the resolved
+where ``\Sigma_{ij} = \tfrac{1}{2} \left ( u_{i, j} + u_{j, i} \right )`` is the resolved
 strain rate.
 The eddy viscosity is given by
 ```math
     \nu_e = \left ( C \Delta_f \right )^2 \sqrt{ \Sigma^2 } \, \Upsilon(Ri) + \nu \, ,
     \tag{eq:smagorinsky-viscosity}
 ```
-where $\Delta_f$ is the "filter width" associated with the finite volume grid spacing,
-$C$ is a user-specified model constant, $\Sigma^2 \equiv \Sigma_{ij} \Sigma{ij}$, and
-$\nu$ is a constant isotropic background viscosity.
-The factor $\Upsilon(Ri)$ reduces $\nu_e$ in regions of
+where ``\Delta_f`` is the "filter width" associated with the finite volume grid spacing,
+``C`` is a user-specified model constant, ``\Sigma^2 \equiv \Sigma_{ij} \Sigma{ij}``, and
+``\nu`` is a constant isotropic background viscosity.
+The factor ``\Upsilon(Ri)`` reduces ``\nu_e`` in regions of
 strong stratification where the resolved gradient Richardson number
-$Ri \equiv N^2 / \Sigma^2$ is large via
+``Ri \equiv N^2 / \Sigma^2`` is large via
 ```math
     \Upsilon(Ri) = \sqrt{1 - \min \left ( 1, C_b N^2 / \Sigma^2 \right )} \, ,
 ```
-where $N^2 = \max \left (0, \partial_z b \right )$ is the squared buoyancy frequency for stable
-stratification with $\partial_z b > 0$ and $C_b$ is a user-specified constant.
+where ``N^2 = \max \left (0, \partial_z b \right )`` is the squared buoyancy frequency for stable
+stratification with ``\partial_z b > 0`` and ``C_b`` is a user-specified constant.
 Roughly speaking, the filter width for the Smagorinsky-Lilly closure is taken as
 ```math
 \Delta_f(\bm{x}) = \left ( \Delta x \Delta y \Delta z \right)^{1/3} \, ,
 ```
-where $\Delta x$, $\Delta y$, and $\Delta z$ are the grid spacing in the
-$\bm{\hat x}$, $\bm{\hat y}$, and $\bm{\hat z}$ directions at location $\bm{x} = (x, y, z)$.
+where ``\Delta x``, ``\Delta y``, and ``\Delta z`` are the grid spacing in the
+``\bm{\hat x}``, ``\bm{\hat y}``, and ``\bm{\hat z}`` directions at location ``\bm{x} = (x, y, z)``.
 
 The effect of subgrid turbulence on tracer mixing is also modeled diffusively via
 ```math
 \bm{q}_c = \kappa_e \bm{\nabla} c \, ,
 ```
-where the eddy diffusivity $\kappa_e$ is
+where the eddy diffusivity ``\kappa_e`` is
 ```math
 \kappa_e = \frac{\nu_e - \nu}{Pr} + \kappa \, ,
 ```
-where $Pr$ is a turbulent Prandtl number and $\kappa$ is a constant isotropic background diffusivity.
-Both $Pr$ and $\kappa$ may be set independently for each tracer.
+where ``Pr`` is a turbulent Prandtl number and ``\kappa`` is a constant isotropic background diffusivity.
+Both ``Pr`` and ``\kappa`` may be set independently for each tracer.
 
 ## Anisotropic minimum dissipation (AMD) turbulence closure
 
@@ -111,13 +111,13 @@ Verstappen18 and described and tested by Vreugdenhil18.
 The AMD model uses an eddy diffusivity hypothesis similar the Smagorinsky-Lilly model.
 In the AMD model, the eddy viscosity and diffusivity for each tracer are defined in terms
 of eddy viscosity and diffusivity *predictors*
-$\nu_e^\dagger$ and $\kappa_e^\dagger$, such that
+``\nu_e^\dagger`` and ``\kappa_e^\dagger``, such that
 ```math
     \nu_e = \max \left ( 0, \nu_e^\dagger \right ) + \nu
     \quad \text{and} \quad
     \kappa_e = \max \left ( 0, \kappa_e^\dagger \right ) + \kappa
 ```
-to ensure that $\nu_e \ge 0$ and $\kappa_e \ge 0$, where $\nu$ and $\kappa$ are the
+to ensure that ``\nu_e \ge 0`` and ``\kappa_e \ge 0``, where ``\nu`` and ``\kappa`` are the
 constant isotropic background viscosity and diffusivities for each tracer.
 The eddy viscosity predictor is
 ```math
@@ -128,7 +128,7 @@ The eddy viscosity predictor is
         + C_b \hat{\delta}_{i3} \left( \hat{\partial}_k \hat{u_i} \right) \hat{\partial}_k b}
         {\left( \hat{\partial}_l \hat{u}_m \right) \left( \hat{\partial}_l \hat{u}_m \right)}
 ```
-while the eddy diffusivity predictor for tracer $c$ is
+while the eddy diffusivity predictor for tracer ``c`` is
 ```math
     \tag{eq:kappa-dagger}
     \kappa_e^\dagger = -(C \Delta_f)^2
@@ -136,23 +136,23 @@ while the eddy diffusivity predictor for tracer $c$ is
         {\left( \hat{\partial}_k \hat{u}_i \right) \left( \hat{\partial}_k c \right) \hat{\partial}_i c}
         {\left( \hat{\partial}_l c \right) \left( \hat{\partial}_l c \right)} \, .
 ```
-In the definitions of the eddy viscosity and eddy diffusivity predictor, $C$ and $C_b$ are
-user-specified model constants, $\Delta_f$ is a "filter width" associated with the finite volume
+In the definitions of the eddy viscosity and eddy diffusivity predictor, ``C`` and ``C_b`` are
+user-specified model constants, ``\Delta_f`` is a "filter width" associated with the finite volume
 grid spacing, and the hat decorators on partial derivatives, velocities, and the Kronecker
-delta $\hat \delta_{i3}$ are defined such that
+delta ``\hat \delta_{i3}`` are defined such that
 ```math
     \hat \partial_i \equiv \Delta_i \partial_i, \qquad
     \hat{u}_i(x, t) \equiv \frac{u_i(x, t)}{\Delta_i}, \quad \text{and} \quad
     \hat{\delta}_{i3} \equiv \frac{\delta_{i3}}{\Delta_3} \, .
 ```
 A velocity gradient, for example, is therefore
-$\hat{\partial}_i \hat{u}_j(x, t) = \frac{\Delta_i}{\Delta_j} \partial_i u_j(x, t)$,
+``\hat{\partial}_i \hat{u}_j(x, t) = \frac{\Delta_i}{\Delta_j} \partial_i u_j(x, t)``,
 while the normalized strain tensor is
 ```math
     \hat{\Sigma}_{ij} =
         \frac{1}{2} \left[ \hat{\partial}_i \hat{u}_j(x, t) + \hat{\partial}_j \hat{u}_i(x, t) \right] \, .
 ```
-The filter width $\Delta_f$ in that appears in the viscosity and diffusivity predictors
+The filter width ``\Delta_f`` in that appears in the viscosity and diffusivity predictors
 is taken as the square root of the harmonic mean of the squares of the filter widths in
 each direction:
 ```math
@@ -160,6 +160,6 @@ each direction:
                                               + \frac{1}{\Delta y^2}
                                               + \frac{1}{\Delta z^2} \right) \, .
 ```
-The constant $C_b$ permits the "buoyancy modification" term it multiplies to be omitted
+The constant ``C_b`` permits the "buoyancy modification" term it multiplies to be omitted
 from a calculation.
-By default we use the model constants $C=1/12$ and $C_b=0$.
+By default we use the model constants ``C=1/12`` and ``C_b=0``.

--- a/docs/src/physics/turbulence_closures.md
+++ b/docs/src/physics/turbulence_closures.md
@@ -115,7 +115,7 @@ of eddy viscosity and diffusivity *predictors*
 ```math
     \nu_e = \max \left ( 0, \nu_e^\dagger \right ) + \nu
     \quad \text{and} \quad
-    \kappa_e = \max \left ( 0, \kappa_e^\dagger \right ) + \kappa
+    \kappa_e = \max \left ( 0, \kappa_e^\dagger \right ) + \kappa \, ,
 ```
 to ensure that ``\nu_e \ge 0`` and ``\kappa_e \ge 0``, where ``\nu`` and ``\kappa`` are the
 constant isotropic background viscosity and diffusivities for each tracer.

--- a/docs/src/verification/convergence_tests.md
+++ b/docs/src/verification/convergence_tests.md
@@ -45,7 +45,7 @@ In one dimension with constant diffusivity ``\kappa`` and in the presence of a
 constant velocity ``U``, a Gaussian evolves according to
 
 ```math
-    c = \frac{\mathrm{e}^{- (x - U t)^2 / 4 \kappa t}}{\sqrt{4 \pi \kappa t}}
+    c = \frac{\mathrm{e}^{- (x - U t)^2 / 4 \kappa t}}{\sqrt{4 \pi \kappa t}} \, .
 ```
 
 For this test we take the initial time as ``t=t_0``.
@@ -67,7 +67,7 @@ In one dimension with constant diffusivity ``\kappa`` and in the presence of a
 constant velocity ``U``, a cosine evolves according to
 
 ```math
-    c = \mathrm{e}^{-\kappa t} \cos (x - U t)
+    c = \mathrm{e}^{-\kappa t} \cos (x - U t) \, .
 ```
 
 The solutions are
@@ -85,13 +85,13 @@ These results validate the correctness of time-stepping, constant diffusivity op
 With zero velocity field and constant diffusivity ``\kappa``, the tracer field
 
 ```math
-c(x, y, t=0) = \cos(x) \cos(y)
+c(x, y, t=0) = \cos(x) \cos(y) \, ,
 ```
 
 decays according to
 
 ```math
-c(x, y, t) = \mathrm{e}^{-2 \kappa t} \cos(x) \cos(y)
+c(x, y, t) = \mathrm{e}^{-2 \kappa t} \cos(x) \cos(y) \, ,
 ```
 
 with either periodic boundary conditions, or insulating boundary conditions in either ``x`` or ``y``.
@@ -108,8 +108,8 @@ The velocity field
 
 ```math
 \begin{aligned}
-u(x, y, t) &= U + \mathrm{e}^{-t} \cos(x - U t) \sin(y) \\
-v(x, y, t) &= - \mathrm{e}^{-t} \sin(x - U t) \cos(y)
+u(x, y, t) &= U + \mathrm{e}^{-t} \cos(x - U t) \sin(y) \, , \\
+v(x, y, t) &= - \mathrm{e}^{-t} \sin(x - U t) \cos(y) \, ,
 \end{aligned}
 ```
 
@@ -147,7 +147,7 @@ With an isotropic Laplacian viscosity ``\nu = 1``, the momentum and continuity e
 ```
 while the equation for vorticity, ``\omega = v_x - u_y = \nabla^2 \psi``, is
 ```math
-\omega_t + \mathrm{J} \left ( \psi, \omega \right ) = \nabla^2 \omega + F_\omega
+\omega_t + \mathrm{J} \left ( \psi, \omega \right ) = \nabla^2 \omega + F_\omega \, .
 ```
 Finally, taking the divergence of the momentum equation, we find a Poisson equation for pressure,
 ```math

--- a/docs/src/verification/convergence_tests.md
+++ b/docs/src/verification/convergence_tests.md
@@ -48,7 +48,7 @@ constant velocity ``U``, a Gaussian evolves according to
     c = \frac{\mathrm{e}^{- (x - U t)^2 / 4 \kappa t}}{\sqrt{4 \pi \kappa t}}
 ```
 
-For this test we take the initial time as $t=t_0$.
+For this test we take the initial time as ``t=t_0``.
 We simulate this problem with advection and diffusion, as well as with ``U=0`` and thus diffusion only, as well as with
 ``\kappa \approx 0`` and thus "advection only".
 The solutions are

--- a/docs/src/verification/stratified_couette_flow.md
+++ b/docs/src/verification/stratified_couette_flow.md
@@ -21,7 +21,7 @@ section. The resulting flow is governed by the Reynolds, Richardson, and Prandtl
 ```math
 \text{Re} = \frac{U_w h}{\nu}, \quad
 \text{Ri} = \frac{\alpha g \Theta_w h}{U_w^2}, \quad
-\text{Pr} = \frac{\nu}{\kappa}
+\text{Pr} = \frac{\nu}{\kappa} \, ,
 ```
 where ``\nu`` is the kinematic viscosity, ``\kappa`` is the thermal diffusivity, ``\alpha`` is the thermal expansion
 coefficient, and ``g`` is the gravitational acceleration.
@@ -32,13 +32,13 @@ define the friction velocity ``u_\tau`` and friction temperature ``\theta_\tau``
 u_\tau^2 = \frac{\tau_w}{\rho_0}
          = \nu \left\vert \frac{\partial U}{\partial z} \right\vert_{z = \pm h}, \quad
 \theta_\tau = \frac{q_w}{u_\tau}
-            = \frac{\kappa}{u_\tau} \left\vert \frac{\partial\Theta}{\partial z} \right\vert_{z = \pm h}
+            = \frac{\kappa}{u_\tau} \left\vert \frac{\partial\Theta}{\partial z} \right\vert_{z = \pm h} \, ,
 ```
 where ``\tau_w`` is the wall stress and ``q_w = u_\tau \theta_\tau`` is the wall heat flux.
 
 From here the friction Reynolds number and the Nusselt number can be defined
 ```math
-\text{Re}_\tau = \frac{u_\tau h}{\nu}, \quad \text{Nu} = \frac{q_w h}{\kappa \Theta_w}
+\text{Re}_\tau = \frac{u_\tau h}{\nu}, \quad \text{Nu} = \frac{q_w h}{\kappa \Theta_w} \, ,
 ```
 which can be computed and compared.
 

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -66,8 +66,8 @@
 # the flux is negative (downwards) when the velocity at the bottom boundary is positive, and 
 # positive (upwards) with the velocity at the bottom boundary is negative.
 # This drag term is "quadratic" because the rate at which momentum is removed is proportional
-# to ``\boldsymbol{u}_h |\boldsymbol{u}_h|``, where 
-# ``\boldsymbol{u}_h = u \boldsymbol{\hat{x}} + v \boldsymbol{\hat{y}}`` is the horizontal velocity.
+# to ``\bm{u}_h |\bm{u}_h|``, where ``\bm{u}_h = u \bm{\hat{x}} + v \bm{\hat{y}}`` is 
+# the horizontal velocity.
 #
 # The ``x``-component of the quadratic bottom drag is thus
 # 
@@ -103,7 +103,7 @@
 # | ``\alpha``     | Background vertical shear ``\partial_z U`` | ``10^{-3}`` | ``\mathrm{s^{-1}}`` |
 # | ``c^D``        | Bottom quadratic drag coefficient | ``10^{-4}`` | none |
 # | ``κ_z``        | Laplacian vertical diffusivity | ``10^{-2}`` | ``\mathrm{m^2 s^{-1}}`` |
-# | ``\varkappa_h``    | Biharmonic horizontal diffusivity | ``10^{-2} \times \Delta x^4 / \mathrm{day}`` | ``\mathrm{m^4 s^{-1}}`` |
+# | ``ϰ_h``        | Biharmonic horizontal diffusivity | ``10^{-2} \times \Delta x^4 / \mathrm{day}`` | ``\mathrm{m^4 s^{-1}}`` |
 #
 # We start off by importing `Oceananigans`, some convenient aliases for dimensions, and a function
 # that generates a pretty string from a number that represents 'time' in seconds:

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -27,29 +27,35 @@
 # ### The geostrophic basic state
 #
 # The geostrophic basic state in the Eady problem is represented by the streamfunction,
+# 
+# ```math
+# ψ(y, z) = - α y (z + L_z) \, ,
+# ```
 #
-# $ ψ(y, z) = - α y (z + L_z) \, ,$
-#
-# where $α$ is the geostrophic shear and $L_z$ is the depth of the domain.
+# where ``α`` is the geostrophic shear and ``L_z`` is the depth of the domain.
 # The background buoyancy includes both the geostrophic flow component,
-# $f ∂_z ψ$, where $f$ is the Coriolis parameter, and a background stable stratification
-# component, $N^2 z$, where $N$ is the buoyancy frequency:
+# ``f ∂_z ψ``, where ``f`` is the Coriolis parameter, and a background stable stratification
+# component, ``N^2 z``, where ``N`` is the buoyancy frequency:
 #
-# $ B(y, z) = f ∂_z ψ + N^2 z = - α f y + N^2 z \, .$
+# ```math
+# B(y, z) = f ∂_z ψ + N^2 z = - α f y + N^2 z \, .
+# ```
 #
 # The background velocity field is related to the geostrophic streamfunction via
-# $ U = - ∂_y ψ$ such that
+# ``U = - ∂_y ψ`` such that
 #
-# $ U(z) = α (z + L_z) \, .$
+# ```math
+# U(z) = α (z + L_z) \, .
+# ```
 #
 # ### Boundary conditions
 #
 # All fields are periodic in the horizontal directions.
 # We use "insulating", or zero-flux boundary conditions on the buoyancy perturbation
 # at the top and bottom. We thus implicitly assume that the background vertical density
-# gradient, $N^2 z$, is maintained by a process external to our simulation.
-# We use free-slip, or zero-flux boundary conditions on $u$ and $v$ at the surface
-# where $z=0$. At the bottom, we impose a momentum flux that extracts momentum and
+# gradient, ``N^2 z``, is maintained by a process external to our simulation.
+# We use free-slip, or zero-flux boundary conditions on ``u`` and ``v`` at the surface
+# where ``z=0``. At the bottom, we impose a momentum flux that extracts momentum and
 # energy from the flow.
 #
 # #### Bottom boundary condition: quadratic bottom drag
@@ -60,44 +66,44 @@
 # the flux is negative (downwards) when the velocity at the bottom boundary is positive, and 
 # positive (upwards) with the velocity at the bottom boundary is negative.
 # This drag term is "quadratic" because the rate at which momentum is removed is proportional
-# to $\boldsymbol{u}_h |\boldsymbol{u}_h|$, where 
-# $\boldsymbol{u}_h = u \boldsymbol{\hat{x}} + v \boldsymbol{\hat{y}}$ is the horizontal velocity.
+# to ``\boldsymbol{u}_h |\boldsymbol{u}_h|``, where 
+# ``\boldsymbol{u}_h = u \boldsymbol{\hat{x}} + v \boldsymbol{\hat{y}}`` is the horizontal velocity.
 #
-# The $x$-component of the quadratic bottom drag is thus
+# The ``x``-component of the quadratic bottom drag is thus
 # 
 # ```math
 # \tau_{xz}(z=L_z) = - c^D u \sqrt{u^2 + v^2} \, ,
 # ```
 #
-# while the $y$-component is
+# while the ``y``-component is
 #
 # ```math
 # \tau_{yz}(z=L_z) = - c^D v \sqrt{u^2 + v^2} \, , 
 # ```
 #
-# where $c^D$ is a dimensionless drag coefficient and $\tau_{xz}(z=L_z)$ and $\tau_{yz}(z=L_z)$
-# denote the flux of $u$ and $v$ momentum at $z = L_z$, the bottom of the domain.
+# where ``c^D`` is a dimensionless drag coefficient and ``\tau_{xz}(z=L_z)`` and ``\tau_{yz}(z=L_z)``
+# denote the flux of ``u`` and ``v`` momentum at ``z = L_z``, the bottom of the domain.
 #
 # ### Vertical and horizontal viscosity and diffusivity
 #
 # Vertical and horizontal viscosties and diffusivities are required
 # to stabilize the Eady problem and can be idealized as modeling the effect of
 # turbulent mixing below the grid scale. For both tracers and velocities we use
-# a Laplacian vertical diffusivity $κ_z ∂_z^2 c$ and a biharmonic horizontal
-# diffusivity $ϰ_h (∂_x^4 + ∂_y^4) c$. 
+# a Laplacian vertical diffusivity ``κ_z ∂_z^2 c`` and a biharmonic horizontal
+# diffusivity ``ϰ_h (∂_x^4 + ∂_y^4) c``. 
 #
 # ### Eady problem summary and parameters
 #
 # To summarize, the Eady problem parameters along with the values we use in this example are
 #
 # | Parameter name | Description | Value | Units |
-# | -------------- | ----------- | ----- | ----- | 
-# | $ f $          | Coriolis parameter | $ 10^{-4} $ | $ \mathrm{s^{-1}} $ |
-# | $ N $          | Buoyancy frequency (square root of $\partial_z B$) | $ 10^{-3} $ | $ \mathrm{s^{-1}} $ |
-# | $ \alpha $     | Background vertical shear $\partial_z U$ | $ 10^{-3} $ | $ \mathrm{s^{-1}} $ |
-# | $ c^D $        | Bottom quadratic drag coefficient | $ 10^{-4} $ | none |
-# | $ κ_z $    | Laplacian vertical diffusivity | $ 10^{-2} $ | $ \mathrm{m^2 s^{-1}} $ |
-# | $ \varkappa_h $    | Biharmonic horizontal diffusivity | $ 10^{-2} \times \Delta x^4 / \mathrm{day} $ | $ \mathrm{m^4 s^{-1}} $ |
+# |:--------------:|:-----------:|:-----:|:-----:| 
+# | ``f``          | Coriolis parameter | ``10^{-4}`` | ``\mathrm{s^{-1}}`` |
+# | ``N``          | Buoyancy frequency (square root of ``\partial_z B``) | ``10^{-3}`` | ``\mathrm{s^{-1}}`` |
+# | ``\alpha``     | Background vertical shear ``\partial_z U`` | ``10^{-3}`` | ``\mathrm{s^{-1}}`` |
+# | ``c^D``        | Bottom quadratic drag coefficient | ``10^{-4}`` | none |
+# | ``κ_z``        | Laplacian vertical diffusivity | ``10^{-2}`` | ``\mathrm{m^2 s^{-1}}`` |
+# | ``\varkappa_h``    | Biharmonic horizontal diffusivity | ``10^{-2} \times \Delta x^4 / \mathrm{day}`` | ``\mathrm{m^4 s^{-1}}`` |
 #
 # We start off by importing `Oceananigans`, some convenient aliases for dimensions, and a function
 # that generates a pretty string from a number that represents 'time' in seconds:
@@ -115,7 +121,7 @@ grid = RegularCartesianGrid(size=(48, 48, 16), x=(0, 1e6), y=(0, 1e6), z=(-4e3, 
 
 # ## Rotation
 #
-# The classical Eady problem is posed on an $f$-plane. We use a Coriolis parameter
+# The classical Eady problem is posed on an ``f``-plane. We use a Coriolis parameter
 # typical to mid-latitudes on Earth,
 
 coriolis = FPlane(f=1e-4) # [s⁻¹]
@@ -129,7 +135,7 @@ background_parameters = ( α = 10 * coriolis.f, # s⁻¹, geostrophic shear
                           N = 1e-3,            # s⁻¹, buoyancy frequency
                          Lz = grid.Lz)         # m, ocean depth
 
-# and then construct the background fields $U$ and $B$
+# and then construct the background fields ``U`` and ``B``
 
 using Oceananigans.Fields: BackgroundField
 
@@ -259,6 +265,7 @@ progress(sim) = @printf("i: % 6d, sim time: % 10s, wall time: % 10s, Δt: % 10s,
                         prettytime(1e-9 * (time_ns() - start_time)),
                         prettytime(sim.Δt.Δt),
                         CFL(sim.model))
+nothing # hide
 
 # ### Build the simulation
 #
@@ -288,7 +295,7 @@ u, v, w = model.velocities # unpack velocity `Field`s
 nothing # hide
 
 # With the vertical vorticity, `ζ`, and the horizontal divergence, `δ` in hand,
-# we create a `JLD2OutputWriter` that saves `ζ` and `δ` and add it to 
+# we create a `JLD2OutputWriter` that saves `ζ` and `δ` and add them to 
 # `simulation`.
 
 using Oceananigans.OutputWriters: JLD2OutputWriter, TimeInterval
@@ -337,6 +344,7 @@ function nice_divergent_levels(c, clim, nlevels=30)
 
     return levels
 end
+nothing # hide
 
 # Now we're ready to animate.
 
@@ -416,7 +424,7 @@ anim = @animate for (i, iter) in enumerate(iterations)
            size = (1000, 800),
            link = :x,
          layout = Plots.grid(2, 2, heights=[0.5, 0.5, 0.2, 0.2]),
-          title = [@sprintf("ζ(t=%s)/f", prettytime(t)) @sprintf("δ(t=%s) (s⁻¹)", prettytime(t)) "" ""])
+          title = [@sprintf("ζ(t=%s) / f", prettytime(t)) @sprintf("δ(t=%s) (s⁻¹)", prettytime(t)) "" ""])
 
     iter == iterations[end] && close(file)
 end

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -7,7 +7,7 @@
 # ## Numerical, domain, and internal wave parameters
 #
 # First, we pick a resolution and domain size. We use a two-dimensional domain
-# that's periodic in $(x, y, z)$:
+# that's periodic in ``(x, y, z)``:
 
 using Oceananigans
 
@@ -64,12 +64,14 @@ model = IncompressibleModel(
 # Next, we set up an initial condition that excites an internal wave that propates
 # through our rotating, stratified fluid. This internal wave has the pressure field
 #
-# $ p(x, y, z, t) = a(x, z) \, \cos(kx + mz - ω t) $.
+# ```math
+# p(x, y, z, t) = a(x, z) \, \cos(kx + mz - ω t).
+# ```
 #
-# where $m$ is the vertical wavenumber, $k$ is the horizontal wavenumber,
-# $ω$ is the wave frequncy, and $a(x, z)$ is a Gaussian envelope.
-# The internal wave dispersion relation links the wave numbers $k$ and $m$,
-# the Coriolis parameter $f$, and the buoyancy frequency N:
+# where ``m`` is the vertical wavenumber, ``k`` is the horizontal wavenumber,
+# ``ω`` is the wave frequncy, and ``a(x, z)`` is a Gaussian envelope.
+# The internal wave dispersion relation links the wave numbers ``k`` and ``m``,
+# the Coriolis parameter ``f``, and the buoyancy frequency ``N``:
 
 ## Non-dimensional internal wave parameters
 m = 16      # vertical wavenumber
@@ -89,16 +91,16 @@ nothing # hide
 A = 1e-9
 δ = grid.Lx / 15
 
-## A Gaussian envelope centered at $(x, z) = (0, 0)$.
+## A Gaussian envelope centered at ``(x, z) = (0, 0)``.
 a(x, z) = A * exp( -( x^2 + z^2 ) / 2δ^2 )
 nothing # hide
 
 # An inertia-gravity wave is a linear solution to the Boussinesq equations.
 # In order that our initial condition excites an inertia-gravity wave, we
 # initialize the velocity and buoyancy perturbation fields to be consistent
-# with the pressure field $p = a \, \cos(kx + mx - ωt)$ at $t=0$.
+# with the pressure field ``p = a \, \cos(kx + mx - ωt)`` at ``t=0``.
 # These relations are sometimes called the "polarization
-# relations". At $t=0$, the polarization relations yield
+# relations". At ``t=0``, the polarization relations yield
 
 u₀(x, y, z) = a(x, z) * k * ω   / (ω^2 - f^2) * cos(k*x + m*z)
 v₀(x, y, z) = a(x, z) * k * f   / (ω^2 - f^2) * sin(k*x + m*z)
@@ -108,7 +110,7 @@ b₀(x, y, z) = a(x, z) * m * N^2 / (ω^2 - N^2) * sin(k*x + m*z)
 set!(model, u=u₀, v=v₀, w=w₀, b=b₀)
 
 # Recall that the buoyancy `b` is a perturbation, so that the total buoyancy field
-# is $N^2 z + b$.
+# is ``N^2 z + b``.
 
 # ## A wave packet on the loose
 #

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -71,7 +71,7 @@ nothing # hide
 
 # ### Boundary conditions
 #
-# At the surface at $z=0$, McWilliams et al. (1997) impose wind stress,
+# At the surface at ``z=0``, McWilliams et al. (1997) impose wind stress,
 
 Qᵘ = -3.72e-5 # m² s⁻²
 nothing # hide
@@ -91,14 +91,14 @@ nothing # hide
 N² = 1.936e-5 # s⁻²
 nothing # hide
 
-# To summarize, we impose a surface flux on $u$,
+# To summarize, we impose a surface flux on ``u``,
 
 using Oceananigans.BoundaryConditions
 
 u_boundary_conditions = UVelocityBoundaryConditions(grid, top = BoundaryCondition(Flux, Qᵘ))
 nothing # hide
 
-# and a surface flux and bottom linear gradient on buoyancy, $b$,
+# and a surface flux and bottom linear gradient on buoyancy, ``b``,
 
 b_boundary_conditions = TracerBoundaryConditions(grid, top = BoundaryCondition(Flux, Qᵇ),
                                                        bottom = BoundaryCondition(Gradient, N²))
@@ -116,8 +116,8 @@ nothing # hide
 # ## Model instantiation
 #
 # Finally, we are ready to build the model. We use the AnisotropicMinimumDissipation
-# model for large eddy simulation. Because our Stokes drift does not vary in $x, y$,
-# we use `UniformStokesDrift`, which expects Stokes drift functions of $z, t$ only.
+# model for large eddy simulation. Because our Stokes drift does not vary in ``x, y``,
+# we use `UniformStokesDrift`, which expects Stokes drift functions of ``z, t`` only.
 
 using Oceananigans.Buoyancy: BuoyancyTracer
 using Oceananigans.SurfaceWaves: UniformStokesDrift
@@ -147,8 +147,8 @@ bᵢ(x, y, z) = N² * z + 1e-1 * Ξ(z) * N² * model.grid.Lz
 nothing # hide
 
 # The velocity initial condition is zero *Eulerian* velocity. This means that we
-# must add the Stokes drift profile to the $u$ velocity field. We also add noise scaled
-# by the friction velocity to $u$ and $w$.
+# must add the Stokes drift profile to the ``u`` velocity field. We also add noise scaled
+# by the friction velocity to ``u`` and ``w``.
 
 uᵢ(x, y, z) = uˢ(z) + sqrt(abs(Qᵘ)) * 1e-1 * Ξ(z)
 
@@ -167,7 +167,7 @@ nothing # hide
 # ### Nice progress messaging
 #
 # We define a function that prints a helpful message with
-# maximum absolute value of $u, v, w$ and the current wall clock time.
+# maximum absolute value of ``u, v, w`` and the current wall clock time.
 
 using Oceananigans.Diagnostics, Printf
 using Oceananigans.Utils: prettytime
@@ -227,8 +227,8 @@ run!(simulation)
 
 # # Making a neat movie
 #
-# We look at the results by plotting vertical slices of $u$ and $w$, and a horizontal
-# slice of $w$ to look for Langmuir cells.
+# We look at the results by plotting vertical slices of ``u`` and ``w``, and a horizontal
+# slice of ``w`` to look for Langmuir cells.
 
 k = searchsortedfirst(grid.zF[:], -8)
 nothing # hide

--- a/examples/ocean_convection_with_plankton.jl
+++ b/examples/ocean_convection_with_plankton.jl
@@ -18,11 +18,15 @@ using Oceananigans, Oceananigans.Utils, Oceananigans.Grids
 # implying a resolution of 0.5 m. Our fluid is initially stratified with
 # a squared buoyancy frequency
 #
-# $ N² = 10⁻⁵ \rm{s⁻²} $
+# ```math
+# N² = 10^{-5} \rm{s^{-2}} \, ,
+# ```
 #
 # and a surface buoyancy flux
 #
-# $ Q_b = 10⁻⁸ \rm{m³ s⁻²} $
+# ```math
+# Q_b = 10^{-8} \mathrm{m}^3 \, \mathrm{s}s^{-2} \, .
+# ```
 #
 # Because we use the physics-based convection whereby buoyancy flux by a
 # positive vertical velocity implies positive flux, a positive buoyancy flux

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -11,7 +11,7 @@
 # ## Model setup
 
 # We instantiate the model with a simple isotropic diffusivity. We also use a 4-th order 
-# advection scheme and Runge-Kutta 3rd order time-stepping scheme.
+# advection scheme and Runge-Kutta 3-rd order time-stepping scheme.
 
 using Oceananigans, Oceananigans.Advection
 
@@ -80,7 +80,7 @@ file = jldopen(simulation.output_writers[:fields].filepath)
 iterations = parse.(Int, keys(file["timeseries/t"]))
 nothing # hide
 
-# Construct the $x$, $y$ grid for plotting purposes,
+# Construct the ``x``, ``y`` grid for plotting purposes,
 
 using Oceananigans.Grids
 


### PR DESCRIPTION
This PR replaces `$..$` with ` ``..`` `  and `$$..$$` with ` ```math ... ``` `.

According to @mortenpi dollar signs are deprecated.

<img width="831" alt="Screen Shot 2020-10-24 at 9 34 31 am" src="https://user-images.githubusercontent.com/7112768/97059461-37e9f500-15dc-11eb-8dd0-beb25351f4ce.png">
