### PR TITLE
Vertically stretched grids for all topologies on CPUs and GPUs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,6 +79,33 @@ steps:
     depends_on: "init_cpu"
 
 #####
+##### Solver tests
+#####
+
+  - label: "🦅 gpu solver tests"
+    env:
+      JULIA_DEPOT_PATH: "$SVERDRUP_HOME/.julia-$BUILDKITE_BUILD_NUMBER"
+      TEST_GROUP: "solvers"
+    commands:
+      - "$SVERDRUP_HOME/julia-$JULIA_VERSION/bin/julia -O0 --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: Oceananigans
+      architecture: GPU
+    depends_on: "init_gpu"
+
+  - label: "🕊️ cpu solver tests"
+    env:
+      JULIA_DEPOT_PATH: "$TARTARUS_HOME/.julia-$BUILDKITE_BUILD_NUMBER"
+      TEST_GROUP: "solvers"
+      CUDA_VISIBLE_DEVICES: "-1"
+    commands:
+      - "$TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia -O0 --color=yes --project -e 'using Pkg; Pkg.test()'"
+    agents:
+      queue: Oceananigans
+      architecture: CPU
+    depends_on: "init_cpu"
+
+#####
 ##### IncompressibleModel and time stepping (part 1)
 #####
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.50.0"
+version = "0.51.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -2,9 +2,9 @@
 
 [[AbstractFFTs]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "051c95d6836228d120f5f4b984dd5aba1624f716"
+git-tree-sha1 = "8ed9de2f1b1a9b1dee48582ad477c6e67b83eb2c"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "0.5.0"
+version = "1.0.0"
 
 [[AbstractTrees]]
 deps = ["Markdown"]
@@ -31,9 +31,9 @@ uuid = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
 version = "0.1.0"
 
 [[BSON]]
-git-tree-sha1 = "dd36d7cf3d185eeaaf64db902c15174b22f5dafb"
+git-tree-sha1 = "2878972c4bc17d9c8d26d48d9ef00fcfe1899e7a"
 uuid = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
-version = "0.2.6"
+version = "0.3.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -57,9 +57,9 @@ version = "2.4.1"
 
 [[CategoricalArrays]]
 deps = ["DataAPI", "Future", "JSON", "Missings", "Printf", "Statistics", "StructTypes", "Unicode"]
-git-tree-sha1 = "99809999c8ee01fa89498480b147f7394ea5450f"
+git-tree-sha1 = "dbfddfafb75fae5356e00529ce67454125935945"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.9.2"
+version = "0.9.3"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
@@ -125,9 +125,9 @@ version = "0.1.3"
 
 [[FFTW]]
 deps = ["AbstractFFTs", "FFTW_jll", "IntelOpenMP_jll", "Libdl", "LinearAlgebra", "MKL_jll", "Reexport"]
-git-tree-sha1 = "8fda0934cb99db617171f7296dc361f4d6fa5424"
+git-tree-sha1 = "1b48dbde42f307e48685fa9213d8b9f8c0d87594"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.3.0"
+version = "1.3.2"
 
 [[FFTW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -195,6 +195,12 @@ git-tree-sha1 = "b616937c31337576360cb9fb872ec7633af7b194"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
 version = "3.6.0"
 
+[[LazyArtifacts]]
+deps = ["Pkg"]
+git-tree-sha1 = "4bb5499a1fc437342ea9ab7e319ede5a457c0968"
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.3.0"
+
 [[LeftChildRightSiblingTrees]]
 deps = ["AbstractTrees"]
 git-tree-sha1 = "71be1eb5ad19cb4f61fa8c73395c0338fd092ae0"
@@ -216,10 +222,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MKL_jll]]
-deps = ["IntelOpenMP_jll", "Libdl", "Pkg"]
-git-tree-sha1 = "eb540ede3aabb8284cb482aa41d00d6ca850b1f8"
+deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
+git-tree-sha1 = "c253236b0ed414624b083e6b72bfe891fbd2c7af"
 uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
-version = "2020.2.254+0"
+version = "2021.1.1+1"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
@@ -247,9 +253,9 @@ uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 version = "0.7.14"
 
 [[OrderedCollections]]
-git-tree-sha1 = "d45739abcfc03b51f6a42712894a593f74c80a23"
+git-tree-sha1 = "4fa2ba51070ec13fcc7517db714445b4ab986bdf"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.3.3"
+version = "1.4.0"
 
 [[Parsers]]
 deps = ["Dates"]
@@ -349,9 +355,9 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[StructTypes]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "65a43f5218197bc7091b76bc273a5e323a1d7b0d"
+git-tree-sha1 = "d7f4287dbc1e590265f50ceda1b40ed2bb31bbbb"
 uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
-version = "1.2.3"
+version = "1.4.0"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions"]

--- a/benchmark/benchmark_fourier_tridiagonal_poisson_solver.jl
+++ b/benchmark/benchmark_fourier_tridiagonal_poisson_solver.jl
@@ -1,0 +1,49 @@
+using BenchmarkTools
+using CUDA
+using Oceananigans
+using Benchmarks
+
+using Oceananigans.Solvers
+
+# Benchmark function
+
+function benchmark_fourier_tridiagonal_poisson_solver(Arch, N, topo)
+    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), topology=topo, size=(N, N, N), x=(0, 1), y=(0, 1), zF=collect(0:N))
+    solver = FourierTridiagonalPoissonSolver(Arch(), grid)
+
+    solve_poisson_equation!(solver) # warmup
+
+    trial = @benchmark begin
+        @sync_gpu solve_poisson_equation!($solver)
+    end samples=10
+
+    return trial
+end
+
+# Benchmark parameters
+
+Architectures = has_cuda() ? [CPU, GPU] : [CPU]
+Ns = [256]
+PB = (Periodic, Bounded)
+Topologies = collect(Iterators.product(PB, PB, (Bounded,)))[:]
+
+# Run and summarize benchmarks
+
+suite = run_benchmarks(benchmark_fourier_tridiagonal_poisson_solver; Architectures, Ns, Topologies)
+
+df = benchmarks_dataframe(suite)
+sort!(df, [:Architectures, :Topologies, :Ns], by=(string, string, identity))
+benchmarks_pretty_table(df, title="Fourier-tridiagonal Poisson solver benchmarks")
+
+if GPU in Architectures
+    df = gpu_speedups_suite(suite) |> speedups_dataframe
+    sort!(df, [:Topologies, :Ns], by=(string, identity))
+    benchmarks_pretty_table(df, title="Fourier-tridiagonal Poisson solver CPU -> GPU speedup")
+end
+
+for Arch in Architectures
+    suite_arch = speedups_suite(suite[@tagged Arch], base_case=(Arch, Ns[1], (Periodic, Periodic, Bounded)))
+    df_arch = speedups_dataframe(suite_arch, slowdown=true)
+    sort!(df_arch, [:Topologies, :Ns], by=string)
+    benchmarks_pretty_table(df_arch, title="Fourier-tridiagonal Poisson solver relative performance ($Arch)")
+end

--- a/benchmark/benchmark_vertically_stretched_incompressible_model.jl
+++ b/benchmark/benchmark_vertically_stretched_incompressible_model.jl
@@ -6,7 +6,7 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_vertically_stretched_incompressible_model(Arch, FT, N)
-    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), topology=topo, size=(N, N, N), x=(0, 1), y=(0, 1), zF=collect(0:N))
+    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), size=(N, N, N), x=(0, 1), y=(0, 1), zF=collect(0:N))
     model = IncompressibleModel(architecture=Arch(), float_type=FT, grid=grid)
 
     time_step!(model, 1) # warmup
