### PR TITLE
Remove duplicate include

### DIFF
--- a/src/Solvers/Solvers.jl
+++ b/src/Solvers/Solvers.jl
@@ -39,7 +39,6 @@ include("plan_transforms.jl")
 include("fft_based_poisson_solver.jl")
 include("fourier_tridiagonal_poisson_solver.jl")
 include("preconditioned_conjugate_gradient_solver.jl")
-include("index_permutations.jl")
 include("solve_for_pressure.jl")
 
 PressureSolver(arch, grid::RegularCartesianGrid) = FFTBasedPoissonSolver(arch, grid)


### PR DESCRIPTION
I accidentally left a duplicate `include("index_permutations.jl")` when resolving some merge conflicts in PR #1348 which led to method redefinition errors. This PR should get rid of those errors.