### PR TITLE
Horizontal divergence and vertical vorticity operators

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_advection.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_advection.jl
@@ -5,14 +5,6 @@ using Oceananigans.Operators
 ###### Horizontally-vector-invariant formulation of momentum advection
 ######
 
-@inline Δy_vᶜᶠᶜ(i, j, k, grid, v) = @inbounds Δy(i, j, k, grid) * v[i, j, k]
-@inline Δx_uᶠᶜᶜ(i, j, k, grid, u) = @inbounds Δx(i, j, k, grid) * u[i, j, k]
-
-@inline Axyᶠᶠᵃ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
-
-@inline Γᶠᶠᶜ(i, j, k, grid, u, v) = δxᶠᵃᵃ(i, j, k, grid, Δy_vᶜᶠᶜ, v) - δyᵃᶠᵃ(i, j, k, grid, Δx_uᶠᶜᶜ, u)
-@inline ζ₃ᶠᶠᶜ(i, j, k, grid, u, v) = Γᶠᶠᶜ(i, j, k, grid, u, v) / Axyᶠᶠᵃ(i, j, k, grid)
-
 @inline ϕ²(i, j, k, grid, ϕ) = @inbounds ϕ[i, j, k]^2
 @inline Khᶜᶜᶜ(i, j, k, grid, u, v) = (ℑxᶜᵃᵃ(i, j, k, grid, ϕ², u) + ℑyᵃᶜᵃ(i, j, k, grid, ϕ², v)) / 2
 
@@ -20,12 +12,12 @@ using Oceananigans.Operators
 @inbounds ζ₁wᶜᶠᶠ(i, j, k, grid, v, w) = ℑyᵃᶠᵃ(i, j, k, grid, w) * δzᵃᵃᶠ(i, j, k, grid, v) / ΔzC(i, j, k, grid)
 
 @inline U_dot_∇u(i, j, k, grid, advection::VectorInvariant, U) = (
-    - ℑyᵃᶜᵃ(i, j, k, grid, ζ₃ᶠᶠᶜ, U.u, U.v) * ℑxyᶠᶜᵃ(i, j, k, grid, U.v)
+    - ℑyᵃᶜᵃ(i, j, k, grid, ζ₃ᶠᶠᵃ, U.u, U.v) * ℑxyᶠᶜᵃ(i, j, k, grid, U.v)
     + δxᶠᵃᵃ(i, j, k, grid, Khᶜᶜᶜ, U.u, U.v) / Δx(i, j, k, grid)
     + ℑzᵃᵃᶜ(i, j, k, grid, ζ₂wᶠᶜᶠ, U.u, U.w))
 
 @inline U_dot_∇v(i, j, k, grid, advection::VectorInvariant, U) = (
-    + ℑxᶜᵃᵃ(i, j, k, grid, ζ₃ᶠᶠᶜ, U.u, U.v) * ℑxyᶜᶠᵃ(i, j, k, grid, U.u)
+    + ℑxᶜᵃᵃ(i, j, k, grid, ζ₃ᶠᶠᵃ, U.u, U.v) * ℑxyᶜᶠᵃ(i, j, k, grid, U.u)
     + δyᵃᶠᵃ(i, j, k, grid, Khᶜᶜᶜ, U.u, U.v) / Δy(i, j, k, grid)
     + ℑzᵃᵃᶜ(i, j, k, grid, ζ₁wᶜᶠᶠ, U.v, U.w))
 

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -14,7 +14,7 @@ export
     ℑᴶxᶜᵃᵃ, ℑᴶxᶠᵃᵃ, ℑᴶyᵃᶜᵃ, ℑᴶyᵃᶠᵃ, ℑᴶzᵃᵃᶜ, ℑᴶzᵃᵃᶠ,
     ℑxyᶜᶜᵃ, ℑxyᶠᶜᵃ, ℑxyᶠᶠᵃ, ℑxyᶜᶠᵃ, ℑxzᶜᵃᶜ, ℑxzᶠᵃᶜ, ℑxzᶠᵃᶠ, ℑxzᶜᵃᶠ, ℑyzᵃᶜᶜ, ℑyzᵃᶠᶜ, ℑyzᵃᶠᶠ, ℑyzᵃᶜᶠ,
     ℑxyzᶜᶜᶠ, ℑxyzᶜᶠᶜ, ℑxyzᶠᶜᶜ, ℑxyzᶜᶠᶠ, ℑxyzᶠᶜᶠ, ℑxyzᶠᶠᶜ,
