### PR TITLE
Adds boundary conditions to ComputedField and KernelComputedField

### DIFF
--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -39,7 +39,7 @@ include("fill_halo_regions_value_gradient.jl")
 include("fill_halo_regions_normal_flow.jl")
 include("fill_halo_regions_periodic.jl")
 include("fill_halo_regions_flux.jl")
-include("fill_halo_regions_flat.jl")
+include("fill_halo_regions_nothing.jl")
 
 include("apply_flux_bcs.jl")
 

--- a/src/BoundaryConditions/fill_halo_regions_flat.jl
+++ b/src/BoundaryConditions/fill_halo_regions_flat.jl
@@ -4,11 +4,11 @@ using Oceananigans.Grids: AbstractGrid, Flat
 ##### Suprise: there is no halo-filling in `Flat` directions
 #####
 
-fill_west_halo!(c, ::Nothing, arch, barrier, grid::AbstractGrid{FT, Flat}, args...) where {FT} = nothing
-fill_east_halo!(c, ::Nothing, arch, barrier, grid::AbstractGrid{FT, Flat}, args...) where {FT} = nothing
+fill_west_halo!(c, ::Nothing, arch, barrier, grid, args...) = nothing
+fill_east_halo!(c, ::Nothing, arch, barrier, grid, args...) = nothing
 
-fill_north_halo!(c, ::Nothing, arch, barrier, grid::AbstractGrid{FT, TX, Flat}, args...) where {FT, TX} = nothing
-fill_south_halo!(c, ::Nothing, arch, barrier, grid::AbstractGrid{FT, TX, Flat}, args...) where {FT, TX} = nothing
+fill_north_halo!(c, ::Nothing, arch, barrier, grid, args...) = nothing
+fill_south_halo!(c, ::Nothing, arch, barrier, grid, args...) = nothing
 
-fill_top_halo!(c, ::Nothing, arch, barrier, grid::AbstractGrid{FT, TX, TY, Flat}, args...) where {FT, TX, TY} = nothing
-fill_bottom_halo!(c, ::Nothing, arch, barrier, grid::AbstractGrid{FT, TX, TY, Flat}, args...) where {FT, TX, TY} = nothing
+fill_top_halo!(c, ::Nothing, arch, barrier, grid, args...) = nothing
+fill_bottom_halo!(c, ::Nothing, arch, barrier, grid, args...) = nothing

--- a/src/BoundaryConditions/fill_halo_regions_nothing.jl
+++ b/src/BoundaryConditions/fill_halo_regions_nothing.jl
@@ -1,7 +1,5 @@
-using Oceananigans.Grids: AbstractGrid, Flat
-
 #####
-##### Suprise: there is no halo-filling in `Flat` directions
+##### Nothing happens when your boundary condition is nothing
 #####
 
 fill_west_halo!(c, ::Nothing, arch, barrier, grid, args...) = nothing

--- a/src/Fields/computed_field.jl
+++ b/src/Fields/computed_field.jl
@@ -39,7 +39,7 @@ DefaultComputedFieldBoundaryCondition(::Type{Flat}, loc) = nothing
 DefaultComputedFieldBoundaryCondition(::Type{Bounded}, ::Type{Center}) = NoFluxBoundaryCondition()
 DefaultComputedFieldBoundaryCondition(::Type{Bounded}, ::Type{Face}) = nothing
 
-function ComputedFieldBoundaryConditions(grid, loc,
+function ComputedFieldBoundaryConditions(grid, loc;
                                            east = DefaultComputedFieldBoundaryCondition(topology(grid, 1), loc[1]),
                                            west = DefaultComputedFieldBoundaryCondition(topology(grid, 1), loc[1]),
                                           south = DefaultComputedFieldBoundaryCondition(topology(grid, 2), loc[2]),

--- a/test/test_kernel_computed_field.jl
+++ b/test/test_kernel_computed_field.jl
@@ -41,10 +41,25 @@ for arch in archs
         compute!(doubled_field)
         @test doubled_field.data[1, 1, 1] == 2π
 
+        # Test boundary conditions / halo filling
+        @test doubled_field.data[0, 1, 1] == doubled_field.data[2, 1, 1] # periodic
+        @test doubled_field.data[1, 0, 1] == doubled_field.data[1, 2, 1] # periodic
+        @test doubled_field.data[1, 1, 0] == doubled_field.data[1, 1, 1] # no flux
+        @test doubled_field.data[1, 1, 1] == doubled_field.data[1, 1, 2] # no flux
+
         set!(doubled_field, 0)
         compute!(multiplied_field)
 
         @test doubled_field.data[1, 1, 1] == 2π
         @test multiplied_field.data[1, 1, 1] == multiple * 2 * π
+
+        doubled_face_field = KernelComputedField(Center, Center, Face,
+                                                 double!, arch, grid,
+                                                 field_dependencies = single_field)
+
+        # Test that nothing happens for fields on faces in bounded directions
+        compute!(doubled_face_field)
+        @test doubled_face_field.data[1, 1, 0] == 0
+        @test doubled_face_field.data[1, 1, 3] == 0
     end
 end


### PR DESCRIPTION
This PR adds `boundary_conditions` to `ComputedField`.

I added a new `DefaultComputedFieldBoundaryCondition`, because `DefaultBoundaryCondition` specifies an `ImpenetrableBoundaryCondition` when a field is located on `Face` and the direction is `Bounded`. But I think this is only appropriate for velocities and is not what we want in general. Arguably, we should change `DefaultBoundaryCondition` instead and implement special behavior for velocity fields...

Strictly speaking the boundary conditions are only "correct" in periodic directions, since we have no way of evaluating what the boundary conditions need to be in `Bounded` directions. Should we use a `nothing` default for `Bounded` directions in all cases for `ComputedField`?

Current tests pass, but I still need to add tests to make sure that halos are filled properly.

cc @tomchor 