### PR TITLE
All-purpose `using Oceananigans`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.51.0"
+version = "0.52.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/model_setup/checkpointing.md
+++ b/docs/src/model_setup/checkpointing.md
@@ -14,7 +14,7 @@ end
 ```
 
 ```jldoctest
-julia> using Oceananigans.OutputWriters, Oceananigans.Utils
+julia> using Oceananigans, Oceananigans.Units
 
 julia> model = IncompressibleModel(grid=RegularRectilinearGrid(size=(16, 16, 16), extent=(1, 1, 1)));
 

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -45,7 +45,7 @@
 # We use a two-dimensional grid with 64² points and 1 m grid spacing:
 
 using Oceananigans
-using Oceananigans.Units
+using Oceananigans.Units: minutes, hour, hours, day
 
 grid = RegularRectilinearGrid(size=(64, 1, 64), extent=(64, 1, 64))
 
@@ -165,7 +165,7 @@ progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
                         prettytime(sim.model.clock.time),
                         prettytime(sim.Δt.Δt))
 
-simulation = Simulation(model, Δt=wizard, stop_time=24hour,
+simulation = Simulation(model, Δt=wizard, stop_time=24hours,
                         iteration_interval=20, progress=progress)
 
 # We add a basic `JLD2OutputWriter` that writes velocities and both

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -45,14 +45,13 @@
 # We use a two-dimensional grid with 64² points and 1 m grid spacing:
 
 using Oceananigans
+using Oceananigans.Units
 
 grid = RegularRectilinearGrid(size=(64, 1, 64), extent=(64, 1, 64))
 
 # ## Boundary conditions
 #
 # We impose a surface buoyancy flux that's initially constant and then decays to zero,
-
-using Oceananigans.Utils
 
 buoyancy_flux(x, y, t, p) = p.initial_buoyancy_flux * exp(-t^4 / (24 * p.shut_off_time^4))
 
@@ -115,13 +114,11 @@ plankton_dynamics = Forcing(growing_and_grazing, field_dependencies = :P,
                             parameters = plankton_dynamics_parameters)
 
 # ## The model
-# 
+#
 # The name "`P`" for phytoplankton is specified in the
-# constructor for `IncompressibleModel`. We additionally specify a fifth-order 
+# constructor for `IncompressibleModel`. We additionally specify a fifth-order
 # advection scheme, third-order Runge-Kutta time-stepping, isotropic viscosity and diffusivities,
 # and Coriolis forces appropriate for planktonic convection at mid-latitudes on Earth.
-
-using Oceananigans.Advection
 
 model = IncompressibleModel(
                    grid = grid,
@@ -147,7 +144,7 @@ stratification(z) = z < -mixed_layer_depth ? N² * z : - N² * mixed_layer_depth
 
 noise(z) = 1e-4 * N² * grid.Lz * randn() * exp(z / 4)
 
-initial_buoyancy(x, y, z) = stratification(z) + noise(z) 
+initial_buoyancy(x, y, z) = stratification(z) + noise(z)
 
 set!(model, b=initial_buoyancy, P=1)
 
@@ -167,14 +164,12 @@ progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
                         sim.model.clock.iteration,
                         prettytime(sim.model.clock.time),
                         prettytime(sim.Δt.Δt))
-                               
+
 simulation = Simulation(model, Δt=wizard, stop_time=24hour,
                         iteration_interval=20, progress=progress)
 
 # We add a basic `JLD2OutputWriter` that writes velocities and both
 # the two-dimensional and horizontally-averaged plankton concentration,
-
-using Oceananigans.OutputWriters, Oceananigans.Fields
 
 averaged_plankton = AveragedField(model.tracers.P, dims=(1, 2))
 
@@ -189,7 +184,7 @@ simulation.output_writers[:simple_output] =
                      force = true)
 
 # !!! info "Using multiple output writers"
-#     Because each output writer is associated with a single output `schedule`, 
+#     Because each output writer is associated with a single output `schedule`,
 #     it often makes sense to use _different_ output writers for different types of output.
 #     For example, reduced fields like `AveragedField` usually consume less disk space than
 #     two- or three-dimensional fields, and can thus be output more frequently without
@@ -221,8 +216,6 @@ nothing # hide
 
 # and then we construct the ``x, z`` grid,
 
-using Oceananigans.Grids: nodes
-
 xw, yw, zw = nodes(model.velocities.w)
 xp, yp, zp = nodes(model.tracers.P)
 nothing # hide
@@ -244,7 +237,7 @@ end
 anim = @animate for (i, iteration) in enumerate(iterations)
 
     @info "Plotting frame $i from iteration $iteration..."
-    
+
     t = file["timeseries/t/$iteration"]
     w = file["timeseries/w/$iteration"][:, 1, :]
     P = file["timeseries/plankton/$iteration"][:, 1, :]
@@ -301,7 +294,7 @@ anim = @animate for (i, iteration) in enumerate(iterations)
              markershape = :circle,
              color = :steelblue,
              markerstrokewidth = 0,
-             markersize = 15, 
+             markersize = 15,
              label = "Current buoyancy flux")
 
     layout = Plots.grid(2, 2, widths=(0.7, 0.3))

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -21,7 +21,7 @@
 #
 # The "Eady problem" simulates the baroclinic instability problem proposed by Eric Eady in
 # the classic paper
-# ["Long waves and cyclone waves," Tellus (1949)](https://www.tandfonline.com/doi/abs/10.3402/tellusa.v1i3.8507).
+# ["Long waves and cyclone waves," Tellus (1949)](https://doi.org/10.3402/tellusa.v1i3.8507).
 # The Eady problem is a simple, canonical model for the generation of mid-latitude
 # atmospheric storms and the ocean eddies that permeate the world sea.
 #
@@ -119,7 +119,7 @@
 
 using Printf
 using Oceananigans
-using Oceananigans.Units
+using Oceananigans.Units: hours, day, days
 
 # ## The grid
 #

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -17,7 +17,7 @@
 # pkg"add Oceananigans, JLD2, Plots"
 # ```
 
-# ## The Eady problem 
+# ## The Eady problem
 #
 # The "Eady problem" simulates the baroclinic instability problem proposed by Eric Eady in
 # the classic paper
@@ -32,11 +32,11 @@
 # is balanced by a bottom boundary condition that extracts momentum from turbulent motions
 # and serves as a crude model for the drag associated with an unresolved and small-scale
 # turbulent bottom boundary layer.
-# 
+#
 # ### The geostrophic basic state
 #
 # The geostrophic basic state in the Eady problem is represented by the streamfunction,
-# 
+#
 # ```math
 # ψ(y, z) = - α y (z + L_z) \, ,
 # ```