-    hdivᶜᶜᵃ, divᶜᶜᶜ, div_xyᶜᶜᵃ, div_xzᶜᵃᶜ, div_yzᵃᶜᶜ,
+    divᶜᶜᶜ, div_xyᶜᶜᵃ, ζ₃ᶠᶠᵃ,
     ∇², ∇²hᶜᶜᵃ, ∇²hᶠᶜᵃ, ∇²hᶜᶠᵃ, ∇⁴hᶜᶜᵃ, ∇⁴hᶠᶜᵃ, ∇⁴hᶜᶠᵃ
 
 #####
@@ -31,6 +31,7 @@ include("difference_operators.jl")
 include("derivative_operators.jl")
 include("interpolation_operators.jl")
 include("divergence_operators.jl")
+include("vorticity_operators.jl")
 include("laplacian_operators.jl")
 include("interpolation_utils.jl")
 

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -30,6 +30,19 @@ using Oceananigans.Grids: RegularCartesianGrid, VerticallyStretchedCartesianGrid
 @inline ΔzF(i, j, k, grid::RegularCartesianGrid) = grid.Δz
 @inline ΔzF(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzF[k]
 
+# Experimental curvilinear grid spacing operators
+@inline Δxᶜᶠᵃ(i, j, k, grid) = grid.Δx
+@inline Δxᶠᶜᵃ(i, j, k, grid) = grid.Δx
+
+@inline Δyᶠᶜᵃ(i, j, k, grid) = grid.Δy
+@inline Δyᶜᶠᵃ(i, j, k, grid) = grid.Δy
+
+@inline Δx_uᶠᶜᵃ(i, j, k, grid, u) = @inbounds Δxᶠᶜᵃ(i, j, k, grid) * u[i, j, k]
+@inline Δx_vᶜᶠᵃ(i, j, k, grid, v) = @inbounds Δxᶜᶠᵃ(i, j, k, grid) * v[i, j, k]
+
+@inline Δy_uᶠᶜᵃ(i, j, k, grid, u) = @inbounds Δyᶠᶜᵃ(i, j, k, grid) * u[i, j, k]
+@inline Δy_vᶜᶠᵃ(i, j, k, grid, v) = @inbounds Δyᶜᶠᵃ(i, j, k, grid) * v[i, j, k]
+
 #####
 ##### Areas
 #####
@@ -41,6 +54,9 @@ using Oceananigans.Grids: RegularCartesianGrid, VerticallyStretchedCartesianGrid
 @inline Ayᵃᵃᶠ(i, j, k, grid) = Δx(i, j, k, grid) * ΔzC(i, j, k, grid)
 
 @inline Azᵃᵃᵃ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
+
+@inline Azᶠᶠᵃ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
+@inline Azᶜᶜᵃ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
 
 #####
 ##### Volumes

--- a/src/Operators/divergence_operators.jl
+++ b/src/Operators/divergence_operators.jl
@@ -3,20 +3,6 @@
 #####
 
 """
-    hdivᶜᶜᵃ(i, j, k, grid, u, v)
-
-Calculates the horizontal divergence ∇ₕ·(u, v) of a 2D velocity field (u, v) via
-
-    1/V * [δxᶜᵃᵃ(Ax * u) + δyᵃᶜᵃ(Ay * v)]
-
-which will end up at the location `cca`.
-"""
-@inline function hdivᶜᶜᵃ(i, j, k, grid, u, v)
-    return 1/Vᵃᵃᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) +
-                                    δyᵃᶜᵃ(i, j, k, grid, Ay_ψᵃᵃᶠ, v))
-end
-
-"""
     divᶜᶜᶜ(i, j, k, grid, u, v, w)
 
 Calculates the divergence ∇·U of a vector field U = (u, v, w),
@@ -36,39 +22,13 @@ end
 
 Calculates the 2D divergence ∂x u + ∂y v via
 
-    1/V * [δxᶜᵃᵃ(Ax * u) + δyᵃᶜᵃ(Ay * v)]
+    1/Azᶜᶜᵃ * [δxᶜᵃᵃ(Δy * u) + δyᵃᶜᵃ(Δx * v)]
 
-which will end up at the location `cca`.
+where `Azᶜᶜᵃ` is the area of the cell centered on (Center, Center, Any) --- a tracer cell,
+`Δy` is the length of the cell centered on (Face, Center, Any) in `y` (a `u` cell),
+and `Δx` is the length of the cell centered on (Center, Face, Any) in `x` (a `v` cell).
+`div_xyᶜᶜᵃ` ends up at the location `cca`.
 """
