### PR TITLE
WENO(N) advection schemes

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -67,6 +67,12 @@ git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "0.3.4+0"
 
+[[Conda]]
+deps = ["JSON", "VersionParsing"]
+git-tree-sha1 = "c0647249d785f1d5139c0cc96db8f6b32f7ec416"
+uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+version = "1.5.0"
+
 [[Crayons]]
 git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
@@ -150,6 +156,12 @@ version = "0.3.0"
 git-tree-sha1 = "c70593677bbf2c3ccab4f7500d0f4dacfff7b75c"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.1.3"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.1"
 
 [[KernelAbstractions]]
 deps = ["Adapt", "CUDA", "Cassette", "InteractiveUtils", "MacroTools", "SpecialFunctions", "StaticArrays", "UUIDs"]
@@ -255,6 +267,12 @@ git-tree-sha1 = "cf59cfed2e2c12e8a2ff0a4f1e9b2cd8650da6db"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.3.2"
 
+[[Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "b417be52e8be24e916e34b3d70ec2da7bdf56a68"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.0.12"
+
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -263,6 +281,12 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[PyCall]]
+deps = ["Conda", "Dates", "Libdl", "LinearAlgebra", "MacroTools", "Serialization", "VersionParsing"]
+git-tree-sha1 = "b6dff5fa725eff4f775f472acd86756d6e31fb02"
+uuid = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+version = "1.92.1"
+
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
@@ -270,6 +294,11 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[RecipesBase]]
+git-tree-sha1 = "b3fb709f3c97bfc6e948be68beeecb55a0b340ae"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.1.1"
 
 [[Reexport]]
 deps = ["Pkg"]