@@ -72,14 +72,14 @@
 # We model the effects of a turbulent bottom boundary layer on the eddy momentum budget
 # with quadratic bottom drag. A quadratic cottom drag is introduced by imposing a vertical flux
 # of horizontal momentum that removes momentum from the layer immediately above: in other words,
-# the flux is negative (downwards) when the velocity at the bottom boundary is positive, and 
+# the flux is negative (downwards) when the velocity at the bottom boundary is positive, and
 # positive (upwards) with the velocity at the bottom boundary is negative.
 # This drag term is "quadratic" because the rate at which momentum is removed is proportional
-# to ``\bm{u}_h |\bm{u}_h|``, where ``\bm{u}_h = u \bm{\hat{x}} + v \bm{\hat{y}}`` is 
+# to ``\bm{u}_h |\bm{u}_h|``, where ``\bm{u}_h = u \bm{\hat{x}} + v \bm{\hat{y}}`` is
 # the horizontal velocity.
 #
 # The ``x``-component of the quadratic bottom drag is thus
-# 
+#
 # ```math
 # \tau_{xz}(z=L_z) = - c^D u \sqrt{u^2 + v^2} \, ,
 # ```
@@ -87,7 +87,7 @@
 # while the ``y``-component is
 #
 # ```math
-# \tau_{yz}(z=L_z) = - c^D v \sqrt{u^2 + v^2} \, , 
+# \tau_{yz}(z=L_z) = - c^D v \sqrt{u^2 + v^2} \, ,
 # ```
 #
 # where ``c^D`` is a dimensionless drag coefficient and ``\tau_{xz}(z=L_z)`` and ``\tau_{yz}(z=L_z)``
@@ -99,14 +99,14 @@
 # to stabilize the Eady problem and can be idealized as modeling the effect of
 # turbulent mixing below the grid scale. For both tracers and velocities we use
 # a Laplacian vertical diffusivity ``κ_z ∂_z^2 c`` and a horizontal
-# hyperdiffusivity ``ϰ_h (∂_x^4 + ∂_y^4) c``. 
+# hyperdiffusivity ``ϰ_h (∂_x^4 + ∂_y^4) c``.
 #
 # ### Eady problem summary and parameters
 #
 # To summarize, the Eady problem parameters along with the values we use in this example are
 #
 # | Parameter name | Description | Value | Units |
-# |:--------------:|:-----------:|:-----:|:-----:| 
+# |:--------------:|:-----------:|:-----:|:-----:|
 # | ``f``          | Coriolis parameter | ``10^{-4}`` | ``\mathrm{s^{-1}}`` |
 # | ``N``          | Buoyancy frequency (square root of ``\partial_z B``) | ``10^{-3}`` | ``\mathrm{s^{-1}}`` |
 # | ``\alpha``     | Background vertical shear ``\partial_z U`` | ``10^{-3}`` | ``\mathrm{s^{-1}}`` |
@@ -114,14 +114,16 @@
 # | ``κ_z``        | Laplacian vertical diffusivity | ``10^{-2}`` | ``\mathrm{m^2 s^{-1}}`` |
 # | ``ϰ_h``        | Biharmonic horizontal diffusivity | ``10^{-2} \times \Delta x^4 / \mathrm{day}`` | ``\mathrm{m^4 s^{-1}}`` |
 #
-# We start off by importing `Oceananigans`, `Printf`, and some convenient utils
-# for specifying dimensional constants:
+# We start off by importing `Oceananigans`, `Printf`, and some convenient constants
+# for specifying dimensional units:
 
-using Oceananigans, Oceananigans.Utils, Printf
+using Printf
+using Oceananigans
+using Oceananigans.Units
 
 # ## The grid
 #
-# We use a three-dimensional grid with a depth of 4000 m and a 
+# We use a three-dimensional grid with a depth of 4000 m and a
 # horizontal extent of 1000 km, appropriate for mesoscale ocean dynamics
 # with characteristic scales of 50-200 km.
 
