### PR TITLE
Timesteppers and forcing functions for shallow water models

### DIFF
--- a/src/Forcings/continuous_forcing.jl
+++ b/src/Forcings/continuous_forcing.jl
@@ -84,13 +84,13 @@ ContinuousForcing(func; parameters=nothing, field_dependencies=()) =
     ContinuousForcing(func, parameters, field_dependencies)
 
 """
-    regularize_forcing(forcing::ContinuousForcing, field, field_name, model_field_names)
+    regularize_forcing(forcing::ContinuousForcing, field, model_field_names)
 
 Regularize `forcing::ContinuousForcing` by determining the indices of `forcing.field_dependencies`
 in `model_field_names`, and associated interpolation functions so `forcing` can be used during
 time-stepping `IncompressibleModel`.
 """
-function regularize_forcing(forcing::ContinuousForcing, field, field_name, model_field_names)
+function regularize_forcing(forcing::ContinuousForcing, field, model_field_names)
 
     X, Y, Z = location(field)
 

--- a/src/Forcings/continuous_forcing.jl
+++ b/src/Forcings/continuous_forcing.jl
@@ -84,13 +84,13 @@ ContinuousForcing(func; parameters=nothing, field_dependencies=()) =
     ContinuousForcing(func, parameters, field_dependencies)
 
 """
-    regularize_forcing(forcing::ContinuousForcing, field, model_field_names)
+    regularize_forcing(forcing::ContinuousForcing, field, field_name, model_field_names)
 
 Regularize `forcing::ContinuousForcing` by determining the indices of `forcing.field_dependencies`
 in `model_field_names`, and associated interpolation functions so `forcing` can be used during
 time-stepping `IncompressibleModel`.
 """
-function regularize_forcing(forcing::ContinuousForcing, field, model_field_names)
+function regularize_forcing(forcing::ContinuousForcing, field, field_name, model_field_names)
 
     X, Y, Z = location(field)
 

--- a/src/Forcings/continuous_forcing.jl
+++ b/src/Forcings/continuous_forcing.jl
@@ -25,8 +25,8 @@ struct ContinuousForcing{X, Y, Z, P, F, D, I, ℑ}
         field_dependencies = tupleit(field_dependencies)
 
         return new{Nothing, Nothing, Nothing,
-                   typeof(parameters), 
-                   typeof(func), 
+                   typeof(parameters),
+                   typeof(func),
                    typeof(field_dependencies),
                    Nothing,
                    Nothing}(func, parameters, field_dependencies, nothing, nothing)
@@ -51,7 +51,7 @@ end
 Construct a "continuous form" forcing with optional `parameters` and optional
 `field_dependencies` on other fields in a model.
 
-If neither `parameters` nor `field_dependencies` are provided, then `func` must be 
+If neither `parameters` nor `field_dependencies` are provided, then `func` must be
 callable with the signature
 
     `func(x, y, z, t)`
@@ -83,21 +83,21 @@ callable with the signature
 ContinuousForcing(func; parameters=nothing, field_dependencies=()) =
     ContinuousForcing(func, parameters, field_dependencies)
 
-""" 
-    regularize_forcing(forcing::ContinuousForcing, field_name, model_field_names)
+"""
+    regularize_forcing(forcing::ContinuousForcing, field, field_name, model_field_names)
 
 Regularize `forcing::ContinuousForcing` by determining the indices of `forcing.field_dependencies`
 in `model_field_names`, and associated interpolation functions so `forcing` can be used during
 time-stepping `IncompressibleModel`.
 """
-function regularize_forcing(forcing::ContinuousForcing, field_name, model_field_names)
+function regularize_forcing(forcing::ContinuousForcing, field, field_name, model_field_names)
 
-    X, Y, Z = assumed_field_location(field_name)
+    X, Y, Z = location(field)
 
     indices, interps = index_and_interp_dependencies(X, Y, Z,
                                                      forcing.field_dependencies,
                                                      model_field_names)
-    
+
     return ContinuousForcing{X, Y, Z}(forcing.func, forcing.parameters, forcing.field_dependencies,
                                       indices, interps)
 end

--- a/src/Forcings/model_forcing.jl
+++ b/src/Forcings/model_forcing.jl
@@ -1,7 +1,7 @@
 @inline zeroforcing(args...) = 0
 
 """
