### PR TITLE
Add NaN checker to simulations by default

### DIFF
--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -7,6 +7,7 @@ export
     run_diagnostic!,
     TimeInterval, IterationInterval, WallTimeInterval
 
+using CUDA
 using Oceananigans
 using Oceananigans.Operators
 using Oceananigans.Utils: TimeInterval, IterationInterval, WallTimeInterval

--- a/src/Diagnostics/nan_checker.jl
+++ b/src/Diagnostics/nan_checker.jl
@@ -6,17 +6,15 @@ end
 """
     NaNChecker(; schedule, fields)
 
-Returns a `NaNChecker` that checks for a `NaN` in the first grid points of `fields`
-when `schedule` actuates. `fields` should be a named tuple.
-
-The simulation is aborted if a `NaN` is found.
+Returns a `NaNChecker` that checks for a `NaN` anywhere in `fields` when `schedule` actuates.
+`fields` should be a named tuple. The simulation is aborted if a `NaN` is found.
 """
 NaNChecker(model=nothing; schedule, fields) = NaNChecker(schedule, fields)
 
 function run_diagnostic!(nc::NaNChecker, model)
     for (name, field) in pairs(nc.fields)
         CUDA.@allowscalar begin
-            if isnan(field.data[1, 1, 1])
+            if any(isnan, field.data.parent)
                 t, i = model.clock.time, model.clock.iteration
                 error("time = $t, iteration = $i: NaN found in $name. Aborting simulation.")
             end

--- a/src/Diagnostics/nan_checker.jl
+++ b/src/Diagnostics/nan_checker.jl
@@ -1,8 +1,3 @@
-"""
-    NaNChecker{F} <: AbstractDiagnostic
-
-A diagnostic that checks for `NaN` values and aborts the simulation if any are found.
-"""
 struct NaNChecker{T, F} <: AbstractDiagnostic
     schedule :: T
       fields :: F
@@ -11,16 +6,20 @@ end
 """
     NaNChecker(; schedule, fields)
 
-Returns a `NaNChecker` that checks for `NaN` anywhere within `fields`
-when `schedule` actuates.
+Returns a `NaNChecker` that checks for a `NaN` in the first grid points of `fields`
+when `schedule` actuates. `fields` should be a named tuple.
+
+The simulation is aborted if a `NaN` is found.
 """
 NaNChecker(model=nothing; schedule, fields) = NaNChecker(schedule, fields)
 
 function run_diagnostic!(nc::NaNChecker, model)
-    for (name, field) in nc.fields
-        if any(isnan, field.data.parent)
-            t, i = model.clock.time, model.clock.iteration
-            error("time = $t, iteration = $i: NaN found in $name. Aborting simulation.")
+    for (name, field) in pairs(nc.fields)
+        CUDA.@allowscalar begin
+            if isnan(field.data[1, 1, 1])
+                t, i = model.clock.time, model.clock.iteration
+                error("time = $t, iteration = $i: NaN found in $name. Aborting simulation.")
+            end
         end
     end
 end

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -70,7 +70,7 @@ function Simulation(model; Δt,
    end
 
    diagnostics[:nan_checker] = NaNChecker(fields=(u=model.velocities.u,),
-                                          schedule=IterationInterval(100))
+                                          schedule=IterationInterval(iteration_interval))
 
    run_time = 0.0
 

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -69,6 +69,8 @@ function Simulation(model; Δt,
              "recalculate the time step every iteration which can be slow."
    end
 
+   diagnostics[:nan_checker] = NaNChecker(fields=model.velocities, schedule=IterationInterval(1))
+
    run_time = 0.0
 
    return Simulation(model, Δt, stop_criteria, stop_iteration, stop_time, wall_time_limit,

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -69,7 +69,8 @@ function Simulation(model; Δt,
              "recalculate the time step every iteration which can be slow."
    end
 
-   diagnostics[:nan_checker] = NaNChecker(fields=model.velocities, schedule=IterationInterval(1))
+   diagnostics[:nan_checker] = NaNChecker(fields=(u=model.velocities.u,),
+                                          schedule=IterationInterval(100))
 
    run_time = 0.0
 

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -69,7 +69,9 @@ function diagnostics_getindex(arch, FT)
     simulation = Simulation(model, Δt=0, stop_iteration=0)
     nc = NaNChecker(model, schedule=IterationInterval(1), fields=model.velocities)
     simulation.diagnostics[:nc] = nc
-    return simulation.diagnostics[1] == nc
+
+    # The first diagnostic is the NaN checker.
+    return simulation.diagnostics[2] == nc
 end
 
 function diagnostics_setindex(arch, FT)


### PR DESCRIPTION
This PR adds a NaN checker that checks for NaNs in the `[1, 1, 1]` grid point of the velocity fields at every time step (which should be very cheap and not affect performance).

When a NaN is detected, an `ErrorException` is thrown so when running in the REPL it'll error and return control to the REPL, while if running a script from the terminal, it will terminate the Julia session (seems like the behavior we all want).

Resolves #938
Resolves #1196