### PR TITLE
Switch to ColPrac: Contributor's Guide on Collaborative Practices for Community Packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,12 @@
 # Contributors Guide
 
-Thank you for considering contributing to Oceananigans! This short guide will
-give you ideas on how you can contribute and help you make a contribution.
+Thank you for considering contributing to Oceananigans! 
 
 Please feel free to ask us questions and chat with us at any time if you're
 unsure about anything.
+
+We follow the [ColPrac guide](https://github.com/SciML/ColPrac) for collaborative
+practices. New contributor should make sure to read that guide.
 
 ## What can I do?
 
@@ -12,7 +14,7 @@ unsure about anything.
   that are self-contained and suitable for a newcomer to try and work on.
 
 * Try to run Oceananigans and play around with it to simulate your favorite
-  fluids and ocean physics. If you run into any problems or find it difficult
+  fluids and ocean physics. If you run into any bugs/problems or find it difficult
   to use or understand, please open an issue!
 
 * Write up an example or tutorial on how to do something useful with
@@ -23,80 +25,11 @@ unsure about anything.
 * Implement a new feature if you need it to use Oceananigans.
 
 If you're interested in working on something, let us know by commenting on
-existing issues or by opening a new issue if. This is to make sure no one else
+existing issues or by opening a new issue. This is to make sure no one else
 is working on the same issue and so we can help and guide you in case there
 is anything you need to know beforehand.
 
-## Ground Rules
+We also hang out on the #oceananigans channel on Julia Slack, which is a great
+place to discuss anything Oceananigans-related, especially contributions! To
+join the Julia Slack, go to [https://julialang.org/slack/](https://julialang.org/slack/).
 
-* Each pull request should consist of a logical collection of changes. You can
-  include multiple bug fixes in a single pull request, but they should be related.
-  For unrelated changes, please submit multiple pull requests.
-* Do not commit changes to files that are irrelevant to your feature or bugfix
-  (eg: .gitignore).
-* Be willing to accept criticism and work on improving your code; we don't want
-  to break other users' code, so care must be taken not to introduce bugs. We
-  discuss pull requests and keep working on them until we believe we've done a
-  good job.
-* Be aware that the pull request review process is not immediate, and is
-  generally proportional to the size of the pull request.
-
-## Reporting a bug
-
-The easiest way to get involved is to report issues you encounter when using
-Oceananigans or by requesting something you think is missing.
-
-* Head over to the [issues](https://github.com/climate-machine/Oceananigans.jl/issues) page.
-* Search to see if your issue already exists or has even been solved previously.
-* If you indeed have a new issue or request, click the "New Issue" button.
-* Please be as specific as possible. Include the version of the code you were using, as
-  well as what operating system you are running. The output of Julia's `versioninfo()`
-  and `] status` is helpful to include. If possible, include complete, minimal example
-  code that reproduces the problem.
-
-## Setting up your development environment
-
-* Install [Julia](https://julialang.org/) on your system.
-* Install git on your system if it is not already there (install XCode command line tools on
-  a Mac or git bash on Windows).
-* Login to your GitHub account and make a fork of the
-  [Oceananigans repository](https://github.com/climate-machine/Oceananigans.jl) by
-  clicking the "Fork" button.
-* Clone your fork of the Oceananigans repository (in terminal on Mac/Linux or git shell/
-  GUI on Windows) in the location you'd like to keep it.
-  ``git clone https://github.com/your-user-name/Oceananigans.jl.git``
-* Navigate to that folder in the terminal or in Anaconda Prompt if you're on Windows.
-* Connect your repository to the upstream (main project).
-  ``git remote add oceananigans https://github.com/climate-machine/Oceananigans.jl.git``
-* Create the development environment by opening Julia via ``julia --project`` then
-  typing in ``] instantiate``. This will install all the dependencies in the ``Project.toml``
-  file.
-* You can test to make sure Oceananigans works by typing in ``] test``.
-
-Your development environment is now ready!
-
-## Pull Requests
-
-Changes and contributions should be made via GitHub pull requests against the ``master`` branch.
-
-When you're done making changes, commit the changes you made. Chris Beams has
-written a [guide](https://chris.beams.io/posts/git-commit/) on how to write
-good commit messages.
-
-When you think your changes are ready to be merged into the main repository,
-push to your fork and [submit a pull request](https://github.com/climate-machine/Oceananigans.jl/compare/).
-
-**Working on your first Pull Request?** You can learn how from this _free_ video series
-[How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github), Aaron Meurer's [tutorial on the git workflow](https://www.asmeurer.com/git-workflow/), or the guide [“How to Contribute to Open Source"](https://opensource.guide/how-to-contribute/).
-
-## Documentation
-
-Now that you've made your awesome contribution, it's time to tell the world how to use it.
-Writing documentation strings is really important to make sure others use your functionality
-properly. Didn't write new functions? That's fine, but be sure that the documentation for
-the code you touched is still in great shape. It is not uncommon to find some strange wording
-or clarification that you can take care of while you are here.
-
-## Credits
-
-This contributor's guide is heavily based on the excellent [MetPy contributor's guide](https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,12 @@ Thank you for considering contributing to Oceananigans!
 Please feel free to ask us questions and chat with us at any time if you're
 unsure about anything.
 
+Best way to get in touch is to either just open a GitHub issue (don't be shy!) or
+to drop by the #oceananigans channel on the Julia Slack (see
+[https://julialang.org/slack/](https://julialang.org/slack/)).
+
 We follow the [ColPrac guide](https://github.com/SciML/ColPrac) for collaborative
-practices. New contributor should make sure to read that guide.
+practices. New contributors should make sure to read that guide.
 
 ## What can I do?
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,19 @@
   <a href="https://github.com/clima/Oceananigans.jl/issues/new">
     <img alt="Ask us anything" src="https://img.shields.io/badge/Ask%20us-anything-1abc9c.svg?style=flat-square">
   </a>
+  <a href="https://github.com/SciML/ColPrac">
+    <img alt="ColPrac: Contributor's Guide on Collaborative Practices for Community Packages" src="https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet?style=flat-square">
+  </a>
   <a href="https://doi.org/10.21105/joss.02018">
     <img alt="JOSS" src="https://joss.theoj.org/papers/10.21105/joss.02018/status.svg">
   </a>
+</p>
+
+<!-- Version and documentation badges -->
+<p align="center">
   <a href="https://github.com/CliMA/Oceananigans.jl/releases">
     <img alt="GitHub tag (latest SemVer pre-release)" src="https://img.shields.io/github/v/tag/CliMA/Oceananigans.jl?include_prereleases&label=latest%20version&logo=github&sort=semver&style=flat-square">
   </a>
-</p>
-
-<!-- Documentation badges -->
-<p align="center">
   <a href="https://clima.github.io/OceananigansDocumentation/stable">
     <img alt="Stable documentation" src="https://img.shields.io/badge/documentation-stable%20release-blue?style=flat-square">
   </a>


### PR DESCRIPTION
This PR changes our contributor's guide to [ColPrac](https://github.com/SciML/ColPrac), which I think is a pretty useful guide on how to work collaboratively on packages.

We already follow some of the guide's suggestions around PRs so might as well follow the entire guide.

What do people think about it?

Might be good to adopt something like ColPrac as more people start working together on Oceananigans. cc @navidcy @whitleyv @francispoulin

Resolves #1044 