### PR TITLE
Time step alignment and NetCDF output for `DateTime` and `TimeDate`

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -73,12 +73,6 @@ git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "0.3.4+0"
 
-[[CompoundPeriods]]
-deps = ["Dates"]
-git-tree-sha1 = "88b8763730e30994a0d6a13b3973ffdcd1a654fe"
-uuid = "a216cea6-0a8c-5945-ab87-5ade47210022"
-version = "0.4.1"
-
 [[Crayons]]
 git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
@@ -116,12 +110,6 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 git-tree-sha1 = "10407a39b87f29d47ebaca8edbc75d7c302ff93e"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 version = "0.1.3"
-
-[[EzXML]]
-deps = ["Printf", "XML2_jll"]
-git-tree-sha1 = "0fa3b52a04a4e210aeb1626def9c90df3ae65268"
-uuid = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
-version = "1.1.0"
 
 [[FFTW]]
 deps = ["AbstractFFTs", "FFTW_jll", "IntelOpenMP_jll", "Libdl", "LinearAlgebra", "MKL_jll", "Reexport"]
@@ -215,12 +203,6 @@ version = "1.9.0+3"
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
-[[Libiconv_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "8e924324b2e9275a51407a4e06deb3455b1e359f"
-uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.0+7"
-
 [[LinearAlgebra]]
 deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -252,12 +234,6 @@ version = "2.16.8+1"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-
-[[Mocking]]
-deps = ["ExprTools"]
-git-tree-sha1 = "916b850daad0d46b8c71f65f719c49957e9513ed"
-uuid = "78c3b35d-d492-501b-9361-3d52fe80e533"
-version = "0.7.1"
 
 [[NCDatasets]]
 deps = ["CFTime", "DataStructures", "Dates", "NetCDF_jll", "Printf"]
@@ -315,11 +291,6 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-
-[[RecipesBase]]
-git-tree-sha1 = "b3fb709f3c97bfc6e948be68beeecb55a0b340ae"
-uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "1.1.1"
 
 [[Reexport]]
 git-tree-sha1 = "57d8440b0c7d98fc4f889e478e80f268d534c9d5"
@@ -405,23 +376,11 @@ version = "1.3.2"
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[[TimeZones]]
-deps = ["Dates", "EzXML", "Mocking", "Pkg", "Printf", "RecipesBase", "Serialization", "Unicode"]
-git-tree-sha1 = "4ba8a9579a243400db412b50300cd61d7447e583"
-uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.5.3"
-
 [[TimerOutputs]]
 deps = ["Printf"]
 git-tree-sha1 = "3318281dd4121ecf9713ce1383b9ace7d7476fdd"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 version = "0.5.7"
-
-[[TimesDates]]
-deps = ["CompoundPeriods", "Dates", "TimeZones"]
-git-tree-sha1 = "b56fad6f36724a4261db450baa69074037846289"
-uuid = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
-version = "0.2.6"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]
@@ -435,12 +394,6 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
-[[XML2_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "be0db24f70aae7e2b89f2f3092e93b8606d659a6"
-uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.10+3"
 
 [[Zlib_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -73,6 +73,12 @@ git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "0.3.4+0"
 
+[[CompoundPeriods]]
+deps = ["Dates"]
+git-tree-sha1 = "88b8763730e30994a0d6a13b3973ffdcd1a654fe"
+uuid = "a216cea6-0a8c-5945-ab87-5ade47210022"
+version = "0.4.1"
+
 [[Crayons]]
 git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
@@ -110,6 +116,12 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 git-tree-sha1 = "10407a39b87f29d47ebaca8edbc75d7c302ff93e"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 version = "0.1.3"
+
+[[EzXML]]
+deps = ["Printf", "XML2_jll"]
+git-tree-sha1 = "0fa3b52a04a4e210aeb1626def9c90df3ae65268"
+uuid = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
+version = "1.1.0"
 
 [[FFTW]]
 deps = ["AbstractFFTs", "FFTW_jll", "IntelOpenMP_jll", "Libdl", "LinearAlgebra", "MKL_jll", "Reexport"]
@@ -203,6 +215,12 @@ version = "1.9.0+3"
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
+[[Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "8e924324b2e9275a51407a4e06deb3455b1e359f"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.16.0+7"
+
 [[LinearAlgebra]]
 deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -234,6 +252,12 @@ version = "2.16.8+1"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Mocking]]
+deps = ["ExprTools"]
+git-tree-sha1 = "916b850daad0d46b8c71f65f719c49957e9513ed"
+uuid = "78c3b35d-d492-501b-9361-3d52fe80e533"
+version = "0.7.1"
 
 [[NCDatasets]]
 deps = ["CFTime", "DataStructures", "Dates", "NetCDF_jll", "Printf"]
@@ -291,6 +315,11 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[RecipesBase]]
+git-tree-sha1 = "b3fb709f3c97bfc6e948be68beeecb55a0b340ae"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.1.1"
 
 [[Reexport]]
 git-tree-sha1 = "57d8440b0c7d98fc4f889e478e80f268d534c9d5"
@@ -376,11 +405,23 @@ version = "1.3.2"
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[TimeZones]]
+deps = ["Dates", "EzXML", "Mocking", "Pkg", "Printf", "RecipesBase", "Serialization", "Unicode"]
+git-tree-sha1 = "4ba8a9579a243400db412b50300cd61d7447e583"
+uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+version = "1.5.3"
+
 [[TimerOutputs]]
 deps = ["Printf"]
 git-tree-sha1 = "3318281dd4121ecf9713ce1383b9ace7d7476fdd"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 version = "0.5.7"
+
+[[TimesDates]]
+deps = ["CompoundPeriods", "Dates", "TimeZones"]
+git-tree-sha1 = "b56fad6f36724a4261db450baa69074037846289"
+uuid = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
+version = "0.2.6"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]
@@ -394,6 +435,12 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "be0db24f70aae7e2b89f2f3092e93b8606d659a6"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.9.10+3"
 
 [[Zlib_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [compat]
 Adapt = "^2, ^3"
@@ -40,7 +39,6 @@ OrderedCollections = "^1.1"
 SafeTestsets = "0.0.1"
 SeawaterPolynomials = "^0.2"
 StructArrays = "0.4, 0.5"
-TimesDates = "0.2"
 julia = "^1.5"
 
 [extras]
@@ -50,6 +48,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [targets]
-test = ["BenchmarkTools", "InteractiveUtils", "Plots", "Test", "TimerOutputs", "Coverage"]
+test = ["BenchmarkTools", "Coverage", "InteractiveUtils", "Plots", "Test", "TimerOutputs", "TimesDates"]

--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [compat]
 Adapt = "^2, ^3"
@@ -39,6 +40,7 @@ OrderedCollections = "^1.1"
 SafeTestsets = "0.0.1"
 SeawaterPolynomials = "^0.2"
 StructArrays = "0.4, 0.5"
+TimesDates = "0.2"
 julia = "^1.5"
 
 [extras]
@@ -46,10 +48,8 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [targets]
-test = ["BenchmarkTools", "InteractiveUtils", "Plots", "Test", "TimerOutputs", "TimesDates", "SeawaterPolynomials", "Coverage"]
+test = ["BenchmarkTools", "InteractiveUtils", "Plots", "Test", "TimerOutputs", "Coverage"]

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -1,3 +1,4 @@
+using Dates
 using NCDatasets
 
 using Oceananigans.Fields
@@ -324,8 +325,12 @@ function NetCDFOutputWriter(model, outputs; filepath, schedule,
         end
 
         # Creates an unlimited dimension "time"
+        time_attrib = model.clock.time isa Dates.AbstractTime ?
+            Dict("longname" => "Time", "units" => "seconds since 2000-01-01 00:00:00") :
+            Dict("longname" => "Time", "units" => "seconds")
+
         defDim(dataset, "time", Inf)
-        defVar(dataset, "time", typeof(model.clock.time), ("time",), attrib=default_dimension_attributes["time"])
+        defVar(dataset, "time", eltype(model.grid), ("time",), attrib=time_attrib)
 
         # Use default output attributes for known outputs if the user has not specified any.
         # Unknown outputs get an empty tuple (no output attributes).

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -3,7 +3,7 @@ using NCDatasets
 using Oceananigans.Fields
 using Oceananigans.Utils: show_schedule
 
-using Dates: now
+using Dates: AbstractTime, now
 using Oceananigans.Grids: topology, halo_size
 using Oceananigans.Utils: versioninfo_with_gpu, oceananigans_versioninfo
 using Oceananigans.TimeSteppers: float_or_date_time
@@ -324,11 +324,12 @@ function NetCDFOutputWriter(model, outputs; filepath, schedule,
                    compression=compression, attrib=default_dimension_attributes[dim_name])
         end
 
-        # Creates an unlimited dimension "time"
-        time_attrib = model.clock.time isa Dates.AbstractTime ?
+        # DateTime and TimeDate are both <: AbstractTime
+        time_attrib = model.clock.time isa AbstractTime ?
             Dict("longname" => "Time", "units" => "seconds since 2000-01-01 00:00:00") :
             Dict("longname" => "Time", "units" => "seconds")
 
+        # Creates an unlimited dimension "time"
         defDim(dataset, "time", Inf)
         defVar(dataset, "time", eltype(model.grid), ("time",), attrib=time_attrib)
 

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -1,4 +1,3 @@
-using Dates
 using NCDatasets
 
 using Oceananigans.Fields
@@ -7,6 +6,7 @@ using Oceananigans.Utils: show_schedule
 using Dates: now
 using Oceananigans.Grids: topology, halo_size
 using Oceananigans.Utils: versioninfo_with_gpu, oceananigans_versioninfo
+using Oceananigans.TimeSteppers: float_or_date_time
 
 dictify(outputs) = outputs
 dictify(outputs::NamedTuple) = Dict(string(k) => dictify(v) for (k, v) in zip(keys(outputs), values(outputs)))
@@ -420,7 +420,7 @@ function write_output!(ow::NetCDFOutputWriter, model)
     ds, verbose, filepath = ow.dataset, ow.verbose, ow.filepath
 
     time_index = length(ds["time"]) + 1
-    ds["time"][time_index] = model.clock.time
+    ds["time"][time_index] = float_or_date_time(model.clock.time)
 
     if verbose
         @info "Writing to NetCDF: $filepath..."

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -88,7 +88,7 @@ function aligned_time_step(sim)
     end
 
     # Align time step with simulation stop time
-    if tick_time(clock, Δt) > sim.stop_time
+    if next_time(clock, Δt) > sim.stop_time
         Δt = unit_time(sim.stop_time - clock.time)
     end
 

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -3,7 +3,7 @@ using Glob
 using Oceananigans.Utils: initialize_schedule!, align_time_step
 using Oceananigans.Fields: set!
 using Oceananigans.OutputWriters: WindowedTimeAverage, checkpoint_superprefix
-using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, RungeKutta3TimeStepper, update_state!
+using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, RungeKutta3TimeStepper, update_state!, tick_time, unit_time
 
 using Oceananigans: AbstractModel
 
@@ -88,8 +88,8 @@ function aligned_time_step(sim)
     end
 
     # Align time step with simulation stop time
-    if clock.time + Δt > sim.stop_time
-        Δt = sim.stop_time - clock.time
+    if tick_time(clock, Δt) > sim.stop_time
+        Δt = unit_time(sim.stop_time - clock.time)
     end
 
     return Δt

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -3,7 +3,7 @@ using Glob
 using Oceananigans.Utils: initialize_schedule!, align_time_step
 using Oceananigans.Fields: set!
 using Oceananigans.OutputWriters: WindowedTimeAverage, checkpoint_superprefix
-using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, RungeKutta3TimeStepper, update_state!, tick_time, unit_time
+using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, RungeKutta3TimeStepper, update_state!, next_time, unit_time
 
 using Oceananigans: AbstractModel
 

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -43,8 +43,8 @@ Base.show(io::IO, c::Clock{T}) where T =
                     ", iteration = ", c.iteration,
                         ", stage = ", c.stage)
 
-tick_time(clock, Δt) = clock.time + Δt
-tick_time(clock::Clock{<:AbstractTime}, Δt) = clock.time + Nanosecond(round(Int, 1e9 * Δt))
+next_time(clock, Δt) = clock.time + Δt
+next_time(clock::Clock{<:AbstractTime}, Δt) = clock.time + Nanosecond(round(Int, 1e9 * Δt))
 
 tick_time!(clock, Δt) = clock.time += Δt
 tick_time!(clock::Clock{<:AbstractTime}, Δt) = clock.time += Nanosecond(round(Int, 1e9 * Δt))

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -1,5 +1,5 @@
 using Adapt
-using Dates: AbstractTime, Nanosecond
+using Dates: AbstractTime, Nanosecond, Millisecond
 using Oceananigans.Utils: prettytime
 
 import Base: show
@@ -16,10 +16,10 @@ mutable struct Clock{T}
          time :: T
     iteration :: Int
         stage :: Int
-    
+
     """
         Clock{T}(time, iteration, stage=1)
-    
+
     Returns a `Clock` with time of type `T`, initialized to the first stage.
     """
     function Clock{T}(time, iteration=0, stage=1) where T
@@ -42,9 +42,15 @@ Base.show(io::IO, c::Clock{T}) where T =
                     ", iteration = ", c.iteration,
                         ", stage = ", c.stage)
 
+tick_time(clock, Δt) = clock.time + Δt
+tick_time(clock::Clock{<:AbstractTime}, Δt) = clock.time + Nanosecond(round(Int, 1e9 * Δt))
+
 tick_time!(clock, Δt) = clock.time += Δt
 tick_time!(clock::Clock{<:AbstractTime}, Δt) = clock.time += Nanosecond(round(Int, 1e9 * Δt))
-    
+
+unit_time(t) = t
+unit_time(t::Millisecond) = t.value / 1000
+
 function tick!(clock, Δt; stage=false)
 
     tick_time!(clock, Δt)

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -1,5 +1,6 @@
 using Adapt
-using Dates: AbstractTime, Nanosecond, Millisecond
+using Dates: AbstractTime, DateTime, Nanosecond, Millisecond
+using TimesDates: TimeDate
 using Oceananigans.Utils: prettytime
 
 import Base: show
@@ -48,9 +49,14 @@ tick_time(clock::Clock{<:AbstractTime}, Δt) = clock.time + Nanosecond(round(Int
 tick_time!(clock, Δt) = clock.time += Δt
 tick_time!(clock::Clock{<:AbstractTime}, Δt) = clock.time += Nanosecond(round(Int, 1e9 * Δt))
 
+# Convert the time to units of clock.time (assumed to be seconds if using DateTime or TimeDate).
 unit_time(t) = t
 unit_time(t::Millisecond) = t.value / 1000
 unit_time(t::Nanosecond) = t.value / 1_000_000_000
+
+# Convert to a base Julia type (a float or DateTime). Mainly used by NetCDFOutputWriter.
+float_or_date_time(t) = t
+float_or_date_time(t::TimeDate) = DateTime(t)
 
 function tick!(clock, Δt; stage=false)
 

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -1,6 +1,5 @@
 using Adapt
 using Dates: AbstractTime, DateTime, Nanosecond, Millisecond
-using TimesDates: TimeDate
 using Oceananigans.Utils: prettytime
 
 import Base: show
@@ -51,12 +50,12 @@ tick_time!(clock::Clock{<:AbstractTime}, Δt) = clock.time += Nanosecond(round(I
 
 # Convert the time to units of clock.time (assumed to be seconds if using DateTime or TimeDate).
 unit_time(t) = t
-unit_time(t::Millisecond) = t.value / 1000
+unit_time(t::Millisecond) = t.value / 1_000
 unit_time(t::Nanosecond) = t.value / 1_000_000_000
 
 # Convert to a base Julia type (a float or DateTime). Mainly used by NetCDFOutputWriter.
 float_or_date_time(t) = t
-float_or_date_time(t::TimeDate) = DateTime(t)
+float_or_date_time(t::AbstractTime) = DateTime(t)
 
 function tick!(clock, Δt; stage=false)
 

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -50,6 +50,7 @@ tick_time!(clock::Clock{<:AbstractTime}, Δt) = clock.time += Nanosecond(round(I
 
 unit_time(t) = t
 unit_time(t::Millisecond) = t.value / 1000
+unit_time(t::Nanosecond) = t.value / 1_000_000_000
 
 function tick!(clock, Δt; stage=false)
 

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -5,6 +5,7 @@ using Oceananigans.Diagnostics
 using Oceananigans.Fields
 using Oceananigans.OutputWriters
 
+using Dates: Millisecond
 using Oceananigans.BoundaryConditions: PBC, FBC, ZFBC, ContinuousBoundaryFunction
 using Oceananigans.TimeSteppers: update_state!
 

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -44,7 +44,7 @@ end
 #####
 
 function run_DateTime_netcdf_tests(arch)
-    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
+    grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
     clock = Clock(time=DateTime(2021, 1, 1))
     model = IncompressibleModel(architecture=arch, grid=grid, clock=clock)
 
@@ -75,7 +75,7 @@ function run_DateTime_netcdf_tests(arch)
 end
 
 function run_TimeDate_netcdf_tests(arch)
-    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
+    grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
     clock = Clock(time=TimeDate(2021, 1, 1))
     model = IncompressibleModel(architecture=arch, grid=grid, clock=clock)
 

--- a/test/test_simulations.jl
+++ b/test/test_simulations.jl
@@ -93,7 +93,7 @@ function run_basic_simulation_tests(arch, Δt)
 end
 
 function run_simulation_date_tests(arch, start_time, stop_time, Δt)
-    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
+    grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
 
     clock = Clock(time=start_time)
     model = IncompressibleModel(architecture=arch, grid=grid, clock=clock)

--- a/test/test_simulations.jl
+++ b/test/test_simulations.jl
@@ -2,98 +2,132 @@ using Oceananigans.Simulations:
     stop, iteration_limit_exceeded, stop_time_exceeded, wall_time_limit_exceeded,
     TimeStepWizard, update_Δt!
 
+function run_time_step_wizard_tests(arch)
+    grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
+    model = IncompressibleModel(architecture=arch, grid=grid)
+
+    Δx = grid.Δx
+    CFL = 0.45
+    u₀ = 7
+    Δt = 2.5
+
+    model.velocities.u[1, 1, 1] = u₀
+
+    wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0)
+    update_Δt!(wizard, model)
+    @test wizard.Δt ≈ CFL * Δx / u₀
+
+    wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0.75)
+    update_Δt!(wizard, model)
+    @test wizard.Δt ≈ 0.75Δt
+
+    wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0, min_Δt=1.99)
+    update_Δt!(wizard, model)
+    @test wizard.Δt ≈ 1.99
+
+    model.velocities.u[1, 1, 1] = u₀/100
+
+    wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=1.1, min_change=0)
+    update_Δt!(wizard, model)
+    @test wizard.Δt ≈ 1.1Δt
+
+    wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0, max_Δt=3.99)
+    update_Δt!(wizard, model)
+    @test wizard.Δt ≈ 3.99
+
+    return nothing
+end
+
+function run_basic_simulation_tests(arch, Δt)
+    grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
+    model = IncompressibleModel(architecture=arch, grid=grid)
+
+    model.clock.time = 0.0
+    model.clock.iteration = 0
+
+    simulation = Simulation(model, Δt=Δt, stop_iteration=1)
+
+    # Just make sure we can construct a simulation without any errors.
+    @test simulation isa Simulation
+
+    @test iteration_limit_exceeded(simulation) == false
+    @test stop(simulation) == false
+
+    run!(simulation)
+
+    # Just make sure run! executes without any errors.
+    @test simulation isa Simulation
+
+    # Some basic tests
+    @test iteration_limit_exceeded(simulation) == true
+    @test stop(simulation) == true
+
+    t = Δt isa Number ? 3 : 5
+    @test model.clock.time ≈ t
+    @test model.clock.iteration == 1
+    @test simulation.run_time > 0
+
+    @test stop_time_exceeded(simulation) == false
+    simulation.stop_time = 1e-12
+    @test stop_time_exceeded(simulation) == true
+
+    @test wall_time_limit_exceeded(simulation) == false
+    simulation.wall_time_limit = 1e-12
+    @test wall_time_limit_exceeded(simulation) == true
+
+    # Test that simulation stops at `stop_iteration`.
+    model = IncompressibleModel(architecture=arch, grid=grid)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=3, iteration_interval=88)
+    run!(simulation)
+
+    @test simulation.model.clock.iteration == 3
+
+    # Test that simulation stops at `stop_time`.
+    model = IncompressibleModel(architecture=arch, grid=grid)
+    simulation = Simulation(model, Δt=Δt, stop_time=20.20, iteration_interval=123)
+    run!(simulation)
+
+    @test simulation.model.clock.time ≈ 20.20
+
+    return nothing
+end
+
+function run_simulation_date_tests(arch, start_time, stop_time, Δt)
+    grid = RegularCartesianGrid(size=(1, 1, 1), extent=(1, 1, 1))
+
+    clock = Clock(time=start_time)
+    model = IncompressibleModel(architecture=arch, grid=grid, clock=clock)
+
+    simulation = Simulation(model, Δt=Δt, stop_time=stop_time)
+
+    @test model.clock.time == start_time
+    @test simulation.stop_time == stop_time
+
+    run!(simulation)
+
+    @test model.clock.time == stop_time
+    @test simulation.stop_time == stop_time
+
+    return nothing
+end
+
 @testset "Time step wizard" begin
     for arch in archs
         @info "Testing time step wizard [$(typeof(arch))]..."
-
-        grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
-        model = IncompressibleModel(architecture=arch, grid=grid)
-
-        Δx = grid.Δx
-        CFL = 0.45
-        u₀ = 7
-        Δt = 2.5
-
-        model.velocities.u[1, 1, 1] = u₀
-
-        wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0)
-        update_Δt!(wizard, model)
-        @test wizard.Δt ≈ CFL * Δx / u₀
-
-        wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0.75)
-        update_Δt!(wizard, model)
-        @test wizard.Δt ≈ 0.75Δt
-
-        wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0, min_Δt=1.99)
-        update_Δt!(wizard, model)
-        @test wizard.Δt ≈ 1.99
-
-        model.velocities.u[1, 1, 1] = u₀/100
-
-        wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=1.1, min_change=0)
-        update_Δt!(wizard, model)
-        @test wizard.Δt ≈ 1.1Δt
-
-        wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0, max_Δt=3.99)
-        update_Δt!(wizard, model)
-        @test wizard.Δt ≈ 3.99
+        run_time_step_wizard_tests(arch)
     end
 end
 
 @testset "Simulations" begin
     for arch in archs
         @info "Testing simulations [$(typeof(arch))]..."