@@ -334,6 +363,12 @@ version = "0.12.5"
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[[SymPy]]
+deps = ["LinearAlgebra", "PyCall", "RecipesBase", "SpecialFunctions"]
+git-tree-sha1 = "ffa9aed9161f7cab0c86119e3fc7e19a6ceac751"
+uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
+version = "1.0.33"
+
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -356,6 +391,11 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[VersionParsing]]
+git-tree-sha1 = "80229be1f670524750d905f8fc8148e5a8c4537f"
+uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
+version = "1.2.0"
 
 [[Zlib_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,9 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 
 [compat]
 Adapt = "^2"

--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -21,7 +21,7 @@ export
     UpwindBiasedThirdOrder,
     UpwindBiasedFifthOrder,
     CenteredFourthOrder,
-    WENO5
+    WENO, WENO5
 
 using Oceananigans.Grids
 using Oceananigans.Operators
@@ -43,6 +43,9 @@ include("centered_second_order.jl")
 include("upwind_biased_third_order.jl")
 include("centered_fourth_order.jl")
 include("upwind_biased_fifth_order.jl")
+
+include("weno_reconstruction.jl")
+include("weno_nth_order.jl")
 include("weno_fifth_order.jl")
 
 include("momentum_advection_operators.jl")

--- a/src/Advection/weno_nth_order.jl
+++ b/src/Advection/weno_nth_order.jl
@@ -1,0 +1,127 @@
+#####
+##### Weighted Essentially Non-Oscillatory (WENO) schemes
+#####
+
+struct WENO{K, FT, C, B, Γ} <: AbstractAdvectionScheme
+    C :: C
+    B :: B
+    γ :: Γ
+    ε :: FT
+    η :: FT
+end
+
+function WENO(FT, n)
+    (n < 3 || iseven(n)) &&
+        error("WENO schemes are only defined for order n = 3, 5, 7, 9, 11, ...")
+
+    @warn "Generated WENO schemes are experimental! They may be very slow (allocate tons of memory) and may not work on GPUs."
+
+    n >= 7 &&
+        @info "Computing WENO-$n smoothness indicator coefficients. This could take a while for n >= 7..."
+
+    k = Int((n + 1) / 2)
+    C = eno_coefficients_matrix(FT, k)
+    B = β_coefficients(FT, k)
+    γ = optimal_weno_weights(FT, k)
+
+    ε = 1e-6  # To avoid dividing by zero
+    η = 2     # WENO exponent
+
+    return WENO{k, FT, typeof(C), typeof(B), typeof(γ)}(C, B, γ, ε, η)
+end
+
+WENO(n) = WENO(Float64, n)
+
+#####
+##### ENO interpolants
+#####
+
+@inline px(i, j, k, weno::WENO{K}, r, ϕ) where K = @inbounds sum(weno.C[ℓ+1, r+1] * ϕ[i-r-1+ℓ, j, k] for ℓ in 0:K-1)
+@inline py(i, j, k, weno::WENO{K}, r, ϕ) where K = @inbounds sum(weno.C[ℓ+1, r+1] * ϕ[i, j-r-1+ℓ, k] for ℓ in 0:K-1)
+@inline pz(i, j, k, weno::WENO{K}, r, ϕ) where K = @inbounds sum(weno.C[ℓ+1, r+1] * ϕ[i, j, k-r-1+ℓ] for ℓ in 0:K-1)
+
+#####
+##### Jiang & Shu (1996) WENO smoothness indicators
+#####
+
+@inline βx(i, j, k, weno::WENO{K}, r, ϕ) where K = @inbounds sum(weno.B[m+1, n+1, r+1] * ϕ[i-r-1+m, j, k] * ϕ[i-r-1+n, j, k] for m in 0:K-1 for n in 0:m)
+@inline βy(i, j, k, weno::WENO{K}, r, ϕ) where K = @inbounds sum(weno.B[m+1, n+1, r+1] * ϕ[i, j-r-1+m, k] * ϕ[i, j-r-1+n, k] for m in 0:K-1 for n in 0:m)
+@inline βz(i, j, k, weno::WENO{K}, r, ϕ) where K = @inbounds sum(weno.B[m+1, n+1, r+1] * ϕ[i, j, k-r-1+m] * ϕ[i, j, k-r-1+n] for m in 0:K-1 for n in 0:m)
+
+#####
+##### WENO raw weights
+#####
+
+@inline αx(i, j, k, weno, r, ϕ) = @inbounds weno.γ[r+1] / (βx(i, j, k, weno, r, ϕ) + weno.ε)^weno.η
+@inline αy(i, j, k, weno, r, ϕ) = @inbounds weno.γ[r+1] / (βy(i, j, k, weno, r, ϕ) + weno.ε)^weno.η
+@inline αz(i, j, k, weno, r, ϕ) = @inbounds weno.γ[r+1] / (βz(i, j, k, weno, r, ϕ) + weno.ε)^weno.η
+
+#####
+##### WENO normalized weights
+#####
+
+@inline function weno_weights_x(i, j, k, weno::WENO{K}, ϕ) where K
+    α = [αx(i, j, k, weno, r, ϕ) for r in 0:K-1]
+    return α ./ sum(α)
+end
+
+@inline function weno_weights_y(i, j, k, weno::WENO{K}, ϕ) where K
+    α = [αy(i, j, k, weno, r, ϕ) for r in 0:K-1]
+    return α ./ sum(α)
+end
+
+@inline function weno_weights_z(i, j, k, weno::WENO{K}, ϕ) where K
+    α = [αz(i, j, k, weno, r, ϕ) for r in 0:K-1]
+    return α ./ sum(α)
+end
+
+#####
+##### WENO flux reconstruction
+#####
+
+@inline function weno_flux_x(i, j, k, weno::WENO{K}, ϕ) where K
+    w = weno_weights_x(i, j, k, weno, ϕ)
+    return sum(w[r+1] * px(i, j, k, weno, r, ϕ) for r in 0:K-1)
+end
+
+@inline function weno_flux_y(i, j, k, weno::WENO{K}, ϕ) where K
+    w = weno_weights_y(i, j, k, weno, ϕ)
+    return sum(w[r+1] * py(i, j, k, weno, r, ϕ) for r in 0:K-1)
+end
+
+@inline function weno_flux_z(i, j, k, weno::WENO{K}, ϕ) where K
+    w = weno_weights_z(i, j, k, weno, ϕ)
+    return sum(w[r+1] * pz(i, j, k, weno, r, ϕ) for r in 0:K-1)
+end
+
+#####
+##### Momentum advection fluxes
+#####
+
+@inline momentum_flux_uu(i, j, k, grid, weno::WENO, u)    = ℑxᶜᵃᵃ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) * weno_flux_x(i, j, k, weno, u)
+@inline momentum_flux_uv(i, j, k, grid, weno::WENO, u, v) = ℑxᶠᵃᵃ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) * weno_flux_y(i, j, k, weno, u)
+@inline momentum_flux_uw(i, j, k, grid, weno::WENO, u, w) = ℑxᶠᵃᵃ(i, j, k, grid, Az_ψᵃᵃᵃ, w) * weno_flux_z(i, j, k, weno, u)
+
+@inline momentum_flux_vu(i, j, k, grid, weno::WENO, u, v) = ℑyᵃᶠᵃ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) * weno_flux_x(i, j, k, weno, v)
+@inline momentum_flux_vv(i, j, k, grid, weno::WENO, v)    = ℑyᵃᶜᵃ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) * weno_flux_y(i, j, k, weno, v)
+@inline momentum_flux_vw(i, j, k, grid, weno::WENO, v, w) = ℑyᵃᶠᵃ(i, j, k, grid, Az_ψᵃᵃᵃ, w) * weno_flux_z(i, j, k, weno, v)
+
+@inline momentum_flux_wu(i, j, k, grid, weno::WENO, u, w) = ℑzᵃᵃᶠ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) * weno_flux_x(i, j, k, weno, w)
+@inline momentum_flux_wv(i, j, k, grid, weno::WENO, v, w) = ℑzᵃᵃᶠ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) * weno_flux_y(i, j, k, weno, w)
+@inline momentum_flux_ww(i, j, k, grid, weno::WENO, w)    = ℑzᵃᵃᶜ(i, j, k, grid, Az_ψᵃᵃᵃ, w) * weno_flux_z(i, j, k, weno, w)
+
+#####
+##### Advective tracer fluxes
+#####
+
+@inline advective_tracer_flux_x(i, j, k, grid, weno::WENO, u, c) = Ax_ψᵃᵃᶠ(i, j, k, grid, u) * weno_flux_x(i, j, k, weno, c)
+@inline advective_tracer_flux_y(i, j, k, grid, weno::WENO, v, c) = Ay_ψᵃᵃᶠ(i, j, k, grid, v) * weno_flux_y(i, j, k, weno, c)
+@inline advective_tracer_flux_z(i, j, k, grid, weno::WENO, w, c) = Az_ψᵃᵃᵃ(i, j, k, grid, w) * weno_flux_z(i, j, k, weno, c)
+
+#####
+##### Need to advect momentum like tracers
+#####
+
+@inline div_ũu(i, j, k, grid, advection::WENO, U) = div_uc(i, j, k, grid, advection, U, U.u)
+@inline div_ũv(i, j, k, grid, advection::WENO, U) = div_uc(i, j, k, grid, advection, U, U.v)
+@inline div_ũw(i, j, k, grid, advection::WENO, U) = div_uc(i, j, k, grid, advection, U, U.w)

