### PR TITLE
Check for NaNs in the model's first field

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.45.0"
+version = "0.45.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Simulations/Simulations.jl
+++ b/src/Simulations/Simulations.jl
@@ -5,7 +5,7 @@ export TimeStepWizard, Simulation, run!
 import Base: show
 
 using OrderedCollections: OrderedDict
-using Oceananigans: AbstractDiagnostic, AbstractOutputWriter
+using Oceananigans: AbstractDiagnostic, AbstractOutputWriter, fields
 
 using Oceananigans.Models
 using Oceananigans.Diagnostics

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -69,7 +69,10 @@ function Simulation(model; Δt,
              "recalculate the time step every iteration which can be slow."
    end
 
-   diagnostics[:nan_checker] = NaNChecker(fields=(u=model.velocities.u,),
+   # Check for NaNs in the model's first field.
+   model_fields = fields(model)
+   field_to_check_nans = NamedTuple{(keys(model_fields)[1],)}((model_fields[1],))
+   diagnostics[:nan_checker] = NaNChecker(fields=field_to_check_nans,
                                           schedule=IterationInterval(iteration_interval))
 
    run_time = 0.0

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -71,7 +71,7 @@ function Simulation(model; Δt,
 
    # Check for NaNs in the model's first field.
    model_fields = fields(model)
-   field_to_check_nans = NamedTuple{(keys(model_fields)[1],)}((model_fields[1],))
+   field_to_check_nans = NamedTuple{keys(model_fields) |> first |> tuple}(first(model_fields) |> tuple)
    diagnostics[:nan_checker] = NaNChecker(fields=field_to_check_nans,
                                           schedule=IterationInterval(iteration_interval))
 


### PR DESCRIPTION
Shallow water model tests are failing on master because `model.velocities.u` does not exist for `ShallowWaterModel`.

This PR fixes this by checking for NaNs in the model's first field.