@@ -31,10 +31,10 @@ suite = run_benchmarks(benchmark_vertically_stretched_incompressible_model; Arch
 
 df = benchmarks_dataframe(suite)
 sort!(df, [:Architectures, :Float_types, :Ns], by=(string, string, identity))
-benchmarks_pretty_table(df, title="Incompressible model benchmarks")
+benchmarks_pretty_table(df, title="Vertically-stretched incompressible model benchmarks")
 
 if GPU in Architectures
     df_Δ = gpu_speedups_suite(suite) |> speedups_dataframe
     sort!(df_Δ, [:Float_types, :Ns], by=(string, identity))
-    benchmarks_pretty_table(df_Δ, title="Incompressible model CPU -> GPU speedup")
+    benchmarks_pretty_table(df_Δ, title="Vertically-stretched incompressible model CPU -> GPU speedup")
 end

--- a/benchmark/benchmark_vertically_stretched_incompressible_model.jl
+++ b/benchmark/benchmark_vertically_stretched_incompressible_model.jl
@@ -1,0 +1,40 @@
+using BenchmarkTools
+using CUDA
+using Oceananigans
+using Benchmarks
+
+# Benchmark function
+
+function benchmark_vertically_stretched_incompressible_model(Arch, FT, N)
+    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), topology=topo, size=(N, N, N), x=(0, 1), y=(0, 1), zF=collect(0:N))
+    model = IncompressibleModel(architecture=Arch(), float_type=FT, grid=grid)
+
+    time_step!(model, 1) # warmup
+
+    trial = @benchmark begin
+        @sync_gpu time_step!($model, 1)
+    end samples=10
+
+    return trial
+end
+
+# Benchmark parameters
+
+Architectures = has_cuda() ? [CPU, GPU] : [CPU]
+Float_types = [Float32, Float64]
+Ns = [32, 64, 128, 256]
+
+# Run and summarize benchmarks
+
+print_system_info()
+suite = run_benchmarks(benchmark_vertically_stretched_incompressible_model; Architectures, Float_types, Ns)
+
+df = benchmarks_dataframe(suite)
+sort!(df, [:Architectures, :Float_types, :Ns], by=(string, string, identity))
+benchmarks_pretty_table(df, title="Incompressible model benchmarks")
+
+if GPU in Architectures
+    df_Δ = gpu_speedups_suite(suite) |> speedups_dataframe
+    sort!(df_Δ, [:Float_types, :Ns], by=(string, identity))
+    benchmarks_pretty_table(df_Δ, title="Incompressible model CPU -> GPU speedup")
+end

--- a/src/Buoyancy/nonlinear_equation_of_state.jl
+++ b/src/Buoyancy/nonlinear_equation_of_state.jl
@@ -1,4 +1,6 @@
 using Oceananigans.Fields: AbstractField
+using Oceananigans.Grids: zF, zC
+using Oceananigans.Operators: Δzᵃᵃᶠ, Δzᵃᵃᶜ
 
 """ Return the geopotential height at `i, j, k` at cell centers. """
 @inline function Zᵃᵃᶜ(i, j, k, grid::AbstractGrid{FT}) where FT

--- a/src/Buoyancy/nonlinear_equation_of_state.jl
+++ b/src/Buoyancy/nonlinear_equation_of_state.jl
@@ -1,14 +1,14 @@
 using Oceananigans.Fields: AbstractField
 
 """ Return the geopotential height at `i, j, k` at cell centers. """
-@inline function Zᵃᵃᶜ(i, j, k, grid::AbstractGrid{FT}) where FT 
+@inline function Zᵃᵃᶜ(i, j, k, grid::AbstractGrid{FT}) where FT
     @inbounds begin
         if k < 1
-            return grid.zC[1] + (1 - k) * grid.Δz
+            return zC(1, grid) + (1 - k) * Δzᵃᵃᶠ(i, j, 1, grid)
         elseif k > grid.Nz
-            return grid.zC[grid.Nz] - (k - grid.Nz) * grid.Δz
+            return zC(grid.Nz, grid) - (k - grid.Nz) * Δzᵃᵃᶠ(i, j, grid.Nz, grid)
         else
-            return grid.zC[k]
+            return zC(k, grid)
         end
     end
 end
@@ -17,11 +17,11 @@ end
 @inline function Zᵃᵃᶠ(i, j, k, grid::AbstractGrid{FT}) where FT
     @inbounds begin
         if k < 1
-            return grid.zF[1] + (1 - k) * grid.Δz
+            return zF(1, grid) + (1 - k) * Δzᵃᵃᶜ(i, j, 1, grid)
         elseif k > grid.Nz + 1
-            return grid.zF[grid.Nz+1] - (k - grid.Nz + 1) * grid.Δz
+            return zF(grid.Nz + 1, grid) - (k - grid.Nz + 1) * Δzᵃᵃᶜ(i, j, k, grid)
         else
-            return grid.zF[k]
+            return zF(k, grid)
         end
     end
 end

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -8,14 +8,14 @@ export
     xnode, ynode, znode, xnodes, ynodes, znodes, nodes,
     xC, xF, yC, yF, zC, zF
 
-import Base: size, length, eltype, show
-
-import Oceananigans: short_show
+using Adapt
+using OffsetArrays
 
 using Oceananigans
 using Oceananigans.Architectures
 
-using OffsetArrays
+import Base: size, length, eltype, show
+import Oceananigans: short_show
 
 #####
 ##### Abstract types

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -86,6 +86,10 @@ Returns 1, which is the 'length' of a field along a reduced dimension.
 @inline y_domain(grid) = domain(topology(grid, 2), grid.Ny, grid.yF)
 @inline z_domain(grid) = domain(topology(grid, 3), grid.Nz, grid.zF)
 
+@inline x_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TX, grid.Nx, grid.xᶠᵃᵃ)
+@inline y_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TY, grid.Ny, grid.yᵃᶠᵃ)
+@inline z_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TZ, grid.Nz, grid.zᵃᵃᶠ)
+
 #####
 ##### << Indexing >>
 #####

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -86,10 +86,6 @@ Returns 1, which is the 'length' of a field along a reduced dimension.
 @inline y_domain(grid) = domain(topology(grid, 2), grid.Ny, grid.yF)
 @inline z_domain(grid) = domain(topology(grid, 3), grid.Nz, grid.zF)
 
-@inline x_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TX, grid.Nx, grid.xᶠᵃᵃ)
-@inline y_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TY, grid.Ny, grid.yᵃᶠᵃ)
-@inline z_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TZ, grid.Nz, grid.zᵃᵃᶠ)
-
 #####
 ##### << Indexing >>
 #####

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -46,8 +46,6 @@ function VerticallyStretchedRectilinearGrid(FT=Float64; architecture = CPU(),
                                               halo = (1, 1, 1),
                                           topology = (Periodic, Periodic, Bounded))
 
