### PR TITLE
Update make_example.jl

### DIFF
--- a/docs/make_example.jl
+++ b/docs/make_example.jl
@@ -1,9 +1,10 @@
 push!(LOAD_PATH, "..")
 
 using Documenter
-using Bibliography
+using DocumenterCitations
 using Literate
 using Plots  # to avoid capturing precompilation output by Literate
+
 using Oceananigans
 using Oceananigans.Operators
 using Oceananigans.Grids

--- a/docs/make_example.jl
+++ b/docs/make_example.jl
@@ -1,7 +1,6 @@
 push!(LOAD_PATH, "..")
 
 using Documenter
-using DocumenterCitations
 using Literate
 using Plots  # to avoid capturing precompilation output by Literate
 
@@ -13,15 +12,6 @@ using Oceananigans.OutputWriters
 using Oceananigans.TurbulenceClosures
 using Oceananigans.TimeSteppers
 using Oceananigans.AbstractOperations
-
-#=
-bib_filepath = joinpath(dirname(@__FILE__), "oceananigans.bib")
-const BIBLIOGRAPHY = import_bibtex(bib_filepath)
-@info "Bibliography: found $(length(BIBLIOGRAPHY)) entries."
-
-include("bibliography.jl")
-include("citations.jl")
-=#
 
 #####
 ##### Generate examples
@@ -37,7 +27,7 @@ const OUTPUT_DIR   = joinpath(@__DIR__, "src/generated")
 
 examples = [
            # "internal_wave.jl",
-            "eady_turbulence.jl"
+            "geostrophic_adjustment.jl"
            ]
 
 for example in examples
@@ -51,7 +41,7 @@ end
 
 example_pages = [
                  #"Internal wave"                    => "generated/internal_wave.md",
-                 "Eady turbulence"                  => "generated/eady_turbulence.md"
+                 "Geostrophic adjustment"            => "generated/geostrophic_adjustment.md"
                 ]
 
 pages = [

--- a/docs/make_example.jl
+++ b/docs/make_example.jl
@@ -1,3 +1,11 @@
+# This script can be used to build the Documentation only with a few examples (e.g., an example 
+# a developer is currently working on). This makes previewing how the example will look like 
+# in the actual documentation much faster. To use it simply run:
+# 
+# $ julia --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'; julia --project=docs/ docs/make_example.jl; open docs/build/index.html
+#
+# from the repo's home directory.
+
 push!(LOAD_PATH, "..")
 
 using Documenter

--- a/docs/make_example.jl
+++ b/docs/make_example.jl
@@ -1,10 +1,13 @@
-# This script can be used to build the Documentation only with a few examples (e.g., an example 
-# a developer is currently working on). This makes previewing how the example will look like 
-# in the actual documentation much faster. To use it simply run:
-# 
-# $ julia --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'; julia --project=docs/ docs/make_example.jl; open docs/build/index.html
-#
-# from the repo's home directory.
+#=
+This script can be used to build the Documentation only with a few examples (e.g., an example 
+a developer is currently working on). This makes previewing how the example will look like 
+in the actual documentation much faster. To use the script, modify it to include the example
+you are working on and then run:
+
+$ julia --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'; julia --project=docs/ docs/make_example.jl
+
+from the repo's home directory and then open `docs/build/index.html` with your favorite browser.
+=#
 
 push!(LOAD_PATH, "..")
 


### PR DESCRIPTION
Simplifies the `make_example.jl` script that is used to build the Documentation only with 1 or 2 examples (e.g., an example one developer is currently working on). This makes previewing how the example will look like in the actual documentation much faster.