--- a/src/Advection/weno_reconstruction.jl
+++ b/src/Advection/weno_reconstruction.jl
@@ -1,5 +1,5 @@
-# using StaticArrays
-# using SymPy
+using StaticArrays
+using SymPy
 
 """
 WENO reconstruction schemes following the lecture notes by Shu (1998) and
@@ -112,7 +112,7 @@ x(j) = j  # Assume uniform grid for now.
 Return a symbolic expression for the `j`th Lagrange basis polynomial ℓ(ξ) for an
 ENO reconstruction scheme of order k and left shift `r` with field values `ϕ`.
 """
-# ℓ(ξ, k, r, j) = prod((ξ - x(m-r)) / (x(j-r) - x(m-r)) for m in 0:k-1 if m != j)
+ℓ(ξ, k, r, j) = prod((ξ - x(m-r)) / (x(j-r) - x(m-r)) for m in 0:k-1 if m != j)
 
 """
     L(ξ, k, r, ϕ)
@@ -120,7 +120,7 @@ ENO reconstruction scheme of order k and left shift `r` with field values `ϕ`.
 Return a symbolic expression for the interpolating Lagrange polynomial p(ξ) for an
 ENO reconstruction scheme of order k and left shift `r` with field values `ϕ`.
 """
-# p(ξ, k, r, ϕ) = sum(ℓ(ξ, k, r, j) * ϕ[j+1] for j in 0:k-1)
+p(ξ, k, r, ϕ) = sum(ℓ(ξ, k, r, j) * ϕ[j+1] for j in 0:k-1)
 
 """
     β(k, r, ϕ)
@@ -129,10 +129,10 @@ Return a symbolic expression for the smoothness indicator β for a WENO reconstr
 scheme with stencils of size `k` and left shift `r` (WENO scheme of order 2k-1). The
 field values are represented by the symbols in `ϕ` which should have length k.
 """
