### PR TITLE
Blending magic and diffusivities-as-functions

### DIFF
--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -7,29 +7,19 @@ min_Δy(grid) = grid.Δy
 min_Δz(grid) = grid.Δz
 
 cell_diffusion_timescale(model) = cell_diffusion_timescale(model.closure, model.diffusivities, model.grid)
-
 cell_diffusion_timescale(::Nothing, diffusivities, grid) = Inf
 
-function cell_diffusion_timescale(closure::IsotropicDiffusivity{N, <:NamedTuple{()}},
-                                  diffusivities, grid) where N
-    return min_Δxyz(grid)^2 / closure.ν
-end
+maximum_numeric_diffusivity(κ::Number) = κ
+maximum_numeric_diffusivity(κ::NamedTuple) = maximum(κ)
+
+# as the name suggests, we give up in the case of a function diffusivity
+maximum_numeric_diffusivity(κ::Function) = 0
 
 function cell_diffusion_timescale(closure::IsotropicDiffusivity, diffusivities, grid)
     Δ = min_Δxyz(grid)
-    max_κ = maximum(closure.κ)
-    return min(Δ^2 / closure.ν, Δ^2 / max_κ)
-end
-
-function cell_diffusion_timescale(closure::AnisotropicDiffusivity{NX, NY, NZ, <:NamedTuple{()}, <:NamedTuple{()}, <:NamedTuple{()}},
-                                  diffusivities, grid) where {NX, NY, NZ}
-    Δx = min_Δx(grid)
-    Δy = min_Δy(grid)
-    Δz = min_Δz(grid)
-
-    return min(Δx^2 / closure.νx,
-               Δy^2 / closure.νy,
-               Δz^2 / closure.νz)
+    max_κ = maximum_numeric_diffusivity(closure.κ)
+    max_ν = maximum_numeric_diffusivity(closure.ν)
+    return min(Δ^2 / max_ν, Δ^2 / max_κ)
 end
 
 function cell_diffusion_timescale(closure::AnisotropicDiffusivity, diffusivities, grid)
@@ -38,27 +28,20 @@ function cell_diffusion_timescale(closure::AnisotropicDiffusivity, diffusivities
     Δy = min_Δy(grid)
     Δz = min_Δz(grid)
 
-    max_κx = maximum(closure.κx)
-    max_κy = maximum(closure.κy)
-    max_κz = maximum(closure.κz)
+    max_νx = maximum_numeric_diffusivity(closure.νx)
+    max_νy = maximum_numeric_diffusivity(closure.νy)
+    max_νz = maximum_numeric_diffusivity(closure.νz)
 
-    return min(Δx^2 / closure.νx,
-               Δy^2 / closure.νy,
-               Δz^2 / closure.νz,
+    max_κx = maximum_numeric_diffusivity(closure.κx)
+    max_κy = maximum_numeric_diffusivity(closure.κy)
+    max_κz = maximum_numeric_diffusivity(closure.κz)
+
+    return min(Δx^2 / max_νx,
+               Δy^2 / max_νy,
+               Δz^2 / max_νz,
                Δx^2 / max_κx,
                Δy^2 / max_κy,
                Δz^2 / max_κz)
-end
-
-function cell_diffusion_timescale(closure::AnisotropicBiharmonicDiffusivity{V, <:NamedTuple{()}, <:NamedTuple{()}},
-                                  diffusivities, grid) where V
-    Δx = min_Δx(grid)
-    Δy = min_Δy(grid)
-    Δz = min_Δz(grid)
-
-    return min(Δx^4 / closure.νx,
-               Δy^4 / closure.νy,
-               Δz^4 / closure.νz)
 end
 
 function cell_diffusion_timescale(closure::AnisotropicBiharmonicDiffusivity, diffusivities, grid)
@@ -66,16 +49,20 @@ function cell_diffusion_timescale(closure::AnisotropicBiharmonicDiffusivity, dif
     Δy = min_Δy(grid)
     Δz = min_Δz(grid)
 
-    max_κx = maximum(closure.κx)
-    max_κy = maximum(closure.κy)
-    max_κz = maximum(closure.κz)
+    max_νx = maximum_numeric_diffusivity(closure.νx)
+    max_νy = maximum_numeric_diffusivity(closure.νy)
+    max_νz = maximum_numeric_diffusivity(closure.νz)
 
-    return min(Δx^4 / closure.νx, 
-               Δy^4 / closure.νy, 
-               Δz^4 / closure.νz,
-               Δx^4 / max_κx,
-               Δy^4 / max_κy, 
-               Δz^4 / max_κz)
+    max_κx = maximum_numeric_diffusivity(closure.κx)
+    max_κy = maximum_numeric_diffusivity(closure.κy)
+    max_κz = maximum_numeric_diffusivity(closure.κz)
+
+    return min(Δx^2 / max_νx,
+               Δy^2 / max_νy,
+               Δz^2 / max_νz,
+               Δx^2 / max_κx,
+               Δy^2 / max_κy,
+               Δz^2 / max_κz)
 end
 
 function cell_diffusion_timescale(closure::SmagorinskyLilly{FT, P, <:NamedTuple{()}},

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -11,9 +11,11 @@ cell_diffusion_timescale(::Nothing, diffusivities, grid) = Inf
 
 maximum_numeric_diffusivity(κ::Number) = κ
 maximum_numeric_diffusivity(κ::NamedTuple) = maximum(κ)
+maximum_numeric_diffusivity(κ::NamedTuple{()}) = 0 # tracers=nothing means empty diffusivity tuples
 
-# as the name suggests, we give up in the case of a function diffusivity
+# As the name suggests, we give up in the case of a function diffusivity
 maximum_numeric_diffusivity(κ::Function) = 0
+
 
 function cell_diffusion_timescale(closure::IsotropicDiffusivity, diffusivities, grid)
     Δ = min_Δxyz(grid)


### PR DESCRIPTION
@mukund-gupta discovered a bug (see #1104) that prevents the use of function diffusivities with the `TimeStepWizard`.

We don't want the wizard to be so all-powerful that it samples a diffusivity function over the whole grid just to compute it's maximum value. So, this PR does the simple thing and avoids limiting the time-step by the diffusivity when it's a function.

A better solution would require users to explicitly ask their time-step to be limited by diffusivities, and for that step to fail when the diffusivity is a function (eg #1087).

It could make sense to add a test for all possible combinations of diffusivities and wizards, but it might be better to wait for a more comprehensive PR that addresses #1087...

Resolves #1104 