-@inline function div_xyᶜᶜᵃ(i, j, k, grid, u, v)
-    return 1/Vᵃᵃᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) +
-                                    δyᵃᶜᵃ(i, j, k, grid, Ay_ψᵃᵃᶠ, v))
-end
-
-"""
-    div_xzᶜᶜᵃ(i, j, k, grid, u, w)
-
-Calculates the 2D divergence ∂x u + ∂z w via
-
-    1/V * [δxᶜᵃᵃ(Ax * u) + δzᵃᵃᶜ(Az * w)]
-
-which will end up at the location `cac`.
-"""
-@inline function div_xzᶜᵃᶜ(i, j, k, grid, u, w)
-    return 1/Vᵃᵃᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) +
-                                    δzᵃᵃᶜ(i, j, k, grid, Az_ψᵃᵃᵃ, w))
-end
-
-"""
-    div_yzᶜᶜᵃ(i, j, k, grid, v, w)
-
-Calculates the 2D divergence ∂y v + ∂z w via
-
-    1/V * [δyᶜᵃᵃ(Ay * v) + δzᵃᵃᶜ(Az * w)]
-
-which will end up at the location `acc`.
-"""
-@inline function div_yzᵃᶜᶜ(i, j, k, grid, v, w)
-    return 1/Vᵃᵃᶜ(i, j, k, grid) * (δyᵃᶜᵃ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) +
-                                    δzᵃᵃᶜ(i, j, k, grid, Az_ψᵃᵃᵃ, w))
-end
+@inline div_xyᶜᶜᵃ(i, j, k, grid, u, v) =
+    1/Azᶜᶜᵃ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Δy_uᶠᶜᵃ, u) +
+                              δyᵃᶜᵃ(i, j, k, grid, Δx_vᶜᶠᵃ, v))

--- a/src/Operators/vorticity_operators.jl
+++ b/src/Operators/vorticity_operators.jl
@@ -1,0 +1,5 @@
+""" Vertical circulation associated with horizontal velocities u, v. """
+@inline Γᶠᶠᵃ(i, j, k, grid, u, v) = δxᶠᵃᵃ(i, j, k, grid, Δy_vᶜᶠᵃ, v) - δyᵃᶠᵃ(i, j, k, grid, Δx_uᶠᶜᵃ, u)
+
+""" Vertical vorticity associated with horizontal velocities u, v. """
+@inline ζ₃ᶠᶠᵃ(i, j, k, grid, u, v) = Γᶠᶠᵃ(i, j, k, grid, u, v) / Azᶠᶠᵃ(i, j, k, grid)

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -1,8 +1,9 @@
 using Oceananigans: CPU, GPU
 using Oceananigans.Models: HydrostaticFreeSurfaceModel
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: VectorInvariant
 using Oceananigans.Grids: Periodic, Bounded
 
-function time_stepping_hydrostatic_free_surface_model_works(arch, topo, coriolis)
+function time_stepping_hydrostatic_free_surface_model_works(arch, topo, coriolis, advection=VectorInvariant())
     grid = RegularCartesianGrid(size=(1, 1, 1), extent=(2π, 2π, 2π), topology=topo)
     model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch, coriolis=coriolis)
     simulation = Simulation(model, Δt=1.0, stop_iteration=1)
@@ -106,6 +107,13 @@ end
             @testset "Time-stepping HydrostaticFreeSurfaceModels [$arch, $(typeof(coriolis))]" begin
                 @info "  Testing time-stepping HydrostaticFreeSurfaceModels [$arch, $(typeof(coriolis))]..."
                 @test time_stepping_hydrostatic_free_surface_model_works(arch, topos[1], coriolis)
+            end
+        end
+
+        for advection in (VectorInvariant(), CenteredSecondOrder(), WENO5())
+            @testset "Time-stepping HydrostaticFreeSurfaceModels [$arch, $(typeof(advection))]" begin
+                @info "  Testing time-stepping HydrostaticFreeSurfaceModels [$arch, $(typeof(advection))]..."
+                @test time_stepping_hydrostatic_free_surface_model_works(arch, topos[1], nothing, advection)
             end
         end
 


### PR DESCRIPTION
This PR cleans up the horizontal divergence and vertical vorticity operators for horizontally-curvilinear grids. It also adds a test to ensure that `HydrostaticFreeSurfaceModel` continues to work with `momentum_advection=VectorInvariant()`.