-    topology != (Periodic, Periodic, Bounded) && error("Only topology = (Periodic, Periodic, Bounded) is supported right now.")
-
     TX, TY, TZ = validate_topology(topology)
     size = validate_size(TX, TY, TZ, size)
     halo = validate_halo(TX, TY, TZ, halo)

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -180,7 +180,7 @@ function show(io::IO, g::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) whe
 end
 
 Adapt.adapt_structure(to, grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
-    VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}(
+    VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, typeof(grid.xF), typeof(Adapt.adapt(to, grid.zF))}(
         grid.Nx, grid.Ny, grid.Nz,
         grid.Hx, grid.Hy, grid.Hz,
         grid.Lx, grid.Ly, grid.Lz,

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -166,6 +166,10 @@ function with_halo(new_halo, old_grid::VerticallyStretchedRectilinearGrid)
     return old_grid
 end
 
+@inline x_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TX, grid.Nx, grid.xᶠᵃᵃ)
+@inline y_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TY, grid.Ny, grid.yᵃᶠᵃ)
+@inline z_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TZ, grid.Nz, grid.zᵃᵃᶠ)
+
 short_show(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
     "VerticallyStretchedRectilinearGrid{$FT, $TX, $TY, $TZ}(Nx=$(grid.Nx), Ny=$(grid.Ny), Nz=$(grid.Nz))"
 
@@ -178,7 +182,7 @@ function show(io::IO, g::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) whe
 end
 
 Adapt.adapt_structure(to, grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
-    VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, typeof(grid.xF), typeof(Adapt.adapt(to, grid.zF))}(
+    VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, typeof(grid.xᶠᵃᵃ), typeof(Adapt.adapt(to, grid.zᵃᵃᶠ))}(
         grid.Nx, grid.Ny, grid.Nz,
         grid.Hx, grid.Hy, grid.Hz,
         grid.Lx, grid.Ly, grid.Lz,

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -193,3 +193,16 @@ Adapt.adapt_structure(to, grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, T
         Adapt.adapt(to, grid.zᵃᵃᶜ),
         grid.xᶠᵃᵃ, grid.yᵃᶠᵃ,
         Adapt.adapt(to, grid.zᵃᵃᶠ))
+
+#####
+##### Should merge with grid_utils.jl at some point
+#####
+
+@inline xnode(::Type{Center}, i, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.xᶜᵃᵃ[i]
+@inline xnode(::Type{Face}, i, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.xᶠᵃᵃ[i]
+
+@inline ynode(::Type{Center}, j, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.yᵃᶜᵃ[j]
+@inline ynode(::Type{Face}, j, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.yᵃᵃᵃ[j]
+
+@inline znode(::Type{Center}, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.zᵃᵃᶜ[k]
+@inline znode(::Type{Face}, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.zᵃᵃᶠ[k]

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -9,36 +9,36 @@ topology `{TX, TY, TZ}`, and coordinate ranges of type `R` (where a range can be
 struct VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, R, A} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
 
     # Number of grid points in (x,y,z).
-     Nx :: Int
-     Ny :: Int
-     Nz :: Int
+    Nx :: Int
+    Ny :: Int
+    Nz :: Int
 
     # Halo size in (x,y,z).
-     Hx :: Int
-     Hy :: Int
-     Hz :: Int
+    Hx :: Int
+    Hy :: Int
+    Hz :: Int
 
     # Domain size [m].
-     Lx :: FT
-     Ly :: FT
-     Lz :: FT
+    Lx :: FT
+    Ly :: FT
+    Lz :: FT
 
     # Grid spacing [m].
-     Δx :: FT
-     Δy :: FT
-    ΔzF :: A
-    ΔzC :: A
+       Δx :: FT
+       Δy :: FT
+    Δzᵃᵃᶜ :: A
+    Δzᵃᵃᶠ :: A
 
     # Range of coordinates at the centers of the cells.
-     xC :: R
-     yC :: R
-     zC :: A
+    xᶜᵃᵃ :: R
+    yᵃᶜᵃ :: R
+    zᵃᵃᶜ :: A
 
     # Range of grid coordinates at the faces of the cells.
     # Note: there are Nx+1 faces in the x-dimension, Ny+1 in the y, and Nz+1 in the z.
-     xF :: R
-     yF :: R
-     zF :: A
+    xᶠᵃᵃ :: R
+    yᵃᶠᵃ :: R
+    zᵃᵃᶠ :: A
 end
 
 function VerticallyStretchedRectilinearGrid(FT=Float64; architecture = CPU(),
@@ -55,7 +55,7 @@ function VerticallyStretchedRectilinearGrid(FT=Float64; architecture = CPU(),
     Hx, Hy, Hz = halo
 
     # Initialize vertically-stretched arrays on CPU
-    Lz, zF, zC, ΔzF, ΔzC = generate_stretched_vertical_grid(FT, topology[3], Nz, Hz, zF)
+    Lz, zᵃᵃᶠ, zᵃᵃᶜ, Δzᵃᵃᶜ, Δzᵃᵃᶠ = generate_stretched_vertical_grid(FT, topology[3], Nz, Hz, zF)
 
     # Construct uniform horizontal grid
     Lh, Nh, Hh, X₁ = (Lx, Ly), size[1:2], halo[1:2], (x[1], y[1])
@@ -74,39 +74,39 @@ function VerticallyStretchedRectilinearGrid(FT=Float64; architecture = CPU(),
     TCx, TCy, TCz = total_length.(Center, topology, size, halo)
 
     # Include halo points in coordinate arrays
-    xF = range(xF₋, xF₊; length = TFx)
-    yF = range(yF₋, yF₊; length = TFy)
+    xᶠᵃᵃ = range(xF₋, xF₊; length = TFx)
+    yᵃᶠᵃ = range(yF₋, yF₊; length = TFy)
 
-    xC = range(xC₋, xC₊; length = TCx)
-    yC = range(yC₋, yC₊; length = TCy)
+    xᶜᵃᵃ = range(xC₋, xC₊; length = TCx)
+    yᵃᶜᵃ = range(yC₋, yC₊; length = TCy)
 
-    # Offset.
-     xC = OffsetArray(xC,  -Hx)
-     yC = OffsetArray(yC,  -Hy)
-     zC = OffsetArray(zC,  -Hz)
-    ΔzC = OffsetArray(ΔzC, -Hz)
+    xᶜᵃᵃ = OffsetArray(xᶜᵃᵃ,  -Hx)
+    yᵃᶜᵃ = OffsetArray(yᵃᶜᵃ,  -Hy)
+    zᵃᵃᶜ = OffsetArray(zᵃᵃᶜ,  -Hz)
 
-     xF = OffsetArray(xF,  -Hx)
-     yF = OffsetArray(yF,  -Hy)
-     zF = OffsetArray(zF,  -Hz)
-    ΔzF = OffsetArray(ΔzF, -Hz)
+    xᶠᵃᵃ = OffsetArray(xᶠᵃᵃ,  -Hx)
+    yᵃᶠᵃ = OffsetArray(yᵃᶠᵃ,  -Hy)
+    zᵃᵃᶠ = OffsetArray(zᵃᵃᶠ,  -Hz)
+
+    Δzᵃᵃᶠ = OffsetArray(Δzᵃᵃᶠ, -Hz)
+    Δzᵃᵃᶜ = OffsetArray(Δzᵃᵃᶜ, -Hz)
 
     # Needed for pressure solver solution to be divergence-free.
     # Will figure out why later...
-    ΔzC[Nz] = ΔzC[Nz-1]
+    Δzᵃᵃᶠ[Nz] = Δzᵃᵃᶠ[Nz-1]
 
     # Seems needed to avoid out-of-bounds error in viscous dissipation
-    # operator wanting to access ΔzC[Nz+2].
-    ΔzC = OffsetArray(cat(ΔzC[0], ΔzC..., ΔzC[Nz], dims=1), -Hz-1)
+    # operators wanting to access Δzᵃᵃᶠ[Nz+2].
+    Δzᵃᵃᶠ = OffsetArray(cat(Δzᵃᵃᶠ[0], Δzᵃᵃᶠ..., Δzᵃᵃᶠ[Nz], dims=1), -Hz-1)
 
     # Convert to appropriate array type for arch
-     zF = OffsetArray(arch_array(architecture,  zF.parent),  zF.offsets...)
-     zC = OffsetArray(arch_array(architecture,  zC.parent),  zC.offsets...)
-    ΔzF = OffsetArray(arch_array(architecture, ΔzF.parent), ΔzF.offsets...)
-    ΔzC = OffsetArray(arch_array(architecture, ΔzC.parent), ΔzC.offsets...)
+    zᵃᵃᶠ  = OffsetArray(arch_array(architecture,  zᵃᵃᶠ.parent),  zᵃᵃᶠ.offsets...)
+    zᵃᵃᶜ  = OffsetArray(arch_array(architecture,  zᵃᵃᶜ.parent),  zᵃᵃᶜ.offsets...)
+    Δzᵃᵃᶜ = OffsetArray(arch_array(architecture, Δzᵃᵃᶜ.parent), Δzᵃᵃᶜ.offsets...)
+    Δzᵃᵃᶠ = OffsetArray(arch_array(architecture, Δzᵃᵃᶠ.parent), Δzᵃᵃᶠ.offsets...)
 
-    return VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, typeof(xF), typeof(zF)}(
-        Nx, Ny, Nz, Hx, Hy, Hz, Lx, Ly, Lz, Δx, Δy, ΔzF, ΔzC, xC, yC, zC, xF, yF, zF)
+    return VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, typeof(xᶠᵃᵃ), typeof(zᵃᵃᶠ)}(
+        Nx, Ny, Nz, Hx, Hy, Hz, Lx, Ly, Lz, Δx, Δy, Δzᵃᵃᶜ, Δzᵃᵃᶠ, xᶜᵃᵃ, yᵃᶜᵃ, zᵃᵃᶜ, xᶠᵃᵃ, yᵃᶠᵃ, zᵃᵃᶠ)
 end
 
 #####
@@ -116,11 +116,11 @@ end
 get_z_face(z::Function, k) = z(k)
 get_z_face(z::AbstractVector, k) = z[k]
 
-lower_exterior_ΔzF(z_topo,          zFi, Hz) = [zFi[end - Hz + k] - zFi[end - Hz + k - 1] for k = 1:Hz]
-lower_exterior_ΔzF(::Type{Bounded}, zFi, Hz) = [zFi[2]  - zFi[1] for k = 1:Hz]
+lower_exterior_Δzᵃᵃᶜ(z_topo,          zFi, Hz) = [zFi[end - Hz + k] - zFi[end - Hz + k - 1] for k = 1:Hz]
+lower_exterior_Δzᵃᵃᶜ(::Type{Bounded}, zFi, Hz) = [zFi[2]  - zFi[1] for k = 1:Hz]
 
-upper_exterior_ΔzF(z_topo,          zFi, Hz) = [zFi[k + 1] - zFi[k] for k = 1:Hz]
-upper_exterior_ΔzF(::Type{Bounded}, zFi, Hz) = [zFi[end]   - zFi[end - 1] for k = 1:Hz]
+upper_exterior_Δzᵃᵃᶜ(z_topo,          zFi, Hz) = [zFi[k + 1] - zFi[k] for k = 1:Hz]
+upper_exterior_Δzᵃᵃᶜ(::Type{Bounded}, zFi, Hz) = [zFi[end]   - zFi[end - 1] for k = 1:Hz]
 
 function generate_stretched_vertical_grid(FT, z_topo, Nz, Hz, zF_generator)
 
@@ -134,8 +134,8 @@ function generate_stretched_vertical_grid(FT, z_topo, Nz, Hz, zF_generator)
     Lz = interior_zF[Nz+1] - interior_zF[1]
 
     # Build halo regions
-    ΔzF₋ = lower_exterior_ΔzF(z_topo, interior_zF, Hz)
-    ΔzF₊ = upper_exterior_ΔzF(z_topo, interior_zF, Hz)
+    ΔzF₋ = lower_exterior_Δzᵃᵃᶜ(z_topo, interior_zF, Hz)
+    ΔzF₊ = lower_exterior_Δzᵃᵃᶜ(z_topo, interior_zF, Hz)
 
     z¹, zᴺ⁺¹ = interior_zF[1], interior_zF[Nz+1]
 
@@ -183,9 +183,9 @@ Adapt.adapt_structure(to, grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, T
         grid.Hx, grid.Hy, grid.Hz,
         grid.Lx, grid.Ly, grid.Lz,
         grid.Δx, grid.Δy,
-        Adapt.adapt(to, grid.ΔzF),
-        Adapt.adapt(to, grid.ΔzC),
-        grid.xC, grid.yC,
-        Adapt.adapt(to, grid.zC),
-        grid.xF, grid.yF,
-        Adapt.adapt(to, grid.zF))
+        Adapt.adapt(to, grid.Δzᵃᵃᶜ),
+        Adapt.adapt(to, grid.Δzᵃᵃᶠ),
+        grid.xᶜᵃᵃ, grid.yᵃᶜᵃ,
+        Adapt.adapt(to, grid.zᵃᵃᶜ),
+        grid.xᶠᵃᵃ, grid.yᵃᶠᵃ,
+        Adapt.adapt(to, grid.zᵃᵃᶠ))

--- a/src/Operators/areas_and_volumes.jl
+++ b/src/Operators/areas_and_volumes.jl
@@ -38,16 +38,16 @@ The operators in this file fall into three categories:
 @inline Δy(i, j, k, grid::ARG) = grid.Δy
 
 @inline ΔzC(i, j, k, grid::RegularRectilinearGrid) = grid.Δz
-@inline ΔzC(i, j, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.ΔzC[k]
+@inline ΔzC(i, j, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.Δzᵃᵃᶠ[k]
 
 @inline ΔzF(i, j, k, grid::RegularRectilinearGrid) = grid.Δz
-@inline ΔzF(i, j, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.ΔzF[k]
+@inline ΔzF(i, j, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.Δzᵃᵃᶜ[k]
 
 @inline Δzᵃᵃᶠ(i, j, k, grid::RegularRectilinearGrid) = grid.Δz
-@inline Δzᵃᵃᶠ(i, j, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.ΔzC[k]
+@inline Δzᵃᵃᶠ(i, j, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.Δzᵃᵃᶠ[k]
 
 @inline Δzᵃᵃᶜ(i, j, k, grid::RegularRectilinearGrid) = grid.Δz
-@inline Δzᵃᵃᶜ(i, j, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.ΔzF[k]
+@inline Δzᵃᵃᶜ(i, j, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.Δzᵃᵃᶜ[k]
 
 #####
 ##### Areas for horiontally-regular algorithms

--- a/src/Solvers/fft_based_poisson_solver.jl
+++ b/src/Solvers/fft_based_poisson_solver.jl
@@ -63,7 +63,7 @@ function solve_poisson_equation!(solver::FFTBasedPoissonSolver)
     CUDA.@allowscalar ϕ[1, 1, 1] = 0
 
     # Apply backward transforms in order
-    [transform!(RHS, solver.buffer) for transform! in solver.transforms.backward]
+    [transform!(ϕ, solver.buffer) for transform! in solver.transforms.backward]
 
     return nothing
 end

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -1,8 +1,9 @@
-struct FourierTridiagonalPoissonSolver{A, G, B, S, T}
+struct FourierTridiagonalPoissonSolver{A, G, B, S, β, T}
                   architecture :: A
                           grid :: G
     batched_tridiagonal_solver :: B
                        storage :: S
+                        buffer :: β
                     transforms :: T
 end
 
@@ -52,7 +53,11 @@ function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
     rhs_storage = arch_array(arch, zeros(complex(eltype(grid)), size(grid)...))
     btsolver = BatchedTridiagonalSolver(arch, dl=ld, d=D, du=ud, f=rhs_storage, grid=grid)
 
-    return FourierTridiagonalPoissonSolver(arch, grid, btsolver, sol_storage, transforms)
+    # Need buffer for index permutations and transposes.
+    buffer_needed = arch isa GPU && Bounded in (TX, TY) ? true : false
+    buffer = buffer_needed ? similar(sol_storage) : nothing
+
+    return FourierTridiagonalPoissonSolver(arch, grid, btsolver, sol_storage, buffer, transforms)
 end
 
 function solve_poisson_equation!(solver::FourierTridiagonalPoissonSolver)
@@ -60,14 +65,20 @@ function solve_poisson_equation!(solver::FourierTridiagonalPoissonSolver)
     RHS = solver.batched_tridiagonal_solver.f
 
     # Apply forward transforms in order
-    [transform!(RHS, nothing) for transform! in solver.transforms.forward]
+    [transform!(RHS, solver.buffer) for transform! in solver.transforms.forward]
 
+    # Solve tridiagonal system of linear equations in z at every column.
     solve_batched_tridiagonal_system!(ϕ, solver.architecture, solver.batched_tridiagonal_solver)
 
     # Apply backward transforms in order
-    [transform!(ϕ, nothing) for transform! in solver.transforms.backward]
+    [transform!(ϕ, solver.buffer) for transform! in solver.transforms.backward]
 
     ϕ .= real.(ϕ)
+
+    # Set the volume mean of the solution to be zero.
+    # Solutions to Poisson's equation are only unique up to a constant (the global mean
+    # of the solution), so we need to pick a constant. We choose the constant to be zero
+    # so that the solution has zero-mean.
     ϕ .= ϕ .- mean(ϕ)
 
     return nothing

--- a/src/Solvers/plan_transforms.jl
+++ b/src/Solvers/plan_transforms.jl
@@ -1,15 +1,15 @@
-#=
-These functions return the transforms required to solve Poisson's equation with
-periodic boundary conditions or staggered Neumann boundary conditions.
-
-Fast Fourier transforms (FFTs) are used in the periodic dimensions and
-real-to-real discrete cosine transforms are used in the wall-bounded dimensions.
-Note that the DCT-II is used for the DCT and the DCT-III for the IDCT
-which correspond to REDFT10 and REDFT01 in FFTW.
-
-They operate on an array with the shape of `A`, which is needed to plan
-efficient transforms. `A` will be mutated.
-=#
+#####
+##### These functions return the transforms required to solve Poisson's equation with
+##### periodic boundary conditions or staggered Neumann boundary conditions.
+#####
+##### Fast Fourier transforms (FFTs) are used in the periodic dimensions and
+##### real-to-real discrete cosine transforms are used in the wall-bounded dimensions.
+##### Note that the DCT-II is used for the DCT and the DCT-III for the IDCT
+##### which correspond to REDFT10 and REDFT01 in FFTW.
+#####
+##### They operate on an array with the shape of `A`, which is needed to plan
+##### efficient transforms. `A` will be mutated.
+#####
 
 function plan_forward_transform(A::Array, ::Periodic, dims, planner_flag=FFTW.PATIENT)
     length(dims) == 0 && return nothing
@@ -47,7 +47,7 @@ function plan_backward_transform(A::CuArray, topo, dims, planner_flag)
     return CUDA.CUFFT.plan_ifft!(A, dims)
 end
 
-function plan_transforms(arch, grid, storage, planner_flag)
+function plan_transforms(arch, grid::RegularRectilinearGrid, storage, planner_flag)
     Nx, Ny, Nz = size(grid)
     topo = topology(grid)
     periodic_dims = findall(t -> t == Periodic, topo)
@@ -163,7 +163,7 @@ function plan_transforms(arch, grid, storage, planner_flag)
     else
         # This is the case where batching transforms is possible. It's always possible on the CPU
         # since FFTW is awesome so it includes all topologies on the CPU.
-        # 
+        #
         # On the GPU batching is possible when the topology is not one of non_batched_topologies
         # (where an FFT is needed along dimension 2), so it includes (Periodic, Periodic, Periodic),
         # (Periodic, Periodic, Bounded), and (Bounded, Periodic, Periodic).
@@ -183,6 +183,27 @@ function plan_transforms(arch, grid, storage, planner_flag)
             DiscreteTransform(backward_periodic_plan, Backward(), arch, grid, periodic_dims),
             DiscreteTransform(backward_bounded_plan, Backward(), arch, grid, bounded_dims)
         )
+    end
+
+    transforms = (forward = forward_transforms, backward = backward_transforms)
+
+    return transforms
+end
+
+function plan_transforms(arch, grid::VerticallyStretchedRectilinearGrid, storage, planner_flag)
+    Nx, Ny, Nz = size(grid)
+    TX, TY, TZ = topo = topology(grid)
+    periodic_dims = findall(t -> t == Periodic, topo)
+    bounded_dims = findall(t -> t == Bounded, topo)
+
+    if (TX, TY) == (Periodic, Periodic)
+        dims = (1, 2)
+
+        forward_plan = plan_forward_transform(storage, Periodic(), dims, planner_flag)
+        forward_transforms = (DiscreteTransform(forward_plan, Forward(), arch, grid, dims),)
+
+        backward_plan = plan_backward_transform(storage, Periodic(), dims, planner_flag)
+        backward_transforms = (DiscreteTransform(backward_plan, Backward(), arch, grid, dims),)
     end
 
     transforms = (forward = forward_transforms, backward = backward_transforms)

--- a/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
+++ b/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
@@ -19,7 +19,7 @@ function run_ocean_large_eddy_simulation_regression_test(arch, grid_type, closur
         grid = RegularRectilinearGrid(size=(N, N, N), extent=(L, L, L))
     elseif grid_type == :vertically_unstretched
         zF = range(-L, 0, length=N+1)
-        grid = VerticallyStretchedRectilinearGrid(size=(N, N, N), x=(0, L), y=(0, L), zF=zF)
+        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(N, N, N), x=(0, L), y=(0, L), zF=zF)
     end
 
     # Boundary conditions

--- a/test/regression_tests/rayleigh_benard_regression_test.jl
+++ b/test/regression_tests/rayleigh_benard_regression_test.jl
@@ -29,7 +29,7 @@ function run_rayleigh_benard_regression_test(arch, grid_type)
         grid = RegularRectilinearGrid(size=(Nx, Ny, Nz), extent=(Lx, Ly, Lz))
     elseif grid_type == :vertically_unstretched
         zF = range(-Lz, 0, length=Nz+1)
-        grid = VerticallyStretchedRectilinearGrid(size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), zF=zF)
+        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), zF=zF)
     end
 
     # Force salinity as a passive tracer (βS=0)

--- a/test/regression_tests/thermal_bubble_regression_test.jl
+++ b/test/regression_tests/thermal_bubble_regression_test.jl
@@ -7,7 +7,7 @@ function run_thermal_bubble_regression_test(arch, grid_type)
         grid = RegularRectilinearGrid(size=(Nx, Ny, Nz), extent=(Lx, Ly, Lz))
     elseif grid_type == :vertically_unstretched
         zF = range(-Lz, 0, length=Nz+1)
-        grid = VerticallyStretchedRectilinearGrid(size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), zF=zF)
+        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), zF=zF)
     end
 
     closure = IsotropicDiffusivity(ν=4e-2, κ=4e-2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,13 +86,18 @@ group = get(ENV, "TEST_GROUP", :all) |> Symbol
             include("test_averaged_field.jl")
             include("test_kernel_computed_field.jl")
             include("test_halo_regions.jl")
-            include("test_solvers.jl")
-            include("test_poisson_solvers.jl")
-            include("test_preconditioned_conjugate_gradient_solver.jl")
             include("test_coriolis.jl")
             include("test_buoyancy.jl")
             include("test_stokes_drift.jl")
             include("test_utils.jl")
+        end
+    end
+
+    if group == :solvers || group == :all
+        @testset "Solvers" begin
+            include("test_solvers.jl")
+            include("test_poisson_solvers.jl")
+            include("test_preconditioned_conjugate_gradient_solver.jl")
         end
     end
 

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -118,25 +118,25 @@ end
 function vertically_stretched_grid_properties_are_same_type(FT, arch)
     grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, 16), x=(0,1), y=(0,1), zF=collect(0:16))
     return all(isa.([grid.Lx, grid.Ly, grid.Lz, grid.Δx, grid.Δy], FT)) &&
-           all(eltype.([grid.ΔzF, grid.ΔzC, grid.xF, grid.yF, grid.zF, grid.xC, grid.yC, grid.zC]) .== FT)
+           all(eltype.([grid.Δzᵃᵃᶜ, grid.Δzᵃᵃᶠ, grid.xᶠᵃᵃ, grid.yᵃᶠᵃ, grid.zᵃᵃᶠ, grid.xᶜᵃᵃ, grid.yᵃᶜᵃ, grid.zᵃᵃᶜ]) .== FT)
 end
 
 function run_architecturally_correct_stretched_grid_tests(FT, arch, zF)
     grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, length(zF)-1), x=(0, 1), y=(0, 1), zF=zF)
 
     ArrayType = array_type(arch)
-    @test grid.zF  isa OffsetArray{FT, 1, <:ArrayType}
-    @test grid.zC  isa OffsetArray{FT, 1, <:ArrayType}
-    @test grid.ΔzF isa OffsetArray{FT, 1, <:ArrayType}
-    @test grid.ΔzC isa OffsetArray{FT, 1, <:ArrayType}
+    @test grid.zᵃᵃᶠ  isa OffsetArray{FT, 1, <:ArrayType}
+    @test grid.zᵃᵃᶜ  isa OffsetArray{FT, 1, <:ArrayType}
+    @test grid.Δzᵃᵃᶠ isa OffsetArray{FT, 1, <:ArrayType}
+    @test grid.Δzᵃᵃᶜ isa OffsetArray{FT, 1, <:ArrayType}
 
     return nothing
 end
 
 function run_correct_constant_grid_spacings_tests(FT, Nz)
     grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=collect(0:Nz))
-    @test all(grid.ΔzF .== 1)
-    @test all(grid.ΔzC .== 1)
+    @test all(grid.Δzᵃᵃᶜ .== 1)
+    @test all(grid.Δzᵃᵃᶠ .== 1)
     return nothing
 end
 
@@ -148,13 +148,13 @@ function run_correct_quadratic_grid_spacings_tests(FT, Nz)
     ΔzF(k) = k^2 - (k-1)^2
     ΔzC(k) = zC(k+1) - zC(k)
 
-    @test all(isapprox.(  grid.zF[1:Nz+1],  zF.(1:Nz+1) ))
-    @test all(isapprox.(  grid.zC[1:Nz],    zC.(1:Nz)   ))
-    @test all(isapprox.( grid.ΔzF[1:Nz],   ΔzF.(1:Nz)   ))
+    @test all(isapprox.(  grid.zᵃᵃᶠ[1:Nz+1],  zF.(1:Nz+1) ))
+    @test all(isapprox.(  grid.zᵃᵃᶜ[1:Nz],    zC.(1:Nz)   ))
+    @test all(isapprox.( grid.Δzᵃᵃᶜ[1:Nz],   ΔzF.(1:Nz)   ))
 
-    # Note that ΔzC[1] involves a halo point, which is not directly determined by
+    # Note that Δzᵃᵃᶠ[1] involves a halo point, which is not directly determined by
     # the user-supplied zF
-    @test all(isapprox.( grid.ΔzC[2:Nz-1], ΔzC.(2:Nz-1) ))
+    @test all(isapprox.( grid.Δzᵃᵃᶠ[2:Nz-1], ΔzC.(2:Nz-1) ))
 
     return nothing
 end
@@ -169,13 +169,13 @@ function run_correct_tanh_grid_spacings_tests(FT, Nz)
     ΔzF(k) = zF(k+1) - zF(k)
     ΔzC(k) = zC(k+1) - zC(k)
 
-    @test all(isapprox.(  grid.zF[1:Nz+1],  zF.(1:Nz+1) ))
-    @test all(isapprox.(  grid.zC[1:Nz],    zC.(1:Nz)   ))
-    @test all(isapprox.( grid.ΔzF[1:Nz],   ΔzF.(1:Nz)   ))
+    @test all(isapprox.(  grid.zᵃᵃᶠ[1:Nz+1],  zF.(1:Nz+1) ))
+    @test all(isapprox.(  grid.zᵃᵃᶜ[1:Nz],    zC.(1:Nz)   ))
+    @test all(isapprox.( grid.Δzᵃᵃᶜ[1:Nz],   ΔzF.(1:Nz)   ))
 
-    # Note that ΔzC[1] involves a halo point, which is not directly determined by
+    # Note that Δzᵃᵃᶠ[1] involves a halo point, which is not directly determined by
     # the user-supplied zF
-    @test all(isapprox.( grid.ΔzC[2:Nz-1], ΔzC.(2:Nz-1) ))
+    @test all(isapprox.( grid.Δzᵃᵃᶠ[2:Nz-1], ΔzC.(2:Nz-1) ))
 
    return nothing
 end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -121,9 +121,8 @@ function vertically_stretched_grid_properties_are_same_type(FT, arch)
            all(eltype.([grid.ΔzF, grid.ΔzC, grid.xF, grid.yF, grid.zF, grid.xC, grid.yC, grid.zC]) .== FT)
 end
 
-function run_architecturally_correct_stretched_grid_tests(FT, arch)
-    Nz = 10
-    grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=collect(0:Nz).^2)
+function run_architecturally_correct_stretched_grid_tests(FT, arch, zF)
+    grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, length(zF)-1), x=(0, 1), y=(0, 1), zF=zF)
 
     ArrayType = array_type(arch)
     @test grid.zF  isa OffsetArray{FT, 1, <:ArrayType}
@@ -340,7 +339,12 @@ end
             @testset "Vertically stretched rectilinear grid construction [$(typeof(arch)), $FT]" begin
                 @info "    Testing vertically stretched rectilinear grid construction [$(typeof(arch)), $FT]..."
                 @test vertically_stretched_grid_properties_are_same_type(FT, arch)
-                run_architecturally_correct_stretched_grid_tests(FT, arch)
+
+                zF1 = collect(0:10).^2
+                zF2 = [1, 3, 5, 10, 15, 33, 50]
+                for zF in [zF1, zF2]
+                    run_architecturally_correct_stretched_grid_tests(FT, arch, zF)
+                end
             end
 
             @testset "Vertically stretched rectilinear grid spacings [$(typeof(arch)), $FT]" begin

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -195,7 +195,6 @@ function flat_extent_regular_rectilinear_grid(FT; topology, size, extent)
     return grid.Lx, grid.Ly, grid.Lz
 end
 
-
 #####
 ##### Test the tests
 #####

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -154,15 +154,15 @@ function vertically_stretched_poisson_solver_correct_answer(FT, arch, Nx, Ny, zF
     ∇²ϕ = CenterField(FT, arch, vs_grid, p_bcs)
 
     R = random_divergence_free_source_term(FT, arch, vs_grid)
-    F = reshape(vs_grid.ΔzC[1:Nz], 1, 1, Nz) .* R  # RHS needs to be multiplied by ΔzC
+    F = CUDA.@allowscalar reshape(vs_grid.ΔzC[1:Nz], 1, 1, Nz) .* R  # RHS needs to be multiplied by ΔzC
     solver.batched_tridiagonal_solver.f .= F
 
     solve_poisson_equation!(solver)
 
-    interior(ϕ) .= real.(solver.storage)
+    CUDA.@allowscalar interior(ϕ) .= real.(solver.storage)
     compute_∇²!(∇²ϕ, ϕ, arch, vs_grid)
 
-    return interior(∇²ϕ) ≈ R
+    return CUDA.@allowscalar interior(∇²ϕ) ≈ R
 end
 
 #####

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -154,7 +154,7 @@ function vertically_stretched_poisson_solver_correct_answer(FT, arch, topo, Nx, 
     ∇²ϕ = CenterField(FT, arch, vs_grid, p_bcs)
 
     R = random_divergence_free_source_term(FT, arch, vs_grid)
-    F = CUDA.@allowscalar reshape(vs_grid.ΔzC[1:Nz], 1, 1, Nz) .* R  # RHS needs to be multiplied by ΔzC
+    F = CUDA.@allowscalar reshape(vs_grid.Δzᵃᵃᶠ[1:Nz], 1, 1, Nz) .* R  # RHS needs to be multiplied by ΔzC
     solver.batched_tridiagonal_solver.f .= F
 
     solve_poisson_equation!(solver)
@@ -235,6 +235,7 @@ topos = collect(Iterators.product(PB, PB, PB))[:]
 
             @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 8, 1:8)
             @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 7, 7, 1:7)
+            @test vertically_stretched_poisson_solver_correct_answer(Float32, arch, topo, 8, 8, 1:8)
 
             zF_even = [1, 2, 4, 7, 11, 16, 22, 29, 37]      # Nz = 8
             zF_odd  = [1, 2, 4, 7, 11, 16, 22, 29, 37, 51]  # Nz = 9
@@ -243,7 +244,6 @@ topos = collect(Iterators.product(PB, PB, PB))[:]
                 @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8,  8, zF)
                 @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 16, 8, zF)
                 @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 16, zF)