-    regularize_forcing(forcing, field, model_field_names)
+    regularize_forcing(forcing, field, field_name, model_field_names)
 
 "Regularizes" or "adds information" to user-defined forcing objects that are passed to
 model constructors. `regularize_forcing` is called inside `model_forcing`.
@@ -11,19 +11,19 @@ the fields (and field locations) of various forcing functions are available. The
 can be used to infer the location at which the forcing is applied, or to add a field
 dependency to a special forcing object, as for `Relxation`.
 """
-regularize_forcing(forcing, field, model_field_names) = forcing # fallback
+regularize_forcing(forcing, field, field_name, model_field_names) = forcing # fallback
 
 """
-    regularize_forcing(forcing::Function, field::Field, model_field_names)
+    regularize_forcing(forcing::Function, field::Field, field_name, model_field_names)
 
 Wrap `forcing` in a `ContinuousForcing` at the location of `field`.
 """
-function regularize_forcing(forcing::Function, field::Field, model_field_names)
+function regularize_forcing(forcing::Function, field::Field, field_name, model_field_names)
     LX, LY, LZ = location(field)
     return ContinuousForcing{LX, LY, LZ}(forcing)
 end
 
-regularize_forcing(::Nothing, field::Field, model_field_names) = zeroforcing
+regularize_forcing(::Nothing, field::Field, field_name, model_field_names) = zeroforcing
 
 """
     model_forcing(model_fields; forcings...)
@@ -38,8 +38,8 @@ function model_forcing(model_fields; forcings...)
 
     regularized_forcings = Tuple(
         field_name in keys(forcings) ?
-            regularize_forcing(forcings[field_name], field, model_field_names) :
-            regularize_forcing(nothing, field, model_field_names)
+            regularize_forcing(forcings[field_name], field, field_name, model_field_names) :
+            regularize_forcing(nothing, field, field_name, model_field_names)
         for (field_name, field) in pairs(model_fields)
     )
 

--- a/src/Forcings/model_forcing.jl
+++ b/src/Forcings/model_forcing.jl
@@ -1,7 +1,7 @@
 @inline zeroforcing(args...) = 0
 
 """
-    regularize_forcing(forcing, field, field_name, model_field_names)
+    regularize_forcing(forcing, field, model_field_names)
 
 "Regularizes" or "adds information" to user-defined forcing objects that are passed to
 model constructors. `regularize_forcing` is called inside `model_forcing`.
@@ -11,19 +11,19 @@ the fields (and field locations) of various forcing functions are available. The
 can be used to infer the location at which the forcing is applied, or to add a field
 dependency to a special forcing object, as for `Relxation`.
 """
-regularize_forcing(forcing, field, field_name, model_field_names) = forcing # fallback
+regularize_forcing(forcing, field, model_field_names) = forcing # fallback
 
 """
-    regularize_forcing(forcing::Function, field::Field, field_name, model_field_names)
+    regularize_forcing(forcing::Function, field::Field, model_field_names)
 
 Wrap `forcing` in a `ContinuousForcing` at the location of `field`.
 """
-function regularize_forcing(forcing::Function, field::Field, field_name, model_field_names)
+function regularize_forcing(forcing::Function, field::Field, model_field_names)
     LX, LY, LZ = location(field)
     return ContinuousForcing{LX, LY, LZ}(forcing)
 end
 
