### PR TITLE
Hello, ocean example

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,7 +40,8 @@ examples = [
     "ocean_wind_mixing_and_convection.jl",
     "langmuir_turbulence.jl",
     "eady_turbulence.jl",
-    "kelvin_helmholtz_instability.jl"
+    "kelvin_helmholtz_instability.jl",
+    "hello_ocean.jl"
 ]
 
 for example in examples

--- a/examples/hello_ocean.jl
+++ b/examples/hello_ocean.jl
@@ -7,29 +7,34 @@
 using Oceananigans, Oceananigans.Grids, Plots
 
 grid = RegularCartesianGrid(size = (1, 64, 64),
-                            x = (0, 1), y = (-4, 4), z = (-4, 4),
-                            topology = (Periodic, Bounded, Bounded))
+                            x = (-6, 6), y = (-6, 6), z = (-3, 3),
+                            topology = (Periodic, Periodic, Bounded))
 
 model = IncompressibleModel(grid = grid,
                             architecture = CPU(),
                             advection = Oceananigans.Advection.WENO5(),
+                            timestepper = :RungeKutta3,
                             tracers = :b,
                             buoyancy = BuoyancyTracer(),
                             closure = IsotropicDiffusivity(ν=1e-3, κ=1e-3))
-         
-@info "Simulating a rising buoyant bubble with" model
 
-set!(model, b = (x, y, z) -> exp(-y^2 - z^2))
+@info "Simulating the ocean with" model
 
-run!(Simulation(model, Δt=0.01, stop_iteration=800))
+set!(model,
+     u = (x, y, z) -> 1 + tanh(z/2),
+     b = (x, y, z) -> z + exp(-x^2) * (tanh(z) - 1))
+
+run!(Simulation(model, Δt=0.1, stop_iteration=1))
 
 # Analyze the data
 
 b = model.tracers.b
 
-plt = contourf(ynodes(b), znodes(b), interior(b)[1, :, :]',
-               xlabel = "y", ylabel = "z", title = "Buoyancy",
-               xlim = (grid.yF[1], grid.yF[end]), ylim = (grid.zF[1], grid.zF[end]),
+@show maximum(abs, b.data)
+
+plt = contourf(xnodes(b), znodes(b), interior(b)[:, 1, :]',
+               xlabel = "x", ylabel = "z", title = "Hello, ocean!",
+               #xlim = (grid.xF[1], grid.xF[end]), ylim = (grid.zF[1], grid.zF[end]),
                aspectratio = :equal, linewidth = 0)
 
 display(plt) # hide

--- a/examples/hello_ocean.jl
+++ b/examples/hello_ocean.jl
@@ -28,7 +28,8 @@ run!(Simulation(model, Δt=0.01, stop_iteration=800))
 b = model.tracers.b
 
 plt = contourf(ynodes(b), znodes(b), interior(b)[1, :, :]',
+               xlabel = "y", ylabel = "z", title = "Buoyancy",
                xlim = (grid.yF[1], grid.yF[end]), ylim = (grid.zF[1], grid.zF[end]),
-               aspectratio = :equal, linewidth = 0, title = "Buoyancy")
+               aspectratio = :equal, linewidth = 0)
 
 display(plt) # hide

--- a/examples/hello_ocean.jl
+++ b/examples/hello_ocean.jl
@@ -26,7 +26,9 @@ run!(Simulation(model, Δt=0.01, stop_iteration=800))
 # Analyze the data
 
 b = model.tracers.b
+
 plt = contourf(ynodes(b), znodes(b), interior(b)[1, :, :]',
                xlim = (grid.yF[1], grid.yF[end]), ylim = (grid.zF[1], grid.zF[end]),
                aspectratio = :equal, linewidth = 0, title = "Buoyancy")
+
 display(plt) # hide

--- a/examples/hello_ocean.jl
+++ b/examples/hello_ocean.jl
@@ -1,0 +1,32 @@
+# # Hello, ocean!
+#
+# > How inappropriate to call this planet Earth, when it is quite clearly _Ocean_.
+#
+#   --Arthur C. Clark
+
+using Oceananigans, Oceananigans.Grids, Plots
+
+grid = RegularCartesianGrid(size = (1, 64, 64),
+                            x = (0, 1), y = (-4, 4), z = (-4, 4),
+                            topology = (Periodic, Bounded, Bounded))
+
+model = IncompressibleModel(grid = grid,
+                            architecture = CPU(),
+                            advection = Oceananigans.Advection.WENO5(),
+                            tracers = :b,
+                            buoyancy = BuoyancyTracer(),
+                            closure = IsotropicDiffusivity(ν=1e-3, κ=1e-3))
+         
+@info "Simulating a rising buoyant bubble with" model
+
+set!(model, b = (x, y, z) -> exp(-y^2 - z^2))
+
+run!(Simulation(model, Δt=0.01, stop_iteration=800))
+
+# Analyze the data
+
+b = model.tracers.b
+plt = contourf(ynodes(b), znodes(b), interior(b)[1, :, :]',
+               xlim = (grid.yF[1], grid.yF[end]), ylim = (grid.zF[1], grid.zF[end]),
+               aspectratio = :equal, linewidth = 0, title = "Buoyancy")
+display(plt) # hide

