### PR TITLE
Adds a few areas and volumes needed for correct Coriolis terms on curvilinear grids

### DIFF
--- a/src/Coriolis/f_plane.jl
+++ b/src/Coriolis/f_plane.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Operators: Δx_vᶜᶠᶜ, Δy_uᶠᶜᶜ
+using Oceananigans.Operators: Δx_vᶜᶠᶜ, Δy_uᶠᶜᶜ, Δxᶠᶜᵃ, Δyᶜᶠᵃ
 
 """
     FPlane{FT} <: AbstractRotation
@@ -39,8 +39,8 @@ function FPlane(FT::DataType=Float64; f=nothing, rotation_rate=Ω_Earth, latitud
     end
 end
 
-@inline x_f_cross_U(i, j, k, grid, coriolis::FPlane, U) = - coriolis.f * ℑxyᶠᶜᵃ(i, j, k, grid, Δx_vᶜᶠᶜ, U[2]) / Δxᶠᶜᶜ(i, j, k, grid)
-@inline y_f_cross_U(i, j, k, grid, coriolis::FPlane, U) =   coriolis.f * ℑxyᶜᶠᵃ(i, j, k, grid, Δy_uᶠᶜᶜ, U[1]) / Δyᶜᶠᶜ(i, j, k, grid)
+@inline x_f_cross_U(i, j, k, grid, coriolis::FPlane, U) = - coriolis.f * ℑxyᶠᶜᵃ(i, j, k, grid, Δx_vᶜᶠᶜ, U[2]) / Δxᶠᶜᵃ(i, j, k, grid)
+@inline y_f_cross_U(i, j, k, grid, coriolis::FPlane, U) =   coriolis.f * ℑxyᶜᶠᵃ(i, j, k, grid, Δy_uᶠᶜᶜ, U[1]) / Δyᶜᶠᵃ(i, j, k, grid)
 
 @inline z_f_cross_U(i, j, k, grid::AbstractGrid{FT}, coriolis::FPlane, U) where FT = zero(FT)
 

--- a/src/Coriolis/f_plane.jl
+++ b/src/Coriolis/f_plane.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Operators: Δx_vᶜᶠᶜ, Δy_uᶠᶜᶜ
+
 """
     FPlane{FT} <: AbstractRotation
 