-# function β(k, r, ϕ)
-#     @vars ξ
-#     return sum(integrate(diff(p(ξ, k, r, ϕ), ξ, l)^2, (ξ, Sym(-1//2), Sym(1//2))) for l in 1:k-1)
-# end
+function β(k, r, ϕ)
+    @vars ξ
+    return sum(integrate(diff(p(ξ, k, r, ϕ), ξ, l)^2, (ξ, Sym(-1//2), Sym(1//2))) for l in 1:k-1)
+end
 
 """
     subscript(n)
@@ -157,20 +157,20 @@ The `B[m, n, r]` coefficient corresponds to the coefficient of the
 `ϕ[r-k+m+1] * ϕ[r-k+n+1]` term where r-k+1 <= m, n <= r and `r` is the left shift of
 the ENO interpolants.
 """
-# function β_coefficients(FT, k)
-#     B = zeros(Float64, k, k, k)
+function β_coefficients(FT, k)
+    B = zeros(Float64, k, k, k)
 
-#     for r in 0:k-1
-#         ϕ = [Sym("ϕᵢ" * subscript_index(n)) for n in r:-1:r-k+1]
-#         β_symbolic = β(k, r, ϕ) |> expand
+    for r in 0:k-1
+        ϕ = [Sym("ϕᵢ" * subscript_index(n)) for n in r:-1:r-k+1]
+        β_symbolic = β(k, r, ϕ) |> expand
 
-#         for m in 1:k, n in 1:k
-#             B[m, n, r+1] = β_symbolic.coeff(ϕ[m] * ϕ[n])
-#         end
-#     end
+        for m in 1:k, n in 1:k
+            B[m, n, r+1] = β_symbolic.coeff(ϕ[m] * ϕ[n])
+        end
+    end
 
-#     B = rationalize.(B, tol=√eps(Float64))
-#     return SArray{Tuple{k,k,k},FT}(B)
-# end
+    B = rationalize.(B, tol=√eps(Float64))
+    return SArray{Tuple{k,k,k},FT}(B)
+end
 
-# β_coefficients(k) = β_coefficients(Rational, k)
+β_coefficients(k) = β_coefficients(Rational, k)

--- a/src/Advection/weno_reconstruction.jl
+++ b/src/Advection/weno_reconstruction.jl
@@ -1,0 +1,176 @@
+# using StaticArrays
+# using SymPy
+
+"""
+WENO reconstruction schemes following the lecture notes by Shu (1998) and
+the review article by Shu (2009). WENO smoothness indicators are due to
+Jiang & Shu (1996).
+
+Shu (1998), "Essentially Non-Oscillatory and Weighted Essentially Non-Oscillatory
+    Schemes for Hyperbolic Conservation Laws", In: Advanced Numerical Approximation
+    of Nonlinear Hyperbolic Equations, edited by Cockburn et al., pp. 325–432.
+    DOI: https://doi.org/10.1007/BFb0096355
+
+Shu (2009) "High Order Weighted Essentially Nonoscillatory Schemes for Convection
+    Dominated Problems", SIAM Review 51(1), pp. 82–126.
+    DOI: https://doi.org/10.1137/070679065
+
+Jiang & Shu (1996) "Efficient Implementation of Weighted ENO Schemes", Journal of
+    Computational Physics 126, pp. 202–228.
+    DOI: https://doi.org/10.1006/jcph.1996.0130
+"""
+
+#####
+##### ENO reconstruction coefficients and WENO weights on a uniform grid
+##### Equation (2.21) from the Shu (1998) lecture notes.
+#####
+
+"""
+    UΠ(k, r, m, l)
+
+Return the product in the numerator of equation (2.21) of Shu (1998) for the `l`th
+term of the `m`th Lagrange basis polynomial of an ENO reconstruction scheme with
+order `k` and left shift `r`.
+"""
+UΠ(k, r, l, m) = prod([r-q+1 for q in 0:k if q ∉ (m, l)])
+
+"""
+    U(k, r, m)
+
+Return the numerator in equation (2.21) of Shu (1998) for the `m`th Lagrange basis
+polynomial of an ENO reconstruction scheme with order `k` and left shift `r`.
+"""
+U(k, r, m) = sum([UΠ(k, r, m, l) for l in 0:k if l != m])
+
+"""
+    D(k, m)
+
+Return the denominator in equation (2.21) of Shu (1998) for the `m`th Lagrange basis
+polynomial of an ENO reconstruction scheme with order `k`.
+"""
+D(k, m) = prod([m - l for l in 0:k if l != m])
+
+"""
+    eno_coefficient(k, r)
+
+Return the `j`th ENO coefficient used to reconstruct a value at the point x(i+½) with
+order of accuracy `k` (stencil size) and left shift `r`.
+"""
+eno_coefficient(k, r, j) = sum([U(k, r, m)//D(k, m) for m in j+1:k])
+
+"""
+    eno_coefficients(k, r)
+
+Return an array of ENO coefficients to reconstruct a value at the point x(i+½) with
+order of accuracy `k` (stencil size) and left shift `r`.
+"""
+eno_coefficients(k, r) = [eno_coefficient(k, r, j) for j in 0:k-1]
+
+"""
+    eno_coefficients_matrix([FT=Rational], k)
+
+Return a k×k static array containing ENO coefficients to reconstruct a value at the
+point x(i+½) with order of accuracy `k` (stencil size) with element type `FT`. Note
+that when combined these ENO interpolants produce a WENO scheme of order 2k-1.
+"""
+eno_coefficients_matrix(FT, k) =
+    cat([eno_coefficients(k, r) for r in 0:k-1]..., dims=1) |> SMatrix{k,k,FT}
+
+eno_coefficients_matrix(k) = eno_coefficients_matrix(Rational, k)
+
+"""
+    optimal_weno_weights([FT=Rational], k)
+
+Return a static vector containing the optimal weights that can be used to weigh ENO
+reconstruction schemes of order `k` to produce a WENO scheme of order 2k-1.
+"""
+function optimal_weno_weights(FT, k)
+    C = zeros(Rational, 2k-1, k)
+    b = eno_coefficients(2k-1, k-1)
+
+    for n in 0:k-1
+        C[n+1:n+k, n+1] .= eno_coefficients(k, k-1-n)
+    end
+
+    γ = C \ b
+    γ = rationalize.(γ, tol=√eps(Float64)) |> reverse
+    return SVector{k,FT}(γ)
+end
+
+optimal_weno_weights(k) = optimal_weno_weights(Rational, k)
+
+#####
+##### Jiang & Shu (1996) WENO smoothness indicators β
+##### See equation (2.61) of Shu (1998).
+#####
+
+x(j) = j  # Assume uniform grid for now.
+
+"""
+    ℓ(ξ, k, r, j)
+
+Return a symbolic expression for the `j`th Lagrange basis polynomial ℓ(ξ) for an
+ENO reconstruction scheme of order k and left shift `r` with field values `ϕ`.
+"""
+# ℓ(ξ, k, r, j) = prod((ξ - x(m-r)) / (x(j-r) - x(m-r)) for m in 0:k-1 if m != j)
+
+"""
+    L(ξ, k, r, ϕ)
+
+Return a symbolic expression for the interpolating Lagrange polynomial p(ξ) for an
+ENO reconstruction scheme of order k and left shift `r` with field values `ϕ`.
+"""
+# p(ξ, k, r, ϕ) = sum(ℓ(ξ, k, r, j) * ϕ[j+1] for j in 0:k-1)
+
+"""
+    β(k, r, ϕ)
+
+Return a symbolic expression for the smoothness indicator β for a WENO reconstruction
+scheme with stencils of size `k` and left shift `r` (WENO scheme of order 2k-1). The
+field values are represented by the symbols in `ϕ` which should have length k.
+"""
+# function β(k, r, ϕ)
+#     @vars ξ
+#     return sum(integrate(diff(p(ξ, k, r, ϕ), ξ, l)^2, (ξ, Sym(-1//2), Sym(1//2))) for l in 1:k-1)
+# end
+
+"""
+    subscript(n)
+
+Convert the integer `n` to a subscript in the form of a unicode string. Note
+that `0x2080` is the unicode encoding for the subscript 0.
+"""
+subscript(n) = join(Char(0x2080 + parse(Int, d)) for d in string(n))
+
+subscript_sign(n) = n > 0 ? "₊" : n < 0 ? "₋" : ""
+
+subscript_index(n) = n == 0 ? "" : subscript_sign(n) * subscript(abs(n))
+
+"""
+    β_coefficients([FT=Rational], k)
+
+Return a k×k×k static array containing the WENO smoothness indicator coefficients
+described by Jiang & Shu (1998) for a WENO reconstruction with stencils of size `k`
+(WENO scheme of order 2k-1) with element type `FT`.
+
+The `B[m, n, r]` coefficient corresponds to the coefficient of the
+`ϕ[r-k+m+1] * ϕ[r-k+n+1]` term where r-k+1 <= m, n <= r and `r` is the left shift of
+the ENO interpolants.
+"""
+# function β_coefficients(FT, k)
+#     B = zeros(Float64, k, k, k)
+
+#     for r in 0:k-1
+#         ϕ = [Sym("ϕᵢ" * subscript_index(n)) for n in r:-1:r-k+1]
+#         β_symbolic = β(k, r, ϕ) |> expand
+
+#         for m in 1:k, n in 1:k
+#             B[m, n, r+1] = β_symbolic.coeff(ϕ[m] * ϕ[n])
+#         end
+#     end
+
+#     B = rationalize.(B, tol=√eps(Float64))
+#     return SArray{Tuple{k,k,k},FT}(B)
+# end
+
+# β_coefficients(k) = β_coefficients(Rational, k)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,6 +88,7 @@ group = get(ENV, "TEST_GROUP", :all) |> Symbol
             include("test_coriolis.jl")
             include("test_buoyancy.jl")
             include("test_surface_waves.jl")
+            include("test_weno_reconstruction.jl")
             include("test_utils.jl")
         end
     end

--- a/test/test_weno_reconstruction.jl
+++ b/test/test_weno_reconstruction.jl
@@ -1,0 +1,131 @@
+# using SymPy
+
+using Oceananigans.Advection:
+    eno_coefficients, optimal_weno_weights, # β,
+    weno_flux_x, weno_flux_y, weno_flux_z,
+    left_biased_interpolate_xᶠᵃᵃ, left_biased_interpolate_yᵃᶠᵃ, left_biased_interpolate_zᵃᵃᶠ
+
+function print_eno_interpolant(k, r)
+    cs = eno_coefficients(k, r)
+
+    ssign(n) = n >= 0 ? "+" : "-"
+    ssubscript(n) = n == 0 ? "i"  : "i" * ssign(n) * string(abs(n))
+
+    print("u(i+1//2) = ")
+    for (j, c) in enumerate(cs)
+        c_s = ssign(c) * " " * string(abs(c))
+        ss_s = ssubscript(j-r-1)
+        print(c_s * " u(" * ss_s * ") ")
+    end
+    print("\n")
+end
+
+function print_eno_interpolants(k)
+    for r in -1:k-1
+        print_eno_interpolant(k, r)
+    end
+    Γ = optimal_weno_weights(k)
+    println("Optimal weights γ: $Γ")
+end
+
+@testset "WENO reconstruction" begin
+    @info "Testing WENO reconstruction..."
+    
+    # Janky regression test
+    
+    # weno5 = WENO(5)
+
+    N = 10
+    a = collect(Float64, (1:N) .^ 2)
+    
+    ax = reshape(a, (N, 1, 1))
+    ay = reshape(a, (1, N, 1))
+    az = reshape(a, (1, 1, N))
+
+    correct = [73//6, 121//6, 181//6, 253//6]
+
+    inds = 4:N-3
+    # @test all([weno_flux_x(i, 1, 1, weno5, ax) for i in inds] .≈ correct) 
+    # @test all([weno_flux_y(1, j, 1, weno5, ay) for j in inds] .≈ correct)
+    # @test all([weno_flux_z(1, 1, k, weno5, az) for k in inds] .≈ correct)
+
+    @test rationalize.([left_biased_interpolate_xᶠᵃᵃ(i, 1, 1, nothing, WENO5(), ax) for i in inds]) == correct
+    @test rationalize.([left_biased_interpolate_yᵃᶠᵃ(1, j, 1, nothing, WENO5(), ay) for j in inds]) == correct
+    @test rationalize.([left_biased_interpolate_zᵃᵃᶠ(1, 1, k, nothing, WENO5(), az) for k in inds]) == correct
+
+    @testset "ENO reconstruction weights" begin
+        @testset "WENO-3" begin
+            @info "WENO-3 coefficients [Compare with Table 2.1 of Shu (1998)]:"
+            print_eno_interpolants(2)
+
+            @test eno_coefficients(2, -1) == [ 3//2, -1//2]
+            @test eno_coefficients(2,  0) == [ 1//2,  1//2]
+            @test eno_coefficients(2,  1) == [-1//2,  3//2]     
+        end
+
+        @testset "WENO-5" begin
+            @info "WENO-5 coefficients [Compare with Table 2.1 of Shu (1998) and equation (2.15) from Shu (2009)]:"
+            print_eno_interpolants(3)
+
+            @test eno_coefficients(3, -1) == [11//6, -7//6,  1//3]
+            @test eno_coefficients(3,  0) == [ 1//3,  5//6, -1//6]
+            @test eno_coefficients(3,  1) == [-1//6,  5//6,  1//3]
+            @test eno_coefficients(3,  2) == [ 1//3, -7//6, 11//6]
+        end
+
+        @testset "WENO-7" begin
+            @info "WENO-7 coefficients [Compare with Table 2.1 of Shu (1998)]:"
+            print_eno_interpolants(4)
+
+            @test eno_coefficients(4, -1) == [25//12, -23//12,  13//12, -1//4 ]
+            @test eno_coefficients(4,  0) == [ 1//4,   13//12,  -5//12,  1//12]
+            @test eno_coefficients(4,  1) == [-1//12,   7//12,   7//12, -1//12]
+            @test eno_coefficients(4,  2) == [ 1//12,  -5//12,  13//12,  1//4 ]
+            @test eno_coefficients(4,  3) == [-1//4,   13//12, -23//12, 25//12]
+        end
+
+        @testset "WENO-9" begin
+            @info "WENO-9 coefficients [Compare with Table 2.1 of Shu (1998) and equation (2.14) of Shu (2009)]:"
+            print_eno_interpolants(5)
+
+            @test eno_coefficients(5, -1) == [ 137//60, -163//60, 137//60,  -21//20,   1//5 ]
+            @test eno_coefficients(5,  0) == [   1//5,    77//60, -43//60,   17//60,  -1//20]
+            @test eno_coefficients(5,  1) == [  -1//20,    9//20,  47//60,  -13//60,   1//30]
+            @test eno_coefficients(5,  2) == [   1//30,  -13//60,  47//60,    9//20,  -1//20]
+            @test eno_coefficients(5,  3) == [  -1//20,   17//60, -43//60,   77//60,   1//5 ]
+            @test eno_coefficients(5,  4) == [   1//5,   -21//20, 137//60, -163//60, 137//60]
+        end
+    end
+
+    @testset "WENO optimal weights" begin
+        @testset "WENO-3" begin
+            # Compare with Table II of Jiang & Shu (1996).
+            @test optimal_weno_weights(2) == [2//3, 1//3]
+        end
+        
+        @testset "WENO-5" begin
+            # Compare with equation (2.15) of Shu (2009).
+            @test optimal_weno_weights(3) == [3//10, 3//5, 1//10]
+        end
+
+        @testset "WENO-7" begin end
+
+        @testset "WENO-9" begin
+            @test optimal_weno_weights(5) == [5//126, 20//63, 10//21, 10//63, 1//126]
+        end
+    end
+
+    # @testset "WENO smoothness indicators" begin
+    #     @testset "WENO-5" begin
+    #         @vars ϕᵢ₋₂  ϕᵢ₋₁ ϕᵢ ϕᵢ₊₁ ϕᵢ₊₂
+            
+    #         β₀_correct = 13//12 * (ϕᵢ₋₂ - 2ϕᵢ₋₁ + ϕᵢ  )^2 + 1//4 * ( ϕᵢ₋₂ - 4ϕᵢ₋₁ + 3ϕᵢ  )^2 |> expand
+    #         β₁_correct = 13//12 * (ϕᵢ₋₁ - 2ϕᵢ   + ϕᵢ₊₁)^2 + 1//4 * ( ϕᵢ₋₁         -  ϕᵢ₊₁)^2 |> expand
+    #         β₂_correct = 13//12 * (ϕᵢ   - 2ϕᵢ₊₁ + ϕᵢ₊₂)^2 + 1//4 * (3ϕᵢ   - 4ϕᵢ₊₁ +  ϕᵢ₊₂)^2 |> expand
+
+    #         @test β(3, 0, (ϕᵢ, ϕᵢ₋₁, ϕᵢ₋₂)) |> expand == β₀_correct
+    #         @test β(3, 1, (ϕᵢ₊₁, ϕᵢ, ϕᵢ₋₁)) |> expand == β₁_correct
+    #         @test β(3, 2, (ϕᵢ₊₂, ϕᵢ₊₁, ϕᵢ)) |> expand == β₂_correct
+    #     end
+    # end
+end

--- a/test/test_weno_reconstruction.jl
+++ b/test/test_weno_reconstruction.jl
@@ -1,7 +1,7 @@
-# using SymPy
+using SymPy
 
 using Oceananigans.Advection:
-    eno_coefficients, optimal_weno_weights, # β,
+    eno_coefficients, optimal_weno_weights, β,
     weno_flux_x, weno_flux_y, weno_flux_z,
     left_biased_interpolate_xᶠᵃᵃ, left_biased_interpolate_yᵃᶠᵃ, left_biased_interpolate_zᵃᵃᶠ
 
@@ -30,14 +30,14 @@ end
 
 @testset "WENO reconstruction" begin
     @info "Testing WENO reconstruction..."
-    
+
     # Janky regression test
-    
-    # weno5 = WENO(5)
+
+    weno5 = WENO(5)
 
     N = 10
     a = collect(Float64, (1:N) .^ 2)
-    
+
     ax = reshape(a, (N, 1, 1))
     ay = reshape(a, (1, N, 1))
     az = reshape(a, (1, 1, N))
@@ -45,9 +45,9 @@ end
     correct = [73//6, 121//6, 181//6, 253//6]
 
     inds = 4:N-3
-    # @test all([weno_flux_x(i, 1, 1, weno5, ax) for i in inds] .≈ correct) 
-    # @test all([weno_flux_y(1, j, 1, weno5, ay) for j in inds] .≈ correct)
-    # @test all([weno_flux_z(1, 1, k, weno5, az) for k in inds] .≈ correct)
+    @test all([weno_flux_x(i, 1, 1, weno5, ax) for i in inds] .≈ correct)
+    @test all([weno_flux_y(1, j, 1, weno5, ay) for j in inds] .≈ correct)
+    @test all([weno_flux_z(1, 1, k, weno5, az) for k in inds] .≈ correct)
 
     @test rationalize.([left_biased_interpolate_xᶠᵃᵃ(i, 1, 1, nothing, WENO5(), ax) for i in inds]) == correct
     @test rationalize.([left_biased_interpolate_yᵃᶠᵃ(1, j, 1, nothing, WENO5(), ay) for j in inds]) == correct
@@ -60,7 +60,7 @@ end
 
             @test eno_coefficients(2, -1) == [ 3//2, -1//2]
             @test eno_coefficients(2,  0) == [ 1//2,  1//2]
-            @test eno_coefficients(2,  1) == [-1//2,  3//2]     
+            @test eno_coefficients(2,  1) == [-1//2,  3//2]
         end
 
         @testset "WENO-5" begin
@@ -102,7 +102,7 @@ end
             # Compare with Table II of Jiang & Shu (1996).
             @test optimal_weno_weights(2) == [2//3, 1//3]
         end
-        
+
         @testset "WENO-5" begin
             # Compare with equation (2.15) of Shu (2009).
             @test optimal_weno_weights(3) == [3//10, 3//5, 1//10]
@@ -115,17 +115,17 @@ end
         end
     end
 
-    # @testset "WENO smoothness indicators" begin
-    #     @testset "WENO-5" begin
-    #         @vars ϕᵢ₋₂  ϕᵢ₋₁ ϕᵢ ϕᵢ₊₁ ϕᵢ₊₂
-            
-    #         β₀_correct = 13//12 * (ϕᵢ₋₂ - 2ϕᵢ₋₁ + ϕᵢ  )^2 + 1//4 * ( ϕᵢ₋₂ - 4ϕᵢ₋₁ + 3ϕᵢ  )^2 |> expand
-    #         β₁_correct = 13//12 * (ϕᵢ₋₁ - 2ϕᵢ   + ϕᵢ₊₁)^2 + 1//4 * ( ϕᵢ₋₁         -  ϕᵢ₊₁)^2 |> expand
-    #         β₂_correct = 13//12 * (ϕᵢ   - 2ϕᵢ₊₁ + ϕᵢ₊₂)^2 + 1//4 * (3ϕᵢ   - 4ϕᵢ₊₁ +  ϕᵢ₊₂)^2 |> expand
+    @testset "WENO smoothness indicators" begin
+        @testset "WENO-5" begin
+            @vars ϕᵢ₋₂  ϕᵢ₋₁ ϕᵢ ϕᵢ₊₁ ϕᵢ₊₂
 
-    #         @test β(3, 0, (ϕᵢ, ϕᵢ₋₁, ϕᵢ₋₂)) |> expand == β₀_correct
-    #         @test β(3, 1, (ϕᵢ₊₁, ϕᵢ, ϕᵢ₋₁)) |> expand == β₁_correct
-    #         @test β(3, 2, (ϕᵢ₊₂, ϕᵢ₊₁, ϕᵢ)) |> expand == β₂_correct
-    #     end
-    # end
+            β₀_correct = 13//12 * (ϕᵢ₋₂ - 2ϕᵢ₋₁ + ϕᵢ  )^2 + 1//4 * ( ϕᵢ₋₂ - 4ϕᵢ₋₁ + 3ϕᵢ  )^2 |> expand
+            β₁_correct = 13//12 * (ϕᵢ₋₁ - 2ϕᵢ   + ϕᵢ₊₁)^2 + 1//4 * ( ϕᵢ₋₁         -  ϕᵢ₊₁)^2 |> expand
+            β₂_correct = 13//12 * (ϕᵢ   - 2ϕᵢ₊₁ + ϕᵢ₊₂)^2 + 1//4 * (3ϕᵢ   - 4ϕᵢ₊₁ +  ϕᵢ₊₂)^2 |> expand
+
+            @test β(3, 0, (ϕᵢ, ϕᵢ₋₁, ϕᵢ₋₂)) |> expand == β₀_correct
+            @test β(3, 1, (ϕᵢ₊₁, ϕᵢ, ϕᵢ₋₁)) |> expand == β₁_correct
+            @test β(3, 2, (ϕᵢ₊₂, ϕᵢ₊₁, ϕᵢ)) |> expand == β₂_correct
+        end
+    end
 end


### PR DESCRIPTION
Originally added in PR #592 but removed in #1221, this PR reintroduces the `weno_nth_order.jl` implementation.

We should look into making it as fast and efficient as the `weno_fifth_order.jl` before merging.

Also this PR adds the cursed SymPy dependency which has caused problems for users in the past (see #990) so would be nice to get rid of it somehow.

X-Ref: #995