### PR TITLE
Updates Docs (Grids section)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.47.0"
+version = "0.47.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -50,15 +50,6 @@ RegularCartesianGrid{Float64, Periodic, Bounded, Bounded}
 grid spacing (Δx, Δy, Δz): (156.25, 156.25, 31.25)
 ```
 
-Note that currently only a subset of the possible topologies are available (the limiting factor being the pressure solver):
-
-```
-Topology = (Periodic, Periodic, Periodic)
-Topology = (Periodic, Periodic, Bounded)
-Topology = (Periodic, Bounded, Bounded)
-Topology = (Bounded, Bounded, Bounded) # Note: only works on CPUs
-```
-
 To specify a two-dimensional, horizontally-periodic model, write
 
 ```jldoctest

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -50,33 +50,6 @@ RegularCartesianGrid{Float64, Periodic, Bounded, Bounded}
 grid spacing (Δx, Δy, Δz): (156.25, 156.25, 31.25)
 ```
 
-To specify a two-dimensional, horizontally-periodic model, write
-
-```jldoctest
-julia> grid = RegularCartesianGrid(topology=(Periodic, Periodic, Flat), size=(64, 64), extent=(1e4, 1e4))
-RegularCartesianGrid{Float64, Periodic, Periodic, Flat}
-                   domain: x ∈ [0.0, 10000.0], y ∈ [0.0, 10000.0], z ∈ [0.0, 0.0]
-                 topology: (Periodic, Periodic, Flat)
-  resolution (Nx, Ny, Nz): (64, 64, 1)
-   halo size (Hx, Hy, Hz): (1, 1, 0)
-grid spacing (Δx, Δy, Δz): (156.25, 156.25, 0.0)
-```
-
-Grid spacing in `Flat` directions is `0`. Notice that two-dimensional domains accept 2-`Tuple`s
-for `size` and `extent`. To specify a one-dimensional "column" model that varies only in ``z``, write
-
-```jldoctest
-julia> grid = RegularCartesianGrid(topology=(Flat, Flat, Bounded), size=128, extent=256)
-RegularCartesianGrid{Float64, Flat, Flat, Bounded}
-                   domain: x ∈ [0.0, 0.0], y ∈ [0.0, 0.0], z ∈ [-256.0, 0.0]
-                 topology: (Flat, Flat, Bounded)
-  resolution (Nx, Ny, Nz): (1, 1, 128)
-   halo size (Hx, Hy, Hz): (0, 0, 1)
-grid spacing (Δx, Δy, Δz): (0.0, 0.0, 2.0)
-```
-
-For one-dimensional domains, `size` and `extent` may either be scalars or 1-`Tuple`s.
-
 ## Specifying domain end points
 
 To specify a domain with a different origin than the default, the `x`, `y`, and `z` keyword arguments must be used.
@@ -91,16 +64,4 @@ RegularCartesianGrid{Float64, Periodic, Periodic, Bounded}
   resolution (Nx, Ny, Nz): (32, 16, 256)
    halo size (Hx, Hy, Hz): (1, 1, 1)
 grid spacing (Δx, Δy, Δz): (6.25, 0.78125, 0.02454369260617026)
-```
-
-For two- and one-dimensional domains, `Flat` dimensions may be omitted, or provided as a scalar:
-
-```jldoctest
-julia> grid = RegularCartesianGrid(size=(32, 32), x=(-100, 100), y=(0, 200), z=-1000, topology=(Periodic, Periodic, Flat))
-RegularCartesianGrid{Float64, Periodic, Periodic, Flat}
-                   domain: x ∈ [-100.0, 100.0], y ∈ [0.0, 200.0], z ∈ [-1000.0, -1000.0]
-                 topology: (Periodic, Periodic, Flat)
-  resolution (Nx, Ny, Nz): (32, 32, 1)
-   halo size (Hx, Hy, Hz): (1, 1, 0)
-grid spacing (Δx, Δy, Δz): (6.25, 6.25, 0.0)
 ```

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -28,7 +28,7 @@ grid spacing (Δx, Δy, Δz): (4.0, 4.0, 2.0)
 
 !!! info "Default domain"
     When using the `extent` keyword, the domain is ``x \in [0, L_x]``, ``y \in [0, L_y]``, and ``z \in [-L_z, 0]``
-    --- a sensible choice for oceanographic applications.
+    -- a sensible choice for oceanographic applications.
 
 ## Specifying the grid's topology
 
@@ -37,8 +37,8 @@ In each direction the grid may be `Periodic` or `Bounded`.
 By default, the `RegularCartesianGrid` constructor assumes the grid topology is horizontally-periodic
 and bounded in the vertical, such that `topology = (Periodic, Periodic, Bounded)`.
 
-A "channel" model that is periodic in the x-direction and wall-bounded
-in the y- and z-dimensions is build with,
+A "channel" model that is periodic in the ``x``-direction and wall-bounded
+in the ``y``- and ``z``-dimensions is build with,
 
 ```jldoctest
 julia> grid = RegularCartesianGrid(topology=(Periodic, Bounded, Bounded), size=(64, 64, 32), extent=(1e4, 1e4, 1e3))
@@ -53,7 +53,7 @@ grid spacing (Δx, Δy, Δz): (156.25, 156.25, 31.25)
 ## Specifying domain end points
 
 To specify a domain with a different origin than the default, the `x`, `y`, and `z` keyword arguments must be used.
-For example, a grid with ``x \in [-100, 100]`` meters, ``y \in [0, 12.5]`` meters, and ``z \in [0, \pi]`` meters
+For example, a grid with ``x \in [-100, 100]`` meters, ``y \in [0, 12.5]`` meters, and ``z \in [-π, π]`` meters
 is constructed via
 
 ```jldoctest


### PR DESCRIPTION
This PR removes the section discussing grid topology restrictions since all the restrictions were alleviated after #1338.

Also, it removes discussions regarding `Flat` topologies since, at the moment, this functionality is not functional (see #1023 and #1024).