-                @test vertically_stretched_poisson_solver_correct_answer(Float32, arch, topo, 8,  8, zF)
                 @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 11, zF)
                 @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 5,  8, zF)
                 @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 7, 13, zF)

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -175,65 +175,79 @@ topos = collect(Iterators.product(PB, PB, PB))[:]
 @testset "Poisson solvers" begin
     @info "Testing Poisson solvers..."
 
-    for arch in archs
-        @testset "Poisson solver instantiation [$(typeof(arch))]" begin
-            @info "  Testing Poisson solver instantiation [$(typeof(arch))]..."
-            for FT in float_types
-                @test poisson_solver_instantiates(arch, FT, 32, 32, 32, FFTW.ESTIMATE)
-                @test poisson_solver_instantiates(arch, FT, 1,  32, 32, FFTW.MEASURE)
-                @test poisson_solver_instantiates(arch, FT, 32,  1, 32, FFTW.ESTIMATE)
-                @test poisson_solver_instantiates(arch, FT,  1,  1, 32, FFTW.MEASURE)
-            end
-        end
+    # for arch in archs
+    #     @testset "Poisson solver instantiation [$(typeof(arch))]" begin
+    #         @info "  Testing Poisson solver instantiation [$(typeof(arch))]..."
+    #         for FT in float_types
+    #             @test poisson_solver_instantiates(arch, FT, 32, 32, 32, FFTW.ESTIMATE)
+    #             @test poisson_solver_instantiates(arch, FT, 1,  32, 32, FFTW.MEASURE)
+    #             @test poisson_solver_instantiates(arch, FT, 32,  1, 32, FFTW.ESTIMATE)
+    #             @test poisson_solver_instantiates(arch, FT,  1,  1, 32, FFTW.MEASURE)
+    #         end
+    #     end
 
