### PR TITLE
Conservatively adapt ReducedField for GPUs

### DIFF
--- a/src/Fields/reduced_field.jl
+++ b/src/Fields/reduced_field.jl
@@ -1,3 +1,5 @@
+using Adapt
+
 import Oceananigans.BoundaryConditions: fill_halo_regions!
 
 #####
@@ -133,3 +135,6 @@ ReducedField(loc::Tuple, args...; kwargs...) = ReducedField(loc..., args...; kwa
 #####
 
 reduced_location(loc; dims) = Tuple(i ∈ dims ? Nothing : loc[i] for i in 1:3)
+
+Adapt.adapt_structure(to, reduced_field::ReducedField{X, Y, Z}) where {X, Y, Z} =
+    ReducedField{X, Y, Z}(adapt(to, reduced_field.data), nothing, nothing, nothing)


### PR DESCRIPTION
This will be needed to make `HydrostaticFreeSurfaceModel.free_surface.η` a `ReducedField`.