### PR TITLE
NetCDFOutputWriter accepts named tuples now

### DIFF
--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -260,6 +260,11 @@ function NetCDFOutputWriter(model, outputs; filepath, schedule,
                                   compression = 0,
                                       verbose = false)
 
+    # We need to convert to a Dict with String keys if user provides a named tuple.
+    if outputs isa NamedTuple
+        outputs = Dict(string(k) => v for (k, v) in zip(keys(outputs), values(outputs)))
+    end
+
     # Ensure we can add any kind of metadata to the global attributes later by converting to pairs of type {Any, Any}.
     global_attributes = Dict{Any, Any}(k => v for (k, v) in global_attributes)
 

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -7,6 +7,9 @@ using Dates: now
 using Oceananigans.Grids: topology, halo_size
 using Oceananigans.Utils: versioninfo_with_gpu, oceananigans_versioninfo
 
+dictify(outputs) = outputs
+dictify(outputs::NamedTuple) = Dict(string(k) => dictify(v) for (k, v) in zip(keys(outputs), values(outputs)))
+
 xdim(::Type{Face}) = ("xF",) 
 ydim(::Type{Face}) = ("yF",)
 zdim(::Type{Face}) = ("zF",)
@@ -261,12 +264,13 @@ function NetCDFOutputWriter(model, outputs; filepath, schedule,
                                       verbose = false)
 
     # We need to convert to a Dict with String keys if user provides a named tuple.
-    if outputs isa NamedTuple
-        outputs = Dict(string(k) => v for (k, v) in zip(keys(outputs), values(outputs)))
-    end
+    outputs = dictify(outputs)
+    output_attributes = dictify(output_attributes)
+    global_attributes = dictify(global_attributes)
+    dimensions = dictify(dimensions)
 
-    # Ensure we can add any kind of metadata to the global attributes later by converting to pairs of type {Any, Any}.
-    global_attributes = Dict{Any, Any}(k => v for (k, v) in global_attributes)
+    # Ensure we can add any kind of metadata to the global attributes later by converting to Dict{Any, Any}.
+    global_attributes = Dict{Any, Any}(global_attributes)
 
     # Add useful metadata
     global_attributes["date"] = "This file was generated on $(now())."

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -219,16 +219,10 @@ function run_thermal_bubble_netcdf_tests_with_halos(arch)
     k1, k2 = round(Int, Nz/4), round(Int, 3Nz/4)
     CUDA.@allowscalar model.tracers.T.data[i1:i2, j1:j2, k1:k2] .+= 0.01
 
-    outputs = Dict(
-        "v" => model.velocities.v,
-        "u" => model.velocities.u,
-        "w" => model.velocities.w,
-        "T" => model.tracers.T,
-        "S" => model.tracers.S
-    )
-
     nc_filepath = "test_dump_with_halos_$(typeof(arch)).nc"
-    nc_writer = NetCDFOutputWriter(model, outputs, filepath=nc_filepath, schedule=IterationInterval(10),
+    nc_writer = NetCDFOutputWriter(model, merge(model.velocities, model.tracers),
+                                   filepath=nc_filepath,
+                                   schedule=IterationInterval(10),
                                    field_slicer=FieldSlicer(with_halos=true))
     push!(simulation.output_writers, nc_writer)
 

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -308,16 +308,16 @@ function run_netcdf_function_output_tests(arch)
     h(model) = model.clock.time .* (   sin.(xnodes(Cell, grid, reshape=true)[:, :, 1])
                                     .* cos.(ynodes(Face, grid, reshape=true)[:, :, 1]))
 
-    outputs = Dict("scalar" => f,  "profile" => g,       "slice" => h)
-       dims = Dict("scalar" => (), "profile" => ("zC",), "slice" => ("xC", "yC"))
+    outputs = (scalar=f, profile=g, slice=h)
+    dims = (scalar=(), profile=("zC",), slice=("xC", "yC"))
 
-    output_attributes = Dict(
-        "scalar"  => Dict("longname" => "Some scalar", "units" => "bananas"),
-        "profile" => Dict("longname" => "Some vertical profile", "units" => "watermelons"),
-        "slice"   => Dict("longname" => "Some slice", "units" => "mushrooms")
+    output_attributes = (
+        scalar = (longname="Some scalar", units="bananas"),
+        profile = (longname="Some vertical profile", units="watermelons"),
+        slice = (longname="Some slice", units="mushrooms")
     )
 
-    global_attributes = Dict("location" => "Bay of Fundy", "onions" => 7)
+    global_attributes = (location="Bay of Fundy", onions=7)
 
     nc_filepath = "test_function_outputs_$(typeof(arch)).nc"
 


### PR DESCRIPTION
Constructing dictionaries for `NetCDFOutputWriter` can be quite boilerplate-y. This PR also helps unify the JLD2 and NetCDF output writers (see #884).