-        @testset "Divergence-free solution [$(typeof(arch))]" begin
-            @info "  Testing divergence-free solution [$(typeof(arch))]..."
+    #     @testset "Divergence-free solution [$(typeof(arch))]" begin
+    #         @info "  Testing divergence-free solution [$(typeof(arch))]..."
 
-            for topo in topos
-                @info "    Testing $topo topology on square grids [$(typeof(arch))]..."
-                for N in [7, 16]
-                    @test divergence_free_poisson_solution(arch, Float64, topo, N, N, N)
-                    @test divergence_free_poisson_solution(arch, Float64, topo, 1, N, N)
-                    @test divergence_free_poisson_solution(arch, Float64, topo, N, 1, N)
-                    @test divergence_free_poisson_solution(arch, Float64, topo, 1, 1, N)
-                end
-            end
+    #         for topo in topos
+    #             @info "    Testing $topo topology on square grids [$(typeof(arch))]..."
+    #             for N in [7, 16]
+    #                 @test divergence_free_poisson_solution(arch, Float64, topo, N, N, N)
+    #                 @test divergence_free_poisson_solution(arch, Float64, topo, 1, N, N)
+    #                 @test divergence_free_poisson_solution(arch, Float64, topo, N, 1, N)
+    #                 @test divergence_free_poisson_solution(arch, Float64, topo, 1, 1, N)
+    #             end
+    #         end
 