-regularize_forcing(::Nothing, field::Field, field_name, model_field_names) = zeroforcing
+regularize_forcing(::Nothing, field::Field, model_field_names) = zeroforcing
 
 """
     model_forcing(model_fields; forcings...)
@@ -38,8 +38,8 @@ function model_forcing(model_fields; forcings...)
 
     regularized_forcings = Tuple(
         field_name in keys(forcings) ?
-            regularize_forcing(forcings[field_name], field, field_name, model_field_names) :
-            regularize_forcing(nothing, field, field_name, model_field_names)
+            regularize_forcing(forcings[field_name], field, model_field_names) :
+            regularize_forcing(nothing, field, model_field_names)
         for (field_name, field) in pairs(model_fields)
     )
 

--- a/src/Forcings/model_forcing.jl
+++ b/src/Forcings/model_forcing.jl
@@ -1,71 +1,45 @@
-using Oceananigans.Utils: with_tracers
-using Oceananigans.Operators: assumed_field_location
-
 @inline zeroforcing(args...) = 0
 
 """
-    regularize_forcing(forcing, field_name, model_field_names)
+    regularize_forcing(forcing, field, field_name, model_field_names)
 
-"Regularizes" or "adds information" to
-user-defined forcing objects that are passed to the `IncompressibleModel`
-constructor. `regularize_forcing` is called inside `model_forcing`.
+"Regularizes" or "adds information" to user-defined forcing objects that are passed to
+model constructors. `regularize_forcing` is called inside `model_forcing`.
+
 We need `regularize_forcing` because it is only until `model_forcing` is called that
-the *names* of various forcing fields are available. The `field_name` can be used to infer
-the location at which the forcing is applied, or to add a field dependency
-to a special forcing object, as for `Relxation`.
+the fields (and field locations) of various forcing functions are available. The `field`
+can be used to infer the location at which the forcing is applied, or to add a field
+dependency to a special forcing object, as for `Relxation`.
 """
-regularize_forcing(forcing, field_name, model_field_names) = forcing # fallback
+regularize_forcing(forcing, field, field_name, model_field_names) = forcing # fallback
 
-""" Wrap `forcing` in a `ContinuousForcing` at the location of `field_name`. """
-function regularize_forcing(forcing::Function, field_name, model_field_names)
-    X, Y, Z = assumed_field_location(field_name)
-    return ContinuousForcing{X, Y, Z}(forcing)
-end
+"""
+    regularize_forcing(forcing::Function, field::Field, field_name, model_field_names)
 
-regularize_forcing(::Nothing, field_name, model_field_names) = zeroforcing
-
-function regularize_forcing(forcing::Function, field::Field)
+Wrap `forcing` in a `ContinuousForcing` at the location of `field`.
+"""
+function regularize_forcing(forcing::Function, field::Field, field_name, model_field_names)
     LX, LY, LZ = location(field)
     return ContinuousForcing{LX, LY, LZ}(forcing)
 end
 
-regularize_forcing(::Nothing, field::Field) = zeroforcing
+regularize_forcing(::Nothing, field::Field, field_name, model_field_names) = zeroforcing
 
 """
-    model_forcing(; u=nothing, v=nothing, w=nothing, tracer_forcings...)
+    model_forcing(model_fields; forcings...)
 
