### PR TITLE
Correct pressure gradients for curvilinear grids in HydrostaticFreeSurfaceModel

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl
@@ -1,5 +1,5 @@
 using Oceananigans.Grids: AbstractGrid
-using Oceananigans.Operators: ∂xᶠᵃᵃ, ∂yᵃᶠᵃ
+using Oceananigans.Operators: ∂xᶠᶜᵃ, ∂yᶜᶠᵃ
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
 
 using Adapt
@@ -22,7 +22,7 @@ function FreeSurface(free_surface::ExplicitFreeSurface{Nothing}, arch, grid)
 end
 
 explicit_barotropic_pressure_x_gradient(i, j, k, grid, free_surface::ExplicitFreeSurface) =
-    free_surface.gravitational_acceleration * ∂xᶠᵃᵃ(i, j, k, grid, free_surface.η)
+    free_surface.gravitational_acceleration * ∂xᶠᶜᵃ(i, j, k, grid, free_surface.η)
 
 explicit_barotropic_pressure_y_gradient(i, j, k, grid, free_surface::ExplicitFreeSurface) =
-    free_surface.gravitational_acceleration * ∂yᵃᶠᵃ(i, j, k, grid, free_surface.η)
+    free_surface.gravitational_acceleration * ∂yᶜᶠᵃ(i, j, k, grid, free_surface.η)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
@@ -1,6 +1,7 @@
 using Oceananigans.Buoyancy
 using Oceananigans.Coriolis
 using Oceananigans.Operators
+using Oceananigans.Operators: ∂xᶠᶜᵃ, ∂yᶜᶠᵃ
 using Oceananigans.StokesDrift
 using Oceananigans.TurbulenceClosures: ∂ⱼ_2ν_Σ₁ⱼ, ∂ⱼ_2ν_Σ₂ⱼ, ∂ⱼ_2ν_Σ₃ⱼ, ∇_κ_∇c
 using Oceananigans.Advection: div_Uc
@@ -43,7 +44,7 @@ implicitly during time-stepping.
     return ( - U_dot_∇u(i, j, k, grid, advection, velocities)
              - explicit_barotropic_pressure_x_gradient(i, j, k, grid, free_surface)
              - x_f_cross_U(i, j, k, grid, coriolis, velocities)
-             - ∂xᶠᵃᵃ(i, j, k, grid, hydrostatic_pressure_anomaly)
+             - ∂xᶠᶜᵃ(i, j, k, grid, hydrostatic_pressure_anomaly)
              + ∂ⱼ_2ν_Σ₁ⱼ(i, j, k, grid, clock, closure, velocities, diffusivities)
              + forcings.u(i, j, k, grid, clock, merge(velocities, (η=free_surface.η,), tracers)))
 end
@@ -86,7 +87,7 @@ implicitly during time-stepping.
     return ( - U_dot_∇v(i, j, k, grid, advection, velocities)
              - explicit_barotropic_pressure_y_gradient(i, j, k, grid, free_surface)
              - y_f_cross_U(i, j, k, grid, coriolis, velocities)
-             - ∂yᵃᶠᵃ(i, j, k, grid, hydrostatic_pressure_anomaly)
+             - ∂yᶜᶠᵃ(i, j, k, grid, hydrostatic_pressure_anomaly)
              + ∂ⱼ_2ν_Σ₂ⱼ(i, j, k, grid, clock, closure, velocities, diffusivities)
              + forcings.v(i, j, k, grid, clock, merge(velocities, (η=free_surface.η,), tracers)))
 end


### PR DESCRIPTION
This PR updates the HydrostaticFreeSurfaceModel RHS kernel functions to use the correctly-located pressure gradient for curvilinear grids.