### PR TITLE
Creating the time-step wizard for shallow water model.

### DIFF
--- a/src/Models/ShallowWaterModels/ShallowWaterModels.jl
+++ b/src/Models/ShallowWaterModels/ShallowWaterModels.jl
@@ -31,6 +31,7 @@ include("solution_and_tracer_tendencies.jl")
 include("calculate_shallow_water_tendencies.jl")
 include("update_shallow_water_state.jl")
 include("shallow_water_advection_operators.jl")
+include("shallow_water_cell_advection_timescale.jl")
 
 # No support for particle advection yet.
 update_particle_properties!(model::ShallowWaterModel, Δt) = nothing

--- a/src/Models/ShallowWaterModels/shallow_water_cell_advection_timescale.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_cell_advection_timescale.jl
@@ -1,0 +1,18 @@
+"Returns the time-scale for advection on a regular grid across a single grid cell 
+ for ShallowWaterModel."
+
+import Oceananigans.Utils: cell_advection_timescale
+
+function shallow_water_cell_advection_timescale(uh, vh, h, grid)
+    uhmax = maximum(abs, uh)
+    vhmax = maximum(abs, vh)
+     hmin = minimum(abs,  h)
+
+    return min(grid.Δx/uhmax*hmin, grid.Δy/vhmax)*hmin
+end
+
+cell_advection_timescale(model::ShallowWaterModel) =
+    shallow_water_cell_advection_timescale(model.solution.uh.data.parent,
+                             model.solution.vh.data.parent,
+                             model.solution.h.data.parent,
+                             model.grid)

--- a/src/Models/ShallowWaterModels/shallow_water_cell_advection_timescale.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_cell_advection_timescale.jl
@@ -6,13 +6,15 @@ import Oceananigans.Utils: cell_advection_timescale
 function shallow_water_cell_advection_timescale(uh, vh, h, grid)
     uhmax = maximum(abs, uh)
     vhmax = maximum(abs, vh)
-     hmin = minimum(abs,  h)
+    hmin  = minimum(abs,  h)
 
-    return min(grid.Δx/uhmax*hmin, grid.Δy/vhmax)*hmin
+    return min(grid.Δx / uhmax, grid.Δy / vhmax) * hmin
 end
 
 cell_advection_timescale(model::ShallowWaterModel) =
-    shallow_water_cell_advection_timescale(model.solution.uh.data.parent,
-                             model.solution.vh.data.parent,
-                             model.solution.h.data.parent,
-                             model.grid)
+    shallow_water_cell_advection_timescale(
+        model.solution.uh.data.parent, 
+        model.solution.vh.data.parent,
+        model.solution.h.data.parent,
+        model.grid
+        )

--- a/test/test_shallow_water_models.jl
+++ b/test/test_shallow_water_models.jl
@@ -13,6 +13,19 @@ function time_stepping_shallow_water_model_works(arch, topo, coriolis, advection
     return model.clock.iteration == 1
 end
 
+function time_step_wizard_shallow_water_model_works(arch, topo, coriolis)
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(2π, 2π, 2π), topology=topo)
+    model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch, coriolis=coriolis)
+    set!(model, h=1)
+
+    wizard = TimeStepWizard(cfl=1.0, Δt=1.0, max_change=1.1, max_Δt=10)
+
+    simulation = Simulation(model, Δt=wizard, stop_iteration=1)
+    run!(simulation)
+
+    return model.clock.iteration == 1
+end
+
 function shallow_water_model_tracers_and_forcings_work(arch)
     grid = RegularCartesianGrid(size=(1, 1, 1), extent=(2π, 2π, 2π))
     model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch, tracers=(:c, :d))
@@ -113,6 +126,11 @@ end
             end
         end
 
+        @testset "Time-step Wizard ShallowWaterModels [$arch, $topos[1]]" begin
+	    @info "  Testing time-step wizard ShallowWaterModels [$arch, $topos[1]]..."
+            @test time_step_wizard_shallow_water_model_works(archs[1], topos[1], nothing)
+        end
+                
         for advection in (nothing, CenteredSecondOrder(), WENO5())
             @testset "Time-stepping ShallowWaterModels [$arch, $(typeof(advection))]" begin
                 @info "  Testing time-stepping ShallowWaterModels [$arch, $(typeof(advection))]..."


### PR DESCRIPTION
This correctly adds the time-step wizard to `ShallowWaterModel`.  

All the tests pass but there are two warnings that maybe should be adressed?

```
...
[2021/02/01 11:45:05.426] INFO    Testing setting shallow water model fields...
[2021/02/01 11:45:12.752] WARN  Performing scalar operations on GPU arrays: This is very slow, consider disallowing these operations with `allowscalar(false)` -@-> /home/fpoulin/.julia/packages/GPUArrays/WV76E/src/host/indexing.jl:43
...
[2021/02/01 11:45:39.457] INFO    Testing time-step wizard ShallowWaterModels [GPU(), ((Periodic, Periodic, Bounded), (Periodic, Bounded, Bounded), (Bounded, Bounded, Bounded))[1]]...
[2021/02/01 11:45:39.641] WARN  You have used the default iteration_interval=1. This simulation will recalculate the time step every iteration which can be slow. -@-> /home/fpoulin/software/Oceananigans.jl/src/Simulations/simulation.jl:68

```