-Return a named tuple of forcing functions for each solution field, wrapping
-forcing function in `ContinuousForcing`s and ensuring that
-`ContinuousForcing`s are located correctly for velocity fields.
+Return a named tuple of forcing functions for each field in `model_fields`, wrapping
+forcing functions in `ContinuousForcing`s and ensuring that `ContinuousForcing`s are
+located correctly for each field.
 """
-function model_forcing(tracer_names; u=nothing, v=nothing, w=nothing, tracer_forcings...)
-
-    model_field_names = tuple(:u, :v, :w, tracer_names...)
-
-    u = regularize_forcing(u, :u, model_field_names)
-    v = regularize_forcing(v, :v, model_field_names)
-    w = regularize_forcing(w, :w, model_field_names)
-
-    # Build tuple of user-specified tracer forcings
-    specified_tracer_forcings_tuple = Tuple(regularize_forcing(f.second, f.first, model_field_names) for f in tracer_forcings)
-    specified_tracer_names = Tuple(f.first for f in tracer_forcings)
-
-    specified_forcings = NamedTuple{specified_tracer_names}(specified_tracer_forcings_tuple)
-
-    # Re-build with defaults for unspecified tracer forcing
-    tracer_forcings = with_tracers(tracer_names, specified_forcings, (name, initial_tuple) -> zeroforcing)
-
-    return merge((u=u, v=v, w=w), tracer_forcings)
-end
-
-function shallow_water_model_forcing(model_fields; forcings...)
+function model_forcing(model_fields; forcings...)
 
     model_field_names = keys(model_fields)
 
     regularized_forcings = Tuple(
         field_name in keys(forcings) ?
-            regularize_forcing(forcings[field_name], field) :
-            regularize_forcing(nothing, field)
+            regularize_forcing(forcings[field_name], field, field_name, model_field_names) :
+            regularize_forcing(nothing, field, field_name, model_field_names)
         for (field_name, field) in pairs(model_fields)
     )
 

--- a/src/Forcings/relaxation.jl
+++ b/src/Forcings/relaxation.jl
@@ -73,9 +73,9 @@ Relaxation{Float64, GaussianMask{:z,Float64}, LinearTarget{:z,Float64}}
 Relaxation(; rate, mask=onefunction, target=zerofunction) = Relaxation(rate, mask, target)
 
 """ Wrap `forcing::Relaxation` in `ContinuousForcing` and add the appropriate field dependency. """
-function regularize_forcing(forcing::Relaxation, field, model_field_names)
+function regularize_forcing(forcing::Relaxation, field, field_name, model_field_names)
     continuous_relaxation = ContinuousForcing(forcing, field_dependencies=field_name)
-    return regularize_forcing(continuous_relaxation, field, model_field_names)
+    return regularize_forcing(continuous_relaxation, field, field_name, model_field_names)
 end
 
 @inline (f::Relaxation)(x, y, z, t, field) =

--- a/src/Forcings/relaxation.jl
+++ b/src/Forcings/relaxation.jl
@@ -73,9 +73,9 @@ Relaxation{Float64, GaussianMask{:z,Float64}, LinearTarget{:z,Float64}}
 Relaxation(; rate, mask=onefunction, target=zerofunction) = Relaxation(rate, mask, target)
 
 """ Wrap `forcing::Relaxation` in `ContinuousForcing` and add the appropriate field dependency. """
-function regularize_forcing(forcing::Relaxation, field, field_name, model_field_names)
+function regularize_forcing(forcing::Relaxation, field, model_field_names)
     continuous_relaxation = ContinuousForcing(forcing, field_dependencies=field_name)
-    return regularize_forcing(continuous_relaxation, field, field_name, model_field_names)
+    return regularize_forcing(continuous_relaxation, field, model_field_names)
 end
 
 @inline (f::Relaxation)(x, y, z, t, field) =

--- a/src/Forcings/relaxation.jl
+++ b/src/Forcings/relaxation.jl
@@ -13,7 +13,7 @@ short_show(::T_onefunction) = "1"
     struct Relaxation{R, M, T}
 
 Callable object for restoring fields to a `target` at
-some `rate` and within a `mask`ed region in `x, y, z`. 
+some `rate` and within a `mask`ed region in `x, y, z`.
 """
 struct Relaxation{R, M, T}
       rate :: R
@@ -73,9 +73,9 @@ Relaxation{Float64, GaussianMask{:z,Float64}, LinearTarget{:z,Float64}}
 Relaxation(; rate, mask=onefunction, target=zerofunction) = Relaxation(rate, mask, target)
 
 """ Wrap `forcing::Relaxation` in `ContinuousForcing` and add the appropriate field dependency. """
-function regularize_forcing(forcing::Relaxation, field_name, model_field_names)
+function regularize_forcing(forcing::Relaxation, field, field_name, model_field_names)
     continuous_relaxation = ContinuousForcing(forcing, field_dependencies=field_name)
