### PR TITLE
[WIP] Fixes bug in show method for boundary conditions

### DIFF
--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -15,7 +15,7 @@
 
 using Oceananigans, Oceananigans.Advection
 
-grid = RegularCartesianGrid(topology = (Periodic, Periodic, Bounded), size=(128, 128, 1), extent=(2π, 2π, 2π))
+grid = RegularCartesianGrid(topology = (Periodic, Periodic, Flat), size=(128, 128), extent=(2π, 2π))
 
 model = IncompressibleModel(timestepper = :RungeKutta3, 
                               advection = UpwindBiasedFifthOrder(),

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -15,7 +15,7 @@
 
 using Oceananigans, Oceananigans.Advection
 
-grid = RegularCartesianGrid(size=(128, 128, 1), extent=(2π, 2π, 2π))
+grid = RegularCartesianGrid(topology = (Periodic, Periodic, Bounded), size=(128, 128, 1), extent=(2π, 2π, 2π))
 
 model = IncompressibleModel(timestepper = :RungeKutta3, 
                               advection = UpwindBiasedFifthOrder(),

--- a/src/BoundaryConditions/show_boundary_conditions.jl
+++ b/src/BoundaryConditions/show_boundary_conditions.jl
@@ -21,12 +21,13 @@ Base.show(io::IO, bc::BC{C, T}) where {C, T} =
 ##### FieldBoundaryConditions
 #####
 
-bctype_str(::FBC)  = "Flux"
-bctype_str(::PBC)  = "Periodic"
-bctype_str(::NFBC) = "NormalFlow"
-bctype_str(::VBC)  = "Value"
-bctype_str(::GBC)  = "Gradient"
-bctype_str(::ZFBC) = "ZeroFlux"
+bctype_str(::FBC)     = "Flux"
+bctype_str(::PBC)     = "Periodic"
+bctype_str(::NFBC)    = "NormalFlow"
+bctype_str(::VBC)     = "Value"
+bctype_str(::GBC)     = "Gradient"
+bctype_str(::ZFBC)    = "ZeroFlux"
+bctype_str(::Nothing) = "Nothing"
 
 short_show(fbcs::FieldBoundaryConditions) =
     string("x=(west=$(bctype_str(fbcs.x.left)), east=$(bctype_str(fbcs.x.right))), ",


### PR DESCRIPTION
This is an 'easy fix' for #1026 -- thanks @ali-ramadhan 

Changes the `two_dimensional_turbulence.jl` example to use `Flat` z dimension.

Closes #1026 