### PR TITLE
Bump v0.49.0 (as a checkpoint)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.48.0"
+version = "0.49.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
There have been 78 commits since the last release so I thought it would be good to put out a checkpoint release. Happy to close this PR if people think this is not necessary.

Release notes could say:

Checkpoint release including very experimental support for curvilinear grids, a vertically-stretched rectilinear grid, and a preconditioned conjugate-gradient solver.

(or nothing at all)

There should be no breaking changes.