### PR TITLE
Fixes bug in internal wave example that resulted in mangled text

### DIFF
--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -8,7 +8,7 @@
 #
 # First let's make sure we have all required packages installed.
 
-# ````julia
+# ```julia
 # using Pkg
 # pkg"add Oceananigans, JLD2, Plots"
 # ```


### PR DESCRIPTION
There were 4 backticks instead of 3.