### PR TITLE
Avoid executing the lines to install dependencies within examples

### DIFF
--- a/docs/src/using_gpus.md
+++ b/docs/src/using_gpus.md
@@ -63,6 +63,6 @@ Then download and install the CUDA Toolkit:
 Once the CUDA Toolkit is installed, you might have to build Oceananigans again
 ```
 julia>]
-(v1.4) pkg> build Oceananigans
+(v1.5) pkg> build Oceananigans
 ```
 The [ocean wind mixing and convection](@ref gpu_example) example is a good one to test out on the GPU.

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -12,7 +12,7 @@
 # The phytoplankton in our model are advected, diffuse, grow, and die according to
 #
 # ```math
-# ∂_t P + \bm{u} ⋅ ∇P - κ ∇²P = (μ₀ \exp(z / λ) - m) \, P \, ,
+# ∂_t P + \bm{u ⋅ ∇} P - κ ∇²P = (μ₀ \exp(z / λ) - m) \, P \, ,
 # ```
 #
 # where ``\bm{u}`` is the turbulent velocity field, ``κ`` is an isotropic diffusivity,
@@ -35,8 +35,10 @@
 #
 # First let's make sure we have all required packages installed.
 
-using Pkg
-pkg"add Oceananigans, Plots, JLD2, Measures"
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, Plots, JLD2, Measures"
+# ```
 
 # ## The grid
 #

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -12,8 +12,10 @@
 #
 # First let's make sure we have all required packages installed.
 
-using Pkg
-pkg"add Oceananigans, JLD2, Plots"
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, JLD2, Plots"
+# ```
 
 # ## The Eady problem 
 #

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -8,8 +8,10 @@
 #
 # First let's make sure we have all required packages installed.
 
-using Pkg
-pkg"add Oceananigans, JLD2, Plots"
+# ````julia
+# using Pkg
+# pkg"add Oceananigans, JLD2, Plots"
+# ```
 
 # ## The physical domain
 #

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -5,8 +5,10 @@
 #
 # First let's make sure we have all required packages installed.
 
-using Pkg
-pkg"add Oceananigans, JLD2, Plots"
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, JLD2, Plots"
+# ```
 
 # ## The physical domain
 #

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -16,8 +16,10 @@
 #
 # First let's make sure we have all required packages installed.
 
-using Pkg
-pkg"add Oceananigans, JLD2, Plots"
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, JLD2, Plots"
+# ```
 
 using Oceananigans
 

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -11,8 +11,10 @@
 #
 # First let's make sure we have all required packages installed.
 
-using Pkg
-pkg"add Oceananigans, JLD2, Plots"
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, JLD2, Plots"
+# ```
 
 # We start by importing all of the packages and functions that we'll need for this
 # example.

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -14,8 +14,10 @@
 #
 # First let's make sure we have all required packages installed.
 
-using Pkg
-pkg"add Oceananigans, JLD2, Plots"
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, JLD2, Plots"
+# ```
 
 # ## Using `Oceananigans.jl`
 #

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -11,8 +11,10 @@
 #
 # First let's make sure we have all required packages installed.
 
-using Pkg
-pkg"add Oceananigans, JLD2, Plots"
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, JLD2, Plots"
+# ```
 
 # ## Model setup
 


### PR DESCRIPTION
This PR instead of executing, e.g.,
```
using Pkg
pkg"add Oceananigans, JLD2, Plots"
```
it just prints them out as markdown "code". This way users can have them in the docs to copy-paste but the Documentation build does not execute them and thus avoids random clutter in Docs like discussed in #1315.

Closes #1315.