### PR TITLE
Update netcdf_output_writer.jl

### DIFF
--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -124,7 +124,7 @@ mutable struct NetCDFOutputWriter{D, O, T, S, A} <: AbstractOutputWriter
 end
 
 """
-function NetCDFOutputWriter(model, outputs; filepath, schedule
+    NetCDFOutputWriter(model, outputs; filepath, schedule
                                    array_type = Array{Float32},
                                  field_slicer = FieldSlicer(),
                             global_attributes = Dict(),


### PR DESCRIPTION
Closes #1275

I'm not sure how to verify if this works. I can't think of any other reason (other than `function` in the first line) why the docstrings would be weird though.