### PR TITLE
Adds Kelvin-Helmholtz instability example

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -60,7 +60,7 @@ example_pages = [
     "Ocean wind mixing and convection" => "generated/ocean_wind_mixing_and_convection.md",
     "Langmuir turbulence"              => "generated/langmuir_turbulence.md",
     "Eady turbulence"                  => "generated/eady_turbulence.md",
-    "Kelvin-Helmhotlz instability"     => "generated/kelvin_helmholtz_instability.md"
+    "Kelvin-Helmholtz instability"     => "generated/kelvin_helmholtz_instability.md"
 ]
 
 model_setup_pages = [

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,7 +39,8 @@ examples = [
     "convecting_plankton.jl",
     "ocean_wind_mixing_and_convection.jl",
     "langmuir_turbulence.jl",
-    "eady_turbulence.jl"
+    "eady_turbulence.jl",
+    "kelvin_helmholtz_instability.jl"
 ]
 
 for example in examples
@@ -58,7 +59,8 @@ example_pages = [
     "Convecting plankton"              => "generated/convecting_plankton.md",
     "Ocean wind mixing and convection" => "generated/ocean_wind_mixing_and_convection.md",
     "Langmuir turbulence"              => "generated/langmuir_turbulence.md",
-    "Eady turbulence"                  => "generated/eady_turbulence.md"
+    "Eady turbulence"                  => "generated/eady_turbulence.md",
+    "Kelvin-Helmhotlz instability"     => "generated/kelvin_helmholtz_instability.md"
 ]
 
 model_setup_pages = [

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -129,6 +129,7 @@ function grow_instability!(simulation, energy)
 
     return growth_rate    
 end
+nothing # hide
 
 # Finally, we write a function that rescales the velocity field
 # at the write
@@ -188,6 +189,7 @@ function estimate_growth_rate!(simulation, energy, ω; convergence_criterion=1e-
 
     return σ
 end
+nothing # hide
 
 # # Eigenplotting
 #
@@ -214,6 +216,7 @@ eigenplot!(ω, σ, t; ω_lim=maximum(abs, ω)+1e-16) =
              clims = (-ω_lim, ω_lim), linewidth = 0,
               size = (600, 300),
              title = eigentitle(σ, t))
+nothing # hide
 
 # # Rev your engines...
 #
@@ -275,10 +278,9 @@ simulation.output_writers[:vorticity] =
                      prefix = "kelvin_helmholtz_instability",
                      force = true)
 
-@info "*** Running a simulation of Kelvin-Helmholtz instability..."
-
 # And now we
 
+@info "*** Running a simulation of Kelvin-Helmholtz instability..."
 run!(simulation)
 
 # ## Pretty things

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -186,6 +186,10 @@ function estimate_growth_rate!(simulation, energy, ω, b; convergence_criterion=
     σ = []
     
     plotseries = Array{Any, 1}(undef, 20)  # expect no more than 20 iterations
+    
+    compute!(ω)
+    plotseries[1] = plot_powermethoditerationplot_powermethoditeration = powermethodplot(interior(ω)[:, 1, :], interior(b)[:, 1, :], σ, nothing)
+    
     iteration = 1
     while convergence(σ) > convergence_criterion
 
@@ -202,7 +206,7 @@ function estimate_growth_rate!(simulation, energy, ω, b; convergence_criterion=
         rescale!(simulation.model, energy)
         compute!(energy)
         
-        plotseries[iteration] = plot_powermethoditeration
+        plotseries[iteration+1] = plot_powermethoditeration
         iteration += 1
         
         @info @sprintf("Kinetic energy after rescaling: %.2e", energy[1, 1, 1])
@@ -226,7 +230,7 @@ perturbation_vorticity = ComputedField(∂z(u) - ∂x(w))
 x, y, z = nodes(perturbation_vorticity)
 xb, yb, zb = nodes(b)
 
-eigentitle(σ, t) = @sprintf("Iteration #%i; growth rate %.2e", length(σ), σ[end])
+eigentitle(σ, t) = length(σ) > 0 ? @sprintf("Iteration #%i; growth rate %.2e", length(σ), σ[end]) : @sprintf("Initial perturbation fields")
 eigentitle(::Nothing, t) = @sprintf("Vorticity at t = %.2f", t)
 
 function eigenplot(ω, b, σ, t; ω_lim=maximum(abs, ω)+1e-16, b_lim=maximum(abs, b)+1e-16)

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -1,0 +1,268 @@
+# # Stratified Kelvin-Helmholtz instability
+#
+# # The domain 
+
+using Oceananigans
+
+using Plots
+
+#pyplot()
+
+grid = RegularCartesianGrid(size=(64, 1, 128), x=(-2π, 2π), y=(0, 1), z=(-3, 3),
+                                  topology=(Periodic, Periodic, Bounded))
+
+# # The background flow
+#
+# Our background flow constists of linear stratification and constant shear
+
+using Oceananigans.Fields, Oceananigans.Grids
+
+shear_flow(x, y, z, t) = tanh(z)
+
+# Ri = ∂z B / (∂z U)²
+stratification(x, y, z, t, p) = p.h * p.Ri * tanh(z / p.h)
+
+Ri = 0.1
+h = 1/10
+
+U = BackgroundField(shear_flow)
+B = BackgroundField(stratification, parameters=(Ri=Ri, h=h))
+
+z = znodes(Cell, grid)
+
+background_b = @. h * Ri * tanh(z / h)
+
+∂z_U = @. sech(z)^2
+∂z_B = @. Ri * sech(z / h)^2
+
+Ri_background = @. ∂z_B / ∂z_U^2
+
+#=
+kwargs = (ylabel = z, linewidth = 2)
+U_plot = plot(shear_flow.(0, 0, z, 0), z, xlabel="U(z)", kwargs...)
+B_plot = plot(background_buoyancy.(0, 0, z, 0), z, xlabel="B(z)", kwargs...)
+Ri_plot = plot(background_Ri.(0, 0, z, 0), z, xlabel="B(z)", kwargs...)
+base_state = plot([shear_flow.(0, 0, z, 0) background_b Ri_background], z,
+                  linewidth=2, xlabel="Ri", ylabel="y",
+                  size = (600, 400),
+                  label = ["U(z)" "B(z)" "Ri(z)"])
+
+display(base_state)
+=#
+
+# # The model
+
+using Oceananigans.Advection
+
+model = IncompressibleModel(timestepper = :RungeKutta3, 
+                            advection = UpwindBiasedFifthOrder(),
+                            grid = grid,
+                            coriolis = nothing,
+                            background_fields = (u=U, b=B),
+                            closure = IsotropicDiffusivity(ν=1e-4, κ=1e-4),
+                            buoyancy = BuoyancyTracer(),
+                            tracers = :b)
+
+# # A _Power_ful algorithm
+
+simulation = Simulation(model, Δt=0.1, iteration_interval=10, stop_iteration=200)
+                        
+"""
+    grow_instability!(simulation, e)
+
+Grow an instability by running `simulation`.
+
+Estimates the growth rate ``σ`` of the instability
+using the fractional change in volume-mean kinetic energy,
+over the course of the `simulation`
+
+``
+e(t₁) / e(t₀) ≈ exp(2 σ (t₁ - t₀))
+``
+
+where ``t₀`` and ``t₁`` are the starting and ending times of the
+simulation. We thus find that
+
+``
+σ ≈ log(e(t₁) / e(t₀)) / (2 * (t₁ - t₀)) .
+``
+"""
+function grow_instability!(simulation, e)
+    ## Initialize
+    simulation.model.clock.iteration = 0
+    t₀ = simulation.model.clock.time = 0
+    e₀ = e[1, 1, 1]
+
+    ## Grow
+    run!(simulation)
+
+    ## Analyze
+    compute!(e)
+    e₁ = e[1, 1, 1]
+    Δt = simulation.model.clock.time - t₀
+
+    ## (u² + v²) / 2 ~ exp(2 σ Δt)
+    σ = growth_rate = log(e₁ / e₀) / 2Δt
+
+    return growth_rate    
+end
+
+# Finally, we write a function that rescales the velocity field
+# at the write
+
+"""
+    rescale!(model, e; target_kinetic_energy=1e-3)
+
+Rescales all model fields so that `e = target_kinetic_energy`.
+
+The rescaling factor is calculated via
+
+``
+r = \\sqrt{e_\\mathrm{target} / e}
+``
+"""
+function rescale!(model, e; target_kinetic_energy=1e-4)
+    compute!(e)
+    r = sqrt(target_kinetic_energy / e[1, 1, 1])
+
+    model.velocities.u.data.parent .*= r
+    model.velocities.v.data.parent .*= r
+    model.velocities.w.data.parent .*= r
+    model.tracers.b.data.parent .*= r
+    return nothing
+end
+
+using Printf
+
+relative_change(σⁿ, σⁿ⁻¹) = isfinite(σⁿ) ? abs((σⁿ - σⁿ⁻¹) / σⁿ) : Inf
+
+"""
+    estimate_growth_rate!(simulation, e, ω; convergence_criterion=1e-2)
+
+Estimates the growth rate.
+"""
+function estimate_growth_rate!(simulation, e, ω; convergence_criterion=1e-3)
+    σ = [0.0, grow_instability!(simulation, e)]
+
+    while relative_change(σ[end], σ[end-1]) > convergence_criterion
+
+        push!(σ, grow_instability!(simulation, e))
+
+        compute!(e)
+
+        @info @sprintf("*** Power iteration %d, e: %.5f, σⁿ: %.2e, relative Δσ: %.2e",
+                       length(σ), e[1, 1, 1], σ[end], relative_change(σ[end], σ[end-1]))
+
+        compute!(ω)
+        display(eigenplot!(interior(ω)[:, 1, :], σ, nothing))
+
+        rescale!(simulation.model, e)
+        compute!(e)
+
+        @info @sprintf("*** Kinetic energy after rescaling: %.5f", e[1, 1, 1])
+                       
+    end
+
+    return σ
+end
+
+# # Eigenplotting
+#
+# A good algorithm wouldn't be complete without a good visualization tool,
+
+using Oceananigans.AbstractOperations
+
+u, v, w = model.velocities
+b = model.tracers.b
+
+perturbation_vorticity = ComputedField(∂z(u) - ∂x(w))
+
+x, y, z = nodes(perturbation_vorticity)
+
+eigentitle(σ, t) = "Iteration $(length(σ)): most unstable eigenmode"
+eigentitle(::Nothing, t) = @sprintf("Vorticity at t = %.2f", t)
+
+eigenplot!(ω, σ, t; ω_lim=maximum(abs, ω)+1e-16) =
+    contourf(x, z, clamp.(ω, -ω_lim, ω_lim)';
+             color = :balance, aspectratio = 1,
+             levels = range(-ω_lim, stop=ω_lim, length=11),
+             xlims = (grid.xF[1], grid.xF[grid.Nx]),
+             ylims = (grid.zF[1], grid.zF[grid.Nz]),
+             clims = (-ω_lim, ω_lim), linewidth = 0,
+             size = (600, 200),
+             title = eigentitle(σ, t))
+
+# # Rev your engines...
+#
+# We initialize the power iteration with random noise.
+# The amplitude of the initial condition is arbitrary since our algorithm
+# will rescale the velocity field iteratively until the simulation's stop_criteria
+# is no longer met.
+
+using Random, Statistics, Oceananigans.AbstractOperations
+
+mean_perturbation_energy = mean(1/2 * (u^2 + w^2), dims=(1, 2, 3))
+
+noise(x, y, z) = 1e-2 * randn()
+
+set!(model, u=noise, w=noise, b=noise)
+
+growth_rates = estimate_growth_rate!(simulation, mean_perturbation_energy, perturbation_vorticity)
+
+@info "\n Power iterations converged! Estimated growth rate: $(growth_rates[end]) \n"
+
+# # Plot the result
+
+scatter(filter(σ -> isfinite(σ) && σ > 0, growth_rates),
+        xlabel = "Power iteration",
+        ylabel = "Growth rate (1/s)",
+        yscale = :log10,
+         label = nothing)
+
+# # The fun part
+#
+# Now for the fun part: simulating the transition to turbulence.
+
+estimated_growth_rate = growth_rates[end]
+
+using Oceananigans.OutputWriters
+
+simulation.output_writers[:vorticity] =
+    JLD2OutputWriter(model, (ω=perturbation_vorticity,),
+                     schedule = TimeInterval(0.1 / estimated_growth_rate),
+                     prefix = "kelvin_helmholtz",
+                     force = true)
+
+## Prep a fresh run
+model.clock.iteration = 0
+model.clock.time = 0
+simulation.stop_time = 10 / estimated_growth_rate
+simulation.stop_iteration = 9.1e18 # pretty big (not Inf tho)
+
+@info "*** Running a simulation of Kelvin-Helmholtz instability..."
+
+run!(simulation)
+
+# ## Pretty things
+#
+# Load it; plot it.
+
+using JLD2
+
+file = jldopen(simulation.output_writers[:vorticity].filepath)
+
+iterations = parse.(Int, keys(file["timeseries/t"]))
+
+@info "Making a neat movie of stratified shear flow..."
+
+anim = @animate for (i, iteration) in enumerate(iterations)
+
+    @info "Plotting frame $i from iteration $iteration..."
+    
+    t = file["timeseries/t/$iteration"]
+    ω_snapshot = file["timeseries/ω/$iteration"][:, 1, :]
+
+    eigenplot = eigenplot!(ω_snapshot, nothing, t, ω_lim=1)
+end
+
+gif(anim, "kelvin_helmholtz.gif", fps = 8) # hide

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -51,11 +51,11 @@ plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 using Oceananigans.Advection
 
 model = IncompressibleModel(timestepper = :RungeKutta3, 
-                              advection = UpwindBiasedFifthOrder(),
+                              advection = WENO5(),
                                    grid = grid,
                                coriolis = nothing,
                       background_fields = (u=U, b=B),
-                                closure = IsotropicDiffusivity(ν=5e-5, κ=5e-5),
+                                closure = IsotropicDiffusivity(ν=1e-4, κ=1e-4),
                                buoyancy = BuoyancyTracer(),
                                 tracers = :b)
 
@@ -72,14 +72,14 @@ model = IncompressibleModel(timestepper = :RungeKutta3,
 # The linear operator ``L`` has eigenmodes ``u_j`` and corresponding and corresponding 
 # eigenvalues ``\lambda_j``,
 # ```math
-# \mathcal{L} \, \phi_j = \lambda \, \phi_j \quad j=1,2,\dots \, .
+# L \, \phi_j = \lambda \, \phi_j \quad j=1,2,\dots \, .
 # ```
 # We use the convention that eigenvalues are ordered according to their real part, ``\real(\lambda_1) \ge \real(\lambda_2) \dotsb``.
 # 
-# Successive application of ``\mathcal{L}`` to a random initial state will render it parallel 
+# Successive application of ``L`` to a random initial state will render it parallel 
 # with eigenmode ``\phi_1``:
 # ```math
-# \lim_{n \to \infty} \mathcal{L}^n \Phi \propto \phi_1 \, .
+# \lim_{n \to \infty} L^n \Phi \propto \phi_1 \, .
 # ```
 # Of course, if ``\phi_1`` is an unstable mode, i.e., its eigenvalue has ``\sigma_1 = \real(\lambda_1) > 0``, then successive application 
 # of ``L`` will lead to exponential amplification. (Or, if ``\sigma_1 < 0``, it will

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -328,7 +328,7 @@ run!(simulation)
 
 # ## Pretty things
 #
-# Load it; plot it.
+# Load it; plot it. First the nonlinear equilibration of the perturbation fields.
 
 using JLD2
 
@@ -346,7 +346,22 @@ anim = @animate for (i, iteration) in enumerate(iterations)
     ω_snapshot = file["timeseries/ω/$iteration"][:, 1, :]
     b_snapshot = file["timeseries/b/$iteration"][:, 1, :]
     
+    eigenplot(ω_snapshot, b_snapshot, nothing, t; ω_lim=1, b_lim=0.1)
+end
+
+gif(anim, "kelvin_helmholtz_instability_perturbations.gif", fps = 8) # hide
+
+# And then the total vorticity & buoyancy of the fluid.
+
+anim2 = @animate for (i, iteration) in enumerate(iterations)
+
+    @info "Plotting frame $i from iteration $iteration..."
+    
+    t = file["timeseries/t/$iteration"]
+    ω_snapshot = file["timeseries/Ω/$iteration"][:, 1, :]
+    b_snapshot = file["timeseries/B/$iteration"][:, 1, :]
+    
     eigenplot(ω_snapshot, b_snapshot, nothing, t; ω_lim=1, b_lim=0.05)
 end
 
-gif(anim, "kelvin_helmholtz_instability.gif", fps = 8) # hide
+gif(anim2, "kelvin_helmholtz_instability_total.gif", fps = 8) # hide

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -213,10 +213,9 @@ growth_rates = estimate_growth_rate!(simulation, mean_perturbation_energy, pertu
 
 # # Plot the result
 
-scatter(filter(σ -> isfinite(σ) && σ > 0, growth_rates),
+scatter(filter(σ -> isfinite(σ), growth_rates),
         xlabel = "Power iteration",
-        ylabel = "Growth rate (1/s)",
-        yscale = :log10,
+        ylabel = "Growth rate",
          label = nothing)
 
 # # The fun part

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -93,14 +93,14 @@ model = IncompressibleModel(timestepper = :RungeKutta3,
 # So, we initialize a `simulation` with random initial conditions with amplitude much less than those of
 # the base state (which are ``O(1)``). Each iteration of the power method includes:
 # - compute the perturbation energy, ``E_0``,
-# - evolve the system for ``\Delta t``,
+# - evolve the system for a time-interval ``\Delta \tau``,
 # - compute the perturbation energy, ``E_1``,
-# - determine the exponential growth of the most unstable mode during interval ``\Delta t`` as  ``\log(E_1 / E_0) / (2 \Delta t)``,
+# - determine the exponential growth of the most unstable mode during the interval ``\Delta \tau`` as  ``\log(E_1 / E_0) / (2 \Delta \tau)``,
 # - repeat the above until growth rate converges.
 # 
 # By fiddling a bit with ``\Delta t`` we can get convergence after only a few iterations.
 # 
-# For this example, we take ``\Delta t = 20``.
+# For this example, we take ``\Delta \tau = 20``.
 
 simulation = Simulation(model, Δt=0.1, iteration_interval=20, stop_iteration=100)
                         
@@ -137,10 +137,10 @@ function grow_instability!(simulation, energy)
     ## Analyze
     compute!(energy)
     energy₁ = energy[1, 1, 1]
-    Δt = simulation.model.clock.time - t₀
+    Δτ = simulation.model.clock.time - t₀
 
-    ## (u² + v²) / 2 ~ exp(2 σ Δt)
-    σ = growth_rate = log(energy₁ / energy₀) / 2Δt
+    ## (u² + v²) / 2 ~ exp(2 σ Δτ)
+    σ = growth_rate = log(energy₁ / energy₀) / 2Δτ
     return growth_rate    
 end
 nothing # hide

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -83,9 +83,8 @@ model = IncompressibleModel(timestepper = :RungeKutta3,
 # ```
 # Of course, if ``\phi_1`` is an unstable mode, i.e., its eigenvalue has ``\sigma_1 = \real(\lambda_1) > 0``, then successive application 
 # of ``L`` will lead to exponential amplification. (Or, if ``\sigma_1 < 0``, it will
-# lead to exponential decay of ``\Phi`` down to machine precision.) Therefore, after applying
-# the linear operator ``L`` to our state ``\Phi``, we should rescale ``\Phi`` back to
-# a pre-selected amplitude.
+# lead to exponential decay of ``\Phi`` down to machine precision.) Therefore, after each 
+# application of the linear operator ``L`` to our state ``\Phi``, we should rescale the output ``L \Phi `` back to a pre-selected amplitude before applying ``L`` again.
 # 
 # Oceananigans.jl, does not include a "linear" version of the equations, but we can ensure we 
 # remain in the "linear" regime if we pick the pre-selected amplitude to be small enough, i.e.,

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -50,16 +50,15 @@ plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 # # Linear Instabilities
 #
 # The base state ``U(z)``, ``B(z)`` is a solution of the inviscid equations of motion. Whether the base state is 
-# stable or not is determined by whether small perturbations about this base state will grow or not. To formalize this 
-# we write down the linearized dynamics that the perturbations about the base state satisfy. These dynamics take the 
-# form
+# stable or not is determined by whether small perturbations about this base state grow or decay. To formalize this, 
+# we study the linearized dynamics satisfied by perturbations about the base state:
 # ```math
 # \partial_t \Phi = L \Phi \, .
 # ```
-# where ``\Phi = (u, v, w, b)`` is a vector of the perturbation velocities ``u, v, w``, and perturbation buoyancy ``b`` 
-# and the linear operator that depends on the base state, ``L = L(U(z), B(z))`` (the `background_fields`). 
+# where ``\Phi = (u, v, w, b)`` is a vector of the perturbation velocities ``u, v, w`` and perturbation buoyancy ``b`` 
+# and ``L`` a linear operator that depends on the base state, ``L = L(U(z), B(z))`` (the `background_fields`).
 # Eigenanalysis of the linear operator ``L`` determines the stability of the base state, such as the Kelvin-Helmholtz 
-# instability. That is, with the ansantz
+# instability. That is, by using the ansantz
 # ```math
 # \Phi(x, y, z, t) = \phi(x, y, z) \, \exp(\lambda t) \, ,
 # ```
@@ -67,7 +66,7 @@ plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 # ```math
 # L \, \phi_j = \lambda \, \phi_j \quad j=1,2,\dots \, .
 # ```
-# We use the convention that eigenvalues are ordered according to their real part, ``\real(\lambda_1) \ge \real(\lambda_2) \ge \dotsb``.
+# Here we use the convention that the eigenvalues are ordered according to their real part, ``\real(\lambda_1) \ge \real(\lambda_2) \ge \dotsb``.
 #
 # Two remarks:
 # 
@@ -83,17 +82,17 @@ plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 # ```math
 # \lim_{n \to \infty} L^n \Phi \propto \phi_1 \, .
 # ```
-# Of course, if ``\phi_1`` is an unstable mode, i.e., its eigenvalue has ``\sigma_1 = \real(\lambda_1) > 0``, then successive application 
+# Of course, if ``\phi_1`` is an unstable mode (i.e., ``\sigma_1 = \real(\lambda_1) > 0``), then successive application 
 # of ``L`` will lead to exponential amplification. (Or, if ``\sigma_1 < 0``, it will
 # lead to exponential decay of ``\Phi`` down to machine precision.) Therefore, after each 
 # application of the linear operator ``L`` to our state ``\Phi``, we should rescale the output
 # ``L \Phi `` back to a pre-selected amplitude before applying ``L`` again.
 # 
 # So, we initialize a `simulation` with random initial conditions with amplitude much less than those of
-# the base state (which are ``O(1)``). Instead of "applying" ``L`` on our initial state, we evolve it
-# for interval ``\Delta \tau``. We measure how much the energy has grown during that interval, rescale to 
-# original energy amplitude and repeat. After some iterations the state will converge to the most unstable
-# eigenmode.
+# the base state (which are ``O(1)``). Instead of "applying" ``L`` on our initial state, we evolve the
+# (approximately) linear dynamics for interval ``\Delta \tau``. We measure how much the energy has grown 
+# during that interval, rescale the perturbations back to original energy amplitude and repeat.
+# After some iterations the state will converge to the most unstable eigenmode.
 # 
 # In summary, each iteration of the power method includes:
 # - compute the perturbation energy, ``E_0``,
@@ -142,14 +141,15 @@ using the fractional change in volume-mean kinetic energy,
 over the course of the `simulation`
 
 ``
-energy(t₁) / energy(t₀) ≈ exp(2 σ (t₁ - t₀))
+energy(t₀ + Δτ) / energy(t₀) ≈ exp(2 σ Δτ)
 ``
 
-where ``t₀`` and ``t₁`` are the starting and ending times of the
-simulation. We thus find that the growth rate is measured by
+where ``t₀`` is the starting time of the simulation and ``t₀ + Δτ`` 
+the ending time of the simulation. We thus find that the growth rate 
+is measured by
 
 ``
-σ = log(energy(t₁) / energy(t₀)) / (2 * (t₁ - t₀)) .
+σ = log(energy(t₀ + Δτ) / energy(t₀)) / (2 * Δτ) .
 ``
 """
 function grow_instability!(simulation, energy)

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -64,18 +64,18 @@ plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 # ```math
 # \Phi(x, y, z, t) = \phi(x, y, z) \, \exp(\lambda t) \, ,
 # ```
-# then ``\lambda`` and ``\phi`` are respectivealy eigenvalues and eigenmodes of ``L``,
+# then ``\lambda`` and ``\phi`` are respectively eigenvalues and eigenmodes of ``L``, i.e., they obey
 # ```math
-# L \, \phi_j = \lambda \, \phi_j \quad j=1,2,\dots \, .
+# L \, \phi_j = \lambda_j \, \phi_j \quad j=1,2,\dots \, .
 # ```
-# Here we use the convention that the eigenvalues are ordered according to their real part, ``\real(\lambda_1) \ge \real(\lambda_2) \ge \dotsb``.
+# From hereafter we'll use the convention that the eigenvalues are ordered according to their real part, ``\real(\lambda_1) \ge \real(\lambda_2) \ge \dotsb``.
 #
 # Two remarks:
 # 
 # - Oceananigans.jl, does not include a linearized version of the equations, but we can ensure we remain in the linear regime if keep our perturbation fields small thus ensuring that terms quadratic in perturbations are much smaller than all other terms. This way we get approximately: ``\partial_t \Phi \approx L \Phi``.
-# - Even with the small-amplitude trick, although Oceananigans.jl will be able to solve the approximately linear equations of motion, it won't allow us to get the linear operator ``L`` and perform eigendecomposition. 
+# - While using the small-amplitude trick Oceananigans.jl is able to solve the approximately linear equations of motion, we still don't have access to the linear operator ``L`` to perform eigendecomposition. 
 # 
-# This last "caveat" can be alleviated using the following algorithm.
+# This last caveat is bypassed with the following algorithm.
 #
 # # A _Power_ful algorithm
 #
@@ -85,10 +85,9 @@ plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 # \lim_{n \to \infty} L^n \Phi \propto \phi_1 \, .
 # ```
 # Of course, if ``\phi_1`` is an unstable mode (i.e., ``\sigma_1 = \real(\lambda_1) > 0``), then successive application 
-# of ``L`` will lead to exponential amplification. (Or, if ``\sigma_1 < 0``, it will
+# of ``L`` will lead to exponential amplification. (Similarly, if ``\sigma_1 < 0``, successive application of ``L`` will
 # lead to exponential decay of ``\Phi`` down to machine precision.) Therefore, after each 
-# application of the linear operator ``L`` to our state ``\Phi``, we should rescale the output
-# ``L \Phi `` back to a pre-selected amplitude before applying ``L`` again.
+# application of the linear operator ``L``, we rescale the output ``L \Phi`` back to a pre-selected amplitude.
 # 
 # So, we initialize a `simulation` with random initial conditions with amplitude much less than those of
 # the base state (which are ``O(1)``). Instead of "applying" ``L`` on our initial state, we evolve the
@@ -126,8 +125,7 @@ model = IncompressibleModel(timestepper = :RungeKutta3,
 # For this example, we take ``\Delta \tau = 15``.
 
 simulation = Simulation(model, Δt=0.1, stop_iteration=150)
-              
-              
+
 # Now some helper functions that will be used during for the power method algorithm.
 # 
 # First a function that evolves the state for ``\Delta \tau`` and measure the energy growth
@@ -280,30 +278,30 @@ function eigenplot(ω, b, σ, t; ω_lim=maximum(abs, ω)+1e-16, b_lim=maximum(ab
     
     plot_ω = contourf(xF, zF, clamp.(ω, -ω_lim, ω_lim)';
                       levels = range(-ω_lim, stop=ω_lim, length=20),
-                      xlims = (xF[1], xF[grid.Nx]),
-                      ylims = (zF[1], zF[grid.Nz]),
-                      clims = (-ω_lim, ω_lim),
-                      title = ω_title(t), kwargs...)
+                       xlims = (xF[1], xF[grid.Nx]),
+                       ylims = (zF[1], zF[grid.Nz]),
+                       clims = (-ω_lim, ω_lim),
+                       title = ω_title(t), kwargs...)
                       
     b_title(t) = t == nothing ? @sprintf("buoyancy") : @sprintf("buoyancy at t = %.2f", t)
     
     plot_b = contourf(xC, zC, clamp.(b, -b_lim, b_lim)';
                     levels = range(-b_lim, stop=b_lim, length=20),
-                    xlims = (xC[1], xC[grid.Nx]),
-                    ylims = (zC[1], zC[grid.Nz]),
-                    clims = (-b_lim, b_lim),
-                    title = b_title(t), kwargs...)
+                     xlims = (xC[1], xC[grid.Nx]),
+                     ylims = (zC[1], zC[grid.Nz]),
+                     clims = (-b_lim, b_lim),
+                     title = b_title(t), kwargs...)
                     
     return plot(plot_ω, plot_b, layout=(1, 2), size=(800, 380))
 end
 
 function power_method_plot(ω, b, σ, t)
     plot_growthrates = scatter(σ,
-                                xlabel = "Power iteration",
-                                ylabel = "Growth rate",
-                                 title = eigentitle(σ, nothing),
-                                 label = nothing)
-                                 
+                             xlabel = "Power iteration",
+                             ylabel = "Growth rate",
+                              title = eigentitle(σ, nothing),
+                              label = nothing)
+                             
     plot_eigenmode = eigenplot(ω, b, σ, nothing)
     
     return plot(plot_growthrates, plot_eigenmode, layout=@layout([A{0.25h}; B]), size=(800, 600))
@@ -401,8 +399,7 @@ anim_perturbations = @animate for (i, iteration) in enumerate(iterations)
     
     t = file["timeseries/t/$iteration"]
     ω_snapshot = file["timeseries/ω/$iteration"][:, 1, :]
-    b_snapshot = file["timeseries/b/$iteration"][:, 1, :]
-    
+    b_snapshot = file["timeseries/b/$iteration"][:, 1, :]  
     ke = file["timeseries/KE/$iteration"][]
     
     push!(time, t)

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -74,7 +74,7 @@ model = IncompressibleModel(timestepper = :RungeKutta3,
 # ```math
 # L \, \phi_j = \lambda \, \phi_j \quad j=1,2,\dots \, .
 # ```
-# We use the convention that eigenvalues are ordered according to their real part, ``\real(\lambda_1) \ge \real(\lambda_2) \dotsb``.
+# We use the convention that eigenvalues are ordered according to their real part, ``\real(\lambda_1) \ge \real(\lambda_2) \ge \dotsb``.
 # 
 # Successive application of ``L`` to a random initial state will render it parallel 
 # with eigenmode ``\phi_1``:

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -192,7 +192,6 @@ function estimate_growth_rate!(simulation, energy, ω, b; convergence_criterion=
     
     iteration = 1
     while convergence(σ) > convergence_criterion
-
         push!(σ, grow_instability!(simulation, energy))
 
         compute!(energy)
@@ -203,10 +202,9 @@ function estimate_growth_rate!(simulation, energy, ω, b; convergence_criterion=
         compute!(ω)
         plotseries[iteration+1] = powermethodplot(interior(ω)[:, 1, :], interior(b)[:, 1, :], σ, nothing)
         iteration += 1
-
+        
         rescale!(simulation.model, energy)
         compute!(energy)
-        
         
         @info @sprintf("Kinetic energy after rescaling: %.2e", energy[1, 1, 1])
     end

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -61,23 +61,33 @@ model = IncompressibleModel(timestepper = :RungeKutta3,
 # # A _Power_ful algorithm
 #
 # We will find the most unstable mode of the Kelvin-Helmholtz instability using the "power method". 
-# In brief, if a linear operator ``\mathcal{L}`` has eigenmodes ``u_j`` and corresponding 
+# Linear instabilities, such as the Kelvin-Helmholtz instability, are described by linearized equations about a base state that take the form
+# ```math
+# \partial_t \Phi = L \Phi \, .
+# ```
+# In this example, ``\Phi = (u, v, w, b)`` is a vector of the velocities ``u, v, w``, and 
+# buoyancy ``b`` and ``L`` is a linear operator that depends on the base state (the `background_fields`) and other problem parameters.
+#
+# The linear operator ``L`` has eigenmodes ``u_j`` and corresponding and corresponding 
 # eigenvalues ``\lambda_j``,
 # ```math
-# \mathcal{L} \, u_j = \lambda \, u_j \, ,
+# \mathcal{L} \, \phi_j = \lambda \, \phi_j \quad j=1,2,\dots \, .
 # ```
-# where we assumed that eigenvalues are ordered according to their real part, ``\real(\lambda_1) \ge \real(\lambda_2) \dotsb``. Successive application of ``\mathcal{L}`` to a random initial state ``\phi``
-# will render it parallel with eigenmode ``u_1``:
+# We use the convention that eigenvalues are ordered according to their real part, ``\real(\lambda_1) \ge \real(\lambda_2) \dotsb``.
+# 
+# Successive application of ``\mathcal{L}`` to a random initial state will render it parallel 
+# with eigenmode ``\phi_1``:
 # ```math
-# \lim_{n \to \infty} \mathcal{L}^n \phi \propto u_1 \, .
+# \lim_{n \to \infty} \mathcal{L}^n \Phi \propto \phi_1 \, .
 # ```
-# Of course, if ``u_1`` is unstable, i.e., has ``\sigma_1 = \real(\lambda_1) > 0``, then successive application 
-# of ``\mathcal{L}`` will lead to exponential amplification. (Or, if ``\sigma_1 < 0``, it will
-# lead to exponential decay down to machine precision.)
-#
-# The power method, thus, relies on rescaling the state after ``\mathcal{L}`` is applied back to
-# a pre-selected amplitude. We select this predetermined amplitude in such manner to ensure that
-# we are in the "linear" regime, i.e., that terms quadratic in perturbations as much smaller.
+# Of course, if ``\phi_1`` is an unstable mode, i.e., has ``\sigma_1 = \real(\lambda_1) > 0``, then successive application 
+# of ``L`` will lead to exponential amplification. (Or, if ``\sigma_1 < 0``, it will
+# lead to exponential decay of ``\Phi`` down to machine precision.) Therefore, after applying
+# the linear operator ``L`` to our state ``\Phi``, we should rescale ``\Phi`` back to
+# a pre-selected amplitude. Oceananigans.jl, does not include a "linear" version of the equations,
+# but we can ensure we remain in the "linear" regime if we pick the pre-selected amplitude to 
+# be small enough, i.e., ensuring that terms quadratic in perturbations are much smaller than 
+# all other terms.
 # 
 # So, we initialize a model with random initial conditions with amplitude much less than those of
 # the base state have amplitude (``O(1)``). For each iteration of the power method includes:

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -188,7 +188,7 @@ function estimate_growth_rate!(simulation, energy, ω, b; convergence_criterion=
     plotseries = Array{Any, 1}(undef, 20)  # expect no more than 20 iterations
     
     compute!(ω)
-    plotseries[1] = plot_powermethoditerationplot_powermethoditeration = powermethodplot(interior(ω)[:, 1, :], interior(b)[:, 1, :], σ, nothing)
+    plotseries[1] = powermethodplot(interior(ω)[:, 1, :], interior(b)[:, 1, :], σ, nothing)
     
     iteration = 1
     while convergence(σ) > convergence_criterion
@@ -201,13 +201,12 @@ function estimate_growth_rate!(simulation, energy, ω, b; convergence_criterion=
                        length(σ), energy[1, 1, 1], σ[end], relative_difference(σ))
 
         compute!(ω)
-        plot_powermethoditeration = powermethodplot(interior(ω)[:, 1, :], interior(b)[:, 1, :], σ, nothing)
+        plotseries[iteration+1] = powermethodplot(interior(ω)[:, 1, :], interior(b)[:, 1, :], σ, nothing)
+        iteration += 1
 
         rescale!(simulation.model, energy)
         compute!(energy)
         
-        plotseries[iteration+1] = plot_powermethoditeration
-        iteration += 1
         
         @info @sprintf("Kinetic energy after rescaling: %.2e", energy[1, 1, 1])
     end
@@ -273,9 +272,11 @@ using Random, Statistics, Oceananigans.AbstractOperations
 
 mean_perturbation_kinetic_energy = mean(1/2 * (u^2 + w^2), dims=(1, 2, 3))
 
-noise(x, y, z) = 1e-6 * randn()
+noise(x, y, z) = randn()
 
 set!(model, u=noise, w=noise, b=noise)
+
+rescale!(simulation.model, mean_perturbation_kinetic_energy, target_kinetic_energy=1e-6)
 
 growth_rates, powermethod_plotseries = estimate_growth_rate!(simulation, mean_perturbation_kinetic_energy, perturbation_vorticity, b)
 

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -5,7 +5,7 @@
 
 using Oceananigans
 
-grid = RegularCartesianGrid(size=(64, 1, 65), x=(-5, 5), y=(0, 1), z=(-5, 5),
+grid = RegularCartesianGrid(size=(64, 1, 64), x=(-5, 5), y=(0, 1), z=(-5, 5),
                                   topology=(Periodic, Periodic, Bounded))
 
 # # The basic state
@@ -37,6 +37,8 @@ using Plots, Oceananigans.Grids
 
 z = znodes(Cell, grid)
 
+zRi = znodes(Face, grid)
+
 Ri, h = B.parameters
 
 kwargs = (ylabel="z", linewidth=2, label=nothing)
@@ -45,7 +47,7 @@ kwargs = (ylabel="z", linewidth=2, label=nothing)
 
  B_plot = plot([stratification(0, 0, z, 0, (Ri=Ri, h=h)) for z in z], z; xlabel="B(z)", color=:red, kwargs...)
 
-Ri_plot = plot(@. Ri * sech(z / h)^2 / sech(z)^2, z; xlabel="Ri(z)", color=:black, kwargs...) # Ri(z)= ∂_z B / (∂_z U)²; derivatives computed by hand
+Ri_plot = plot(@. Ri * sech(zRi / h)^2 / sech(zRi)^2, zRi; xlabel="Ri(z)", color=:black, kwargs...) # Ri(z)= ∂_z B / (∂_z U)²; derivatives computed by hand
 
 plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -338,7 +338,7 @@ iterations = parse.(Int, keys(file["timeseries/t"]))
 
 @info "Making a neat movie of stratified shear flow..."
 
-anim = @animate for (i, iteration) in enumerate(iterations)
+anim_perturbations = @animate for (i, iteration) in enumerate(iterations)
 
     @info "Plotting frame $i from iteration $iteration..."
     
@@ -349,11 +349,11 @@ anim = @animate for (i, iteration) in enumerate(iterations)
     eigenplot(ω_snapshot, b_snapshot, nothing, t; ω_lim=1, b_lim=0.1)
 end
 
-gif(anim, "kelvin_helmholtz_instability_perturbations.gif", fps = 8) # hide
+gif(anim_perturbations, "kelvin_helmholtz_instability_perturbations.gif", fps = 8) # hide
 
 # And then the total vorticity & buoyancy of the fluid.
 
-anim2 = @animate for (i, iteration) in enumerate(iterations)
+anim_total = @animate for (i, iteration) in enumerate(iterations)
 
     @info "Plotting frame $i from iteration $iteration..."
     
@@ -364,4 +364,4 @@ anim2 = @animate for (i, iteration) in enumerate(iterations)
     eigenplot(ω_snapshot, b_snapshot, nothing, t; ω_lim=1, b_lim=0.05)
 end
 
-gif(anim2, "kelvin_helmholtz_instability_total.gif", fps = 8) # hide
+gif(anim_total, "kelvin_helmholtz_instability_total.gif", fps = 8) # hide

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -81,23 +81,27 @@ model = IncompressibleModel(timestepper = :RungeKutta3,
 # ```math
 # \lim_{n \to \infty} \mathcal{L}^n \Phi \propto \phi_1 \, .
 # ```
-# Of course, if ``\phi_1`` is an unstable mode, i.e., has ``\sigma_1 = \real(\lambda_1) > 0``, then successive application 
+# Of course, if ``\phi_1`` is an unstable mode, i.e., its eigenvalue has ``\sigma_1 = \real(\lambda_1) > 0``, then successive application 
 # of ``L`` will lead to exponential amplification. (Or, if ``\sigma_1 < 0``, it will
 # lead to exponential decay of ``\Phi`` down to machine precision.) Therefore, after applying
 # the linear operator ``L`` to our state ``\Phi``, we should rescale ``\Phi`` back to
-# a pre-selected amplitude. Oceananigans.jl, does not include a "linear" version of the equations,
-# but we can ensure we remain in the "linear" regime if we pick the pre-selected amplitude to 
-# be small enough, i.e., ensuring that terms quadratic in perturbations are much smaller than 
-# all other terms.
+# a pre-selected amplitude.
 # 
-# So, we initialize a model with random initial conditions with amplitude much less than those of
-# the base state have amplitude (``O(1)``). For each iteration of the power method includes:
-# - compute the perturbation energy, ``E_0``
-# - evolve the system for ``\Delta t``
-# - compute the perturbation energy, ``E_1``
-# - determine the exponential growth of the most unstable mode during interval ``\Delta t`` as
-#  ``\sigma = \log(E_1 / E_0) / (2 \Delta t)``.
-# - repeat the above until ``\sigma`` converges.
+# Oceananigans.jl, does not include a "linear" version of the equations, but we can ensure we 
+# remain in the "linear" regime if we pick the pre-selected amplitude to be small enough, i.e.,
+# ensuring that terms quadratic in perturbations are much smaller than all other terms.
+# 
+# So, we initialize a `simulation` with random initial conditions with amplitude much less than those of
+# the base state (which are ``O(1)``). Each iteration of the power method includes:
+# - compute the perturbation energy, ``E_0``,
+# - evolve the system for ``\Delta t``,
+# - compute the perturbation energy, ``E_1``,
+# - determine the exponential growth of the most unstable mode during interval ``\Delta t`` as  ``\log(E_1 / E_0) / (2 \Delta t)``,
+# - repeat the above until growth rate converges.
+# 
+# By fiddling a bit with ``\Delta t`` we can get convergence after only a few iterations.
+# 
+# For this example, we take ``\Delta t = 20``.
 
 simulation = Simulation(model, Δt=0.1, iteration_interval=20, stop_iteration=100)
                         

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -56,14 +56,14 @@ plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 # ```math
 # \partial_t \Phi = L \Phi \, .
 # ```
-# where ``\Phi = (u, v, w, b, p)`` is a vector of the perturbation velocities ``u, v, w``, perturbation buoyancy ``b``,
-# and perturbation pressure ``p`` and the linear operator that depends on the base state, ``L = L(U(z), B(z))`` (the 
-# `background_fields`). Eigenanalysis of the linear operator ``L`` determines the stability of the base state, such 
-# as the Kelvin-Helmholtz instability. That is, with the ansantz
+# where ``\Phi = (u, v, w, b)`` is a vector of the perturbation velocities ``u, v, w``, and perturbation buoyancy ``b`` 
+# and the linear operator that depends on the base state, ``L = L(U(z), B(z))`` (the `background_fields`). 
+# Eigenanalysis of the linear operator ``L`` determines the stability of the base state, such as the Kelvin-Helmholtz 
+# instability. That is, with the ansantz
 # ```math
 # \Phi(x, y, z, t) = \phi(x, y, z) \, \exp(\lambda t) \, ,
 # ```
-# then ``\lambda`` and ``\phi`` are the eigenvalue and eigenmode of ``L``,
+# then ``\lambda`` and ``\phi`` are respectivealy eigenvalues and eigenmodes of ``L``,
 # ```math
 # L \, \phi_j = \lambda \, \phi_j \quad j=1,2,\dots \, .
 # ```
@@ -71,13 +71,8 @@ plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 #
 # Two remarks:
 # 
-# - Oceananigans.jl, does not include a linearized version of the equations, but we can ensure we 
-# remain in the linear regime if keep our perturbation fields small thus ensuring that terms 
-# quadratic in perturbations are much smaller than all other terms. This way we get approximately: ``\partial_t 
-# \Phi \approx L \Phi``.
-# - Even with the small-amplitude trick, although Oceananigans.jl will be able to solve the 
-# approximately linear equations of motion, it won't allow us to get the linear operator ``L``
-# and perform eigendecomposition. 
+# - Oceananigans.jl, does not include a linearized version of the equations, but we can ensure we remain in the linear regime if keep our perturbation fields small thus ensuring that terms quadratic in perturbations are much smaller than all other terms. This way we get approximately: ``\partial_t \Phi \approx L \Phi``.
+# - Even with the small-amplitude trick, although Oceananigans.jl will be able to solve the approximately linear equations of motion, it won't allow us to get the linear operator ``L`` and perform eigendecomposition. 
 # 
 # This last "caveat" can be alleviated using the following algorithm.
 #
@@ -181,8 +176,8 @@ nothing # hide
 # Finally, we write a function that rescales the state. The rescaling is done via measureing the
 # kinetic energy and then rescaling back to a prescribed energy value.
 # 
-# (Meauring the growth via kinetic energy will work fine _unless_ an unstable mode has _only_
-# buoynancy perturbation. In that case, the total perturbation energy will be adequate.)
+# (Measuring the growth via the kinetic energy works fine _unless_ an unstable mode has _only_
+# buoynancy structure. In that case, the total perturbation energy will be adequate.)
 
 """
     rescale!(model, energy; target_kinetic_energy=1e-3)
@@ -211,6 +206,7 @@ relative_difference(σ) = length(σ) > 1 ? abs((σ[end] - σ[end-1]) / σ[end-1]
 
 """ Check if the growth rate has converged. If the array `σ` has at least 2 elements then return the relative difference between ``σ[end]`` and ``σ[end-1]``. """
 convergence(σ) = length(σ) > 1 ? abs((σ[end] - σ[end-1]) / σ[end]) : 9.1e18 # pretty big (not Inf tho)
+nothing # hide
 
 # and the main function that performs the power method iteration.
 # (Note that `estimate_growth_rate!()` also return the plot of the perturbation field after each iteration.

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -5,7 +5,7 @@
 
 using Oceananigans
 
-grid = RegularCartesianGrid(size=(64, 1, 64), x=(-5, 5), y=(0, 1), z=(-5, 5),
+grid = RegularCartesianGrid(size=(64, 1, 65), x=(-5, 5), y=(0, 1), z=(-5, 5),
                                   topology=(Periodic, Periodic, Bounded))
 
 # # The basic state
@@ -37,8 +37,6 @@ using Plots, Oceananigans.Grids
 
 z = znodes(Cell, grid)
 
-zRi = znodes(Face, grid)
-
 Ri, h = B.parameters
 
 kwargs = (ylabel="z", linewidth=2, label=nothing)
@@ -47,7 +45,7 @@ kwargs = (ylabel="z", linewidth=2, label=nothing)
 
  B_plot = plot([stratification(0, 0, z, 0, (Ri=Ri, h=h)) for z in z], z; xlabel="B(z)", color=:red, kwargs...)
 
-Ri_plot = plot(@. Ri * sech(zRi / h)^2 / sech(zRi)^2, zRi; xlabel="Ri(z)", color=:black, kwargs...) # Ri(z)= ∂_z B / (∂_z U)²; derivatives computed by hand
+Ri_plot = plot(@. Ri * sech(z / h)^2 / sech(z)^2, z; xlabel="Ri(z)", color=:black, kwargs...) # Ri(z)= ∂_z B / (∂_z U)²; derivatives computed by hand
 
 plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -44,7 +44,7 @@ kwargs = (ylabel="z", linewidth=2, label=nothing)
  B_plot = plot([stratification(0, 0, z, 0, (Ri=Ri, h=h)) for z in z], z; xlabel="B(z)", color=:red, kwargs...)
 Ri_plot = plot(@. Ri * sech(z / h)^2 / sech(z)^2, z; xlabel="Ri(z)", color=:black, kwargs...) # Ri(z); derivatives computed by hand
 
-plot(U_plot, B_plot, Ri_plot, layout=(1, 3))
+plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 
 
 # # Linear Instabilities


### PR DESCRIPTION
This PR adds an example that computes the linear instability of a vertically shear mean flow profile U(z) accompanied with a sheared buoyancy profile B(z) and then evolves the unstable eigenmode to its nonlinear equilibration.

[preview of the docs](https://clima.github.io/OceananigansDocumentation/previews/PR1125/generated/kelvin_helmholtz_instability/)