--- a/examples/hello_ocean.jl
+++ b/examples/hello_ocean.jl
@@ -6,8 +6,8 @@
 
 using Oceananigans, Oceananigans.Grids, Plots
 
-grid = RegularCartesianGrid(size = (1, 64, 64),
-                            x = (-6, 6), y = (-6, 6), z = (-3, 3),
+grid = RegularCartesianGrid(size = (64, 1, 64),
+                            x = (-5, 5), y = (-5, 5), z = (-3, 1),
                             topology = (Periodic, Periodic, Bounded))
 
 model = IncompressibleModel(grid = grid,
@@ -20,11 +20,14 @@ model = IncompressibleModel(grid = grid,
 
 @info "Simulating the ocean with" model
 
-set!(model,
-     u = (x, y, z) -> 1 + tanh(z/2),
-     b = (x, y, z) -> z + exp(-x^2) * (tanh(z) - 1))
+Σ(ξ) = (1 - tanh(ξ)) / 2
+Π(ξ, δ=1) = (Σ(ξ - δ) - Σ(ξ + δ)) / 2
 
-run!(Simulation(model, Δt=0.1, stop_iteration=1))
+set!(model,
+     u = (x, y, z) -> Σ(-z),
+     b = (x, y, z) -> - Π(4x, 1) * Σ(32z))
+
+run!(Simulation(model, Δt=0.01, stop_iteration=200))
 
 # Analyze the data
 
@@ -34,7 +37,7 @@ b = model.tracers.b
 
 plt = contourf(xnodes(b), znodes(b), interior(b)[:, 1, :]',
                xlabel = "x", ylabel = "z", title = "Hello, ocean!",
-               #xlim = (grid.xF[1], grid.xF[end]), ylim = (grid.zF[1], grid.zF[end]),
+               xlim = (grid.xF[1], grid.xF[end]), ylim = (grid.zF[1], grid.zF[end]),
                aspectratio = :equal, linewidth = 0)
 
 display(plt) # hide


### PR DESCRIPTION
This PR adds a new minimal example that simulates and plots a rising buoyant bubble:

```julia
# # Hello, ocean!
#
# > How inappropriate to call this planet Earth, when it is quite clearly _Ocean_.
#
#   --Arthur C. Clark

using Oceananigans, Oceananigans.Grids, Plots

grid = RegularCartesianGrid(size = (1, 64, 64),
                            x = (0, 1), y = (-4, 4), z = (-4, 4),
                            topology = (Periodic, Bounded, Bounded))

model = IncompressibleModel(grid = grid,
                            architecture = CPU(),
                            advection = Oceananigans.Advection.WENO5(),
                            tracers = :b,
                            buoyancy = BuoyancyTracer(),
                            closure = IsotropicDiffusivity(ν=1e-3, κ=1e-3))

@info "Simulating a rising buoyant bubble with" model

set!(model, b = (x, y, z) -> exp(-y^2 - z^2))

run!(Simulation(model, Δt=0.01, stop_iteration=800))

# Analyze the data

b = model.tracers.b

plt = contourf(ynodes(b), znodes(b), interior(b)[1, :, :]',
               xlabel = "y", ylabel = "z", title = "Buoyancy",
               xlim = (grid.yF[1], grid.yF[end]), ylim = (grid.zF[1], grid.zF[end]),
               aspectratio = :equal, linewidth = 0)

display(plt) # hide
```

If we do think an example like this would be nice to have, it might make sense to replace the README example with this one (and perhaps otherwise improve the README).

I didn't add it to the list of examples in the docs, but it is set up (in it's minimal way) for Literate-ing. Or we can un-literate it.

Suggest away and I shall commit!

The script produces

![image](https://user-images.githubusercontent.com/15271942/99148581-9859d880-2656-11eb-989a-a137635e11df.png)

Could also add a `pkg"add Oceananigans, Plots"` at the top per the discussion on #1149, but it might better to unify all the examples at once in a dedicated PR.