### PR TITLE
Fix index permutation for GPU DCT when dimension size is odd

### DIFF
--- a/src/Solvers/index_permutations.jl
+++ b/src/Solvers/index_permutations.jl
@@ -29,7 +29,7 @@ for example, `i ∈ 1:N` becomes
 
 if `N=8`.
 """
-@inline _unpermute_index(i, N) = ifelse(i <= N/2, 2i-1, 2(N-i+1))
+@inline _unpermute_index(i, N) = ifelse(i <= ceil(N/2), 2i-1, 2(N-i+1))
 
 @inline   permute_index(::TriplyPeriodic, ::GPU, i, j, k, Nx, Ny, Nz) = i, j, k
 @inline unpermute_index(::TriplyPeriodic, ::GPU, i, j, k, Nx, Ny, Nz) = i, j, k

--- a/test/test_pressure_solvers.jl
+++ b/test/test_pressure_solvers.jl
@@ -75,7 +75,12 @@ function analytical_poisson_solver_test(arch, N, topo; FT=Float64, mode=1)
     end
 
     solve_poisson_equation!(solver, grid)
-    ϕ = real(Array(solver.storage))
+
+    if arch isa GPU && topo == PBB_topo
+        ϕ = real(Array(solver.storage.storage1))
+    else
+        ϕ = real(Array(solver.storage))
+    end
 
     L¹_error = mean(abs, ϕ - Ψ.(xC, yC, zC))
 


### PR DESCRIPTION
Thanks to @leios and @francispoulin for feedback that helped locate the issue!

Resolves #1170 

This PR fixes a bug in how index unpermutation is done as part of the Makhoul (1980) fast cosine transform algorithm we use for the GPU. It only affected wall-bounded dimensions of odd length (see below).

Oceananigans was effectively setting the pressure to zero at the topmost grid point (it was actually accessing memory from out-of-bounds but since the bug was pretty consistent I assume it always grabbed some close-to-zero number).

I'm shocked that no test picked this up... But looking at our tests, we don't test dimensions of odd length on the GPU. This is probably because in earlier versions of Oceananigans, GPU models only supported dimension lengths that were multiples of 16 (due to hard-coded thread-block layouts). So we probably don't have many, if any, comprehensive GPU tests with odd-sized wall-bounded dimensions. 

TODO:
- [x] Add a test that fails due to this bug.
- [x] Confirm that the minimal icy moon setup does not blow up if Nz is even.
- [x] Commit fix. Test should pass and minimal icy moon should not blow up.
- [x] Ensure `divergence_free_poisson_solution` test runs on GPU with odd sizes (currently only even sizes are tested).
- [x] Ensure `poisson_solver_convergence` test runs on the GPU with even and odd sizes (currently it is not tested on the GPU).

# Reproduction

```julia
julia> permute(i, N) = isodd(i) ? floor(Int, i/2) + 1 : N - floor(Int, (i-1)/2)
permute (generic function with 1 method)

julia> unpermute(i, N) = i <= N/2 ? 2i-1 : 2(N-i+1)
unpermute (generic function with 1 method)
```

This works fine for dimensions of even length:

```julia
julia> N = 4
4

julia> L = [permute(i, N) for i in 1:N]
4-element Array{Int64,1}:
 1
 4
 2
 3

julia> [unpermute(i, N) for i in L]
4-element Array{Int64,1}:
 1
 2
 3
 4
```

but fails for dimensions of odd length:

```julia
julia> N = 5
5

julia> L = [permute(i, N) for i in 1:N]
5-element Array{Int64,1}:
 1
 5
 2
 4
 3

julia> [unpermute(i, N) for i in L]
5-element Array{Int64,1}:
 1
 2
 3
 4
 6
```

# Fix

```julia
julia> unpermute(i, N) = i <= ceil(N/2) ? 2i-1 : 2(N-i+1)
unpermute (generic function with 1 method)
```

```julia
julia> N = 5
5

julia> L = [permute(i, N) for i in 1:N]
5-element Array{Int64,1}:
 1
 5
 2
 4
 3
```

```julia
julia> [unpermute(i, N) for i in L]
5-element Array{Int64,1}:
 1
 2
 3
 4
 5
```