### PR TITLE
Remove "colorbar oscillations" in examples

### DIFF
--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -205,9 +205,9 @@ iterations = parse.(Int, keys(file["timeseries/t"]))
 
 """ Returns colorbar levels equispaced between `(-clim, clim)` and encompassing the extrema of `c`. """
 function divergent_levels(c, clim, nlevels=21)
-    levels = range(-clim, stop=clim, length=nlevels)
     cmax = maximum(abs, c)
-    return ((-clim, clim), clim > cmax ? levels : levels = vcat([-cmax], levels, [cmax]))
+    levels = clim > cmax ? range(-clim, stop=clim, length=nlevels) : range(-cmax, stop=cmax, length=nlevels)
+    return (levels[1], levels[end]), levels
 end
 
 """ Returns colorbar levels equispaced between `clims` and encompassing the extrema of `c`."""

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -122,25 +122,22 @@ anim = @animate for (i, iteration) in enumerate(iterations)
     ω_snapshot = file["timeseries/ω/$iteration"][:, :, 1]
     s_snapshot = file["timeseries/s/$iteration"][:, :, 1]
 
-    ω_max = maximum(abs, ω_snapshot) + 1e-9
     ω_lim = 2.0
+    ω_levels = range(-ω_lim, stop=ω_lim, length=20)
 
-    s_max = maximum(abs, s_snapshot) + 1e-9
     s_lim = 0.2
-
-    ω_levels = vcat([-ω_max], range(-ω_lim, stop=ω_lim, length=20), [ω_max])
-    s_levels = vcat(range(0, stop=s_lim, length=20), [s_max]) 
+    s_levels = range(0, stop=s_lim, length=20)
 
     kwargs = (xlabel="x", ylabel="y", aspectratio=1, linewidth=0, colorbar=true,
               xlims=(0, model.grid.Lx), ylims=(0, model.grid.Ly))
-
-    ω_plot = contourf(xω, yω, ω_snapshot';
+              
+    ω_plot = contourf(xω, yω, clamp.(ω_snapshot, -ω_lim, ω_lim)';
                        color = :balance,
                       levels = ω_levels,
                        clims = (-ω_lim, ω_lim),
                       kwargs...)
 
-    s_plot = contourf(xs, ys, s_snapshot';
+    s_plot = contourf(xs, ys, clamp.(s_snapshot', 0, s_lim)';
                        color = :thermal,
                       levels = s_levels,
                        clims = (0, s_lim),


### PR DESCRIPTION
Currently colorbars in some of the examples "oscillate". See, e.g., vorticity colormap as is now:

![two_dimensional_turbulence](https://user-images.githubusercontent.com/7112768/97361670-fca93800-18f3-11eb-82a7-0af10b7674a1.gif)

After this PR:

![two_dimensional_turbulence_2](https://user-images.githubusercontent.com/7112768/97361783-2cf0d680-18f4-11eb-96e2-df596c177099.gif)