@@ -37,8 +39,9 @@ function FPlane(FT::DataType=Float64; f=nothing, rotation_rate=Ω_Earth, latitud
     end
 end
 
-@inline x_f_cross_U(i, j, k, grid, coriolis::FPlane, U) = - coriolis.f * ℑxyᶠᶜᵃ(i, j, k, grid, U[2])
-@inline y_f_cross_U(i, j, k, grid, coriolis::FPlane, U) =   coriolis.f * ℑxyᶜᶠᵃ(i, j, k, grid, U[1])
+@inline x_f_cross_U(i, j, k, grid, coriolis::FPlane, U) = - coriolis.f * ℑxyᶠᶜᵃ(i, j, k, grid, Δx_vᶜᶠᶜ, U[2]) / Δxᶠᶜᶜ(i, j, k, grid)
+@inline y_f_cross_U(i, j, k, grid, coriolis::FPlane, U) =   coriolis.f * ℑxyᶜᶠᵃ(i, j, k, grid, Δy_uᶠᶜᶜ, U[1]) / Δyᶜᶠᶜ(i, j, k, grid)
+
 @inline z_f_cross_U(i, j, k, grid::AbstractGrid{FT}, coriolis::FPlane, U) where FT = zero(FT)
 
 Base.show(io::IO, f_plane::FPlane{FT}) where FT =

--- a/src/Coriolis/f_plane.jl
+++ b/src/Coriolis/f_plane.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Operators: Δx_vᶜᶠᶜ, Δy_uᶠᶜᶜ, Δxᶠᶜᵃ, Δyᶜᶠᵃ
+using Oceananigans.Operators: Δx_vᶜᶠᵃ, Δy_uᶠᶜᵃ, Δxᶠᶜᵃ, Δyᶜᶠᵃ
 
 """
     FPlane{FT} <: AbstractRotation
@@ -39,8 +39,8 @@ function FPlane(FT::DataType=Float64; f=nothing, rotation_rate=Ω_Earth, latitud
     end
 end
 
-@inline x_f_cross_U(i, j, k, grid, coriolis::FPlane, U) = - coriolis.f * ℑxyᶠᶜᵃ(i, j, k, grid, Δx_vᶜᶠᶜ, U[2]) / Δxᶠᶜᵃ(i, j, k, grid)
-@inline y_f_cross_U(i, j, k, grid, coriolis::FPlane, U) =   coriolis.f * ℑxyᶜᶠᵃ(i, j, k, grid, Δy_uᶠᶜᶜ, U[1]) / Δyᶜᶠᵃ(i, j, k, grid)
+@inline x_f_cross_U(i, j, k, grid, coriolis::FPlane, U) = - coriolis.f * ℑxyᶠᶜᵃ(i, j, k, grid, Δx_vᶜᶠᵃ, U[2]) / Δxᶠᶜᵃ(i, j, k, grid)
+@inline y_f_cross_U(i, j, k, grid, coriolis::FPlane, U) =   coriolis.f * ℑxyᶜᶠᵃ(i, j, k, grid, Δy_uᶠᶜᵃ, U[1]) / Δyᶜᶠᵃ(i, j, k, grid)
 
 @inline z_f_cross_U(i, j, k, grid::AbstractGrid{FT}, coriolis::FPlane, U) where FT = zero(FT)
 

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -31,14 +31,14 @@ using Oceananigans.Grids: RegularCartesianGrid, VerticallyStretchedCartesianGrid
 @inline ΔzF(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzF[k]
 
 # Experimental grid spacing operators for Coriolis forces
-@inline Δxᶜᶠᶜ(i, j, k, grid) = grid.Δx
-@inline Δxᶠᶜᶜ(i, j, k, grid) = grid.Δx
+@inline Δxᶜᶠᵃ(i, j, k, grid) = grid.Δx
+@inline Δxᶠᶜᵃ(i, j, k, grid) = grid.Δx
 
-@inline Δyᶠᶜᶜ(i, j, k, grid) = grid.Δy
-@inline Δyᶜᶠᶜ(i, j, k, grid) = grid.Δy
+@inline Δyᶠᶜᵃ(i, j, k, grid) = grid.Δy
+@inline Δyᶜᶠᵃ(i, j, k, grid) = grid.Δy
 
-@inline Δx_vᶜᶠᶜ(i, j, k, grid, v) = @inbounds Δxᶜᶠᶜ(i, j, k, grid) * v[i, j, k]
-@inline Δy_uᶠᶜᶜ(i, j, k, grid, v) = @inbounds Δyᶠᶜᶜ(i, j, k, grid) * u[i, j, k]
+@inline Δx_vᶜᶠᵃ(i, j, k, grid, v) = @inbounds Δxᶜᶠᵃ(i, j, k, grid) * v[i, j, k]
+@inline Δy_uᶠᶜᵃ(i, j, k, grid, v) = @inbounds Δyᶠᶜᵃ(i, j, k, grid) * u[i, j, k]
 
 #####
 ##### Areas

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -30,6 +30,16 @@ using Oceananigans.Grids: RegularCartesianGrid, VerticallyStretchedCartesianGrid
 @inline ΔzF(i, j, k, grid::RegularCartesianGrid) = grid.Δz
 @inline ΔzF(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzF[k]
 
+# Experimental grid spacing operators for Coriolis forces
+@inline Δxᶜᶠᶜ(i, j, k, grid) = grid.Δx
+@inline Δxᶠᶜᶜ(i, j, k, grid) = grid.Δx
+
+@inline Δyᶠᶜᶜ(i, j, k, grid) = grid.Δy
+@inline Δyᶜᶠᶜ(i, j, k, grid) = grid.Δy
+
+@inline Δx_vᶜᶠᶜ(i, j, k, grid, v) = @inbounds Δxᶜᶠᶜ(i, j, k, grid) * v[i, j, k]
+@inline Δy_uᶠᶜᶜ(i, j, k, grid, v) = @inbounds Δyᶠᶜᶜ(i, j, k, grid) * u[i, j, k]
+
 #####
 ##### Areas
 #####

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -38,7 +38,7 @@ using Oceananigans.Grids: RegularCartesianGrid, VerticallyStretchedCartesianGrid
 @inline Δyᶜᶠᵃ(i, j, k, grid) = grid.Δy
 
 @inline Δx_vᶜᶠᵃ(i, j, k, grid, v) = @inbounds Δxᶜᶠᵃ(i, j, k, grid) * v[i, j, k]
-@inline Δy_uᶠᶜᵃ(i, j, k, grid, v) = @inbounds Δyᶠᶜᵃ(i, j, k, grid) * u[i, j, k]
+@inline Δy_uᶠᶜᵃ(i, j, k, grid, u) = @inbounds Δyᶠᶜᵃ(i, j, k, grid) * u[i, j, k]
 
 #####
 ##### Areas


### PR DESCRIPTION
This PR adds areas, volumes, and a few product operators needed to evaluate correct Coriolis terms on curvilinear grids, following

https://mitgcm.readthedocs.io/en/latest/algorithm/algorithm.html#id8

Before merging we should discuss:

- Should I update all the Coriolis terms? (`beta_plane.jl, non_traditional_f_plane.jl`, etc?)
- Are we ok using three-letter codes, even though we only plan to support horizontally-curvilinear grids (rather than vertically curvilinear grids) in the near future?
- Should we add more regression tests / evaluate existing regression tests before changing terms that are not covered?
- It's not feasible to adapt the _entire_ codebase to work on curvilinear grids right now. How should we handle throwing errors for cases that are not supported? Adding `RegularCartesianGrid` annotations in key places seems like the easiest strategy, but we should be careful not to miss any. We can perhaps add annotations to _all_ operators, and then support curvilinearity in as parsimonious fashion as possible to be conservative.