-    return regularize_forcing(continuous_relaxation, field_name, model_field_names)
+    return regularize_forcing(continuous_relaxation, field, field_name, model_field_names)
 end
 
 @inline (f::Relaxation)(x, y, z, t, field) =
@@ -121,7 +121,7 @@ struct GaussianMask{D, T}
         T = promote_type(typeof(center), typeof(width))
         return new{D, T}(center, width)
     end
-end    
+end
 
 @inline (g::GaussianMask{:x})(x, y, z) = exp(-(x - g.center)^2 / (2 * g.width^2))
 @inline (g::GaussianMask{:y})(x, y, z) = exp(-(y - g.center)^2 / (2 * g.width^2))
@@ -147,7 +147,7 @@ with `intercept` and `gradient`, and varying along direction `D`.
 Examples
 ========
 
-* Create a linear target function varying in `z`, equal to `0` at 
+* Create a linear target function varying in `z`, equal to `0` at
   `z=0` and with gradient 10⁻⁶:
 
 ```julia

--- a/src/Models/IncompressibleModels/incompressible_model.jl
+++ b/src/Models/IncompressibleModels/incompressible_model.jl
@@ -138,7 +138,8 @@ function IncompressibleModel(;
     timestepper = TimeStepper(timestepper, architecture, grid, tracernames(tracers))
 
     # Regularize forcing and closure for model tracer and velocity fields.
-    forcing = model_forcing(tracernames(tracers); forcing...)
+    model_fields = merge(velocities, tracers)
+    forcing = model_forcing(model_fields; forcing...)
     closure = with_tracers(tracernames(tracers), closure)
 
     return IncompressibleModel(architecture, grid, clock, advection, buoyancy, coriolis, surface_waves,

--- a/src/Models/ShallowWaterModels/shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_model.jl
@@ -11,7 +11,7 @@ using Oceananigans.BoundaryConditions: UVelocityBoundaryConditions,
 using Oceananigans.Fields: Field, tracernames, TracerFields, XFaceField, YFaceField, CellField
 using Oceananigans.Forcings: model_forcing
 using Oceananigans.Grids: with_halo
-using Oceananigans.TimeSteppers: Clock, TimeStepper, RungeKutta3TimeStepper
+using Oceananigans.TimeSteppers: Clock, TimeStepper
 using Oceananigans.TurbulenceClosures: ν₀, κ₀, with_tracers, DiffusivityFields, IsotropicDiffusivity
 using Oceananigans.Utils: inflate_halo_size, tupleit
 
@@ -21,12 +21,12 @@ function ShallowWaterTendencyFields(arch, grid, tracer_names)
     vh = YFaceField(arch, grid, VVelocityBoundaryConditions(grid))
     h  = CellField(arch,  grid, TracerBoundaryConditions(grid))
     tracers = TracerFields(tracer_names, arch, grid)
-    
+
     return merge((uh=uh, vh=vh, h=h), tracers)
 end
 
 function ShallowWaterSolutionFields(arch, grid, bcs)
-    
+
     uh_bcs = :uh ∈ keys(bcs) ? bcs.uh : UVelocityBoundaryConditions(grid)
     vh_bcs = :vh ∈ keys(bcs) ? bcs.vh : VVelocityBoundaryConditions(grid)
     h_bcs  = :h  ∈ keys(bcs) ? bcs.h  : TracerBoundaryConditions(grid)
@@ -39,7 +39,7 @@ function ShallowWaterSolutionFields(arch, grid, bcs)
 end
 
 struct ShallowWaterModel{G, A<:AbstractArchitecture, T, V, R, F, E, B, Q, C, K, TS} <: AbstractModel{TS}
-    
+
                           grid :: G         # Grid of physical points on which `Model` is solved
                   architecture :: A         # Computer `Architecture` on which `Model` is run
                          clock :: Clock{T}  # Tracks iteration number and simulation time of `Model`
@@ -63,13 +63,14 @@ function ShallowWaterModel(;
                                clock = Clock{eltype(grid)}(0, 0, 1),
                            advection = UpwindBiasedFifthOrder(),
                             coriolis = nothing,
-                             forcing = NamedTuple(),
+                 forcing::NamedTuple = NamedTuple(),
                              closure = nothing,
                           bathymetry = nothing,
                             solution = nothing,
                  tracers::NamedTuple = NamedTuple(),
                        diffusivities = nothing,
-     boundary_conditions::NamedTuple = NamedTuple())
+     boundary_conditions::NamedTuple = NamedTuple(),
+                 timestepper::Symbol = :RungeKutta3)
 
     grid.Nz == 1 || throw(ArgumentError("ShallowWaterModel must be constructed with Nz=1!"))
 
@@ -77,22 +78,23 @@ function ShallowWaterModel(;
 
     Hx, Hy, Hz = inflate_halo_size(grid.Hx, grid.Hy, grid.Hz, advection)
     grid = with_halo((Hx, Hy, Hz), grid)
-    
+
     boundary_conditions = regularize_field_boundary_conditions(boundary_conditions, grid, nothing)
-    
+
     solution = ShallowWaterSolutionFields(architecture, grid, boundary_conditions)
     tracers  = TracerFields(tracers, architecture, grid, boundary_conditions)
     diffusivities = DiffusivityFields(diffusivities, architecture, grid,
                                       tracernames(tracers), boundary_conditions, closure)
 
-    timestepper = RungeKutta3TimeStepper(architecture, grid, tracernames(tracers);
-                                         Gⁿ = ShallowWaterTendencyFields(architecture, grid, tracernames(tracers)),
-                                         G⁻ = ShallowWaterTendencyFields(architecture, grid, tracernames(tracers)))
+    # Instantiate timestepper if not already instantiated
+    timestepper = TimeStepper(timestepper, architecture, grid, tracernames(tracers);
+                              Gⁿ = ShallowWaterTendencyFields(architecture, grid, tracernames(tracers)),
+                              G⁻ = ShallowWaterTendencyFields(architecture, grid, tracernames(tracers)))
 
     # Regularize forcing and closure for model tracer and velocity fields.
     forcing = model_forcing(tracernames(tracers); forcing...)
     closure = with_tracers(tracernames(tracers), closure)
-    
+
     return ShallowWaterModel(grid,
                              architecture,
                              clock,

--- a/src/Models/ShallowWaterModels/shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_model.jl
@@ -9,7 +9,7 @@ using Oceananigans.BoundaryConditions: UVelocityBoundaryConditions,
                                        TracerBoundaryConditions
 
 using Oceananigans.Fields: Field, tracernames, TracerFields, XFaceField, YFaceField, CellField
-using Oceananigans.Forcings: model_forcing
+using Oceananigans.Forcings: model_forcing, shallow_water_model_forcing
 using Oceananigans.Grids: with_halo
 using Oceananigans.TimeSteppers: Clock, TimeStepper
 using Oceananigans.TurbulenceClosures: ν₀, κ₀, with_tracers, DiffusivityFields, IsotropicDiffusivity
@@ -67,7 +67,7 @@ function ShallowWaterModel(;
                              closure = nothing,
                           bathymetry = nothing,
                             solution = nothing,
-                 tracers::NamedTuple = NamedTuple(),
+                             tracers = (),
                        diffusivities = nothing,
      boundary_conditions::NamedTuple = NamedTuple(),
                  timestepper::Symbol = :RungeKutta3)
@@ -92,7 +92,8 @@ function ShallowWaterModel(;
                               G⁻ = ShallowWaterTendencyFields(architecture, grid, tracernames(tracers)))
 
     # Regularize forcing and closure for model tracer and velocity fields.
-    forcing = model_forcing(tracernames(tracers); forcing...)
+    model_fields = merge(solution, tracers)
+    forcing = shallow_water_model_forcing(model_fields; forcing...)
     closure = with_tracers(tracernames(tracers), closure)
 
     return ShallowWaterModel(grid,

--- a/src/Models/ShallowWaterModels/shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_model.jl
@@ -9,7 +9,7 @@ using Oceananigans.BoundaryConditions: UVelocityBoundaryConditions,
                                        TracerBoundaryConditions
 
 using Oceananigans.Fields: Field, tracernames, TracerFields, XFaceField, YFaceField, CellField
-using Oceananigans.Forcings: model_forcing, shallow_water_model_forcing
+using Oceananigans.Forcings: model_forcing
 using Oceananigans.Grids: with_halo
 using Oceananigans.TimeSteppers: Clock, TimeStepper
 using Oceananigans.TurbulenceClosures: ν₀, κ₀, with_tracers, DiffusivityFields, IsotropicDiffusivity
@@ -93,7 +93,7 @@ function ShallowWaterModel(;
 
     # Regularize forcing and closure for model tracer and velocity fields.
     model_fields = merge(solution, tracers)
-    forcing = shallow_water_model_forcing(model_fields; forcing...)
+    forcing = model_forcing(model_fields; forcing...)
     closure = with_tracers(tracernames(tracers), closure)
 
     return ShallowWaterModel(grid,

--- a/src/Models/ShallowWaterModels/solution_and_tracer_tendencies.jl
+++ b/src/Models/ShallowWaterModels/solution_and_tracer_tendencies.jl
@@ -24,7 +24,8 @@ Compute the tendency for the x-directional transport, uh
 
     return ( - div_hUu(i, j, k, grid, advection, solution)
              - ∂xᶠᵃᵃ(i, j, k, grid, gh2, solution.h, gravitational_acceleration)
-             - x_f_cross_U(i, j, k, grid, coriolis, solution) )
+             - x_f_cross_U(i, j, k, grid, coriolis, solution)
+             + forcings.uh(i, j, k, grid, clock, merge(solution, tracers)))
 end
 
 """
@@ -45,7 +46,8 @@ Compute the tendency for the y-directional transport, vh.
 
     return ( - div_hUv(i, j, k, grid, advection, solution)
              - ∂yᵃᶠᵃ(i, j, k, grid, gh2, solution.h, gravitational_acceleration)
-             - y_f_cross_U(i, j, k, grid, coriolis, solution) )
+             - y_f_cross_U(i, j, k, grid, coriolis, solution)
+             + forcings.vh(i, j, k, grid, clock, merge(solution, tracers)))
 end
 
 """
@@ -63,7 +65,8 @@ Compute the tendency for the height, h.
                                      clock)
 
     return ( - ∂xᶜᵃᵃ(i, j, k, grid, solution.uh)
-             - ∂yᵃᶜᵃ(i, j, k, grid, solution.vh) )
+             - ∂yᵃᶜᵃ(i, j, k, grid, solution.vh)
+             + forcings.h(i, j, k, grid, clock, merge(solution, tracers)))
 end
 
 @inline function tracer_tendency(i, j, k, grid,

--- a/src/Operators/interpolation_utils.jl
+++ b/src/Operators/interpolation_utils.jl
@@ -59,10 +59,12 @@ opertator for fields that have no instrinsic location, like numbers or functions
 """
 interpolation_operator(::Nothing, to) = identity
 
-assumed_field_location(name) = name === :u ? (Face, Cell, Cell) :
-                               name === :v ? (Cell, Face, Cell) :
-                               name === :w ? (Cell, Cell, Face) :
-                                             (Cell, Cell, Cell)
+assumed_field_location(name) = name === :u  ? (Face, Cell, Cell) :
+                               name === :v  ? (Cell, Face, Cell) :
+                               name === :w  ? (Cell, Cell, Face) :
+                               name === :uh ? (Face, Cell, Cell) :
+                               name === :vh ? (Cell, Face, Cell) :
+                                              (Cell, Cell, Cell)
 
 """
     index_and_interp_dependencies(X, Y, Z, dependencies, model_field_names)

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -34,7 +34,6 @@ julia> stepper = TimeStepper(:QuasiAdamsBashforth2, CPU(), grid, tracernames)
 function TimeStepper(name::Symbol, args...; kwargs...)
     fullname = Symbol(name, :TimeStepper)
     return @eval $fullname($args...; $kwargs...)
-    # return eval(Expr(:call, fullname, args...; kwargs...))
 end
 
 # Fallback

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -31,9 +31,10 @@ Example
 
 julia> stepper = TimeStepper(:QuasiAdamsBashforth2, CPU(), grid, tracernames)
 """
-function TimeStepper(name::Symbol, args...)
+function TimeStepper(name::Symbol, args...; kwargs...)
     fullname = Symbol(name, :TimeStepper)
-    return eval(Expr(:call, fullname, args...))
+    return @eval $fullname($args...; $kwargs...)
+    # return eval(Expr(:call, fullname, args...; kwargs...))
 end
 
 # Fallback

--- a/test/test_shallow_water_models.jl
+++ b/test/test_shallow_water_models.jl
@@ -1,16 +1,38 @@
 using Oceananigans.Models: ShallowWaterModel
 using Oceananigans.Grids: Periodic, Bounded
 
-function time_stepping_shallow_water_model_works(arch, topo, coriolis, advection)
+function time_stepping_shallow_water_model_works(arch, topo, coriolis, advection; timestepper=:RungeKutta3)
     grid = RegularCartesianGrid(size=(1, 1, 1), extent=(2π, 2π, 2π), topology=topo)
     model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch, coriolis=coriolis,
-                              advection=advection)
+                              advection=advection, timestepper=:RungeKutta3)
     set!(model, h=1)
 
     simulation = Simulation(model, Δt=1.0, stop_iteration=1)
     run!(simulation)
 
     return model.clock.iteration == 1
+end
+
+function shallow_water_model_tracers_and_forcings_work(arch)
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(2π, 2π, 2π))
+    model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch, tracers=(:c, :d))
+    set!(model, h=1)
+
+    @test model.tracers.c isa Field
+    @test model.tracers.d isa Field
+
+    @test haskey(model.forcing, :uh)
+    @test haskey(model.forcing, :vh)
+    @test haskey(model.forcing, :h)
+    @test haskey(model.forcing, :c)
+    @test haskey(model.forcing, :d)
+
+    simulation = Simulation(model, Δt=1.0, stop_iteration=1)
+    run!(simulation)
+
+    @test model.clock.iteration == 1
+
+    return nothing
 end
 
 @testset "Shallow Water Models" begin
@@ -96,6 +118,18 @@ end
                 @info "  Testing time-stepping ShallowWaterModels [$arch, $(typeof(advection))]..."
                 @test time_stepping_shallow_water_model_works(arch, topos[1], nothing, advection)
             end
+        end
+
+        for timestepper in (:RungeKutta3, :QuasiAdamsBashforth2)
+            @testset "Time-stepping ShallowWaterModels [$arch, $timestepper]" begin
+                @info "  Testing time-stepping ShallowWaterModels [$arch, $timestepper]..."
+                @test time_stepping_shallow_water_model_works(arch, topos[1], nothing, nothing, timestepper=timestepper)
+            end
+        end
+
+        @testset "ShallowWaterModel with tracers and forcings [$arch]" begin
+            @info "  Testing ShallowWaterModel with tracers and forcings [$arch]..."
+            shallow_water_model_tracers_and_forcings_work(arch)
         end
     end
 end


### PR DESCRIPTION
This PR (pair programmed with @francispoulin) allows users to select the `timestepper` and adds support for `forcing` functions as part of the `ShallowWaterModel`. We also added some simple tests.

We also added a `shallow_water_model_forcing` function that should readily generalize to `IncompressibleModel` while being shorter, so we can consider using it to replace `model_forcing`.

Resolves #1284