### PR TITLE
Make sure users always construct a model with an `AbstractArchitecture`

### DIFF
--- a/src/Models/incompressible_model.jl
+++ b/src/Models/incompressible_model.jl
@@ -77,7 +77,7 @@ Keyword arguments
 """
 function IncompressibleModel(;
                    grid,
-           architecture = CPU(),
+           architecture::AbstractArchitecture = CPU(),
              float_type = Float64,
                   clock = Clock{float_type}(0, 0, 1),
               advection = CenteredSecondOrder(),

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -49,6 +49,12 @@ end
 @testset "Models" begin
     @info "Testing models..."
 
+    @testset "Model constructor errors" begin
+        grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
+        @test_throws TypeError IncompressibleModel(architecture=CPU, grid=grid)
+        @test_throws TypeError IncompressibleModel(architecture=GPU, grid=grid)
+    end
+
     topos = ((Periodic, Periodic, Periodic),
              (Periodic, Periodic,  Bounded),
              (Periodic,  Bounded,  Bounded),


### PR DESCRIPTION
Resolves #1118

Needs a `@test_throws`. Ruins the formatting of the `IncompressibleModel` constructor but small price to pay.