-            Ns = [11, 16]
-            for topo in topos
-                @info "    Testing $topo topology on rectangular grids with even and prime sizes [$(typeof(arch))]..."
-                for Nx in Ns, Ny in Ns, Nz in Ns
-                    @test divergence_free_poisson_solution(arch, Float64, topo, Nx, Ny, Nz)
-                end
-            end
+    #         Ns = [11, 16]
+    #         for topo in topos
+    #             @info "    Testing $topo topology on rectangular grids with even and prime sizes [$(typeof(arch))]..."
+    #             for Nx in Ns, Ny in Ns, Nz in Ns
+    #                 @test divergence_free_poisson_solution(arch, Float64, topo, Nx, Ny, Nz)
+    #             end
+    #         end
 
-            # Do a couple at Float32 (kinda expensive to repeat all tests...)
-            @test divergence_free_poisson_solution(arch, Float32, (Periodic, Bounded, Periodic), 16, 16, 16)
-            @test divergence_free_poisson_solution(arch, Float32, (Bounded, Periodic, Bounded), 7,  11, 13)
-        end
+    #         # Do a couple at Float32 (kinda expensive to repeat all tests...)
+    #         @test divergence_free_poisson_solution(arch, Float32, (Periodic, Bounded, Periodic), 16, 16, 16)
+    #         @test divergence_free_poisson_solution(arch, Float32, (Bounded, Periodic, Bounded), 7,  11, 13)
+    #     end
 
