### PR TITLE
Two dimensional turbulence shallow water example

### DIFF
--- a/examples/Bickley_jet_HydrostaticModel.jl
+++ b/examples/Bickley_jet_HydrostaticModel.jl
@@ -1,0 +1,127 @@
+using Oceananigans
+using Oceananigans.Models: HydrostaticFreeSurfaceModel
+using Oceananigans.Fields, Oceananigans.AbstractOperations
+using Oceananigans.OutputWriters: NetCDFOutputWriter, IterationInterval
+
+using NCDatasets, Plots, Printf, Oceananigans.Grids
+using LinearAlgebra
+using Polynomials
+using IJulia
+
+Lx = 6.61
+Ly = 20
+Lz = 1
+Nx = 256
+Ny = 256
+
+f  = 1
+
+grid = RegularCartesianGrid(size = (Nx, Ny, 1),
+                            x = (0, Lx), y = (0, Ly), z = (0, Lz),
+                            topology = (Periodic, Bounded, Bounded))
+
+model = HydrostaticFreeSurfaceModel(
+    grid=grid, 
+    coriolis=FPlane(f=f)
+    )
+
+ U = 1.0
+ g = model.free_surface.gravitational_acceleration
+Δη = f * U / g
+ ϵ = 1e-2
+
+ Ω(x, y, z) = 2 * U * sech(y - Ly/2)^2 * tanh(y - Ly/2)
+uⁱ(x, y, z) =  U * sech(y - Ly/2)^2 .+ ϵ * exp(- (y - Ly/2)^2 ) * randn()
+ηⁱ(x, y, z) = -Δη * tanh(y - Ly/2)
+
+set!(model, u=uⁱ, η=ηⁱ)
+
+ u_op = model.velocities.u
+ v_op = model.velocities.v
+ ω_op = @at (Face, Center, Center) ∂x(v_op) - ∂y(u_op)
+ω_pert = @at (Face, Center, Center) ω_op - Ω
+
+ω_field = ComputedField(ω_op)
+ω_pert  = ComputedField(ω_pert)
+
+
+simulation = Simulation(model, Δt = 1e-3, stop_iteration = 150000)
+
+simulation.output_writers[:fields] = 
+    NetCDFOutputWriter(
+        model, 
+        (ω = ω_field, ωp = ω_pert),
+        filepath="Bickley_jet_HY.nc",
+        schedule = IterationInterval(1000),
+        mode = "c")
+
+growth_rate(model) = norm(interior(model.velocities.v))
+fields_to_output = (growth_rate = growth_rate,)
+dims = (growth_rate=(),)
+simulation.output_writers[:growth] = 
+    NetCDFOutputWriter(
+        model, 
+        fields_to_output, 
+        filepath="growth_rate_hydrostatic.nc", 
+        schedule=IterationInterval(1), 
+        dimensions=dims,
+        mode = "c")
+
+run!(simulation)
+
+xc = xnodes(model.free_surface.η)
+yc = ynodes(model.free_surface.η)
+
+kwargs = (
+         xlabel = "x",
+         ylabel = "y",
+           fill = true,
+         levels = 20,
+      linewidth = 0,
+          color = :balance,
+       colorbar = true,
+           ylim = (0, Ly),
+           xlim = (0, Lx)
+)
+
+ds = NCDataset(simulation.output_writers[:fields].filepath, "r")
+
+iterations = keys(ds["time"])
+
+anim = @animate for (iter, t) in enumerate(ds["time"])
+     ω = ds["ω"][:,:,1,iter]
+    ωp = ds["ωp"][:,:,1,iter]
+
+     ω_max = maximum(abs, ω)
+    ωp_max = maximum(abs, ωp)
+
+     plot_ω = contour(xc, yc, ω',  clim=(-ω_max,  ω_max),  title=@sprintf("Total ζ at t = %.3f", t); kwargs...)
+    plot_ωp = contour(xc, yc, ωp', clim=(-ωp_max, ωp_max), title=@sprintf("Perturbation ζ at t = %.3f", t); kwargs...)
+
+    plot(plot_ω, plot_ωp, layout = (1,2), size=(1200, 500))
+
+    print("At t = ", t, " maximum of ωp = ", maximum(abs, ωp), "\n")
+end
+
+close(ds)
+
+mp4(anim, "Bickley_Jet_HydrostaticFreeSurface.mp4", fps = 15)
+
+ds2 = NCDataset(simulation.output_writers[:growth].filepath, "r")
+
+iterations = keys(ds2["time"])
+
+t = ds2["time"][:]
+σ = ds2["growth_rate"][:]
+
+close(ds2)
+
+I = 50000:60000
+best_fit = fit((t[I]), log.(σ[I]), 1)
+poly = 2 .* exp.(best_fit[0] .+ best_fit[1]*t[I])
+
+plt = plot(t[1000:end], log.(σ[1000:end]), lw=4, label="sigma", title="growth rate", legend=:bottomright)
+plot!(plt, t[I], log.(poly), lw=4, label="best fit")
+savefig(plt, "growth_rates.png")
+
+print("Best slope = ", best_fit[1])

--- a/examples/Bickley_jet_IncompressibleModel.jl
+++ b/examples/Bickley_jet_IncompressibleModel.jl
@@ -1,0 +1,97 @@
+using Oceananigans
+
+Lx = 2π
+Ly = 20
+Lz = 1
+Nx = 256
+Ny = 256
+
+f  = 1
+
+grid = RegularCartesianGrid(size = (Nx, Ny, 1),
+                            x = (0, Lx), y = (0, Ly), z = (0, Lz),
+                            topology = (Periodic, Bounded, Bounded))
+
+using Oceananigans.Models: IncompressibleModel
+using Oceananigans.Fields, Oceananigans.AbstractOperations
+
+model = IncompressibleModel(
+    grid=grid, 
+    coriolis=FPlane(f=f)
+    )
+
+ U = 1.0
+ f = model.coriolis.f
+ ϵ = 1e-2
+
+  Ω(x, y, z) = 2 * U * sech(y - Ly/2)^2 * tanh(y - Ly/2)
+ uⁱ(x, y, z) =     U * sech(y - Ly/2)^2 .+ ϵ * exp(- (y - Ly/2)^2 ) * randn()
+
+set!(model, u=uⁱ)
+
+u_op = model.velocities.u
+v_op = model.velocities.v
+ω_op = @at (Face, Center, Center) ∂x(v_op) - ∂y(u_op)
+ω_pert = @at (Face, Center, Center) ω_op - Ω
+
+u_field = ComputedField(u_op)
+ω_field = ComputedField(ω_op)
+ω_pert  = ComputedField(ω_pert)
+
+simulation = Simulation(model, Δt = 1e-2, stop_iteration = 15000)
+
+using Oceananigans.OutputWriters: JLD2OutputWriter, IterationInterval
+
+simulation.output_writers[:fields] = 
+    JLD2OutputWriter(
+        model, 
+        (u = u_field, ω = ω_field, ωp = ω_pert), 
+        schedule = IterationInterval(100),
+        prefix = "Bickley_Jet",
+        force = true)
+
+run!(simulation)
+
+using JLD2, Plots, Printf, Oceananigans.Grids
+using LinearAlgebra
+using IJulia
+
+xc = xnodes(model.velocities.u)
+yc = ynodes(model.velocities.u)
+
+kwargs = (
+         xlabel = "x",
+         ylabel = "y",
+           fill = true,
+         levels = 20,
+      linewidth = 0,
+          color = :balance,
+       colorbar = true,
+           xlim = (0, Ly),
+           ylim = (0, Lx)
+)
+
+file = jldopen(simulation.output_writers[:fields].filepath)
+
+iterations = parse.(Int, keys(file["timeseries/t"]))
+
+anim = @animate for (i, iter) in enumerate(iterations)
+
+     t = file["timeseries/t/$iter"]
+     ω = file["timeseries/ω/$iter"][:, :, 1]
+    ωp = file["timeseries/ωp/$iter"][:, :, 1]
+
+     ω_max = maximum(abs, ω)
+    ωp_max = maximum(abs, ωp)
+
+     plot_ω = contour(yc, xc, ω,  clim=(-ω_max,  ω_max),  title=@sprintf("Total ζ at t = %.3f", t); kwargs...)
+    plot_ωp = contour(yc, xc, ωp, clim=(-ωp_max, ωp_max), title=@sprintf("Perturbation ζ at t = %.3f", t); kwargs...)
+
+    plot(plot_ω, plot_ωp, layout = (1,2), size=(1200, 500))
+
+    print("At t = ", t, " maximum of ωp = ", maximum(abs, ωp), "\n")
+end
+
+close(file)
+
+mp4(anim, "Bickley_Jet_IncompressibleModel.mp4", fps = 15) # hide

--- a/examples/Bickley_jet_shallow_water.jl
+++ b/examples/Bickley_jet_shallow_water.jl
@@ -1,0 +1,149 @@
+using Oceananigans.Architectures: CPU, architecture
+using Oceananigans.Models: ShallowWaterModel
+using Oceananigans.Grids: Periodic, Bounded, RegularCartesianGrid
+using Oceananigans.Grids: xnodes, ynodes, interior
+using Oceananigans.Simulations: Simulation, set!, run!, TimeStepWizard
+using Oceananigans.Coriolis: FPlane
+using Oceananigans.Advection: WENO5
+using Oceananigans.OutputWriters: NetCDFOutputWriter, IterationInterval
+using Oceananigans.Fields, Oceananigans.AbstractOperations
+using Oceananigans.TurbulenceClosures: AnisotropicBiharmonicDiffusivity
+#using Oceananigans:TimeStepper: RungeKutta3
+
+import Oceananigans.Utils: cell_advection_timescale, prettytime
+
+using NCDatasets, Plots, Printf, Oceananigans.Grids
+using LinearAlgebra
+using Polynomials
+using IJulia
+
+Lx = 2π
+Ly = 20
+Lz = 1
+Nx = 64
+Ny = 64
+
+f  = 1
+g = 9.80665
+
+grid = RegularCartesianGrid(size = (Nx, Ny, 1),
+                            x = (0, Lx), y = (0, Ly), z = (0, Lz),
+                            topology = (Periodic, Bounded, Bounded))
+
+model = ShallowWaterModel(
+    architecture=CPU(),
+    timestepper=:RungeKutta3,
+    advection=WENO5(),
+    grid=grid,
+    gravitational_acceleration=g,
+    coriolis=FPlane(f=f),
+#    closure=AnisotropicBiharmonicDiffusivity(νh=10) 
+    )
+
+ U = 1.0
+Δη = f * U / g
+ ϵ = 1e-4
+   
+ Ω(x, y, z) = 2 * U * sech(y - Ly/2)^2 * tanh(y - Ly/2)
+uⁱ(x, y, z) =  U * sech(y - Ly/2)^2 .+ ϵ * exp(- (y - Ly/2)^2 ) * randn()
+ηⁱ(x, y, z) = -Δη * tanh(y - Ly/2)
+hⁱ(x, y, z) = model.grid.Lz .+ ηⁱ(x, y, z)   
+uhⁱ(x, y, z) = uⁱ(x, y, z) * hⁱ(x, y, z)
+vhⁱ(x, y, z) = vⁱ(x, y, z) * hⁱ(x, y, z)
+
+set!(model, uh = uhⁱ , h = hⁱ)
+
+u_op   = model.solution.uh / model.solution.h
+v_op   = model.solution.vh / model.solution.h
+ω_op   = @at (Center, Center, Center) ∂x(v_op) - ∂y(u_op)
+ω_pert = @at (Center, Center, Center) ω_op - Ω
+
+ω_field = ComputedField(ω_op)
+ω_pert  = ComputedField(ω_pert)
+
+progress(sim) = @printf("Iteration: %d, time: %s, norm ω: \n",
+                        sim.model.clock.iteration,
+                        prettytime(sim.model.clock.time))
+
+simulation = Simulation(model, Δt = 1e-4, stop_iteration = 10000)
+
+simulation.output_writers[:fields] = 
+    NetCDFOutputWriter(
+        model, 
+        (ω = ω_field, ωp = ω_pert),
+        filepath="Bickley_jet_SW.nc",
+        schedule = IterationInterval(1000),
+        mode = "c")
+
+growth_rate(model) = norm(interior(v_op))
+fields_to_output = (growth_rate = growth_rate,)
+dims = (growth_rate=(),)
+simulation.output_writers[:growth] = 
+    NetCDFOutputWriter(
+        model, 
+        fields_to_output, 
+        filepath="growth_rate_shallowwater.nc", 
+        schedule=IterationInterval(1), 
+        dimensions=dims,
+        mode = "c")
+        
+        
+run!(simulation)
+
+xc = xnodes(model.solution.h)
+yc = ynodes(model.solution.h)
+
+kwargs = (
+         xlabel = "x",
+         ylabel = "y",
+           fill = true,
+         levels = 20,
+      linewidth = 0,
+          color = :balance,
+       colorbar = true,
+           ylim = (0, Ly),
+           xlim = (0, Lx)
+)
+
+ds = NCDataset(simulation.output_writers[:fields].filepath, "r")
+
+iterations = keys(ds["time"])
+
+anim = @animate for (iter, t) in enumerate(ds["time"])
+     ω = ds["ω"][:,:,1,iter]
+    ωp = ds["ωp"][:,:,1,iter]
+
+     ω_max = maximum(abs, ω)
+    ωp_max = maximum(abs, ωp)
+
+     plot_ω = contour(xc, yc, ω',  clim=(-ω_max,  ω_max),  title=@sprintf("Total ζ at t = %.3f", t); kwargs...)
+    plot_ωp = contour(xc, yc, ωp', clim=(-ωp_max, ωp_max), title=@sprintf("Perturbation ζ at t = %.3f", t); kwargs...)
+
+    plot(plot_ω, plot_ωp, layout = (1,2), size=(1200, 500))
+
+    print("At t = ", t, " maximum of ωp = ", maximum(abs, ωp), "\n")
+end
+
+close(ds)
+
+mp4(anim, "Bickley_Jet_ShallowWater.mp4", fps=15)
+
+ds2 = NCDataset(simulation.output_writers[:growth].filepath, "r")
+
+iterations = keys(ds2["time"])
+
+t = ds2["time"][:]
+σ = ds2["growth_rate"][:]
+
+close(ds2)
+
+#I = 50000:60000
+I = 40:100 
+best_fit = fit((t[I]), log.(σ[I]), 1)
+poly = 2 .* exp.(best_fit[0] .+ best_fit[1]*t[I])
+
+plt = plot(t[1000:end], log.(σ[1000:end]), lw=4, label="sigma", title="growth rate", legend=:bottomright)
+plot!(plt, t[I], log.(poly), lw=4, label="best fit")
+savefig(plt, "growth_rates.png")
+
+print("Best slope = ", best_fit[1])

--- a/examples/geostrophic_adjustment_compare_models.jl
+++ b/examples/geostrophic_adjustment_compare_models.jl
@@ -1,0 +1,189 @@
+# # Geostrophic adjustment using Oceananigans.HydrostaticFreeSurfaceMode l
+#
+# This example demonstrates how to simulate the one-dimensional geostrophic adjustment of a
+# free surface using `Oceananigans.HydrostaticFreeSurfaceModel`. Here, we solve the hydrostatic
+# Boussinesq equations beneath a free surface with a small-amplitude about rest ``z = 0``,
+# with boundary conditions expanded around ``z = 0``, and free surface dynamics linearized under 
+# the assumption # ``η / H \ll 1``, where ``η`` is the free surface displacement, and ``H`` is 
+# the total depth of the fluid.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
+
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, JLD2, Plots"
+# ```
+
+# ## A one-dimensional domain
+#
+# We use a one-dimensional domain of geophysical proportions,
+
+using Oceananigans
+using Oceananigans.Utils: kilometers
+
+grid = RegularCartesianGrid(size = (128, 1, 1),
+                            x = (0, 1000kilometers), y = (0, 1), z = (-400, 0),
+                            topology = (Bounded, Periodic, Bounded))
+
+# and Coriolis parameter appropriate for the mid-latitudes on Earth,
+
+coriolis = FPlane(f=1e-4)
+
+# ## Building a `HydrostaticFreeSurfaceModel`
+#
+# We use `grid` and `coriolis` to build a simple `HydrostaticFreeSurfaceModel`,
+
+using Oceananigans.Models: HydrostaticFreeSurfaceModel
+using Oceananigans.Models: ShallowWaterModel
+
+model = HydrostaticFreeSurfaceModel(grid=grid, coriolis=coriolis)
+model2= ShallowWaterModel(grid=grid,
+                          coriolis=coriolis,
+                          gravitational_acceleration=model.free_surface.gravitational_acceleration,
+                          architecture=CPU())
+
+# ## A geostrophic adjustment initial value problem
+#
+# We pose a geostrophic adjustment problem that consists of a partially-geostrophic
+# Gaussian height field complemented by a geostrophic y-velocity,
+
+Gaussian(x, L) = exp(-x^2 / 2L^2)
+
+U = 0.1 # geostrophic velocity
+L = grid.Lx / 40 # Gaussian width
+x₀ = grid.Lx / 4 # Gaussian center
+
+vᵍ(x, y, z) = - U * (x - x₀) / L * Gaussian(x - x₀, L)
+
+g = model.free_surface.gravitational_acceleration
+
+η₀ = coriolis.f * U * L / g # geostrohpic free surface amplitude
+
+ηᵍ(x, y, z) = η₀ * Gaussian(x - x₀, L)
+
+# We use an initial height field that's twice the geostrophic solution,
+# thus superimposing a geostrophic and ageostrophic component in the free
+# surface displacement field:
+
+ηⁱ(x, y, z) = 2 * ηᵍ(x, y, z)
+
+hⁱ(x, y, z) = 2 * ηᵍ(x, y, z) + grid.Lz
+vhⁱ(x, y, z) = vᵍ(x, y, z) * hⁱ(x, y, z)
+# We set the initial condition to ``vᵍ`` and ``ηⁱ``,
+
+set!(model, v=vᵍ, η=ηⁱ)
+set!(model2, vh=vhⁱ, h=hⁱ)
+
+# ## Running a `Simulation`
+#
+# We pick a time-step that resolves the surface dynamics,
+
+gravity_wave_speed = sqrt(g * grid.Lz) # hydrostatic (shallow water) gravity wave speed
+
+wave_propagation_time_scale = model.grid.Δx / gravity_wave_speed
+
+simulation = Simulation(model, Δt = 0.1 * wave_propagation_time_scale, stop_iteration = 1000)
+simulation2 = Simulation(model2, Δt = 0.1 * wave_propagation_time_scale, stop_iteration = 1000)
+
+
+# ## Output
+#
+# We output the velocity field and free surface displacement,
+
+output_fields = merge(model.velocities, (η=model.free_surface.η,))
+output_fields2 = merge(model2.solution)
+
+using Oceananigans.OutputWriters: JLD2OutputWriter, IterationInterval
+
+simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
+                                                      schedule = IterationInterval(10),
+                                                      prefix = "geostrophic_adjustment",
+                                                      force = true)
+
+simulation2.output_writers[:fields] = JLD2OutputWriter(model2, output_fields2,
+                                                       schedule = IterationInterval(10),
+                                                       prefix = "geostrophic_adjustment2",
+                                                       force = true)
+
+run!(simulation)
+run!(simulation2)
+
+# ## Visualizing the results
+
+using JLD2, Plots, Printf, Oceananigans.Grids
+using Oceananigans.Utils: hours
+using IJulia
+
+xη = xw = xv = xnodes(model.free_surface.η)
+xu = xnodes(model.velocities.u)
+
+file = jldopen(simulation.output_writers[:fields].filepath)
+
+iterations = parse.(Int, keys(file["timeseries/t"]))
+
+anim = @animate for (i, iter) in enumerate(iterations)
+
+    u = file["timeseries/u/$iter"][:, 1, 1]
+    v = file["timeseries/v/$iter"][:, 1, 1]
+    η = file["timeseries/η/$iter"][:, 1, 1]
+    t = file["timeseries/t/$iter"]
+
+    titlestr = @sprintf("Geostrophic adjustment at t = %.1f hours", t / hours)
+
+    v_plot = plot(xv / kilometers, v, linewidth = 2, title = titlestr,
+                  label = "", xlabel = "x (km)", ylabel = "v (m s⁻¹)", ylims = (-U, U))
+
+    u_plot = plot(xu / kilometers, u, linewidth = 2,
+                  label = "", xlabel = "x (km)", ylabel = "u (m s⁻¹)", ylims = (-2e-3, 2e-3))
+
+    η_plot = plot(xη / kilometers, η, linewidth = 2,
+                  label = "", xlabel = "x (km)", ylabel = "η (m)", ylims = (-η₀/10, 2η₀))
+
+    plot(v_plot, u_plot, η_plot, layout = (3, 1), size = (800, 600))
+end
+
+close(file)
+
+mp4(anim, "geostrophic_adjustment.mp4", fps = 15) # hide
+
+
+
+### Now for ShallowWaterModel
+
+xη = xw = xv = xnodes(model2.solution.h)
+xu = xnodes(model2.solution.uh)
+
+file2 = jldopen(simulation2.output_writers[:fields].filepath)
+
+iterations2 = parse.(Int, keys(file2["timeseries/t"]))
+
+anim = @animate for (i, iter) in enumerate(iterations2)
+
+    uh = file2["timeseries/uh/$iter"][:, 1, 1]
+    vh = file2["timeseries/vh/$iter"][:, 1, 1]
+    h  = file2["timeseries/h/$iter"][:, 1, 1]
+    t = file2["timeseries/t/$iter"]
+
+    u = 0.5*(uh[2:end] .+ uh[1:end-1]) ./ h
+    v = vh ./ h
+    η = h .- grid.Lz
+
+    titlestr = @sprintf("Geostrophic adjustment2 at t = %.1f hours", t / hours)
+
+    v_plot = plot(xv / kilometers, v, linewidth = 2, title = titlestr,
+                  label = "", xlabel = "x (km)", ylabel = "v (m s⁻¹)", ylims = (-U, U))
+
+    u_plot = plot(xu[2:end] / kilometers, u, linewidth = 2,
+                  label = "", xlabel = "x (km)", ylabel = "u (m s⁻¹)", ylims = (-2e-3, 2e-3))
+
+    η_plot = plot(xη / kilometers, η, linewidth = 2,
+                  label = "", xlabel = "x (km)", ylabel = "η (m)", ylims = (-η₀/10, 2η₀))
+
+    plot(v_plot, u_plot, η_plot, layout = (3, 1), size = (800, 600))
+end
+
+close(file2)
+
+mp4(anim, "geostrophic_adjustment2.mp4", fps = 15) # hide

--- a/examples/geostrophic_adjustment_compare_models_y.jl
+++ b/examples/geostrophic_adjustment_compare_models_y.jl
@@ -1,0 +1,189 @@
+# # Geostrophic adjustment using Oceananigans.HydrostaticFreeSurfaceMode l
+#
+# This example demonstrates how to simulate the one-dimensional geostrophic adjustment of a
+# free surface using `Oceananigans.HydrostaticFreeSurfaceModel`. Here, we solve the hydrostatic
+# Boussinesq equations beneath a free surface with a small-amplitude about rest ``z = 0``,
+# with boundary conditions expanded around ``z = 0``, and free surface dynamics linearized under 
+# the assumption # ``η / H \ll 1``, where ``η`` is the free surface displacement, and ``H`` is 
+# the total depth of the fluid.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
+
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, JLD2, Plots"
+# ```
+
+# ## A one-dimensional domain
+#
+# We use a one-dimensional domain of geophysical proportions,
+
+using Oceananigans
+using Oceananigans.Utils: kilometers
+
+grid = RegularCartesianGrid(size = (1, 128, 1),
+                            x = (0, 1), y = (0, 1000kilometers), z = (-400, 0),
+                            topology = (Bounded, Periodic, Bounded))
+
+# and Coriolis parameter appropriate for the mid-latitudes on Earth,
+
+coriolis = FPlane(f=1e-4)
+
+# ## Building a `HydrostaticFreeSurfaceModel`
+#
+# We use `grid` and `coriolis` to build a simple `HydrostaticFreeSurfaceModel`,
+
+using Oceananigans.Models: HydrostaticFreeSurfaceModel
+using Oceananigans.Models: ShallowWaterModel
+
+model = HydrostaticFreeSurfaceModel(grid=grid, coriolis=coriolis)
+model2= ShallowWaterModel(grid=grid,
+                          coriolis=coriolis,
+                          gravitational_acceleration=model.free_surface.gravitational_acceleration,
+                          architecture=CPU())
+
+# ## A geostrophic adjustment initial value problem
+#
+# We pose a geostrophic adjustment problem that consists of a partially-geostrophic
+# Gaussian height field complemented by a geostrophic y-velocity,
+
+Gaussian(y, L) = exp(-y^2 / 2L^2)
+
+U = 0.1 # geostrophic velocity
+L = grid.Ly / 40 # Gaussian width
+y₀ = grid.Ly / 4 # Gaussian center
+
+uᵍ(x, y, z) =  U * (y - y₀) / L * Gaussian(y - y₀, L)
+
+g = model.free_surface.gravitational_acceleration
+
+η₀ = coriolis.f * U * L / g # geostrohpic free surface amplitude
+
+ηᵍ(x, y, z) = η₀ * Gaussian(y - y₀, L)
+
+# We use an initial height field that's twice the geostrophic solution,
+# thus superimposing a geostrophic and ageostrophic component in the free
+# surface displacement field:
+
+ηⁱ(x, y, z) = 2 * ηᵍ(x, y, z)
+
+ hⁱ(x, y, z) = 2 * ηᵍ(x, y, z) + grid.Lz
+uhⁱ(x, y, z) = uᵍ(x, y, z) * hⁱ(x, y, z)
+# We set the initial condition to ``vᵍ`` and ``ηⁱ``,
+
+set!(model,  u=uᵍ,   η=ηⁱ)
+set!(model2, uh=uhⁱ, h=hⁱ)
+
+# ## Running a `Simulation`
+#
+# We pick a time-step that resolves the surface dynamics,
+
+gravity_wave_speed = sqrt(g * grid.Lz) # hydrostatic (shallow water) gravity wave speed
+
+wave_propagation_time_scale = model.grid.Δy / gravity_wave_speed
+
+simulation  = Simulation(model,  Δt = 0.1 * wave_propagation_time_scale, stop_iteration = 1000)
+simulation2 = Simulation(model2, Δt = 0.1 * wave_propagation_time_scale, stop_iteration = 1000)
+
+
+# ## Output
+#
+# We output the velocity field and free surface displacement,
+
+output_fields = merge(model.velocities, (η=model.free_surface.η,))
+output_fields2 = merge(model2.solution)
+
+using Oceananigans.OutputWriters: JLD2OutputWriter, IterationInterval
+
+simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
+                                                      schedule = IterationInterval(10),
+                                                      prefix = "geostrophic_adjustment",
+                                                      force = true)
+
+simulation2.output_writers[:fields] = JLD2OutputWriter(model2, output_fields2,
+                                                       schedule = IterationInterval(10),
+                                                       prefix = "geostrophic_adjustment2",
+                                                       force = true)
+
+run!(simulation)
+run!(simulation2)
+
+# ## Visualizing the results
+
+using JLD2, Plots, Printf, Oceananigans.Grids
+using Oceananigans.Utils: hours
+using IJulia
+
+yη = yw = yv = ynodes(model.free_surface.η)
+yu = ynodes(model.velocities.u)
+
+file = jldopen(simulation.output_writers[:fields].filepath)
+
+iterations = parse.(Int, keys(file["timeseries/t"]))
+
+anim = @animate for (i, iter) in enumerate(iterations)
+
+    u = file["timeseries/u/$iter"][1, :, 1]
+    v = file["timeseries/v/$iter"][1, :, 1]
+    η = file["timeseries/η/$iter"][1, :, 1]
+    t = file["timeseries/t/$iter"]
+
+    titlestr = @sprintf("Geostrophic adjustment at t = %.1f hours", t / hours)
+
+    u_plot = plot(yu / kilometers, u, linewidth = 2, title = titlestr,
+                  label = "", xlabel = "y (km)", ylabel = "u (m s⁻¹)")
+
+    v_plot = plot(yu / kilometers, v, linewidth = 2,
+                  label = "", xlabel = "y (km)", ylabel = "v (m s⁻¹)")
+
+    η_plot = plot(yη / kilometers, η, linewidth = 2,
+                  label = "", xlabel = "y (km)", ylabel = "η (m)", ylims = (-η₀/10, 2η₀))
+
+    plot(u_plot, v_plot, η_plot, layout = (3, 1), size = (800, 600))
+end
+
+close(file)
+
+mp4(anim, "geostrophic_adjustment.mp4", fps = 15) # hide
+
+
+
+### Now for ShallowWaterModel
+
+yη = yw = yv = ynodes(model2.solution.h)
+yu = ynodes(model2.solution.uh)
+
+file2 = jldopen(simulation2.output_writers[:fields].filepath)
+
+iterations2 = parse.(Int, keys(file2["timeseries/t"]))
+
+anim = @animate for (i, iter) in enumerate(iterations2)
+
+    uh = file2["timeseries/uh/$iter"][1, :, 1]
+    vh = file2["timeseries/vh/$iter"][1, :, 1]
+     h = file2["timeseries/h/$iter"][1, :, 1]
+     t = file2["timeseries/t/$iter"]
+
+    v = 0.5*(vh[2:end] .+ vh[1:end-1]) ./ h[1:end-1]
+    u = uh ./ h
+    η = h .- grid.Lz
+
+    titlestr = @sprintf("Geostrophic adjustment2 at t = %.1f hours", t / hours)
+
+    u_plot = plot(yu / kilometers, u, linewidth = 2, title = titlestr,
+                  label = "", xlabel = "y (km)", ylabel = "u (m s⁻¹)")
+
+    v_plot = plot(yv[2:end] / kilometers, v, linewidth = 2,
+                  label = "", xlabel = "y (km)", ylabel = "v (m s⁻¹)")
+
+    η_plot = plot(yη / kilometers, η, linewidth = 2,
+                  label = "", xlabel = "y (km)", ylabel = "η (m)", ylims = (-η₀/10, 2η₀))
+
+    plot(u_plot, v_plot, η_plot, layout = (3, 1), size = (800, 600))
+end
+
+close(file2)
+
+mp4(anim, "geostrophic_adjustment2.mp4", fps = 15) # hide

--- a/examples/new_turbulence_shallow_water.jl
+++ b/examples/new_turbulence_shallow_water.jl
@@ -1,0 +1,87 @@
+using Statistics
+using Oceananigans
+#using Oceananigans.Distributed
+
+using Oceananigans.Architectures: CPU, architecture
+using Oceananigans.Models: ShallowWaterModel
+using Oceananigans.Grids: Periodic, Bounded, RegularCartesianGrid
+using Oceananigans.Grids: xnodes, ynodes, interior
+using Oceananigans.Simulations: Simulation, set!, run!, TimeStepWizard
+using Oceananigans.Coriolis: FPlane
+using Oceananigans.Advection: WENO5
+using Oceananigans.OutputWriters: NetCDFOutputWriter, IterationInterval, TimeInterval
+using Oceananigans.Fields, Oceananigans.AbstractOperations
+using Oceananigans.TurbulenceClosures: AnisotropicBiharmonicDiffusivity
+
+topo = (Periodic, Periodic, Bounded)
+#grid = RegularRectilinearGrid(topology=topo, size=(128, 128, 1), extent=(4π, 4π, 1), halo=(3, 3, 3))
+grid = RegularCartesianGrid(size = (64, 64, 1),
+                            x = (0, 4π), y = (0, 4π), z = (0, 10),
+                            topology = (Periodic, Periodic, Bounded))
+arch = CPU()
+
+model = ShallowWaterModel(
+    architecture = arch,
+            grid = grid,
+     timestepper = :RungeKutta3,
+       advection = WENO5(),
+         closure = IsotropicDiffusivity(ν=1e-5),
+gravitational_acceleration = 10.0
+)
+
+set!(model, h=model.grid.Lz)
+
+ϵ=1e-1
+uh₀ = ϵ * rand(size(model.grid)...);
+uh₀ .-= mean(uh₀);
+set!(model, uh=uh₀, vh=uh₀)
+
+
+progress(sim) = @info "Iteration: $(sim.model.clock.iteration), time: $(sim.model.clock.time)"
+simulation = Simulation(model, Δt=0.001, stop_time=200, iteration_interval=1, progress=progress)
+
+uh, vh, h = model.solution
+outputs = (ζ=ComputedField(∂x(vh/h) - ∂y(uh/h)), h)
+filepath = "mpi_shallow_water_turbulence.nc"
+simulation.output_writers[:fields] =
+    NetCDFOutputWriter(model, outputs, filepath=filepath, schedule=TimeInterval(1.0), mode="c")
+
+run!(simulation)
+
+using Printf
+using NCDatasets
+#using CairoMakie
+using Plots
+
+xc = xnodes(model.solution.h)
+yc = ynodes(model.solution.h)
+
+kwargs = (
+         xlabel = "x",
+         ylabel = "y",
+           fill = true,
+         levels = 20,
+      linewidth = 0,
+          color = :balance,
+       colorbar = true
+)
+
+ds = NCDataset("mpi_shallow_water_turbulence.nc", "r")
+
+iterations = keys(ds["time"])
+
+anim = @animate for (iter, t) in enumerate(ds["time"])
+    ζ = ds["ζ"][:,:,1,iter]
+
+    plot_ζ = contour(xc, yc, ζ',  title=@sprintf("Total ζ at t = %.3f", t); kwargs...)
+
+    display(plot_ζ)
+    
+    print("At t = ", t, " maximum of ζ = ", maximum(abs, ζ), " and minimum of h = ", minimum(h), "\n")
+end
+
+close(ds)
+
+mp4(anim, "new_turbulence_shallow_water.mp4", fps=15)
+gif(anim, "new_turbulence_shallow_water.gif", fps=15)
+

--- a/examples/two_dimensional_turbulence_shallow_water.jl
+++ b/examples/two_dimensional_turbulence_shallow_water.jl
@@ -1,0 +1,112 @@
+using Oceananigans.Architectures: CPU, architecture
+using Oceananigans.Models: ShallowWaterModel
+using Oceananigans.Grids: Periodic, Bounded, RegularCartesianGrid
+using Oceananigans.Grids: xnodes, ynodes, interior
+using Oceananigans.Simulations: Simulation, set!, run!, TimeStepWizard
+using Oceananigans.Coriolis: FPlane
+using Oceananigans.Advection: WENO5
+using Oceananigans.OutputWriters: JLD2OutputWriter, IterationInterval
+using Oceananigans.Fields, Oceananigans.AbstractOperations
+
+using Statistics
+using Plots
+using Printf
+using JLD2
+using LinearAlgebra
+
+Lx = 2π 
+Ly = 2π
+Lz = 2π
+
+Nx = 128
+Ny = Nx
+
+f = 100         
+g = 1
+
+grid = RegularCartesianGrid(
+        size=(Nx, Ny, 1), 
+      extent=(Lx, Ly, Lz),
+    topology=(Periodic, Periodic, Bounded)
+    )
+
+model = ShallowWaterModel(
+                  architecture=CPU(),
+                     advection=WENO5(),
+                          grid=grid,
+    gravitational_acceleration=g,
+                      coriolis=FPlane(f=f)
+    )
+
+hᵢ = model.grid.Lz .+ 0.1*rand(size(model.grid)...)
+
+set!(model, h = hᵢ)
+
+uh, vh, h = model.solution
+
+u_op   = model.solution.uh / model.solution.h
+v_op   = model.solution.vh / model.solution.h
+η_op   = model.solution.h - model.grid.Lz
+ω_op   = @at (Center, Center, Center) ∂x(v_op) - ∂y(u_op)
+s_op   = sqrt(u_op^2 + v_op^2) 
+
+u_field = ComputedField(u_op)
+v_field = ComputedField(v_op)
+η_field = ComputedField(η_op)
+ω_field = ComputedField(ω_op)
+s_field = ComputedField(s_op)
+
+simulation = Simulation(model, Δt=1e-3, stop_iteration=1000)
+
+simulation.output_writers[:fields] =
+    JLD2OutputWriter(
+        model,
+        (u = u_field, v = v_field, η = η_field, ω = ω_field, s = s_field),
+        prefix = "two_dimensional_turbulence_shallow_water",
+        schedule=IterationInterval(20),
+        force = true)
+
+run!(simulation)
+
+file = jldopen(simulation.output_writers[:fields].filepath)
+
+iterations = parse.(Int, keys(file["timeseries/t"]))
+
+xc = xnodes(model.solution.h)
+yc = ynodes(model.solution.h)
+
+kwargs = (
+         xlabel = "x",
+         ylabel = "y",
+           fill = true,
+         levels = 20,
+      linewidth = 0,
+          color = :balance,
+       colorbar = true,
+           xlim = (0, Ly),
+           ylim = (0, Lx)
+)
+
+@info "Making a movie of the vorticity and speed fields..."
+
+anim = @animate for (i, iteration) in enumerate(iterations[2:end])
+
+    @info "Plotting frame $i from iteration $iteration..."
+
+    t = file["timeseries/t/$iteration"]
+    ω_snapshot = file["timeseries/ω/$iteration"][:, :, 1]
+    s_snapshot = file["timeseries/s/$iteration"][:, :, 1]
+
+    ω_plot = contour(yc, xc, ω_snapshot, title=@sprintf("ζ at t = %.3f", t); kwargs...)
+    s_plot = contour(yc, xc, s_snapshot, title=@sprintf("s at t = %.3f", t); kwargs...)
+
+    plot(
+        ω_plot, 
+        s_plot, 
+        layout = (1,2), 
+        size=(1200,500) 
+        )
+    
+end
+
+gif(anim, "two_dimensional_turbulence_shallow_water.gif", fps=8)


### PR DESCRIPTION
Inspired by @Lichriszz and their problem in [#1362](https://github.com/CliMA/Oceananigans.jl/discussions/1362#discussioncomment-374286) I started to make an example of two dimensional turbulence using the shallow water model.  At the moment the results are not necessarily worth looking at but I wonder if people could look at the code [here](https://github.com/CliMA/Oceananigans.jl/blob/fjp/two-dimensional-turbulence-shallow-water-example/examples/two_dimensional_turbulence_shallow_water.jl) and say whether the set up is what we want?

A few issues that I have come cross are the following:

- [x] Use the time stepping wizard for numerical stability
- [x] Reduce the number of import statements
- [ ] Plot the vorticity and the divergence fields
- [x] Pick the parameters to get nice results.  What is a good a reference for a planar geometry?
- [ ] Should test on GPU
- [ ] Should test with higher resolution.

One possible paper is [Polvani et al (1994)](https://aip.scitation.org/doi/pdf/10.1063/1.166002)