@@ -133,7 +135,7 @@ grid = RegularRectilinearGrid(size=(48, 48, 16), x=(0, 1e6), y=(0, 1e6), z=(-4e3
 # typical to mid-latitudes on Earth,
 
 coriolis = FPlane(f=1e-4) # [s⁻¹]
-                            
+
 # ## The background flow
 #
 # We build a `NamedTuple` of parameters that describe the background flow,
@@ -144,8 +146,6 @@ basic_state_parameters = ( α = 10 * coriolis.f, # s⁻¹, geostrophic shear
                           Lz = grid.Lz)         # m, ocean depth
 
 # and then construct the background fields ``U`` and ``B``
-
-using Oceananigans.Fields: BackgroundField
 
 ## Background fields are defined via functions of x, y, z, t, and optional parameters
 U(x, y, z, t, p) = + p.α * (z + p.Lz)
@@ -167,7 +167,7 @@ cᴰ = 1e-4 # quadratic drag coefficient
 drag_bc_u = BoundaryCondition(Flux, drag_u, field_dependencies=(:u, :v), parameters=cᴰ)
 drag_bc_v = BoundaryCondition(Flux, drag_v, field_dependencies=(:u, :v), parameters=cᴰ)
 
-u_bcs = UVelocityBoundaryConditions(grid, bottom = drag_bc_u) 
+u_bcs = UVelocityBoundaryConditions(grid, bottom = drag_bc_u)
 v_bcs = VVelocityBoundaryConditions(grid, bottom = drag_bc_v)
 
 # ## Turbulence closures
@@ -187,8 +187,6 @@ biharmonic_horizontal_diffusivity = AnisotropicBiharmonicDiffusivity(νh=κ₄h,
 #
 # We instantiate the model with the fifth-order WENO advection scheme, a 3rd order
 # Runge-Kutta time-stepping scheme, and a `BuoyancyTracer`.
-
-using Oceananigans.Advection: WENO5
 
 model = IncompressibleModel(
            architecture = CPU(),
@@ -247,7 +245,7 @@ nothing # hide
 # for numerical stability given the specified background flow, Coriolis
 # time scales, and diffusion time scales.
 
-## Calculate absolute limit on time-step using diffusivities and 
+## Calculate absolute limit on time-step using diffusivities and
 ## background velocity.
 Ū = basic_state_parameters.α * grid.Lz
 
@@ -258,8 +256,6 @@ wizard = TimeStepWizard(cfl=1.0, Δt=max_Δt, max_change=1.1, max_Δt=max_Δt)
 # ### A progress messenger
 #
 # We write a function that prints out a helpful progress message while the simulation runs.
-
-using Oceananigans.Diagnostics: AdvectiveCFL
 
 CFL = AdvectiveCFL(wizard)
 
@@ -288,9 +284,6 @@ simulation = Simulation(model, Δt = wizard, iteration_interval = 20,
 # we use `ComputedField`s to diagnose and output vertical vorticity and divergence.
 # Note that `ComputedField`s take "AbstractOperations" on `Field`s as input:
 
-using Oceananigans.AbstractOperations
-using Oceananigans.Fields: ComputedField
-
 u, v, w = model.velocities # unpack velocity `Field`s
 
 ## Vertical vorticity [s⁻¹]
@@ -300,10 +293,8 @@ u, v, w = model.velocities # unpack velocity `Field`s
 δ = ComputedField(-∂z(w))
 
 # With the vertical vorticity, `ζ`, and the horizontal divergence, `δ` in hand,
-# we create a `JLD2OutputWriter` that saves `ζ` and `δ` and add them to 
+# we create a `JLD2OutputWriter` that saves `ζ` and `δ` and add them to
 # `simulation`.
-
-using Oceananigans.OutputWriters: JLD2OutputWriter, TimeInterval
 
 simulation.output_writers[:fields] = JLD2OutputWriter(model, (ζ=ζ, δ=δ),
                                                       schedule = TimeInterval(4hours),
@@ -321,11 +312,9 @@ run!(simulation)
 # the iterations we ended up saving at, and ploting slices of the saved
 # fields. We prepare for animating the flow by creating coordinate arrays,
 # opening the file, building a vector of the iterations that we saved
-# data at, and defining a function for computing colorbar limits: 
+# data at, and defining a function for computing colorbar limits:
 
 using JLD2, Plots
-
-using Oceananigans.Grids: nodes
 
 ## Coordinate arrays
 xζ, yζ, zζ = nodes(ζ)
@@ -377,15 +366,15 @@ anim = @animate for (i, iter) in enumerate(iterations)
                  xlabel = "x (m)", ylabel = "y (m)",
                  aspectratio = 1,
                  linewidth = 0, color = :balance, legend = false)
-                 
+
     xz_kwargs = (xlims = (0, grid.Lx), ylims = (-grid.Lz, 0),
                  xlabel = "x (m)", ylabel = "z (m)",
                  aspectratio = grid.Lx / grid.Lz * 0.5,
                  linewidth = 0, color = :balance, legend = false)
-                 
+
     R_xy = contourf(xζ, yζ, surface_R'; clims=(-Rlim, Rlim), levels=Rlevels, xy_kwargs...)
     δ_xy = contourf(xδ, yδ, surface_δ'; clims=(-δlim, δlim), levels=δlevels, xy_kwargs...)
-    R_xz = contourf(xζ, zζ, slice_R'; clims=(-Rlim, Rlim), levels=Rlevels, xz_kwargs...) 
+    R_xz = contourf(xζ, zζ, slice_R'; clims=(-Rlim, Rlim), levels=Rlevels, xz_kwargs...)
     δ_xz = contourf(xδ, zδ, slice_δ'; clims=(-δlim, δlim), levels=δlevels, xz_kwargs...)
 
     plot(R_xy, δ_xy, R_xz, δ_xz,

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -3,8 +3,8 @@
 # This example demonstrates how to simulate the one-dimensional geostrophic adjustment of a
 # free surface using `Oceananigans.HydrostaticFreeSurfaceModel`. Here, we solve the hydrostatic
 # Boussinesq equations beneath a free surface with a small-amplitude about rest ``z = 0``,
-# with boundary conditions expanded around ``z = 0``, and free surface dynamics linearized under 
-# the assumption ``η / H \ll 1``, where ``η`` is the free surface displacement, and ``H`` is 
+# with boundary conditions expanded around ``z = 0``, and free surface dynamics linearized under
+# the assumption ``η / H \ll 1``, where ``η`` is the free surface displacement, and ``H`` is
 # the total depth of the fluid.
 #
 # ## Install dependencies
@@ -21,10 +21,10 @@
 # We use a one-dimensional domain of geophysical proportions,
 
 using Oceananigans
-using Oceananigans.Utils: kilometers
+using Oceananigans.Units
 
 grid = RegularRectilinearGrid(size = (128, 1, 1),
-                            x = (0, 1000kilometers), y = (0, 1), z = (-400, 0),
+                            x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),
                             topology = (Bounded, Periodic, Bounded))
 
 # and Coriolis parameter appropriate for the mid-latitudes on Earth,
@@ -34,8 +34,6 @@ coriolis = FPlane(f=1e-4)
 # ## Building a `HydrostaticFreeSurfaceModel`
 #
 # We use `grid` and `coriolis` to build a simple `HydrostaticFreeSurfaceModel`,
-
-using Oceananigans.Models: HydrostaticFreeSurfaceModel
 
 model = HydrostaticFreeSurfaceModel(grid=grid, coriolis=coriolis)
 
@@ -84,8 +82,6 @@ simulation = Simulation(model, Δt = 0.1 * wave_propagation_time_scale, stop_ite
 
 output_fields = merge(model.velocities, (η=model.free_surface.η,))
 
-using Oceananigans.OutputWriters: JLD2OutputWriter, IterationInterval
-
 simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
                                                       schedule = IterationInterval(10),
                                                       prefix = "geostrophic_adjustment",
@@ -95,8 +91,7 @@ run!(simulation)
 
 # ## Visualizing the results
 
-using JLD2, Plots, Printf, Oceananigans.Grids
-using Oceananigans.Utils: hours
+using JLD2, Plots, Printf
 
 xη = xw = xv = xnodes(model.free_surface.η)
 xu = xnodes(model.velocities.u)
@@ -116,7 +111,7 @@ anim = @animate for (i, iter) in enumerate(iterations)
 
     v_plot = plot(xv / kilometers, v, linewidth = 2, title = titlestr,
                   label = "", xlabel = "x (km)", ylabel = "v (m s⁻¹)", ylims = (-U, U))
-                  
+
     u_plot = plot(xu / kilometers, u, linewidth = 2,
                   label = "", xlabel = "x (km)", ylabel = "u (m s⁻¹)", ylims = (-2e-3, 2e-3))
 

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -21,7 +21,7 @@
 # We use a one-dimensional domain of geophysical proportions,
 
 using Oceananigans
-using Oceananigans.Units: hours
+using Oceananigans.Units: hours, meters, kilometers
 
 grid = RegularRectilinearGrid(size = (128, 1, 1),
                             x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -21,7 +21,7 @@
 # We use a one-dimensional domain of geophysical proportions,
 
 using Oceananigans
-using Oceananigans.Units
+using Oceananigans.Units: hours
 
 grid = RegularRectilinearGrid(size = (128, 1, 1),
                             x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -40,8 +40,6 @@ coriolis = FPlane(f=0.2)
 # and `N` is the "buoyancy frequency". This means that the modeled buoyancy field
 # perturbs the basic state `B(z)`.
 
-using Oceananigans.Fields: BackgroundField
-
 ## Background fields are functions of `x, y, z, t`, and optional parameters.
 ## Here we have one parameter, the buoyancy frequency
 B_func(x, y, z, t, N) = N^2 * z
@@ -55,11 +53,9 @@ B = BackgroundField(B_func, parameters=N)
 # We add a small amount of `IsotropicDiffusivity` to keep the model stable
 # during time-stepping, and specify that we're using a single tracer called
 # `b` that we identify as buoyancy by setting `buoyancy=BuoyancyTracer()`.
-  
-using Oceananigans.Advection
 
 model = IncompressibleModel(
-                 grid = grid, 
+                 grid = grid,
             advection = CenteredFourthOrder(),
           timestepper = :RungeKutta3,
               closure = IsotropicDiffusivity(ν=1e-6, κ=1e-6),
@@ -94,7 +90,7 @@ f = coriolis.f
 ω = sqrt(ω²)
 nothing # hide
 
-# We define a Gaussian envelope for the wave packet so that we can 
+# We define a Gaussian envelope for the wave packet so that we can
 # observe wave propagation.
 
 ## Some Gaussian parameters
@@ -127,10 +123,8 @@ set!(model, u=u₀, v=v₀, w=w₀, b=b₀)
 # We're ready to release the packet. We build a simulation with a constant time-step,
 
 simulation = Simulation(model, Δt = 0.1 * 2π/ω, stop_iteration = 15)
-                        
-# and add an output writer that saves the vertical velocity field every two iterations:
 
-using Oceananigans.OutputWriters: JLD2OutputWriter, IterationInterval
+# and add an output writer that saves the vertical velocity field every two iterations:
 
 simulation.output_writers[:velocities] = JLD2OutputWriter(model, model.velocities,
                                                           schedule = IterationInterval(1),
@@ -146,7 +140,7 @@ run!(simulation)
 # To visualize the solution, we load snapshots of the data and use it to make contour
 # plots of vertical velocity.
 
-using JLD2, Printf, Plots, Oceananigans.Grids
+using JLD2, Printf, Plots
 
 # We use coordinate arrays appropriate for the vertical velocity field,
 

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -31,8 +31,6 @@ grid = RegularRectilinearGrid(size=(64, 1, 64), x=(-5, 5), y=(0, 1), z=(-5, 5),
 #
 # and the width of the stratification layer, ``h``.
 
-using Oceananigans.Fields
-
 shear_flow(x, y, z, t) = tanh(z)
 
 stratification(x, y, z, t, p) = p.h * p.Ri * tanh(z / p.h)
@@ -44,7 +42,7 @@ B = BackgroundField(stratification, parameters=(Ri=0.1, h=1/4))
 # Our basic state thus has a thin layer of stratification in the center of
 # the channel, embedded within a thicker shear layer surrounded by unstratified fluid.
 
-using Plots, Oceananigans.Grids
+using Plots
 
 zF = znodes(Face, grid)
 zC = znodes(Center, grid)
@@ -61,9 +59,9 @@ Ri_plot = plot(@. Ri * sech(zF / h)^2 / sech(zF)^2, zF; xlabel="Ri(z)", color=:b
 
 plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 
-# In unstable flows it is often useful to determine the dominant spatial structure of the 
-# instability and the growth rate at which the instability grows. If the simulation idealizes a physical flow, this can be used to make 
-# predictions as to what should develop and how quickly.  Since these instabilities are often attributed to a linear instability, 
+# In unstable flows it is often useful to determine the dominant spatial structure of the
+# instability and the growth rate at which the instability grows. If the simulation idealizes a physical flow, this can be used to make
+# predictions as to what should develop and how quickly.  Since these instabilities are often attributed to a linear instability,
 # we can determine information about the structure and the growth rate of the instability by analyzing the linear operator
 # that governs small perturbations about a base state, or by solving for the linear dynamics.
 
@@ -73,15 +71,15 @@ plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 
 # # Linear Instabilities
 #
-# The base state ``U(z)``, ``B(z)`` is a solution of the inviscid equations of motion. Whether the base state is 
-# stable or not is determined by whether small perturbations about this base state grow or decay. To formalize this, 
+# The base state ``U(z)``, ``B(z)`` is a solution of the inviscid equations of motion. Whether the base state is
+# stable or not is determined by whether small perturbations about this base state grow or decay. To formalize this,
 # we study the linearized dynamics satisfied by perturbations about the base state:
 # ```math
 # \partial_t \Phi = L \Phi \, .
 # ```
-# where ``\Phi = (u, v, w, b)`` is a vector of the perturbation velocities ``u, v, w`` and perturbation buoyancy ``b`` 
+# where ``\Phi = (u, v, w, b)`` is a vector of the perturbation velocities ``u, v, w`` and perturbation buoyancy ``b``
 # and ``L`` a linear operator that depends on the base state, ``L = L(U(z), B(z))`` (the `background_fields`).
-# Eigenanalysis of the linear operator ``L`` determines the stability of the base state, such as the Kelvin-Helmholtz 
+# Eigenanalysis of the linear operator ``L`` determines the stability of the base state, such as the Kelvin-Helmholtz
 # instability. That is, by using the ansantz
 # ```math
 # \Phi(x, y, z, t) = \phi(x, y, z) \, \exp(\lambda t) \, ,
@@ -97,43 +95,41 @@ plot(U_plot, B_plot, Ri_plot, layout=(1, 3), size=(800, 400))
 # As we touched upon briefly above, Oceananigans.jl, does not include a linearized version of the equations. Furthermore, Oceananigans.jl does
 # not give us access to the linear operator ``L`` so that we can perform eigenanalysis. Below we discuss an alternative way
 # of approximating the eigenanalysis results. The method boils down to solving the nonlinear equations while continually renormalize
-# the magnitude of the perturbations to ensure that nonlinear terms (terms that are quadratic or higher in perturbations) remain negligibly small, 
+# the magnitude of the perturbations to ensure that nonlinear terms (terms that are quadratic or higher in perturbations) remain negligibly small,
 # i.e.,much smaller than the background flow.
 
 # # The power method algorithm
 #
-# Successive application of ``L`` to a random initial state will eventually render it parallel 
+# Successive application of ``L`` to a random initial state will eventually render it parallel
 # with eigenmode ``\phi_1``:
 # ```math
 # \lim_{n \to \infty} L^n \Phi \propto \phi_1 \, .
 # ```
-# Of course, if ``\phi_1`` is an unstable mode (i.e., ``\sigma_1 = \real(\lambda_1) > 0``), then successive application 
+# Of course, if ``\phi_1`` is an unstable mode (i.e., ``\sigma_1 = \real(\lambda_1) > 0``), then successive application
 # of ``L`` will lead to exponential amplification. (Similarly, if ``\sigma_1 < 0``, successive application of ``L`` will
-# lead to exponential decay of ``\Phi`` down to machine precision.) Therefore, after each 
+# lead to exponential decay of ``\Phi`` down to machine precision.) Therefore, after each
 # application of the linear operator ``L``, we rescale the output ``L \Phi`` back to a pre-selected amplitude.
-# 
+#
 # So, we initialize a `simulation` with random initial conditions with amplitude much less than those of
 # the base state (which are ``O(1)``). Instead of "applying" ``L`` on our initial state, we evolve the
-# (approximately) linear dynamics for interval ``\Delta \tau``. We measure how much the energy has grown 
+# (approximately) linear dynamics for interval ``\Delta \tau``. We measure how much the energy has grown
 # during that interval, rescale the perturbations back to original energy amplitude and repeat.
 # After some iterations the state will converge to the most unstable eigenmode.
-# 
+#
 # In summary, each iteration of the power method includes:
 # - compute the perturbation energy, ``E_0``,
 # - evolve the system for a time-interval ``\Delta \tau``,
 # - compute the perturbation energy, ``E_1``,
 # - determine the exponential growth of the most unstable mode during the interval ``\Delta \tau`` as  ``\log(E_1 / E_0) / (2 \Delta \tau)``,
 # - repeat the above until growth rate converges.
-# 
+#
 # By fiddling a bit with ``\Delta t`` we can get convergence after only a few iterations.
-# 
+#
 # Let's apply all these to our example.
 
 # # The model
 
-using Oceananigans.Advection
-
-model = IncompressibleModel(timestepper = :RungeKutta3, 
+model = IncompressibleModel(timestepper = :RungeKutta3,
                               advection = UpwindBiasedFifthOrder(),
                                    grid = grid,
                                coriolis = nothing,
@@ -142,7 +138,7 @@ model = IncompressibleModel(timestepper = :RungeKutta3,
                                buoyancy = BuoyancyTracer(),
                                 tracers = :b)
 
-# We have included a "pinch" of viscosity and diffusivity in anticipation of what will follow furtherdown: 
+# We have included a "pinch" of viscosity and diffusivity in anticipation of what will follow furtherdown:
 # viscosity and diffusivity will ensure numerical stability when we evolve the unstable mode to the point it becomes nonlinear.
 
 # For this example, we take ``\Delta \tau = 15``.
@@ -150,7 +146,7 @@ model = IncompressibleModel(timestepper = :RungeKutta3,
 simulation = Simulation(model, Δt=0.1, stop_iteration=150)
 
 # Now some helper functions that will be used during for the power method algorithm.
-# 
+#
 # First a function that evolves the state for ``\Delta \tau`` and measure the energy growth
 # over that period.
 
@@ -167,8 +163,8 @@ over the course of the `simulation`
 energy(t₀ + Δτ) / energy(t₀) ≈ exp(2 σ Δτ)
 ``
 
-where ``t₀`` is the starting time of the simulation and ``t₀ + Δτ`` 
-the ending time of the simulation. We thus find that the growth rate 
+where ``t₀`` is the starting time of the simulation and ``t₀ + Δτ``
+the ending time of the simulation. We thus find that the growth rate
 is measured by
 
 ``
@@ -192,15 +188,15 @@ function grow_instability!(simulation, energy)
 
     ## ½(u² + v²) ~ exp(2 σ Δτ)
     σ = growth_rate = log(energy₁ / energy₀) / 2Δτ
-    
-    return growth_rate    
+
+    return growth_rate
 end
 nothing # hide
 
 # Finally, we write a function that rescales the state. The rescaling is done via computing the
 # kinetic energy and then rescaling all flow fields so that the kinetic energy assumes a targetted value.
-# 
-# (Measuring the perturbation growth via the kinetic energy works fine _unless_ an unstable mode _only_ has 
+#
+# (Measuring the perturbation growth via the kinetic energy works fine _unless_ an unstable mode _only_ has
 # buoyancy structure. In that case, the total perturbation energy is more adequate.)
 
 """
@@ -225,9 +221,9 @@ using Printf
 
 # Some more helper function for the power method,
 
-""" 
+"""
     convergence(σ)
-    
+
 Check if the growth rate has converged. If the array `σ` has at least 2 elements then returns the
 relative difference between ``σ[end]`` and ``σ[end-1]``.
 """
@@ -248,11 +244,11 @@ function estimate_growth_rate(simulation, energy, ω, b; convergence_criterion=1
     σ = []
 
     power_method_data = []
-    
+
     compute!(ω)
-    
+
     push!(power_method_data, (ω=collect(interior(ω)[:, 1, :]), b=collect(interior(b)[:, 1, :]), σ=deepcopy(σ)))
-    
+
     while convergence(σ) > convergence_criterion
         compute!(energy)
 
@@ -266,7 +262,7 @@ function estimate_growth_rate(simulation, energy, ω, b; convergence_criterion=1
                        length(σ), energy[1, 1, 1], σ[end], convergence(σ))
 
         compute!(ω)
-        
+
         rescale!(simulation.model, energy)
 
         push!(power_method_data, (ω=collect(interior(ω)[:, 1, :]), b=collect(interior(b)[:, 1, :]), σ=deepcopy(σ)))
@@ -280,8 +276,6 @@ nothing # hide
 #
 # A good algorithm wouldn't be complete without a good visualization,
 
-using Oceananigans.AbstractOperations
-
 u, v, w = model.velocities
 b = model.tracers.b
 
@@ -294,27 +288,27 @@ xC, yC, zC = nodes(b)
 eigentitle(σ, t) = length(σ) > 0 ? @sprintf("Iteration #%i; growth rate %.2e", length(σ), σ[end]) : @sprintf("Initial perturbation fields")
 
 function eigenplot(ω, b, σ, t; ω_lim=maximum(abs, ω)+1e-16, b_lim=maximum(abs, b)+1e-16)
-    
+
     kwargs = (xlabel="x", ylabel="z", linewidth=0, label=nothing, color = :balance, aspectratio = 1,)
-    
+
     ω_title(t) = t == nothing ? @sprintf("vorticity") : @sprintf("vorticity at t = %.2f", t)
-    
+
     plot_ω = contourf(xF, zF, clamp.(ω, -ω_lim, ω_lim)';
                       levels = range(-ω_lim, stop=ω_lim, length=20),
                        xlims = (xF[1], xF[grid.Nx]),
                        ylims = (zF[1], zF[grid.Nz]),
                        clims = (-ω_lim, ω_lim),
                        title = ω_title(t), kwargs...)
-                      
+
     b_title(t) = t == nothing ? @sprintf("buoyancy") : @sprintf("buoyancy at t = %.2f", t)
-    
+
     plot_b = contourf(xC, zC, clamp.(b, -b_lim, b_lim)';
                     levels = range(-b_lim, stop=b_lim, length=20),
                      xlims = (xC[1], xC[grid.Nx]),
                      ylims = (zC[1], zC[grid.Nz]),
                      clims = (-b_lim, b_lim),
                      title = b_title(t), kwargs...)
-                    
+
     return plot(plot_ω, plot_b, layout=(1, 2), size=(800, 380))
 end
 
@@ -324,9 +318,9 @@ function power_method_plot(ω, b, σ, t)
                              ylabel = "Growth rate",
                               title = eigentitle(σ, nothing),
                               label = nothing)
-                             
+
     plot_eigenmode = eigenplot(ω, b, σ, nothing)
-    
+
     return plot(plot_growthrates, plot_eigenmode, layout=@layout([A{0.25h}; B]), size=(800, 600))
 end
 nothing # hide
@@ -335,7 +329,7 @@ nothing # hide
 #
 # We initialize the power iteration with random noise and rescale to have a `target_kinetic_energy`
 
-using Random, Statistics, Oceananigans.AbstractOperations
+using Random, Statistics
 
 mean_perturbation_kinetic_energy = mean(1/2 * (u^2 + w^2), dims=(1, 2, 3))
 
@@ -378,11 +372,9 @@ simulation.stop_iteration = 9.1e18 # pretty big (not Inf tho)
 initial_eigenmode_energy = 5e-5
 rescale!(simulation.model, mean_perturbation_kinetic_energy, target_kinetic_energy=initial_eigenmode_energy)
 
-# Let's save and plot the perturbation vorticity and buoyancy and also the total vorticity and 
+# Let's save and plot the perturbation vorticity and buoyancy and also the total vorticity and
 # buoyancy (perturbation + basic state). It'll be also neat to plot the kinetic energy time-series
 # and confirm it grows with the estimated growth rate.
-
-using Oceananigans.OutputWriters
 
 total_vorticity = ComputedField(∂z(u) + ∂z(model.background_fields.velocities.u) - ∂x(w))
 
@@ -424,12 +416,12 @@ function plot_energy_timeseries(time, KE, estimated_growth_rate, initial_eigenmo
             xlabel = "time",
             ylabel = "kinetic energy",
             )
-            
+
     energy_plot = plot!(time, KE,
               label = "perturbation kinetic energy",
               lw = 6,
               alpha = 0.5)
-              
+
     return energy_plot
 end
 
@@ -439,19 +431,19 @@ KE = []
 anim_perturbations = @animate for (i, iteration) in enumerate(iterations)
 
     @info "Plotting frame $i from iteration $iteration..."
-    
+
     t = file["timeseries/t/$iteration"]
     ω_snapshot = file["timeseries/ω/$iteration"][:, 1, :]
     b_snapshot = file["timeseries/b/$iteration"][:, 1, :]
     ke = file["timeseries/KE/$iteration"][]
-    
+
     push!(time, t)
     push!(KE, ke)
-    
+
     energy_plot = plot_energy_timeseries(time, KE, estimated_growth_rate, initial_eigenmode_energy, simulation.stop_time)
-    
+
     eigenmode_plot = eigenplot(ω_snapshot, b_snapshot, nothing, t; ω_lim=1, b_lim=0.05)
-  
+
     plot(eigenmode_plot, energy_plot, layout=@layout([A{0.6h}; B]), size=(800, 600))
 
 end
@@ -466,19 +458,19 @@ KE = []
 anim_total = @animate for (i, iteration) in enumerate(iterations)
 
     @info "Plotting frame $i from iteration $iteration..."
-    
+
     t = file["timeseries/t/$iteration"]
     ω_snapshot = file["timeseries/Ω/$iteration"][:, 1, :]
     b_snapshot = file["timeseries/B/$iteration"][:, 1, :]
     ke = file["timeseries/KE/$iteration"][]
-    
+
     push!(time, t)
     push!(KE, ke)
-    
+
     energy_plot = plot_energy_timeseries(time, KE, estimated_growth_rate, initial_eigenmode_energy, simulation.stop_time)
-            
+
     eigenmode_plot = eigenplot(ω_snapshot, b_snapshot, nothing, t; ω_lim=1, b_lim=0.05)
-  
+
     plot(eigenmode_plot, energy_plot, layout=@layout([A{0.6h}; B]), size=(800, 600))
 end
 

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -22,7 +22,7 @@
 # ```
 
 using Oceananigans
-using Oceananigans.Units
+using Oceananigans.Units: minute, minutes, hours
 
 # ## Model set-up
 #

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -5,7 +5,7 @@
 #
 # > [McWilliams, J. C. et al., "Langmuir Turbulence in the ocean," Journal of Fluid Mechanics (1997)](https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/langmuir-turbulence-in-the-ocean/638FD0E368140E5972144348DB930A38).
 #
-# This example demonstrates 
+# This example demonstrates
 #
 #   * How to run large eddy simulations with surface wave effects via the
 #     Craik-Leibovich approximation.
@@ -22,6 +22,7 @@
 # ```
 
 using Oceananigans
+using Oceananigans.Units
 
 # ## Model set-up
 #
@@ -92,8 +93,6 @@ uˢ(z) = Uˢ * exp(z / vertical_scale)
 # At the surface at ``z=0``, McWilliams et al. (1997) impose a wind stress
 # on ``u``,
 
-using Oceananigans.BoundaryConditions
-
 Qᵘ = -3.72e-5 # m² s⁻², surface kinematic momentum flux
 
 u_boundary_conditions = UVelocityBoundaryConditions(grid, top = BoundaryCondition(Flux, Qᵘ))
@@ -127,10 +126,6 @@ coriolis = FPlane(f=1e-4) # s⁻¹
 # Non-Oscillatory (WENO) advection scheme and the `AnisotropicMinimumDissipation`
 # model for large eddy simulation. Because our Stokes drift does not vary in ``x, y``,
 # we use `UniformStokesDrift`, which expects Stokes drift functions of ``z, t`` only.
-
-using Oceananigans.Advection
-using Oceananigans.Buoyancy: BuoyancyTracer
-using Oceananigans.StokesDrift: UniformStokesDrift
 
 model = IncompressibleModel(
            architecture = CPU(),
@@ -176,8 +171,6 @@ set!(model, u=uᵢ, w=wᵢ, b=bᵢ)
 # We use the `TimeStepWizard` for adaptive time-stepping
 # with a Courant-Freidrichs-Lewy (CFL) number of 1.0,
 
-using Oceananigans.Utils
-
 wizard = TimeStepWizard(cfl=1.0, Δt=45.0, max_change=1.1, max_Δt=1minute)
 
 # ### Nice progress messaging
@@ -185,7 +178,7 @@ wizard = TimeStepWizard(cfl=1.0, Δt=45.0, max_change=1.1, max_Δt=1minute)
 # We define a function that prints a helpful message with
 # maximum absolute value of ``u, v, w`` and the current wall clock time.
 
-using Oceananigans.Diagnostics, Printf
+using Printf
 
 umax = FieldMaximum(abs, model.velocities.u)
 vmax = FieldMaximum(abs, model.velocities.v)
@@ -224,8 +217,6 @@ simulation = Simulation(model, iteration_interval = 10,
 # We set up an output writer for the simulation that saves all velocity fields,
 # tracer fields, and the subgrid turbulent diffusivity.
 
-using Oceananigans.OutputWriters
-
 output_interval = 5minutes
 
 fields_to_output = merge(model.velocities, model.tracers, (νₑ=model.diffusivities.νₑ,))
@@ -240,8 +231,6 @@ simulation.output_writers[:fields] =
 #
 # We also set up output of time- and horizontally-averaged velocity field and
 # momentum fluxes,
-
-using Oceananigans.Fields
 
 u, v, w = model.velocities
 
@@ -273,8 +262,6 @@ k = searchsortedfirst(grid.zF[:], -8)
 nothing # hide
 
 # Making the coordinate arrays takes a few lines of code,
-
-using Oceananigans.Grids
 
 xw, yw, zw = nodes(model.velocities.w)
 xu, yu, zu = nodes(model.velocities.u)
@@ -383,7 +370,7 @@ anim = @animate for (i, iter) in enumerate(iterations)
     wxy_title = @sprintf("w(x, y, t) (m s⁻¹) at z=-8 m and t = %s ", prettytime(t))
     wxz_title = @sprintf("w(x, z, t) (m s⁻¹) at y=0 m and t = %s", prettytime(t))
     uxz_title = @sprintf("u(x, z, t) (m s⁻¹) at y=0 m and t = %s", prettytime(t))
-         
+
     plot(wxy_plot, B_plot, wxz_plot, U_plot, uxz_plot, fluxes_plot,
          layout = Plots.grid(3, 2, widths=(0.7, 0.3)), size = (900.5, 1000.5),
          title = [wxy_title "" wxz_title "" uxz_title ""])

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -25,12 +25,6 @@ using Plots
 using JLD2
 
 using Oceananigans
-using Oceananigans.Utils
-
-using Oceananigans.Grids: nodes
-using Oceananigans.Advection: UpwindBiasedFifthOrder
-using Oceananigans.Diagnostics: FieldMaximum
-using Oceananigans.OutputWriters: JLD2OutputWriter, FieldSlicer, TimeInterval
 
 # ## The grid
 #
@@ -64,7 +58,7 @@ Qᵀ = Qʰ / (ρₒ * cᴾ) # K m⁻¹ s⁻¹, surface _temperature_ flux
 
 dTdz = 0.01 # K m⁻¹
 
-T_bcs = TracerBoundaryConditions(grid, 
+T_bcs = TracerBoundaryConditions(grid,
                                  top = BoundaryCondition(Flux, Qᵀ),
                                  bottom = BoundaryCondition(Gradient, dTdz))
 
@@ -94,7 +88,7 @@ nothing # hide
 
 # where `S` is salinity. We use an evporation rate of 1 millimeter per hour,
 
-evaporation_rate = 1e-3 / hour 
+evaporation_rate = 1e-3 / hour
 
 # We build the `Flux` evaporation `BoundaryCondition` with the function `Qˢ`,
 # indicating that `Qˢ` depends on salinity `S` and passing
@@ -200,7 +194,7 @@ run!(simulation)
 # We animate the data saved in `ocean_wind_mixing_and_convection.jld2`.
 # We prepare for animating the flow by creating coordinate arrays,
 # opening the file, building a vector of the iterations that we saved
-# data at, and defining functions for computing colorbar limits: 
+# data at, and defining functions for computing colorbar limits:
 
 ## Coordinate arrays
 xw, yw, zw = nodes(model.velocities.w)
@@ -262,7 +256,7 @@ anim = @animate for (i, iter) in enumerate(iterations[intro:end])
     T_title = "temperature (ᵒC)"
     S_title = "salinity (g kg⁻¹)"
     ν_title = "eddy viscosity (m² s⁻¹)"
-                       
+
     ## Arrange the plots side-by-side.
     plot(w_plot, T_plot, S_plot, ν_plot, layout=(2, 2), size=(1200, 600),
          title=[w_title T_title S_title ν_title])

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -25,6 +25,7 @@ using Plots
 using JLD2
 
 using Oceananigans
+using Oceananigans.Units
 
 # ## The grid
 #

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -25,7 +25,7 @@ using Plots
 using JLD2
 
 using Oceananigans
-using Oceananigans.Units
+using Oceananigans.Units: minute, minutes, hour
 
 # ## The grid
 #

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -32,7 +32,7 @@ using Oceananigans
 # A core Oceananigans type is `IncompressibleModel`. We build an `IncompressibleModel`
 # by passing it a `grid`, plus information about the equations we would like to solve.
 #
-# Below, we build a regular rectilinear grid with 128 grid points in the `z`-direction, 
+# Below, we build a regular rectilinear grid with 128 grid points in the `z`-direction,
 # where `z` spans from `z = -0.5` to `z = 0.5`,
 
 grid = RegularRectilinearGrid(size=(1, 1, 128), x=(0, 1), y=(0, 1), z=(-0.5, 0.5))
@@ -71,7 +71,6 @@ set!(model, T=initial_temperature)
 # To see the new data in `model.tracers.T`, we plot it:
 
 using Plots
-using Oceananigans.Grids: znodes # for obtaining the z-coordinates of model.tracers.T
 
 z = znodes(model.tracers.T)
 

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -1,6 +1,6 @@
 # # Two dimensional turbulence example
 #
-# In this example, we initialize a random velocity field and observe its turbulent decay 
+# In this example, we initialize a random velocity field and observe its turbulent decay
 # in a two-dimensional domain. This example demonstrates:
 #
 #   * How to run a model with no tracers and no buoyancy model.
@@ -22,11 +22,11 @@
 # a fifth-order advection scheme, third-order Runge-Kutta time-stepping,
 # and a small isotropic viscosity.
 
-using Oceananigans, Oceananigans.Advection
+using Oceananigans
 
 grid = RegularRectilinearGrid(size=(128, 128, 1), extent=(2π, 2π, 2π))
 
-model = IncompressibleModel(timestepper = :RungeKutta3, 
+model = IncompressibleModel(timestepper = :RungeKutta3,
                               advection = UpwindBiasedFifthOrder(),
                                    grid = grid,
                                buoyancy = nothing,
@@ -48,14 +48,12 @@ set!(model, u=u₀, v=u₀)
 
 # ## Computing vorticity and speed
 
-using Oceananigans.Fields, Oceananigans.AbstractOperations
-
-# To make our equations prettier, we unpack `u`, `v`, and `w` from 
+# To make our equations prettier, we unpack `u`, `v`, and `w` from
 # the `NamedTuple` model.velocities:
 u, v, w = model.velocities
 
 # Next we create two objects called `ComputedField`s that calculate
-# _(i)_ vorticity that measures the rate at which the fluid rotates 
+# _(i)_ vorticity that measures the rate at which the fluid rotates
 # and is defined as
 #
 # ```math
@@ -87,8 +85,6 @@ simulation = Simulation(model, Δt=0.2, stop_time=50, iteration_interval=100, pr
 #
 # We set up an output writer for the simulation that saves the vorticity every 20 iterations.
 
-using Oceananigans.OutputWriters
-
 simulation.output_writers[:fields] = JLD2OutputWriter(model, (ω=ω_field, s=s_field),
                                                       schedule = TimeInterval(2),
                                                       prefix = "two_dimensional_turbulence",
@@ -112,8 +108,6 @@ iterations = parse.(Int, keys(file["timeseries/t"]))
 
 # Construct the ``x, y`` grid for plotting purposes,
 
-using Oceananigans.Grids
-
 xω, yω, zω = nodes(ω_field)
 xs, ys, zs = nodes(s_field)
 nothing # hide
@@ -127,7 +121,7 @@ using Plots
 anim = @animate for (i, iteration) in enumerate(iterations)
 
     @info "Plotting frame $i from iteration $iteration..."
-    
+
     t = file["timeseries/t/$iteration"]
     ω_snapshot = file["timeseries/ω/$iteration"][:, :, 1]
     s_snapshot = file["timeseries/s/$iteration"][:, :, 1]
@@ -140,7 +134,7 @@ anim = @animate for (i, iteration) in enumerate(iterations)
 
     kwargs = (xlabel="x", ylabel="y", aspectratio=1, linewidth=0, colorbar=true,
               xlims=(0, model.grid.Lx), ylims=(0, model.grid.Ly))
-              
+
     ω_plot = contourf(xω, yω, clamp.(ω_snapshot', -ω_lim, ω_lim);
                        color = :balance,
                       levels = ω_levels,

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -1,6 +1,6 @@
 module Models
 
-export IncompressibleModel, NonDimensionalModel
+export IncompressibleModel, NonDimensionalModel, HydrostaticFreeSurfaceModel, ShallowWaterModel
 
 using Oceananigans: AbstractModel
 

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -12,8 +12,10 @@ export
     OceananigansLogger,
 
     # Grids
+    Center, Face,
     Periodic, Bounded, Flat,
     RegularRectilinearGrid, VerticallyStretchedRectilinearGrid,
+    xnodes, ynodes, znodes, nodes,
 
     # Advection schemes
     CenteredSecondOrder, CenteredFourthOrder, UpwindBiasedThirdOrder, UpwindBiasedFifthOrder, WENO5,

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -43,7 +43,7 @@ export
     BuoyancyTracer, SeawaterBuoyancy,
     LinearEquationOfState, RoquetIdealizedNonlinearEquationOfState, TEOS10,
 
-    # Stokes drift (surface waves) via Craik-Leibovich equations
+    # Surface wave Stokes drift via Craik-Leibovich equations
     UniformStokesDrift,
 
     # Turbulence closures

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -1,6 +1,7 @@
 module StokesDrift
 
 export
+    UniformStokesDrift,
     ∂t_uˢ,
     ∂t_vˢ,
     ∂t_wˢ,

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -1,3 +1,9 @@
+module Units
+
+export second, minute, hour, day, year, meter, kilometer,
+       seconds, minutes, hours, days, years, meters, kilometers,
+       KiB, MiB, GiB, TiB
+
 #####
 ##### Convenient definitions
 #####
@@ -127,3 +133,5 @@ const GiB = 1024MiB
 A `Float64` constant equal to 1024`GiB`. Useful for increasing the clarity of scripts, e.g. `max_filesize = 2TiB`.
 """
 const TiB = 1024GiB
+
+end

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -1,9 +1,6 @@
 module Utils
 
 export
-    second, minute, hour, day, year, meter, kilometer,
-    seconds, minutes, hours, days, years, meters, kilometers,
-    KiB, MiB, GiB, TiB,
     launch_config, work_layout, launch!,
     cell_advection_timescale,
     TimeStepWizard, update_Δt!,
@@ -31,7 +28,6 @@ short_show(f::Function) = string(Symbol(f))
 ##### Include utils
 #####
 
-include("units.jl")
 include("automatic_halo_sizing.jl")
 include("kernel_launching.jl")
 include("cell_advection_timescale.jl")

--- a/src/Utils/pretty_time.jl
+++ b/src/Utils/pretty_time.jl
@@ -1,6 +1,8 @@
 using Printf
 using Dates: AbstractTime
 
+using Oceananigans.Units
+
 maybe_int(t) = isinteger(t) ? Int(t) : t
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ using Oceananigans.OutputWriters
 using Oceananigans.TurbulenceClosures
 using Oceananigans.AbstractOperations
 using Oceananigans.Logger
+using Oceananigans.Units
 using Oceananigans.Utils
 using Oceananigans.Architectures: device # to resolve conflict with CUDA.device
 

--- a/test/test_stokes_drift.jl
+++ b/test/test_stokes_drift.jl
@@ -3,9 +3,9 @@ function instantiate_stokes_drift()
     ∂t_vˢ(z, t) = exp(z/20) * cos(t)
     ∂z_uˢ(z, t) = exp(z/20) * cos(t)
     ∂z_vˢ(z, t) = exp(z/20) * cos(t)
-    stokes_drift = StokesDrift.UniformStokesDrift(∂t_uˢ=∂t_uˢ, ∂t_vˢ=∂t_vˢ,
-                                                  ∂z_uˢ=∂z_uˢ, ∂z_vˢ=∂z_vˢ)
-                                                    
+    stokes_drift = UniformStokesDrift(∂t_uˢ=∂t_uˢ, ∂t_vˢ=∂t_vˢ,
+                                      ∂z_uˢ=∂z_uˢ, ∂z_vˢ=∂z_vˢ)
+
     return true
 end
 


### PR DESCRIPTION
This PR ensures enough things are exported by Oceananigans that all the examples can get by with just `using Oceananigans`.

The purpose of this PR is to make the package more user friendly as missing names, e.g. `ComputedField`, have become a large source of errors for new users.

As this is a large change to the user interface, I've bumped v0.52.0.

Resolves #1075
Resolves #1131
Resolves #1132