-
-        grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
-        model = IncompressibleModel(architecture=arch, grid=grid)
-
         for Δt in (3, TimeStepWizard(Δt=5.0))
-            model.clock.time = 0.0
-            model.clock.iteration = 0
-
-            simulation = Simulation(model, Δt=Δt, stop_iteration=1)
-
-            # Just make sure we can construct a simulation without any errors.
-            @test simulation isa Simulation
-
-            @test iteration_limit_exceeded(simulation) == false
-            @test stop(simulation) == false
-
-            run!(simulation)
-
-            # Just make sure run! executes without any errors.
-            @test simulation isa Simulation
-
-            # Some basic tests
-            @test iteration_limit_exceeded(simulation) == true
-            @test stop(simulation) == true
-
-            t = Δt isa Number ? 3 : 5
-            @test model.clock.time ≈ t
-            @test model.clock.iteration == 1
-            @test simulation.run_time > 0
-
-            @test stop_time_exceeded(simulation) == false
-            simulation.stop_time = 1e-12
-            @test stop_time_exceeded(simulation) == true
-
-            @test wall_time_limit_exceeded(simulation) == false
-            simulation.wall_time_limit = 1e-12
-            @test wall_time_limit_exceeded(simulation) == true
-
-            # Test that simulation stops at `stop_iteration`.
-            model = IncompressibleModel(architecture=arch, grid=grid)
-            simulation = Simulation(model, Δt=Δt, stop_iteration=3, iteration_interval=88)
-            run!(simulation)
-
-            @test simulation.model.clock.iteration == 3
-
-            # Test that simulation stops at `stop_time`.
-            model = IncompressibleModel(architecture=arch, grid=grid)
-            simulation = Simulation(model, Δt=Δt, stop_time=20.20, iteration_interval=123)
-            run!(simulation)
-
-            @test simulation.model.clock.time ≈ 20.20
+            run_basic_simulation_tests(arch, Δt)
         end
+
+        @info "Testing simulations with DateTime [$(typeof(arch))]..."
+        run_simulation_date_tests(arch, 0.0, 1.0, 0.3)
+        run_simulation_date_tests(arch, DateTime(2020), DateTime(2021), 100days)
+        run_simulation_date_tests(arch, TimeDate(2020), TimeDate(2021), 100days)
     end
 end


### PR DESCRIPTION
This PR adds support for time step alignment and NetCDF output with `DateTime` (from `Base.Dates`) and `TimeDate` (from TimesDates.jl).

Confusing names but `DateTime` is a base Julia type, has millisecond accuracy, and is understood by NCDatasets.jl while `TimeDate` comes from TimesDates.jl, has nanosecond accuracy, and must be converted to a `DateTime` to be written to NetCDF by NCDatasets.jl.

Interestingly the way NetCDF stores dates and times is by storing a floating point value and some metadata describing it as e.g. "seconds since 2000-01-01 00:00:00". Could be minutes, hours, days, since 1900, etc.

Not sure if we'll need the nanosecond accuracy but millisecond accuracy can cause an error on the order of a day after ~100 million iterations which could matter if used to compare Oceananigans.jl against ocean reanalysis products?