### PR TITLE
AbstractRectilinearGrid and curvilinear horizontal grid spacing and gradient operators

### DIFF
--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -4,7 +4,7 @@ export
     Center, Face,
     AbstractTopology, Periodic, Bounded, Flat, topology,
     AbstractGrid,
-    AbstractCartesianGrid, RegularCartesianGrid, VerticallyStretchedCartesianGrid,
+    AbstractRectilinearGrid, RegularCartesianGrid, VerticallyStretchedCartesianGrid,
     xnode, ynode, znode, xnodes, ynodes, znodes, nodes,
     xC, xF, yC, yF, zC, zF
 
@@ -73,11 +73,11 @@ Abstract supertype for grids with elements of type `FT` and topology `{TX, TY, T
 abstract type AbstractGrid{FT, TX, TY, TZ} end
 
 """
-    AbstractCartesianGrid{FT, TX, TY, TZ}
+    AbstractRectilinearGrid{FT, TX, TY, TZ}
 
 Abstract supertype for grids with elements of type `FT` and topology `{TX, TY, TZ}`.
 """
-abstract type AbstractCartesianGrid{FT, TX, TY, TZ} <: AbstractGrid{FT, TX, TY, TZ} end
+abstract type AbstractRectilinearGrid{FT, TX, TY, TZ} <: AbstractGrid{FT, TX, TY, TZ} end
 
 Base.eltype(::AbstractGrid{FT}) where FT = FT
 Base.size(grid::AbstractGrid) = (grid.Nx, grid.Ny, grid.Nz)

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -3,7 +3,8 @@ module Grids
 export
     Center, Face,
     AbstractTopology, Periodic, Bounded, Flat, topology,
-    AbstractGrid, RegularCartesianGrid, VerticallyStretchedCartesianGrid,
+    AbstractGrid,
+    AbstractCartesianGrid, RegularCartesianGrid, VerticallyStretchedCartesianGrid,
     xnode, ynode, znode, xnodes, ynodes, znodes, nodes,
     xC, xF, yC, yF, zC, zF
 
@@ -70,6 +71,13 @@ struct Flat <: AbstractTopology end
 Abstract supertype for grids with elements of type `FT` and topology `{TX, TY, TZ}`.
 """
 abstract type AbstractGrid{FT, TX, TY, TZ} end
+
+"""
+    AbstractCartesianGrid{FT, TX, TY, TZ}
+
+Abstract supertype for grids with elements of type `FT` and topology `{TX, TY, TZ}`.
+"""
+abstract type AbstractCartesianGrid{FT, TX, TY, TZ} <: AbstractGrid{FT, TX, TY, TZ} end
 
 Base.eltype(::AbstractGrid{FT}) where FT = FT
 Base.size(grid::AbstractGrid) = (grid.Nx, grid.Ny, grid.Nz)

--- a/src/Grids/regular_cartesian_grid.jl
+++ b/src/Grids/regular_cartesian_grid.jl
@@ -5,7 +5,7 @@ A Cartesian grid with with constant grid spacings `Δx`, `Δy`, and `Δz` betwee
 and cell faces, elements of type `FT`, topology `{TX, TY, TZ}`, and coordinate ranges
 of type `R`.
 """
-struct RegularCartesianGrid{FT, TX, TY, TZ, R} <: AbstractGrid{FT, TX, TY, TZ}
+struct RegularCartesianGrid{FT, TX, TY, TZ, R} <: AbstractCartesianGrid{FT, TX, TY, TZ}
     # Number of grid points in (x,y,z).
     Nx :: Int
     Ny :: Int

--- a/src/Grids/regular_cartesian_grid.jl
+++ b/src/Grids/regular_cartesian_grid.jl
@@ -1,11 +1,11 @@
 """
-    RegularCartesianGrid{FT, TX, TY, TZ, R} <: AbstractGrid{FT, TX, TY, TZ}
+    RegularCartesianGrid{FT, TX, TY, TZ, R} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
 
 A Cartesian grid with with constant grid spacings `Δx`, `Δy`, and `Δz` between cell centers
 and cell faces, elements of type `FT`, topology `{TX, TY, TZ}`, and coordinate ranges
 of type `R`.
 """
-struct RegularCartesianGrid{FT, TX, TY, TZ, R} <: AbstractCartesianGrid{FT, TX, TY, TZ}
+struct RegularCartesianGrid{FT, TX, TY, TZ, R} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
     # Number of grid points in (x,y,z).
     Nx :: Int
     Ny :: Int

--- a/src/Grids/vertically_stretched_cartesian_grid.jl
+++ b/src/Grids/vertically_stretched_cartesian_grid.jl
@@ -1,12 +1,12 @@
 """
-    VerticallyStretchedCartesianGrid{FT, TX, TY, TZ, R, A} <: AbstractGrid{FT, TX, TY, TZ}
+    VerticallyStretchedCartesianGrid{FT, TX, TY, TZ, R, A} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
 
 A Cartesian grid with with constant horizontal grid spacings `Δx` and `Δy`, and
 non-uniform or stretched vertical grid spacing `Δz` between cell centers and cell faces,
 topology `{TX, TY, TZ}`, and coordinate ranges of type `R` (where a range can be used) and
 `A` (where an array is needed).
 """
-struct VerticallyStretchedCartesianGrid{FT, TX, TY, TZ, R, A} <: AbstractCartesianGrid{FT, TX, TY, TZ}
+struct VerticallyStretchedCartesianGrid{FT, TX, TY, TZ, R, A} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
 
     # Number of grid points in (x,y,z).
      Nx :: Int

--- a/src/Grids/vertically_stretched_cartesian_grid.jl
+++ b/src/Grids/vertically_stretched_cartesian_grid.jl
@@ -6,7 +6,7 @@ non-uniform or stretched vertical grid spacing `Δz` between cell centers and ce
 topology `{TX, TY, TZ}`, and coordinate ranges of type `R` (where a range can be used) and
 `A` (where an array is needed).
 """
-struct VerticallyStretchedCartesianGrid{FT, TX, TY, TZ, R, A} <: AbstractGrid{FT, TX, TY, TZ}
+struct VerticallyStretchedCartesianGrid{FT, TX, TY, TZ, R, A} <: AbstractCartesianGrid{FT, TX, TY, TZ}
 
     # Number of grid points in (x,y,z).
      Nx :: Int

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -2,7 +2,10 @@ module Operators
 
 export
     Δx, Δy, ΔzF, ΔzC,
-    Axᵃᵃᶜ, Axᵃᵃᶠ, Ayᵃᵃᶜ, Ayᵃᵃᶠ, Azᵃᵃᵃ,
+    Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶠᶠᵃ, Δxᶜᶠᵃ,
+    Δyᶜᶜᵃ, Δyᶠᶜᵃ, Δyᶠᶠᵃ, Δyᶜᶠᵃ,
+    Axᵃᵃᶜ, Axᵃᵃᶠ, Ayᵃᵃᶜ, Ayᵃᵃᶠ,
+    Azᵃᵃᵃ, Azᶠᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ,
     Vᵃᵃᶜ, Vᵃᵃᶠ,
     δxᶜᵃᵃ, δxᶠᵃᵃ, δyᵃᶜᵃ, δyᵃᶠᵃ, δzᵃᵃᶜ, δzᵃᵃᶠ,
     Ax_ψᵃᵃᶠ, Ax_ψᵃᵃᶜ, Ay_ψᵃᵃᶠ, Ay_ψᵃᵃᶜ, Az_ψᵃᵃᵃ,
@@ -27,6 +30,7 @@ const AG  = AbstractGrid
 const RCG = RegularCartesianGrid
 
 include("areas_and_volumes.jl")
+include("field_metric_products.jl")
 include("difference_operators.jl")
 include("derivative_operators.jl")
 include("interpolation_operators.jl")

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -67,7 +67,7 @@ using Oceananigans.Grids: AbstractRectilinearGrid, RegularCartesianGrid, Vertica
 ##### Horizontally-curvilinear grid areas
 #####
 
+@inline Azᶜᶜᵃ(i, j, k, grid::AbstractRectilinearGrid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
 @inline Azᶠᶠᵃ(i, j, k, grid::AbstractRectilinearGrid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
 @inline Azᶜᶠᵃ(i, j, k, grid::AbstractRectilinearGrid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
-@inline Azᶠᶠᵃ(i, j, k, grid::AbstractRectilinearGrid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
 @inline Azᶠᶜᵃ(i, j, k, grid::AbstractRectilinearGrid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -18,7 +18,7 @@ although not all may be used in practice.
 using Oceananigans.Grids: AbstractRectilinearGrid, RegularCartesianGrid, VerticallyStretchedCartesianGrid
 
 #####
-##### Cartesian grid spacings
+##### Rectilinear grid lengths
 #####
 
 @inline Δx(i, j, k, grid::AbstractRectilinearGrid) = grid.Δx
@@ -31,23 +31,7 @@ using Oceananigans.Grids: AbstractRectilinearGrid, RegularCartesianGrid, Vertica
 @inline ΔzF(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzF[k]
 
 #####
-##### Curvilinear grid spacing operators
-#####
-
-@inline Δxᶜᶠᵃ(i, j, k, grid) = grid.Δx
-@inline Δxᶠᶜᵃ(i, j, k, grid) = grid.Δx
-
-@inline Δyᶠᶜᵃ(i, j, k, grid) = grid.Δy
-@inline Δyᶜᶠᵃ(i, j, k, grid) = grid.Δy
-
-@inline Δx_uᶠᶜᵃ(i, j, k, grid, u) = @inbounds Δxᶠᶜᵃ(i, j, k, grid) * u[i, j, k]
-@inline Δx_vᶜᶠᵃ(i, j, k, grid, v) = @inbounds Δxᶜᶠᵃ(i, j, k, grid) * v[i, j, k]
-
-@inline Δy_uᶠᶜᵃ(i, j, k, grid, u) = @inbounds Δyᶠᶜᵃ(i, j, k, grid) * u[i, j, k]
-@inline Δy_vᶜᶠᵃ(i, j, k, grid, v) = @inbounds Δyᶜᶠᵃ(i, j, k, grid) * v[i, j, k]
-
-#####
-##### Areas
+##### Rectilinear areas
 #####
 
 @inline Axᵃᵃᶜ(i, j, k, grid) = Δy(i, j, k, grid) * ΔzF(i, j, k, grid)
@@ -58,12 +42,32 @@ using Oceananigans.Grids: AbstractRectilinearGrid, RegularCartesianGrid, Vertica
 
 @inline Azᵃᵃᵃ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
 
-@inline Azᶠᶠᵃ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
-@inline Azᶜᶜᵃ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
-
 #####
-##### Volumes
+##### Rectilinear volumes
 #####
 
 @inline Vᵃᵃᶜ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid) * ΔzF(i, j, k, grid)
 @inline Vᵃᵃᶠ(i, j, k, grid) = Δx(i, j, k, grid) * Δy(i, j, k, grid) * ΔzC(i, j, k, grid)
+
+#####
+##### Horizontally-curvilinear grid lengths
+#####
+
+@inline Δxᶜᶜᵃ(i, j, k, grid::AbstractRectilinearGrid) = grid.Δx
+@inline Δxᶜᶠᵃ(i, j, k, grid::AbstractRectilinearGrid) = grid.Δx
+@inline Δxᶠᶠᵃ(i, j, k, grid::AbstractRectilinearGrid) = grid.Δx
+@inline Δxᶠᶜᵃ(i, j, k, grid::AbstractRectilinearGrid) = grid.Δx
+
+@inline Δyᶜᶜᵃ(i, j, k, grid::AbstractRectilinearGrid) = grid.Δy
+@inline Δyᶠᶜᵃ(i, j, k, grid::AbstractRectilinearGrid) = grid.Δy
+@inline Δyᶜᶠᵃ(i, j, k, grid::AbstractRectilinearGrid) = grid.Δy
+@inline Δyᶠᶠᵃ(i, j, k, grid::AbstractRectilinearGrid) = grid.Δy
+
+#####
+##### Horizontally-curvilinear grid areas
+#####
+
+@inline Azᶠᶠᵃ(i, j, k, grid::AbstractRectilinearGrid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
+@inline Azᶜᶠᵃ(i, j, k, grid::AbstractRectilinearGrid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
+@inline Azᶠᶠᵃ(i, j, k, grid::AbstractRectilinearGrid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)
+@inline Azᶠᶜᵃ(i, j, k, grid::AbstractRectilinearGrid) = Δx(i, j, k, grid) * Δy(i, j, k, grid)

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -15,14 +15,14 @@ may involve defining more grid spacing operators, potentially up to eight per di
 although not all may be used in practice.
 """
 
-using Oceananigans.Grids: RegularCartesianGrid, VerticallyStretchedCartesianGrid
+using Oceananigans.Grids: AbstractRectilinearGrid, RegularCartesianGrid, VerticallyStretchedCartesianGrid
 
 #####
-##### Grid spacings
+##### Cartesian grid spacings
 #####
 
-@inline Δx(i, j, k, grid) = grid.Δx
-@inline Δy(i, j, k, grid) = grid.Δy
+@inline Δx(i, j, k, grid::AbstractRectilinearGrid) = grid.Δx
+@inline Δy(i, j, k, grid::AbstractRectilinearGrid) = grid.Δy
 
 @inline ΔzC(i, j, k, grid::RegularCartesianGrid) = grid.Δz
 @inline ΔzC(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzC[k]
@@ -30,7 +30,10 @@ using Oceananigans.Grids: RegularCartesianGrid, VerticallyStretchedCartesianGrid
 @inline ΔzF(i, j, k, grid::RegularCartesianGrid) = grid.Δz
 @inline ΔzF(i, j, k, grid::VerticallyStretchedCartesianGrid) = @inbounds grid.ΔzF[k]
 
-# Experimental grid spacing operators for Coriolis forces
+#####
+##### Curvilinear grid spacing operators
+#####
+
 @inline Δxᶜᶠᵃ(i, j, k, grid) = grid.Δx
 @inline Δxᶠᶜᵃ(i, j, k, grid) = grid.Δx
 

--- a/src/Operators/derivative_operators.jl
+++ b/src/Operators/derivative_operators.jl
@@ -38,14 +38,24 @@
 ##### Second derivatives
 #####
 
-@inline ∂²xᶜᵃᵃ(i, j, k, grid, c, args...) = ∂xᶜᵃᵃ(i, j, k, grid, ∂xᶠᵃᵃ, c, args...)
-@inline ∂²xᶠᵃᵃ(i, j, k, grid, u, args...) = ∂xᶠᵃᵃ(i, j, k, grid, ∂xᶜᵃᵃ, u, args...)
+@inline ∂²xᶜᵃᵃ(i, j, k, grid, c) = ∂xᶜᵃᵃ(i, j, k, grid, ∂xᶠᵃᵃ, c)
+@inline ∂²xᶠᵃᵃ(i, j, k, grid, u) = ∂xᶠᵃᵃ(i, j, k, grid, ∂xᶜᵃᵃ, u)
 
-@inline ∂²yᵃᶜᵃ(i, j, k, grid, c, args...) = ∂yᵃᶜᵃ(i, j, k, grid, ∂yᵃᶠᵃ, c, args...)
-@inline ∂²yᵃᶠᵃ(i, j, k, grid, v, args...) = ∂yᵃᶠᵃ(i, j, k, grid, ∂yᵃᶜᵃ, v, args...)
+@inline ∂²yᵃᶜᵃ(i, j, k, grid, c) = ∂yᵃᶜᵃ(i, j, k, grid, ∂yᵃᶠᵃ, c)
+@inline ∂²yᵃᶠᵃ(i, j, k, grid, v) = ∂yᵃᶠᵃ(i, j, k, grid, ∂yᵃᶜᵃ, v)
 
-@inline ∂²zᵃᵃᶜ(i, j, k, grid, c, args...) = ∂zᵃᵃᶜ(i, j, k, grid, ∂zᵃᵃᶠ, c, args...)
-@inline ∂²zᵃᵃᶠ(i, j, k, grid, w, args...) = ∂zᵃᵃᶠ(i, j, k, grid, ∂zᵃᵃᶜ, w, args...)
+@inline ∂²zᵃᵃᶜ(i, j, k, grid, c) = ∂zᵃᵃᶜ(i, j, k, grid, ∂zᵃᵃᶠ, c)
+@inline ∂²zᵃᵃᶠ(i, j, k, grid, w) = ∂zᵃᵃᶠ(i, j, k, grid, ∂zᵃᵃᶜ, w)
+
+
+@inline ∂²xᶜᵃᵃ(i, j, k, grid, c::T, args...) where T<:Function = ∂xᶜᵃᵃ(i, j, k, grid, ∂xᶠᵃᵃ, c, args...)
+@inline ∂²xᶠᵃᵃ(i, j, k, grid, u::T, args...) where T<:Function = ∂xᶠᵃᵃ(i, j, k, grid, ∂xᶜᵃᵃ, u, args...)
+
+@inline ∂²yᵃᶜᵃ(i, j, k, grid, c::T, args...) where T<:Function = ∂yᵃᶜᵃ(i, j, k, grid, ∂yᵃᶠᵃ, c, args...)
+@inline ∂²yᵃᶠᵃ(i, j, k, grid, v::T, args...) where T<:Function = ∂yᵃᶠᵃ(i, j, k, grid, ∂yᵃᶜᵃ, v, args...)
+
+@inline ∂²zᵃᵃᶜ(i, j, k, grid, c::T, args...) where T<:Function = ∂zᵃᵃᶜ(i, j, k, grid, ∂zᵃᵃᶠ, c, args...)
+@inline ∂²zᵃᵃᶠ(i, j, k, grid, w::T, args...) where T<:Function = ∂zᵃᵃᶠ(i, j, k, grid, ∂zᵃᵃᶜ, w, args...)
 
 #####
 ##### Fourth derivatives

--- a/src/Operators/derivative_operators.jl
+++ b/src/Operators/derivative_operators.jl
@@ -12,14 +12,14 @@
 @inline ∂zᵃᵃᶠ(i, j, k, grid, c) = δzᵃᵃᶠ(i, j, k, grid, c) / ΔzC(i, j, k, grid)
 
 
-@inline ∂xᶜᵃᵃ(i, j, k, grid, u::T, args...) where T<:Function = δxᶜᵃᵃ(i, j, k, grid, u, args...) / Δx(i, j, k, grid)
-@inline ∂xᶠᵃᵃ(i, j, k, grid, c::T, args...) where T<:Function = δxᶠᵃᵃ(i, j, k, grid, c, args...) / Δx(i, j, k, grid)
+@inline ∂xᶜᵃᵃ(i, j, k, grid, f::F, args...) where F<:Function = δxᶜᵃᵃ(i, j, k, grid, f, args...) / Δx(i, j, k, grid)
+@inline ∂xᶠᵃᵃ(i, j, k, grid, f::F, args...) where F<:Function = δxᶠᵃᵃ(i, j, k, grid, f, args...) / Δx(i, j, k, grid)
 
-@inline ∂yᵃᶜᵃ(i, j, k, grid, v::T, args...) where T<:Function = δyᵃᶜᵃ(i, j, k, grid, v, args...) / Δy(i, j, k, grid)
-@inline ∂yᵃᶠᵃ(i, j, k, grid, c::T, args...) where T<:Function = δyᵃᶠᵃ(i, j, k, grid, c, args...) / Δy(i, j, k, grid)
+@inline ∂yᵃᶜᵃ(i, j, k, grid, f::F, args...) where F<:Function = δyᵃᶜᵃ(i, j, k, grid, f, args...) / Δy(i, j, k, grid)
+@inline ∂yᵃᶠᵃ(i, j, k, grid, f::F, args...) where T<:Function = δyᵃᶠᵃ(i, j, k, grid, f, args...) / Δy(i, j, k, grid)
 
-@inline ∂zᵃᵃᶜ(i, j, k, grid, w::T, args...) where T<:Function = δzᵃᵃᶜ(i, j, k, grid, w, args...) / ΔzF(i, j, k, grid)
-@inline ∂zᵃᵃᶠ(i, j, k, grid, c::T, args...) where T<:Function = δzᵃᵃᶠ(i, j, k, grid, c, args...) / ΔzC(i, j, k, grid)
+@inline ∂zᵃᵃᶜ(i, j, k, grid, f::F, args...) where F<:Function = δzᵃᵃᶜ(i, j, k, grid, f, args...) / ΔzF(i, j, k, grid)
+@inline ∂zᵃᵃᶠ(i, j, k, grid, f::F, args...) where F<:Function = δzᵃᵃᶠ(i, j, k, grid, f, args...) / ΔzC(i, j, k, grid)
 
 #####
 ##### Operators of the form A*δ(q) where A is an area and q is some quantity.
@@ -48,14 +48,14 @@
 @inline ∂²zᵃᵃᶠ(i, j, k, grid, w) = ∂zᵃᵃᶠ(i, j, k, grid, ∂zᵃᵃᶜ, w)
 
 
-@inline ∂²xᶜᵃᵃ(i, j, k, grid, c::T, args...) where T<:Function = ∂xᶜᵃᵃ(i, j, k, grid, ∂xᶠᵃᵃ, c, args...)
-@inline ∂²xᶠᵃᵃ(i, j, k, grid, u::T, args...) where T<:Function = ∂xᶠᵃᵃ(i, j, k, grid, ∂xᶜᵃᵃ, u, args...)
+@inline ∂²xᶜᵃᵃ(i, j, k, grid, f::F, args...) where F<:Function = ∂xᶜᵃᵃ(i, j, k, grid, ∂xᶠᵃᵃ, f, args...)
+@inline ∂²xᶠᵃᵃ(i, j, k, grid, f::F, args...) where F<:Function = ∂xᶠᵃᵃ(i, j, k, grid, ∂xᶜᵃᵃ, f, args...)
 
-@inline ∂²yᵃᶜᵃ(i, j, k, grid, c::T, args...) where T<:Function = ∂yᵃᶜᵃ(i, j, k, grid, ∂yᵃᶠᵃ, c, args...)
-@inline ∂²yᵃᶠᵃ(i, j, k, grid, v::T, args...) where T<:Function = ∂yᵃᶠᵃ(i, j, k, grid, ∂yᵃᶜᵃ, v, args...)
+@inline ∂²yᵃᶜᵃ(i, j, k, grid, f::F, args...) where F<:Function = ∂yᵃᶜᵃ(i, j, k, grid, ∂yᵃᶠᵃ, f, args...)
+@inline ∂²yᵃᶠᵃ(i, j, k, grid, f::F, args...) where F<:Function = ∂yᵃᶠᵃ(i, j, k, grid, ∂yᵃᶜᵃ, f, args...)
 
-@inline ∂²zᵃᵃᶜ(i, j, k, grid, c::T, args...) where T<:Function = ∂zᵃᵃᶜ(i, j, k, grid, ∂zᵃᵃᶠ, c, args...)
-@inline ∂²zᵃᵃᶠ(i, j, k, grid, w::T, args...) where T<:Function = ∂zᵃᵃᶠ(i, j, k, grid, ∂zᵃᵃᶜ, w, args...)
+@inline ∂²zᵃᵃᶜ(i, j, k, grid, f::F, args...) where F<:Function = ∂zᵃᵃᶜ(i, j, k, grid, ∂zᵃᵃᶠ, f, args...)
+@inline ∂²zᵃᵃᶠ(i, j, k, grid, f::F, args...) where F<:Function = ∂zᵃᵃᶠ(i, j, k, grid, ∂zᵃᵃᶜ, f, args...)
 
 #####
 ##### Fourth derivatives

--- a/src/Operators/derivative_operators.jl
+++ b/src/Operators/derivative_operators.jl
@@ -2,14 +2,24 @@
 ##### Rectilinear derivative operators
 #####
 
-@inline ∂xᶜᵃᵃ(i, j, k, grid, u, args...) = δxᶜᵃᵃ(i, j, k, grid, u, args...) / Δx(i, j, k, grid)
-@inline ∂xᶠᵃᵃ(i, j, k, grid, c, args...) = δxᶠᵃᵃ(i, j, k, grid, c, args...) / Δx(i, j, k, grid)
+@inline ∂xᶜᵃᵃ(i, j, k, grid, u) = δxᶜᵃᵃ(i, j, k, grid, u) / Δx(i, j, k, grid)
+@inline ∂xᶠᵃᵃ(i, j, k, grid, c) = δxᶠᵃᵃ(i, j, k, grid, c) / Δx(i, j, k, grid)
 
-@inline ∂yᵃᶜᵃ(i, j, k, grid, v, args...) = δyᵃᶜᵃ(i, j, k, grid, v, args...) / Δy(i, j, k, grid)
-@inline ∂yᵃᶠᵃ(i, j, k, grid, c, args...) = δyᵃᶠᵃ(i, j, k, grid, c, args...) / Δy(i, j, k, grid)
+@inline ∂yᵃᶜᵃ(i, j, k, grid, v) = δyᵃᶜᵃ(i, j, k, grid, v) / Δy(i, j, k, grid)
+@inline ∂yᵃᶠᵃ(i, j, k, grid, c) = δyᵃᶠᵃ(i, j, k, grid, c) / Δy(i, j, k, grid)
 
-@inline ∂zᵃᵃᶜ(i, j, k, grid, w, args...) = δzᵃᵃᶜ(i, j, k, grid, w, args...) / ΔzF(i, j, k, grid)
-@inline ∂zᵃᵃᶠ(i, j, k, grid, c, args...) = δzᵃᵃᶠ(i, j, k, grid, c, args...) / ΔzC(i, j, k, grid)
+@inline ∂zᵃᵃᶜ(i, j, k, grid, w) = δzᵃᵃᶜ(i, j, k, grid, w) / ΔzF(i, j, k, grid)
+@inline ∂zᵃᵃᶠ(i, j, k, grid, c) = δzᵃᵃᶠ(i, j, k, grid, c) / ΔzC(i, j, k, grid)
+
+
+@inline ∂xᶜᵃᵃ(i, j, k, grid, u::T, args...) where T<:Function = δxᶜᵃᵃ(i, j, k, grid, u, args...) / Δx(i, j, k, grid)
+@inline ∂xᶠᵃᵃ(i, j, k, grid, c::T, args...) where T<:Function = δxᶠᵃᵃ(i, j, k, grid, c, args...) / Δx(i, j, k, grid)
+
+@inline ∂yᵃᶜᵃ(i, j, k, grid, v::T, args...) where T<:Function = δyᵃᶜᵃ(i, j, k, grid, v, args...) / Δy(i, j, k, grid)
+@inline ∂yᵃᶠᵃ(i, j, k, grid, c::T, args...) where T<:Function = δyᵃᶠᵃ(i, j, k, grid, c, args...) / Δy(i, j, k, grid)
+
+@inline ∂zᵃᵃᶜ(i, j, k, grid, w::T, args...) where T<:Function = δzᵃᵃᶜ(i, j, k, grid, w, args...) / ΔzF(i, j, k, grid)
+@inline ∂zᵃᵃᶠ(i, j, k, grid, c::T, args...) where T<:Function = δzᵃᵃᶠ(i, j, k, grid, c, args...) / ΔzC(i, j, k, grid)
 
 #####
 ##### Operators of the form A*δ(q) where A is an area and q is some quantity.

--- a/src/Operators/derivative_operators.jl
+++ b/src/Operators/derivative_operators.jl
@@ -16,7 +16,7 @@
 @inline ∂xᶠᵃᵃ(i, j, k, grid, f::F, args...) where F<:Function = δxᶠᵃᵃ(i, j, k, grid, f, args...) / Δx(i, j, k, grid)
 
 @inline ∂yᵃᶜᵃ(i, j, k, grid, f::F, args...) where F<:Function = δyᵃᶜᵃ(i, j, k, grid, f, args...) / Δy(i, j, k, grid)
-@inline ∂yᵃᶠᵃ(i, j, k, grid, f::F, args...) where T<:Function = δyᵃᶠᵃ(i, j, k, grid, f, args...) / Δy(i, j, k, grid)
+@inline ∂yᵃᶠᵃ(i, j, k, grid, f::F, args...) where F<:Function = δyᵃᶠᵃ(i, j, k, grid, f, args...) / Δy(i, j, k, grid)
 
 @inline ∂zᵃᵃᶜ(i, j, k, grid, f::F, args...) where F<:Function = δzᵃᵃᶜ(i, j, k, grid, f, args...) / ΔzF(i, j, k, grid)
 @inline ∂zᵃᵃᶠ(i, j, k, grid, f::F, args...) where F<:Function = δzᵃᵃᶠ(i, j, k, grid, f, args...) / ΔzC(i, j, k, grid)

--- a/src/Operators/derivative_operators.jl
+++ b/src/Operators/derivative_operators.jl
@@ -1,28 +1,15 @@
 #####
-##### Derivative operators
+##### Cartesian derivative operators
 #####
 
-@inline ∂xᶜᵃᵃ(i, j, k, grid, u) = δxᶜᵃᵃ(i, j, k, grid, u) / Δx(i, j, k, grid)
-@inline ∂xᶠᵃᵃ(i, j, k, grid, c) = δxᶠᵃᵃ(i, j, k, grid, c) / Δx(i, j, k, grid)
+@inline ∂xᶜᵃᵃ(i, j, k, grid, u, args...) = δxᶜᵃᵃ(i, j, k, grid, u, args...) / Δx(i, j, k, grid)
+@inline ∂xᶠᵃᵃ(i, j, k, grid, c, args...) = δxᶠᵃᵃ(i, j, k, grid, c, args...) / Δx(i, j, k, grid)
 
-@inline ∂yᵃᶜᵃ(i, j, k, grid, v) = δyᵃᶜᵃ(i, j, k, grid, v) / Δy(i, j, k, grid)
-@inline ∂yᵃᶠᵃ(i, j, k, grid, c) = δyᵃᶠᵃ(i, j, k, grid, c) / Δy(i, j, k, grid)
+@inline ∂yᵃᶜᵃ(i, j, k, grid, v, args...) = δyᵃᶜᵃ(i, j, k, grid, v, args...) / Δy(i, j, k, grid)
+@inline ∂yᵃᶠᵃ(i, j, k, grid, c, args...) = δyᵃᶠᵃ(i, j, k, grid, c, args...) / Δy(i, j, k, grid)
 
-@inline ∂zᵃᵃᶜ(i, j, k, grid, w) = δzᵃᵃᶜ(i, j, k, grid, w) / ΔzF(i, j, k, grid)
-@inline ∂zᵃᵃᶠ(i, j, k, grid, c) = δzᵃᵃᶠ(i, j, k, grid, c) / ΔzC(i, j, k, grid)
-
-#####
-##### Derivative operators acting on functions
-#####
-
-@inline ∂xᶜᵃᵃ(i, j, k, grid, f::F, args...) where F<:Function = (f(i+1, j, k, grid, args...) - f(i,   j, k, grid, args...)) / Δx(i, j, k, grid)
-@inline ∂xᶠᵃᵃ(i, j, k, grid, f::F, args...) where F<:Function = (f(i,   j, k, grid, args...) - f(i-1, j, k, grid, args...)) / Δx(i, j, k, grid)
-
-@inline ∂yᵃᶜᵃ(i, j, k, grid, f::F, args...) where F<:Function = (f(i, j+1, k, grid, args...) - f(i, j,   k, grid, args...)) / Δy(i, j, k, grid)
-@inline ∂yᵃᶠᵃ(i, j, k, grid, f::F, args...) where F<:Function = (f(i, j,   k, grid, args...) - f(i, j-1, k, grid, args...)) / Δy(i, j, k, grid)
-
-@inline ∂zᵃᵃᶜ(i, j, k, grid, f::F, args...) where F<:Function = (f(i, j, k+1, grid, args...) - f(i, j, k,   grid, args...)) / ΔzF(i, j, k, grid)
-@inline ∂zᵃᵃᶠ(i, j, k, grid, f::F, args...) where F<:Function = (f(i, j, k,   grid, args...) - f(i, j, k-1, grid, args...)) / ΔzC(i, j, k, grid)
+@inline ∂zᵃᵃᶜ(i, j, k, grid, w, args...) = δzᵃᵃᶜ(i, j, k, grid, w, args...) / ΔzF(i, j, k, grid)
+@inline ∂zᵃᵃᶠ(i, j, k, grid, c, args...) = δzᵃᵃᶠ(i, j, k, grid, c, args...) / ΔzC(i, j, k, grid)
 
 #####
 ##### Operators of the form A*δ(q) where A is an area and q is some quantity.
@@ -41,33 +28,24 @@
 ##### Second derivatives
 #####
 
-@inline ∂²xᶜᵃᵃ(i, j, k, grid, c) = ∂xᶜᵃᵃ(i, j, k, grid, ∂xᶠᵃᵃ, c)
-@inline ∂²xᶠᵃᵃ(i, j, k, grid, u) = ∂xᶠᵃᵃ(i, j, k, grid, ∂xᶜᵃᵃ, u)
+@inline ∂²xᶜᵃᵃ(i, j, k, grid, c, args...) = ∂xᶜᵃᵃ(i, j, k, grid, ∂xᶠᵃᵃ, c, args...)
+@inline ∂²xᶠᵃᵃ(i, j, k, grid, u, args...) = ∂xᶠᵃᵃ(i, j, k, grid, ∂xᶜᵃᵃ, u, args...)
 
-@inline ∂²yᵃᶜᵃ(i, j, k, grid, c) = ∂yᵃᶜᵃ(i, j, k, grid, ∂yᵃᶠᵃ, c)
-@inline ∂²yᵃᶠᵃ(i, j, k, grid, v) = ∂yᵃᶠᵃ(i, j, k, grid, ∂yᵃᶜᵃ, v)
+@inline ∂²yᵃᶜᵃ(i, j, k, grid, c, args...) = ∂yᵃᶜᵃ(i, j, k, grid, ∂yᵃᶠᵃ, c, args...)
+@inline ∂²yᵃᶠᵃ(i, j, k, grid, v, args...) = ∂yᵃᶠᵃ(i, j, k, grid, ∂yᵃᶜᵃ, v, args...)
 
-@inline ∂²zᵃᵃᶜ(i, j, k, grid, c) = ∂zᵃᵃᶜ(i, j, k, grid, ∂zᵃᵃᶠ, c)
-@inline ∂²zᵃᵃᶠ(i, j, k, grid, w) = ∂zᵃᵃᶠ(i, j, k, grid, ∂zᵃᵃᶜ, w)
-
-@inline ∂²xᶜᵃᵃ(i, j, k, grid, f::F, args...) where F<:Function = ∂xᶜᵃᵃ(i, j, k, grid, ∂xᶠᵃᵃ, f, args...)
-@inline ∂²xᶠᵃᵃ(i, j, k, grid, f::F, args...) where F<:Function = ∂xᶠᵃᵃ(i, j, k, grid, ∂xᶜᵃᵃ, f, args...)
-
-@inline ∂²yᵃᶜᵃ(i, j, k, grid, f::F, args...) where F<:Function = ∂yᵃᶜᵃ(i, j, k, grid, ∂yᵃᶠᵃ, f, args...)
-@inline ∂²yᵃᶠᵃ(i, j, k, grid, f::F, args...) where F<:Function = ∂yᵃᶠᵃ(i, j, k, grid, ∂yᵃᶜᵃ, f, args...)
-
-@inline ∂²zᵃᵃᶜ(i, j, k, grid, f::F, args...) where F<:Function = ∂zᵃᵃᶜ(i, j, k, grid, ∂zᵃᵃᶠ, f, args...)
-@inline ∂²zᵃᵃᶠ(i, j, k, grid, f::F, args...) where F<:Function = ∂zᵃᵃᶠ(i, j, k, grid, ∂zᵃᵃᶜ, f, args...)
+@inline ∂²zᵃᵃᶜ(i, j, k, grid, c, args...) = ∂zᵃᵃᶜ(i, j, k, grid, ∂zᵃᵃᶠ, c, args...)
+@inline ∂²zᵃᵃᶠ(i, j, k, grid, w, args...) = ∂zᵃᵃᶠ(i, j, k, grid, ∂zᵃᵃᶜ, w, args...)
 
 #####
 ##### Fourth derivatives
 #####
 
-@inline ∂⁴xᶜᵃᵃ(i, j, k, grid, c) = ∂²xᶜᵃᵃ(i, j, k, grid, ∂²xᶜᵃᵃ, c)
-@inline ∂⁴xᶠᵃᵃ(i, j, k, grid, u) = ∂²xᶠᵃᵃ(i, j, k, grid, ∂²xᶠᵃᵃ, u)
+@inline ∂⁴xᶜᵃᵃ(i, j, k, grid, c, args...) = ∂²xᶜᵃᵃ(i, j, k, grid, ∂²xᶜᵃᵃ, c, args...)
+@inline ∂⁴xᶠᵃᵃ(i, j, k, grid, u, args...) = ∂²xᶠᵃᵃ(i, j, k, grid, ∂²xᶠᵃᵃ, u, args...)
 
-@inline ∂⁴yᵃᶜᵃ(i, j, k, grid, c) = ∂²yᵃᶜᵃ(i, j, k, grid, ∂²yᵃᶜᵃ, c)
-@inline ∂⁴yᵃᶠᵃ(i, j, k, grid, v) = ∂²yᵃᶠᵃ(i, j, k, grid, ∂²yᵃᶠᵃ, v)
+@inline ∂⁴yᵃᶜᵃ(i, j, k, grid, c, args...) = ∂²yᵃᶜᵃ(i, j, k, grid, ∂²yᵃᶜᵃ, c, args...)
+@inline ∂⁴yᵃᶠᵃ(i, j, k, grid, v, args...) = ∂²yᵃᶠᵃ(i, j, k, grid, ∂²yᵃᶠᵃ, v, args...)
 
-@inline ∂⁴zᵃᵃᶜ(i, j, k, grid, c) = ∂²zᵃᵃᶜ(i, j, k, grid, ∂²zᵃᵃᶜ, c)
-@inline ∂⁴zᵃᵃᶠ(i, j, k, grid, w) = ∂²zᵃᵃᶠ(i, j, k, grid, ∂²zᵃᵃᶠ, w)
+@inline ∂⁴zᵃᵃᶜ(i, j, k, grid, c, args...) = ∂²zᵃᵃᶜ(i, j, k, grid, ∂²zᵃᵃᶜ, c, args...)
+@inline ∂⁴zᵃᵃᶠ(i, j, k, grid, w, args...) = ∂²zᵃᵃᶠ(i, j, k, grid, ∂²zᵃᵃᶠ, w, args...)

--- a/src/Operators/derivative_operators.jl
+++ b/src/Operators/derivative_operators.jl
@@ -1,5 +1,5 @@
 #####
-##### Cartesian derivative operators
+##### Rectilinear derivative operators
 #####
 
 @inline ∂xᶜᵃᵃ(i, j, k, grid, u, args...) = δxᶜᵃᵃ(i, j, k, grid, u, args...) / Δx(i, j, k, grid)
@@ -49,3 +49,19 @@
 
 @inline ∂⁴zᵃᵃᶜ(i, j, k, grid, c, args...) = ∂²zᵃᵃᶜ(i, j, k, grid, ∂²zᵃᵃᶜ, c, args...)
 @inline ∂⁴zᵃᵃᶠ(i, j, k, grid, w, args...) = ∂²zᵃᵃᶠ(i, j, k, grid, ∂²zᵃᵃᶠ, w, args...)
+
+#####
+##### Horizontally curvilinear derivative operators
+#####
+
+@inline ∂xᶜᶜᵃ(i, j, k, grid, u, args...) = δxᶜᵃᵃ(i, j, k, grid, u, args...) / Δxᶜᶜᵃ(i, j, k, grid)
+@inline ∂xᶜᶠᵃ(i, j, k, grid, ζ, args...) = δxᶜᵃᵃ(i, j, k, grid, ζ, args...) / Δxᶜᶠᵃ(i, j, k, grid)
+
+@inline ∂xᶠᶠᵃ(i, j, k, grid, v, args...) = δxᶠᵃᵃ(i, j, k, grid, v, args...) / Δxᶠᶠᵃ(i, j, k, grid)
+@inline ∂xᶠᶜᵃ(i, j, k, grid, c, args...) = δxᶠᵃᵃ(i, j, k, grid, c, args...) / Δxᶠᶜᵃ(i, j, k, grid)
+
+@inline ∂yᶜᶜᵃ(i, j, k, grid, v, args...) = δyᵃᶜᵃ(i, j, k, grid, v, args...) / Δyᶜᶜᵃ(i, j, k, grid)
+@inline ∂yᶠᶜᵃ(i, j, k, grid, ζ, args...) = δyᵃᶜᵃ(i, j, k, grid, ζ, args...) / Δyᶠᶜᵃ(i, j, k, grid)
+
+@inline ∂yᶠᶠᵃ(i, j, k, grid, u, args...) = δyᵃᶠᵃ(i, j, k, grid, u, args...) / Δyᶠᶠᵃ(i, j, k, grid)
+@inline ∂yᶜᶠᵃ(i, j, k, grid, c, args...) = δyᵃᶠᵃ(i, j, k, grid, c, args...) / Δyᶜᶠᵃ(i, j, k, grid)

--- a/src/Operators/difference_operators.jl
+++ b/src/Operators/difference_operators.jl
@@ -27,17 +27,6 @@ using Oceananigans.Grids: Flat
 @inline δzᵃᵃᶠ(i, j, k, grid, f::F, args...) where F<:Function = f(i, j, k,   grid, args...) - f(i, j, k-1, grid, args...)
 
 #####
-##### Operators that calculate A*q where A is an area and q is some quantity.
-##### Useful for defining flux difference operators and other flux operators.
-#####
-
-@inline Ax_ψᵃᵃᶠ(i, j, k, grid, u) = @inbounds Axᵃᵃᶠ(i, j, k, grid) * u[i, j, k]
-@inline Ax_ψᵃᵃᶜ(i, j, k, grid, c) = @inbounds Axᵃᵃᶜ(i, j, k, grid) * c[i, j, k]
-@inline Ay_ψᵃᵃᶠ(i, j, k, grid, v) = @inbounds Ayᵃᵃᶠ(i, j, k, grid) * v[i, j, k]
-@inline Ay_ψᵃᵃᶜ(i, j, k, grid, c) = @inbounds Ayᵃᵃᶜ(i, j, k, grid) * c[i, j, k]
-@inline Az_ψᵃᵃᵃ(i, j, k, grid, c) = @inbounds Azᵃᵃᵃ(i, j, k, grid) * c[i, j, k]
-
-#####
 ##### "Flux difference" operators of the form δ(A*f) where A is an area and f is an array.
 #####
 

--- a/src/Operators/field_metric_products.jl
+++ b/src/Operators/field_metric_products.jl
@@ -1,0 +1,21 @@
+#####
+##### Products between fields and grid lengths
+#####
+
+@inline Δx_uᶠᶜᵃ(i, j, k, grid, u) = @inbounds Δxᶠᶜᵃ(i, j, k, grid) * u[i, j, k]
+@inline Δx_vᶜᶠᵃ(i, j, k, grid, v) = @inbounds Δxᶜᶠᵃ(i, j, k, grid) * v[i, j, k]
+
+@inline Δy_uᶠᶜᵃ(i, j, k, grid, u) = @inbounds Δyᶠᶜᵃ(i, j, k, grid) * u[i, j, k]
+@inline Δy_vᶜᶠᵃ(i, j, k, grid, v) = @inbounds Δyᶜᶠᵃ(i, j, k, grid) * v[i, j, k]
+
+#####
+##### Products between fields and grid areas
+#####
+
+@inline Ax_ψᵃᵃᶠ(i, j, k, grid, u) = @inbounds Axᵃᵃᶠ(i, j, k, grid) * u[i, j, k]
+@inline Ax_ψᵃᵃᶜ(i, j, k, grid, c) = @inbounds Axᵃᵃᶜ(i, j, k, grid) * c[i, j, k]
+@inline Ay_ψᵃᵃᶠ(i, j, k, grid, v) = @inbounds Ayᵃᵃᶠ(i, j, k, grid) * v[i, j, k]
+@inline Ay_ψᵃᵃᶜ(i, j, k, grid, c) = @inbounds Ayᵃᵃᶜ(i, j, k, grid) * c[i, j, k]
+@inline Az_ψᵃᵃᵃ(i, j, k, grid, c) = @inbounds Azᵃᵃᵃ(i, j, k, grid) * c[i, j, k]
+
+

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -57,8 +57,8 @@ end
 @testset "Operators" begin
     @info "Testing operators..."
 
-    @testset "Regular grid spacings, areas, and volume operators"
-        @info "  Testing regular grid spacing, areas, and volume operators..."
+    @testset "Regular grid lengths, areas, and volume operators"
+        @info "  Testing regular grid lengths, areas, and volume operators..."
         grid = RegularCartesianGrid(size=(1, 1, 1), extent=(π, 2π, 3π))
 
         for δ in (Δx, Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ) 

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -57,6 +57,39 @@ end
 @testset "Operators" begin
     @info "Testing operators..."
 
+    @testset "Regular grid spacings, areas, and volume operators"
+        @info "  Testing regular grid spacing, areas, and volume operators..."
+        grid = RegularCartesianGrid(size=(1, 1, 1), extent=(π, 2π, 3π))
+
+        for δ in (Δx, Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ) 
+            @test δ(1, 1, 1, grid) == π
+        end
+
+        for δ in (Δy, Δyᶜᶜᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Δyᶠᶠᵃ) 
+            @test δ(1, 1, 1, grid) == 2π
+        end
+
+        for δ in (ΔzF, ΔzC)
+            @test δ(1, 1, 1, grid) == 3π
+        end
+
+        for A in (Axᵃᵃᶜ, Axᵃᵃᶠ)
+            @test A(1, 1, 1, grid) = 3 * π^2   
+        end
+
+        for A in (Ayᵃᵃᶜ, Ayᵃᵃᶠ)
+            @test A(1, 1, 1, grid) = 6 * π^2   
+        end
+
+        for A in (Azᵃᵃᵃ, Azᶠᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ)
+            @test A(1, 1, 1, grid) = 2 * π^2   
+        end
+
+        for V in (Vᵃᵃᶜ, Vᵃᵃᶠ)
+            @test V(1, 1, 1, grid) == 12 * π^3
+        end
+    end
+
     @testset "Function differentiation" begin
         @info "  Testing function differentiation..."
         @test test_function_differentiation()

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -57,37 +57,61 @@ end
 @testset "Operators" begin
     @info "Testing operators..."
 
-    @testset "Regular grid lengths, areas, and volume operators"
-        @info "  Testing regular grid lengths, areas, and volume operators..."
-        grid = RegularCartesianGrid(size=(1, 1, 1), extent=(π, 2π, 3π))
+    @testset "Grid lengths, areas, and volume operators" begin
+        @info "  Testing grid lengths, areas, and volume operators..."
 
-        for δ in (Δx, Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ) 
-            @test δ(1, 1, 1, grid) == π
+        FT = Float64
+        grid = RegularCartesianGrid(FT, size=(1, 1, 1), extent=(π, 2π, 3π))
+
+        @testset "Easterly lengths" begin
+            @info "    Testing easterly lengths..."
+            for δ in (Δx, Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ) 
+                @test δ(1, 1, 1, grid) == FT(π)
+            end
         end
 
-        for δ in (Δy, Δyᶜᶜᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Δyᶠᶠᵃ) 
-            @test δ(1, 1, 1, grid) == 2π
+        @testset "Westerly lengths" begin
+            @info "    Testing westerly lengths..."
+            for δ in (Δy, Δyᶜᶜᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Δyᶠᶠᵃ) 
+                @test δ(1, 1, 1, grid) == FT(2π)
+            end
         end
 
-        for δ in (ΔzF, ΔzC)
-            @test δ(1, 1, 1, grid) == 3π
+        @testset "Vertical lengths" begin
+            @info "    Testing vertical lengths..."
+            for δ in (ΔzF, ΔzC)
+                @test δ(1, 1, 1, grid) == FT(3π)
+            end
         end
 
-        for A in (Axᵃᵃᶜ, Axᵃᵃᶠ)
-            @test A(1, 1, 1, grid) = 3 * π^2   
+        @testset "East-normal areas in the yz-plane" begin
+            @info "    Testing areas with easterly normal in the yz-plane..."
+            for A in (Axᵃᵃᶜ, Axᵃᵃᶠ)
+                @test A(1, 1, 1, grid) == FT(6 * π^2)
+            end
         end
 
-        for A in (Ayᵃᵃᶜ, Ayᵃᵃᶠ)
-            @test A(1, 1, 1, grid) = 6 * π^2   
+        @testset "West-normal areas in the xz-plane" begin
+            @info "    Testing areas with westerly normal in the xz-plane..."
+            for A in (Ayᵃᵃᶜ, Ayᵃᵃᶠ)
+                @test A(1, 1, 1, grid) == FT(3 * π^2)
+            end
         end
 
-        for A in (Azᵃᵃᵃ, Azᶠᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ)
-            @test A(1, 1, 1, grid) = 2 * π^2   
+        @testset "Horizontal areas in the xy-plane" begin
+            @info "    Testing horizontal areas in the xy-plane..."
+            for A in (Azᵃᵃᵃ, Azᶠᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ)
+                @test A(1, 1, 1, grid) == FT(2 * π^2)
+            end
         end
 
-        for V in (Vᵃᵃᶜ, Vᵃᵃᶠ)
-            @test V(1, 1, 1, grid) == 12 * π^3
+        @testset "Volumes" begin
+            @info "    Testing volumes..."
+            for V in (Vᵃᵃᶜ, Vᵃᵃᶠ)
+                @test V(1, 1, 1, grid) == FT(6 * π^3)
+            end
         end
+
     end
 
     @testset "Function differentiation" begin


### PR DESCRIPTION
This PR adds horizontal grid spacing and gradient operators valid on curvilinear grids.

This means that a class of gradient operators will persist which are only valid on Rectilinear grids. To help prevent bugs associated with incorrectly applying these restricted operators to general grids, this PR also adds a new type `AbstractRectilinearGrid`.

Note: apparently we have been using the term "Cartesian" incorrectly, since ["Cartesian" only applies to coordinate systems with _unit_ areas and volumes](https://en.wikipedia.org/wiki/Regular_grid). So really we have a `RegularRectilinearGrid` and `VerticallyStretchedRectilinearGrid` (in the later case, horizontal regularity is implicit).