-        @testset "Convergence to analytic solution [$(typeof(arch))]" begin
-            @info "  Testing convergence to analytic solution [$(typeof(arch))]..."
-            for topo in topos
-                @test poisson_solver_convergence(arch, topo, 2^6, 2^7)
-                @test poisson_solver_convergence(arch, topo, 67, 131, mode=2)
-            end
-        end
-    end
+    #     @testset "Convergence to analytic solution [$(typeof(arch))]" begin
+    #         @info "  Testing convergence to analytic solution [$(typeof(arch))]..."
+    #         for topo in topos
+    #             @test poisson_solver_convergence(arch, topo, 2^6, 2^7)
+    #             @test poisson_solver_convergence(arch, topo, 67, 131, mode=2)
+    #         end
+    #     end
+    # end
 
-    vs_topos = [(Periodic, Periodic, Bounded)]
+    # Vertically stretched topologies to test.
+    vs_topos = [
+        (Periodic, Periodic, Bounded),
+        # (Periodic, Bounded,  Bounded),
+        # (Bounded,  Periodic, Bounded),
+        # (Bounded,  Bounded,  Bounded)
+    ]
 
     for arch in archs, topo in vs_topos
         @testset "Vertically stretched Poisson solver [FACR, $(typeof(arch)), $topo]" begin
             @info "  Testing vertically stretched Poisson solver [FACR, $(typeof(arch)), $topo]..."
 
             @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 8, 1:8)
+            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 7, 7, 1:7)
 
-            zF = [1, 2, 4, 7, 11, 16, 22, 29, 37]
-            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 8, zF)
-            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 16, 8, zF)
-            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 16, zF)
-            @test vertically_stretched_poisson_solver_correct_answer(Float32, arch, topo, 8, 8, zF)
+            zF_even = [1, 2, 4, 7, 11, 16, 22, 29, 37]      # Nz = 8
+            zF_odd  = [1, 2, 4, 7, 11, 16, 22, 29, 37, 51]  # Nz = 9
+
+            for zF in [zF_even, zF_odd]
+                @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8,  8, zF)
+                @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 16, 8, zF)
+                @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 16, zF)
+                @test vertically_stretched_poisson_solver_correct_answer(Float32, arch, topo, 8,  8, zF)
+                @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 11, zF)
+                @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 5,  8, zF)
+                @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 7, 13, zF)
+            end
         end
     end
 end

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -144,9 +144,9 @@ end
 ##### Vertically stretched Poisson solver
 #####
 
-function vertically_stretched_poisson_solver_correct_answer(FT, arch, Nx, Ny, zF)
+function vertically_stretched_poisson_solver_correct_answer(FT, arch, topo, Nx, Ny, zF)
     Nz = length(zF) - 1
-    vs_grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(Nx, Ny, Nz), x=(0, 1), y=(0, 1), zF=zF)
+    vs_grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, topology=topo, size=(Nx, Ny, Nz), x=(0, 1), y=(0, 1), zF=zF)
     solver = FourierTridiagonalPoissonSolver(arch, vs_grid)
 
     p_bcs = PressureBoundaryConditions(vs_grid)
@@ -221,17 +221,19 @@ topos = collect(Iterators.product(PB, PB, PB))[:]
         end
     end
 
