### PR TITLE
Convective adjustment and thinking about vertically implicit diffusion

### DIFF
--- a/src/TurbulenceClosures/convective_adjustment.jl
+++ b/src/TurbulenceClosures/convective_adjustment.jl
@@ -1,0 +1,36 @@
+function convective_adjustment!(model, Δt, K)
+    grid = model.grid
+    Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
+    Δz = model.grid.Δz
+    T = model.tracers.T
+
+    ∂T∂z = ComputedField(@at (Cell, Cell, Cell) ∂z(T))
+    compute!(∂T∂z)
+
+    κ = zeros(Nx, Ny, Nz)
+    for k in 1:Nz, j in 1:Ny, i in 1:Nx
+        κ[i, j, k] = ∂T∂z[i, j, k] < 0 ? K : 0
+    end
+
+    T_interior = interior(T)
+    Tⁿ⁺¹ = zeros(Nx, Ny, Nz)
+
+    for j in 1:Ny, i in 1:Nx
+        ld = [-Δt/Δz^2 * κ[i, j, k]   for k in 2:Nz]
+        ud = [-Δt/Δz^2 * κ[i, j, k+1] for k in 1:Nz-1]
+
+        d = zeros(Nz)
+        for k in 1:Nz-1
+            d[k] = 1 + Δt/Δz^2 * (κ[i, j, k] + κ[i, j, k+1])
+        end
+        d[Nz] = 1 + Δt/Δz^2 * κ[i, j, Nz]
+
+        𝓛 = Tridiagonal(ld, d, ud)
+
+        Tⁿ⁺¹[i, j, :] .= 𝓛 \ T_interior[i, j, :]
+    end
+
+    set!(model, T=Tⁿ⁺¹)
+
+    return nothing
+end


### PR DESCRIPTION
For now this PR just adds a function `convective_adjustment!(model, Δt, K)` that performs a convective adjustment step on a model. 

I believe this results in an operator splitting method for treating vertically implicit diffusion using backward Euler.

## TODO

If this seems like an appropriate method for implementing vertically implicit diffusion, I'd suggest the following steps for turning this PR into something that can be merged:
1. Define a new closure
    ```julia
	struct ConvectiveAdjustment{K, ∂}
	       κ :: K
    	∂b∂z :: ∂
		...
	end
    ```
2. Maybe `ConvectiveAdjustment` should act on a `BuoyancyField`?
3. Refactor `convective_adjustment!` to use the `BatchedTridiagonalSolver`.
4. Add a free convection test to test that using `ConvectiveAdjustment` on a linearly stratified column model results in a mixed layer with ∂b/∂z ≈ 0 (could also test for the mixed layer depth).

`ConvectiveAdjustment` could then be used as part of a tuple of turbulence closures, e.g.

```julia
closure = (IsotropicDiffusivity(κ=1e-4), ConvectiveAdjustment(κv=10))
```

## Future plans?

Vertically implicit diffusion with the `BatchedTridiagonalSolver` could then be abstracted to support other parameterizations such as `OceanTurb.KPP` and `OceanTurb.TKEMassFlux`.

I think @glwagner envisioned a more general way of time-stepping implicit terms in general, i.e. adding IMEX time-steppers I think?

## Note on user interface

Right now the user must manually call `convective_adjustment!` inside the `simulation.progress` callback so it's very awkward to use, but it should be usable if we need it.

Ideally `convective_adjustment!` would be called at the end of each time step, perhaps by `time_step!` or by a simulation callback. The second approach would require resolving #1138.