### PR TITLE
Add support for only keeping the latest checkpoint

### DIFF
--- a/docs/src/model_setup/checkpointing.md
+++ b/docs/src/model_setup/checkpointing.md
@@ -19,7 +19,7 @@ julia> using Oceananigans.OutputWriters, Oceananigans.Utils
 julia> model = IncompressibleModel(grid=RegularRectilinearGrid(size=(16, 16, 16), extent=(1, 1, 1)));
 
 julia> checkpointer = Checkpointer(model, schedule=TimeInterval(5years), prefix="model_checkpoint")
-Checkpointer{TimeInterval,Array{Symbol,1}}(TimeInterval(1.5768e8, 0.0), ".", "model_checkpoint", [:architecture, :grid, :clock, :coriolis, :buoyancy, :closure, :velocities, :tracers, :timestepper, :particles], false, false)
+Checkpointer{TimeInterval,Array{Symbol,1}}(TimeInterval(1.5768e8, 0.0), ".", "model_checkpoint", [:architecture, :grid, :clock, :coriolis, :buoyancy, :closure, :velocities, :tracers, :timestepper, :particles], false, false, false)
 ```
 
 The default options should provide checkpoint files that are easy to restore from in most cases. For more advanced

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -92,8 +92,12 @@ function Checkpointer(model; schedule,
 
     mkpath(dir)
 
-    return Checkpointer(schedule, dir, prefix, properties, force, cleanup, verbose)
+    return Checkpointer(schedule, dir, prefix, properties, force, verbose, cleanup)
 end
+
+#####
+##### Checkpointer utils
+#####
 
 """ Returns the full prefix (the `superprefix`) associated with `checkpointer`. """
 checkpoint_superprefix(prefix) = prefix * "_iteration"
@@ -105,6 +109,48 @@ Returns the path to the `c`heckpointer file associated with model `iteration`.
 """
 checkpoint_path(iteration::Int, c::Checkpointer) =
     joinpath(c.dir, string(checkpoint_superprefix(c.prefix), iteration, ".jld2"))
+
+# This is the default name used in the simulation.output_writers ordered dict.
+defaultname(::Checkpointer, nelems) = :checkpointer
+
+""" Returns `filepath`. Shortcut for `run!(simulation, pickup=filepath)`. """
+checkpoint_path(filepath::AbstractString, checkpointers) = filepath
+
+function checkpoint_path(pickup, checkpointers)
+    length(checkpointers) == 0 && error("No checkpointers found: cannot pickup simulation!")
+    length(checkpointers) > 1 && error("Multiple checkpointers found: not sure which one to pickup simulation from!")
+    return checkpoint_path(pickup, first(checkpointers))
+end
+
+"""
+    checkpoint_path(pickup::Bool, checkpointer)
+
+For `pickup=true`, parse the filenames in `checkpointer.dir` associated with
+`checkpointer.prefix` and return the path to the file whose name contains
+the largest iteration.
+"""
+function checkpoint_path(pickup::Bool, checkpointer::Checkpointer)
+    filepaths = glob(checkpoint_superprefix(checkpointer.prefix) * "*.jld2", checkpointer.dir)
+
+    if length(filepaths) == 0 # no checkpoint files found
+        return nothing
+    else
+        return latest_checkpoint(checkpointer, filepaths)
+    end
+end
+
+function latest_checkpoint(checkpointer, filepaths)
+    filenames = basename.(filepaths)
+    leading = length(checkpoint_superprefix(checkpointer.prefix))
+    trailing = 5 # length(".jld2")
+    iterations = map(name -> parse(Int, name[leading+1:end-trailing]), filenames)
+    latest_iteration, idx = findmax(iterations)
+    return filepaths[idx]
+end
+
+#####
+##### Writing checkpoints
+#####
 
 function write_output!(c::Checkpointer, model)
     filepath = checkpoint_path(model.clock.iteration, c)
@@ -119,6 +165,7 @@ function write_output!(c::Checkpointer, model)
     t2, sz = time_ns(), filesize(filepath)
     c.verbose && @info "Checkpointing done: time=$(prettytime((t2-t1)/1e9)), size=$(pretty_filesize(sz))"
 
+    @show c.cleanup
     c.cleanup && cleanup_checkpoints(c)
 
     return nothing
@@ -127,12 +174,78 @@ end
 function cleanup_checkpoints(checkpointer)
     filepaths = glob(checkpoint_superprefix(checkpointer.prefix) * "*.jld2", checkpointer.dir)
     latest_checkpoint_filepath = latest_checkpoint(checkpointer, filepaths)
+    @show filepaths
+    @show latest_checkpoint_filepath
     [rm(filepath) for filepath in filepaths if filepath != latest_checkpoint_filepath]
     return nothing
 end
 
-# This is the default name used in the simulation.output_writers ordered dict.
-defaultname(::Checkpointer, nelems) = :checkpointer
+#####
+##### set! for checkpointer filepaths
+#####
+
+"""
+    set!(model, filepath::AbstractString)
+
+Set data in `model.velocities`, `model.tracers`, `model.timestepper.Gⁿ`, and
+`model.timestepper.G⁻` to checkpointed data stored at `filepath`.
+"""
+function set!(model, filepath::AbstractString)
+
+    jldopen(filepath, "r") do file
+
+        # Validate the grid
+        checkpointed_grid = file["grid"]
+        model.grid == checkpointed_grid ||
+            error("The grid associated with $filepath and model.grid are not the same!")
+
+        # Set model fields and tendency fields
+        model_fields = merge(model.velocities, model.tracers)
+
+        for name in propertynames(model_fields)
+            # Load data for each model field
+            address = name ∈ (:u, :v, :w) ? "velocities/$name" : "tracers/$name"
+            parent_data = file[address * "/data"]
+
+            model_field = model_fields[name]
+            copyto!(model_field.data.parent, parent_data)
+
+            # Load tendency data
+            #
+            # Note: this step is unecessary for models that use RungeKutta3TimeStepper and
+            # tendency restoration could be depcrecated in the future.
+
+            # Tendency "n"
+            parent_data = file["timestepper/Gⁿ/$name/data"]
+
+            tendencyⁿ_field = model.timestepper.Gⁿ[name]
+            copyto!(tendencyⁿ_field.data.parent, parent_data)
+
+            # Tendency "n-1"
+            parent_data = file["timestepper/G⁻/$name/data"]
+
+            tendency⁻_field = model.timestepper.G⁻[name]
+            copyto!(tendency⁻_field.data.parent, parent_data)
+        end
+
+        if !isnothing(model.particles)
+            copyto!(model.particles.properties, file["particles"])
+        end
+
+        checkpointed_clock = file["clock"]
+
+        # Update model clock
+        model.clock.iteration = checkpointed_clock.iteration
+        model.clock.time = checkpointed_clock.time
+
+    end
+
+    return nothing
+end
+
+#####
+##### Nuke!
+#####
 
 function restore_if_not_missing(file, address)
     if !ismissing(file[address])
@@ -238,67 +351,4 @@ function restore_from_checkpoint(filepath; kwargs...)
     model = IncompressibleModel(; kwargs...)
 
     return model
-end
-
-#####
-##### set! for checkpointer filepaths
-#####
-
-"""
-    set!(model, filepath::AbstractString)
-
-Set data in `model.velocities`, `model.tracers`, `model.timestepper.Gⁿ`, and
-`model.timestepper.G⁻` to checkpointed data stored at `filepath`.
-"""
-function set!(model, filepath::AbstractString)
-
-    jldopen(filepath, "r") do file
-
-        # Validate the grid
-        checkpointed_grid = file["grid"]
-        model.grid == checkpointed_grid ||
-            error("The grid associated with $filepath and model.grid are not the same!")
-
-        # Set model fields and tendency fields
-        model_fields = merge(model.velocities, model.tracers)
-
-        for name in propertynames(model_fields)
-            # Load data for each model field
-            address = name ∈ (:u, :v, :w) ? "velocities/$name" : "tracers/$name"
-            parent_data = file[address * "/data"]
-
-            model_field = model_fields[name]
-            copyto!(model_field.data.parent, parent_data)
-
-            # Load tendency data
-            #
-            # Note: this step is unecessary for models that use RungeKutta3TimeStepper and
-            # tendency restoration could be depcrecated in the future.
-
-            # Tendency "n"
-            parent_data = file["timestepper/Gⁿ/$name/data"]
-
-            tendencyⁿ_field = model.timestepper.Gⁿ[name]
-            copyto!(tendencyⁿ_field.data.parent, parent_data)
-
-            # Tendency "n-1"
-            parent_data = file["timestepper/G⁻/$name/data"]
-
-            tendency⁻_field = model.timestepper.G⁻[name]
-            copyto!(tendency⁻_field.data.parent, parent_data)
-        end
-
-        if !isnothing(model.particles)
-            copyto!(model.particles.properties, file["particles"])
-        end
-
-        checkpointed_clock = file["clock"]
-
-        # Update model clock
-        model.clock.iteration = checkpointed_clock.iteration
-        model.clock.time = checkpointed_clock.time
-
-    end
-
-    return nothing
 end

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -7,7 +7,7 @@ using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, RungeKutta3Tim
 
 using Oceananigans: AbstractModel
 
-import Oceananigans.OutputWriters: checkpoint_path
+import Oceananigans.OutputWriters: checkpoint_path, set!
 
 # Simulations are for running
 
@@ -190,43 +190,4 @@ function run!(sim; pickup=false)
     end
 
     return nothing
-end
-
-#####
-##### Util for "picking up" a simulation from a checkpoint
-#####
-
-""" Returns `filepath`. Shortcut for `run!(simulation, pickup=filepath)`. """
-checkpoint_path(filepath::AbstractString, checkpointers) = filepath
-
-function checkpoint_path(pickup, checkpointers)
-    length(checkpointers) == 0 && error("No checkpointers found: cannot pickup simulation!")
-    length(checkpointers) > 1 && error("Multiple checkpointers found: not sure which one to pickup simulation from!")
-    return checkpoint_path(pickup, first(checkpointers))
-end
-
-"""
-    checkpoint_path(pickup::Bool, checkpointer)
-
-For `pickup=true`, parse the filenames in `checkpointer.dir` associated with
-`checkpointer.prefix` and return the path to the file whose name contains
-the largest iteration.
-"""
-function checkpoint_path(pickup::Bool, checkpointer::Checkpointer)
-    filepaths = glob(checkpoint_superprefix(checkpointer.prefix) * "*.jld2", checkpointer.dir)
-
-    if length(filepaths) == 0 # no checkpoint files found
-        return nothing
-    else
-        return latest_checkpoint(checkpointer, filepaths)
-    end
-end
-
-function latest_checkpoint(checkpointer, filepaths)
-    filenames = basename.(filepaths)
-    leading = length(checkpoint_superprefix(checkpointer.prefix))
-    trailing = 5 # length(".jld2")
-    iterations = map(name -> parse(Int, name[leading+1:end-trailing]), filenames)
-    latest_iteration, idx = findmax(iterations)
-    return filepaths[idx]
 end

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -801,7 +801,7 @@ function run_cross_architecture_checkpointer_tests(arch1, arch2)
 end
 
 function run_checkpointer_cleanup_tests(arch)
-    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
+    grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
     model = IncompressibleModel(architecture=arch, grid=grid)
     simulation = Simulation(model, Δt=0.2, stop_iteration=10)
 


### PR DESCRIPTION
This PR adds support for "cleaning up" previous checkpoints. Setting `cleanup=true` will cause the checkpointer to delete all previous checkpoints after the latest one has been written.

Pair programmed with @qwert2266.