-    for arch in archs
-        @testset "Vertically stretched Poisson solver [FACR, $(typeof(arch))]" begin
-            @info "  Testing vertically stretched Poisson solver [FACR, $(typeof(arch))]..."
+    vs_topos = [(Periodic, Periodic, Bounded)]
 
-            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, 8, 8, 1:8)
+    for arch in archs, topo in vs_topos
+        @testset "Vertically stretched Poisson solver [FACR, $(typeof(arch)), $topo]" begin
+            @info "  Testing vertically stretched Poisson solver [FACR, $(typeof(arch)), $topo]..."
+
+            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 8, 1:8)
 
             zF = [1, 2, 4, 7, 11, 16, 22, 29, 37]
-            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, 8, 8, zF)
-            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, 16, 8, zF)
-            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, 8, 16, zF)
-            @test vertically_stretched_poisson_solver_correct_answer(Float32, arch, 8, 8, zF)
+            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 8, zF)
+            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 16, 8, zF)
+            @test vertically_stretched_poisson_solver_correct_answer(Float64, arch, topo, 8, 16, zF)
+            @test vertically_stretched_poisson_solver_correct_answer(Float32, arch, topo, 8, 8, zF)
         end
     end
 end

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -175,58 +175,58 @@ topos = collect(Iterators.product(PB, PB, PB))[:]
 @testset "Poisson solvers" begin
     @info "Testing Poisson solvers..."
 
-    # for arch in archs
-    #     @testset "Poisson solver instantiation [$(typeof(arch))]" begin
-    #         @info "  Testing Poisson solver instantiation [$(typeof(arch))]..."
-    #         for FT in float_types
-    #             @test poisson_solver_instantiates(arch, FT, 32, 32, 32, FFTW.ESTIMATE)
-    #             @test poisson_solver_instantiates(arch, FT, 1,  32, 32, FFTW.MEASURE)
-    #             @test poisson_solver_instantiates(arch, FT, 32,  1, 32, FFTW.ESTIMATE)
-    #             @test poisson_solver_instantiates(arch, FT,  1,  1, 32, FFTW.MEASURE)
-    #         end
-    #     end
+    for arch in archs
+        @testset "Poisson solver instantiation [$(typeof(arch))]" begin
+            @info "  Testing Poisson solver instantiation [$(typeof(arch))]..."
+            for FT in float_types
+                @test poisson_solver_instantiates(arch, FT, 32, 32, 32, FFTW.ESTIMATE)
+                @test poisson_solver_instantiates(arch, FT, 1,  32, 32, FFTW.MEASURE)
+                @test poisson_solver_instantiates(arch, FT, 32,  1, 32, FFTW.ESTIMATE)
+                @test poisson_solver_instantiates(arch, FT,  1,  1, 32, FFTW.MEASURE)
+            end
+        end
 
-    #     @testset "Divergence-free solution [$(typeof(arch))]" begin
-    #         @info "  Testing divergence-free solution [$(typeof(arch))]..."
+        @testset "Divergence-free solution [$(typeof(arch))]" begin
+            @info "  Testing divergence-free solution [$(typeof(arch))]..."
 
-    #         for topo in topos
-    #             @info "    Testing $topo topology on square grids [$(typeof(arch))]..."
-    #             for N in [7, 16]
-    #                 @test divergence_free_poisson_solution(arch, Float64, topo, N, N, N)
-    #                 @test divergence_free_poisson_solution(arch, Float64, topo, 1, N, N)
-    #                 @test divergence_free_poisson_solution(arch, Float64, topo, N, 1, N)
-    #                 @test divergence_free_poisson_solution(arch, Float64, topo, 1, 1, N)
-    #             end
-    #         end
+            for topo in topos
+                @info "    Testing $topo topology on square grids [$(typeof(arch))]..."
+                for N in [7, 16]
+                    @test divergence_free_poisson_solution(arch, Float64, topo, N, N, N)
+                    @test divergence_free_poisson_solution(arch, Float64, topo, 1, N, N)
+                    @test divergence_free_poisson_solution(arch, Float64, topo, N, 1, N)
+                    @test divergence_free_poisson_solution(arch, Float64, topo, 1, 1, N)
+                end
+            end
 
-    #         Ns = [11, 16]
-    #         for topo in topos
-    #             @info "    Testing $topo topology on rectangular grids with even and prime sizes [$(typeof(arch))]..."
-    #             for Nx in Ns, Ny in Ns, Nz in Ns
-    #                 @test divergence_free_poisson_solution(arch, Float64, topo, Nx, Ny, Nz)
-    #             end
-    #         end
+            Ns = [11, 16]
+            for topo in topos
+                @info "    Testing $topo topology on rectangular grids with even and prime sizes [$(typeof(arch))]..."
+                for Nx in Ns, Ny in Ns, Nz in Ns
+                    @test divergence_free_poisson_solution(arch, Float64, topo, Nx, Ny, Nz)
+                end
+            end
 
-    #         # Do a couple at Float32 (kinda expensive to repeat all tests...)
-    #         @test divergence_free_poisson_solution(arch, Float32, (Periodic, Bounded, Periodic), 16, 16, 16)
-    #         @test divergence_free_poisson_solution(arch, Float32, (Bounded, Periodic, Bounded), 7,  11, 13)
-    #     end
+            # Do a couple at Float32 (kinda expensive to repeat all tests...)
+            @test divergence_free_poisson_solution(arch, Float32, (Periodic, Bounded, Periodic), 16, 16, 16)
+            @test divergence_free_poisson_solution(arch, Float32, (Bounded, Periodic, Bounded), 7,  11, 13)
+        end
 
-    #     @testset "Convergence to analytic solution [$(typeof(arch))]" begin
-    #         @info "  Testing convergence to analytic solution [$(typeof(arch))]..."
-    #         for topo in topos
-    #             @test poisson_solver_convergence(arch, topo, 2^6, 2^7)
-    #             @test poisson_solver_convergence(arch, topo, 67, 131, mode=2)
-    #         end
-    #     end
-    # end
+        @testset "Convergence to analytic solution [$(typeof(arch))]" begin
+            @info "  Testing convergence to analytic solution [$(typeof(arch))]..."
+            for topo in topos
+                @test poisson_solver_convergence(arch, topo, 2^6, 2^7)
+                @test poisson_solver_convergence(arch, topo, 67, 131, mode=2)
+            end
+        end
+    end
 
     # Vertically stretched topologies to test.
     vs_topos = [
         (Periodic, Periodic, Bounded),
-        # (Periodic, Bounded,  Bounded),
-        # (Bounded,  Periodic, Bounded),
-        # (Bounded,  Bounded,  Bounded)
+        (Periodic, Bounded,  Bounded),
+        (Bounded,  Periodic, Bounded),
+        (Bounded,  Bounded,  Bounded)
     ]
 
     for arch in archs, topo in vs_topos

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -60,8 +60,7 @@ include("regression_tests/ocean_large_eddy_simulation_regression_test.jl")
     @info "Running regression tests..."
 
     for arch in archs
-        grid_types = arch isa CPU ? [:regular, :vertically_unstretched] : [:regular]
-        for grid_type in grid_types
+        for grid_type in [:regular, :vertically_unstretched]
             @testset "Thermal bubble [$(typeof(arch)), $grid_type grid]" begin
                 @info "  Testing thermal bubble regression [$(typeof(arch)), $grid_type grid]"
                 run_thermal_bubble_regression_test(arch, grid_type)


### PR DESCRIPTION
This PR completes the implementation of the vertically stretched grid (PR #1348) by supporting all topologies on the CPU and GPU.

Well, I think a batched tridiagonal solve in the vertical is only possible if the z dimension is `Bounded`, so "all topologies" only includes the four topologies with z being `Bounded`.

If the stretched dimension is periodic, then I think the system of linear equations is no longer tridiagonal (you get non-zero elements in the corner of the matrix). I vaguely recall @christophernhill mentioning that there may be a way around this?

I'm also going to bump v0.51.0 in this PR.

X-Ref: #586