### PR TITLE
Test and fix bugs in `RegularLatitudeLongitudeGrid`

### DIFF
--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -3,7 +3,7 @@ module Grids
 export
     Center, Face,
     Periodic, Bounded, Flat, topology,
-    RegularRectilinearGrid, VerticallyStretchedRectilinearGrid, RegularLatitudeLongitudeGrid,
+    AbstractGrid, RegularRectilinearGrid, VerticallyStretchedRectilinearGrid, RegularLatitudeLongitudeGrid,
     xnode, ynode, znode, xnodes, ynodes, znodes, nodes,
     xC, xF, yC, yF, zC, zF
 

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -2,9 +2,8 @@ module Grids
 
 export
     Center, Face,
-    AbstractTopology, Periodic, Bounded, Flat, topology,
-    AbstractGrid,
-    AbstractRectilinearGrid, RegularRectilinearGrid, VerticallyStretchedRectilinearGrid,
+    Periodic, Bounded, Flat, topology,
+    RegularRectilinearGrid, VerticallyStretchedRectilinearGrid, RegularLatitudeLongitudeGrid,
     xnode, ynode, znode, xnodes, ynodes, znodes, nodes,
     xC, xF, yC, yF, zC, zF
 

--- a/src/Grids/regular_latitude_longitude_grid.jl
+++ b/src/Grids/regular_latitude_longitude_grid.jl
@@ -51,31 +51,21 @@ function RegularLatitudeLongitudeGrid(FT=Float64; size, latitude, longitude, z, 
     Lϕ = ϕ₂ - ϕ₁
     Lz = z₂ - z₁
 
-    Δϕ = Lϕ / Nϕ
-    Δλ = Lλ / Nλ
-    Δz = Lz / Nz
+            Λ₁ = (λ₁, ϕ₁, z₁)
+            L  = (Lλ, Lϕ, Lz)
+    Δλ, Δϕ, Δz = Δ = @. L / N
 
-    # Now including halos
-    λF₋ = λ₁ - Hλ * Δλ
-    ϕF₋ = ϕ₁ - Hϕ * Δϕ
-    zF₋ = z₁ - Hz * Δz
+    # Calculate end points for cell faces and centers
+    λF₋, ϕF₋, zF₋ = ΛF₋ = @. Λ₁ - H * Δ
+    λF₊, ϕF₊, zF₊ = ΛF₊ = @. ΛF₋ + total_extent(topo, H, Δ, L)
 
-    λF₊ = λ₂ + Hλ * Δλ
-    ϕF₊ = ϕ₂ + Hϕ * Δϕ
-    zF₊ = z₂ + Hz * Δz
-
-    λC₋ = λF₋ + Δλ / 2
-    ϕC₋ = ϕF₋ + Δϕ / 2
-    zC₋ = zF₋ + Δz / 2
-
-    λC₊ = λC₋ + Lλ + Δλ * (2Hλ - 1)
-    ϕC₊ = ϕC₋ + Lϕ + Δϕ * (2Hϕ - 1)
-    zC₊ = zC₋ + Lz + Δz * (2Hz - 1)
+    λC₋, ϕC₋, zC₋ = ΛC₋ = @. ΛF₋ + Δ / 2
+    λC₊, ϕC₊, zC₊ = ΛC₊ = @. ΛC₋ + L + Δ * (2H - 1)
 
     TFλ, TFϕ, TFz = total_length.(Face, topo, N, H)
     TCλ, TCϕ, TCz = total_length.(Center, topo, N, H)
 
-    λᶠᵃᵃ = range(λF₋, λF₊, length = Nλ + 2Hλ + 1)
+    λᶠᵃᵃ = range(λF₋, λF₊, length = TFλ)
     ϕᵃᶠᵃ = range(ϕF₋, ϕF₊, length = TFϕ)
     zᵃᵃᶠ = range(zF₋, zF₊, length = TFz)
 

--- a/src/Grids/regular_latitude_longitude_grid.jl
+++ b/src/Grids/regular_latitude_longitude_grid.jl
@@ -33,6 +33,9 @@ function RegularLatitudeLongitudeGrid(FT=Float64; size, latitude, longitude, z, 
     ϕ₁, ϕ₂ = latitude
     @assert -90 <= ϕ₁ < ϕ₂ <= 90
 
+    (ϕ₁ == -90 || ϕ₂ == 90) &&
+        @warn "Are you sure you want to use a latitude-longitude grid with a grid point at the pole?"
+
     z₁, z₂ = z
     @assert z₁ < z₂
 
@@ -41,41 +44,38 @@ function RegularLatitudeLongitudeGrid(FT=Float64; size, latitude, longitude, z, 
     TZ = Bounded
     topo = (TX, TY, TZ)
 
-    Nx, Ny, Nz = N = validate_size(TX, TY, TZ, size)
-    Hx, Hy, Hz = H = validate_halo(TX, TY, TZ, halo)
+    Nλ, Nϕ, Nz = N = validate_size(TX, TY, TZ, size)
+    Hλ, Hϕ, Hz = H = validate_halo(TX, TY, TZ, halo)
 
     Lλ = λ₂ - λ₁
     Lϕ = ϕ₂ - ϕ₁
     Lz = z₂ - z₁
 
-    Δϕ = Lλ / Nx
-    Δλ = Lϕ / Ny
+    Δϕ = Lϕ / Nϕ
+    Δλ = Lλ / Nλ
     Δz = Lz / Nz
 
     # Now including halos
-    λF₋ = λ₁ - Hx * Δλ
-    ϕF₋ = ϕ₁ - Hy * Δϕ
+    λF₋ = λ₁ - Hλ * Δλ
+    ϕF₋ = ϕ₁ - Hϕ * Δϕ
     zF₋ = z₁ - Hz * Δz
 
-    λF₊ = λ₂ + Hx * Δλ
-    ϕF₊ = ϕ₂ + Hy * Δϕ
+    λF₊ = λ₂ + Hλ * Δλ
+    ϕF₊ = ϕ₂ + Hϕ * Δϕ
     zF₊ = z₂ + Hz * Δz
 
     λC₋ = λF₋ + Δλ / 2
     ϕC₋ = ϕF₋ + Δϕ / 2
     zC₋ = zF₋ + Δz / 2
 
-    λC₊ = λF₋ + total_extent(TX, Hx, Δλ, Lλ)
-    ϕC₊ = ϕF₋ + total_extent(TY, Hy, Δϕ, Lϕ)
-    zC₊ = zF₋ + total_extent(TZ, Hz, Δz, Lz)
+    λC₊ = λC₋ + Lλ + Δλ * (2Hλ - 1)
+    ϕC₊ = ϕC₋ + Lϕ + Δϕ * (2Hϕ - 1)
+    zC₊ = zC₋ + Lz + Δz * (2Hz - 1)
 
     TFλ, TFϕ, TFz = total_length.(Face, topo, N, H)
     TCλ, TCϕ, TCz = total_length.(Center, topo, N, H)
 
-    # FIXME? MITgcm generates (xG, yG) vorticity grid points then interpolates them to generate (xC, yC):
-    # https://github.com/MITgcm/MITgcm/blob/fc300b65987b52171b1110c7930f580ca71dead0/model/src/ini_spherical_polar_grid.F#L86-L89
-
-    λᶠᵃᵃ = range(λF₋, λF₊, length = TFλ)
+    λᶠᵃᵃ = range(λF₋, λF₊, length = Nλ + 2Hλ + 1)
     ϕᵃᶠᵃ = range(ϕF₋, ϕF₊, length = TFϕ)
     zᵃᵃᶠ = range(zF₋, zF₊, length = TFz)
 
@@ -83,15 +83,15 @@ function RegularLatitudeLongitudeGrid(FT=Float64; size, latitude, longitude, z, 
     ϕᵃᶜᵃ = range(ϕC₋, ϕC₊, length = TCϕ)
     zᵃᵃᶜ = range(zC₋, zC₊, length = TCz)
 
-    λᶠᵃᵃ = OffsetArray(λᶠᵃᵃ, -Hx)
-    ϕᵃᶠᵃ = OffsetArray(ϕᵃᶠᵃ, -Hy)
+    λᶠᵃᵃ = OffsetArray(λᶠᵃᵃ, -Hλ)
+    ϕᵃᶠᵃ = OffsetArray(ϕᵃᶠᵃ, -Hϕ)
     zᵃᵃᶠ = OffsetArray(zᵃᵃᶠ, -Hz)
 
-    λᶜᵃᵃ = OffsetArray(λᶜᵃᵃ, -Hx)
-    ϕᵃᶜᵃ = OffsetArray(ϕᵃᶜᵃ, -Hy)
+    λᶜᵃᵃ = OffsetArray(λᶜᵃᵃ, -Hλ)
+    ϕᵃᶜᵃ = OffsetArray(ϕᵃᶜᵃ, -Hϕ)
     zᵃᵃᶜ = OffsetArray(zᵃᵃᶜ, -Hz)
 
-    return RegularLatitudeLongitudeGrid{FT, TX, TY, TZ, typeof(λᶠᵃᵃ)}(Nx, Ny, Nz, Hx, Hy, Hz, Lλ, Lϕ, Lz, Δλ, Δϕ, Δz, λᶠᵃᵃ, λᶜᵃᵃ, ϕᵃᶠᵃ, ϕᵃᶜᵃ, zᵃᵃᶠ, zᵃᵃᶜ, radius)
+    return RegularLatitudeLongitudeGrid{FT, TX, TY, TZ, typeof(λᶠᵃᵃ)}(Nλ, Nϕ, Nz, Hλ, Hϕ, Hz, Lλ, Lϕ, Lz, Δλ, Δϕ, Δz, λᶠᵃᵃ, λᶜᵃᵃ, ϕᵃᶠᵃ, ϕᵃᶜᵃ, zᵃᵃᶠ, zᵃᵃᶜ, radius)
 end
 
 function domain_string(grid::RegularLatitudeLongitudeGrid)

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -14,7 +14,7 @@ export
     # Grids
     Center, Face,
     Periodic, Bounded, Flat,
-    RegularRectilinearGrid, VerticallyStretchedRectilinearGrid,
+    RegularRectilinearGrid, VerticallyStretchedRectilinearGrid, RegularLatitudeLongitudeGrid,
     xnodes, ynodes, znodes, nodes,
 
     # Advection schemes

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -378,9 +378,7 @@ end
 #####
 
 function test_basic_lat_lon_bounded_domain(FT)
-    Nλ = 18
-    Nϕ = 9
-
+    Nλ = Nϕ = 18
     Hλ = Hϕ = 1
 
     grid = RegularLatitudeLongitudeGrid(FT, size=(Nλ, Nϕ, 1), longitude=(-90, 90), latitude=(-45, 45), z=(0, 1), halo=(Hλ, Hϕ, 1))
@@ -396,7 +394,7 @@ function test_basic_lat_lon_bounded_domain(FT)
     @test grid.Lz == 1
 
     @test grid.Δλ == 10
-    @test grid.Δϕ == 10
+    @test grid.Δϕ == 5
     @test grid.Δz == 1
 
     @test length(grid.λᶠᵃᵃ) == Nλ + 2Hλ + 1
@@ -415,7 +413,7 @@ function test_basic_lat_lon_bounded_domain(FT)
     @test grid.λᶠᵃᵃ[Nλ+2] == 90 + grid.Δλ
 
     @test grid.ϕᵃᶠᵃ[0] == -45 - grid.Δϕ
-    @test grid.ϕᵃᶜᵃ[Nϕ+1] == 45 + grid.Δϕ
+    @test grid.ϕᵃᶠᵃ[Nϕ+2] == 45 + grid.Δϕ
 
     @test all(diff(grid.λᶠᵃᵃ.parent) .== grid.Δλ)
     @test all(diff(grid.λᶜᵃᵃ.parent) .== grid.Δλ)
@@ -428,9 +426,9 @@ end
 
 function test_basic_lat_lon_periodic_domain(FT)
     Nλ = 36
-    Nϕ = 18
+    Nϕ = 32
 
-    grid = RegularLatitudeLongitudeGrid(FT, size=(Nλ, Nϕ, 1), longitude=(-180, 180), latitude=(-90, 90), z=(0, 1))
+    grid = RegularLatitudeLongitudeGrid(FT, size=(Nλ, Nϕ, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
 
     @test topology(grid) == (Periodic, Bounded, Bounded)
 
@@ -439,18 +437,30 @@ function test_basic_lat_lon_periodic_domain(FT)
     @test grid.Nz == 1
 
     @test grid.Lx == 360
-    @test grid.Ly == 180
+    @test grid.Ly == 160
     @test grid.Lz == 1
 
     @test grid.Δλ == 10
-    @test grid.Δϕ == 10
+    @test grid.Δϕ == 5
     @test grid.Δz == 1
+
+    @test length(grid.λᶠᵃᵃ) == Nλ + 2Hλ + 1
+    @test length(grid.λᶜᵃᵃ) == Nλ + 2Hλ
+
+    @test length(grid.ϕᵃᶠᵃ) == Nϕ + 2Hϕ + 1
+    @test length(grid.ϕᵃᶜᵃ) == Nϕ + 2Hϕ
 
     @test grid.λᶠᵃᵃ[1] == -180
     @test grid.λᶠᵃᵃ[Nλ+1] == 180
 
-    @test grid.ϕᵃᶠᵃ[1] == -45
-    @test grid.ϕᵃᶠᵃ[Nϕ+1] == 45
+    @test grid.ϕᵃᶠᵃ[1] == -80
+    @test grid.ϕᵃᶠᵃ[Nϕ+1] == 80
+
+    @test grid.λᶠᵃᵃ[0] == -180 - grid.Δλ
+    @test grid.λᶠᵃᵃ[Nλ+2] == 180 + grid.Δλ
+
+    @test grid.ϕᵃᶠᵃ[0] == -80 - grid.Δϕ
+    @test grid.ϕᵃᶠᵃ[Nϕ+2] == 80 + grid.Δϕ
 
     @test all(diff(grid.λᶠᵃᵃ.parent) .== grid.Δλ)
     @test all(diff(grid.λᶜᵃᵃ.parent) .== grid.Δλ)
@@ -559,5 +569,10 @@ end
             test_basic_lat_lon_bounded_domain(FT)
             test_basic_lat_lon_periodic_domain(FT)
         end
+
+        # Testing show function
+        grid = RegularLatitudeLongitudeGrid(FT, size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
+        show(grid); println();
+        @test grid isa RegularLatitudeLongitudeGrid
     end
 end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -445,20 +445,20 @@ function test_basic_lat_lon_periodic_domain(FT)
     @test grid.Δϕ == 5
     @test grid.Δz == 1
 
-    @test length(grid.λᶠᵃᵃ) == Nλ + 2Hλ + 1
+    @test length(grid.λᶠᵃᵃ) == Nλ + 2Hλ
     @test length(grid.λᶜᵃᵃ) == Nλ + 2Hλ
 
     @test length(grid.ϕᵃᶠᵃ) == Nϕ + 2Hϕ + 1
     @test length(grid.ϕᵃᶜᵃ) == Nϕ + 2Hϕ
 
     @test grid.λᶠᵃᵃ[1] == -180
-    @test grid.λᶠᵃᵃ[Nλ+1] == 180
+    @test grid.λᶠᵃᵃ[Nλ] == 180 - grid.Δλ
 
     @test grid.ϕᵃᶠᵃ[1] == -80
     @test grid.ϕᵃᶠᵃ[Nϕ+1] == 80
 
     @test grid.λᶠᵃᵃ[0] == -180 - grid.Δλ
-    @test grid.λᶠᵃᵃ[Nλ+2] == 180 + grid.Δλ
+    @test grid.λᶠᵃᵃ[Nλ+1] == 180
 
     @test grid.ϕᵃᶠᵃ[0] == -80 - grid.Δϕ
     @test grid.ϕᵃᶠᵃ[Nϕ+2] == 80 + grid.Δϕ

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -427,8 +427,9 @@ end
 function test_basic_lat_lon_periodic_domain(FT)
     Nλ = 36
     Nϕ = 32
+    Hλ = Hϕ = 1
 
-    grid = RegularLatitudeLongitudeGrid(FT, size=(Nλ, Nϕ, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
+    grid = RegularLatitudeLongitudeGrid(FT, size=(Nλ, Nϕ, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1), halo=(Hλ, Hϕ, 1))
 
     @test topology(grid) == (Periodic, Bounded, Bounded)
 
@@ -571,7 +572,7 @@ end
         end
 
         # Testing show function
-        grid = RegularLatitudeLongitudeGrid(FT, size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
+        grid = RegularLatitudeLongitudeGrid(size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
         show(grid); println();
         @test grid isa RegularLatitudeLongitudeGrid
     end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -1,13 +1,166 @@
-using Oceananigans.Grids: total_extent
+using Oceananigans.Grids: total_extent, halo_size
 
 #####
-##### Grid utilities and such
+##### Regular rectilinear grids
 #####
 
-function test_xnode_ynode_znode_are_correct(FT, N=3)
+function test_regular_rectilinear_correct_size(FT)
+    grid = RegularRectilinearGrid(FT, size=(4, 6, 8), extent=(2π, 4π, 9π))
 
+    @test grid.Nx == 4
+    @test grid.Ny == 6
+    @test grid.Nz == 8
+
+    # Checking ≈ as the grid could be storing Float32 values.
+    @test grid.Lx ≈ 2π
+    @test grid.Ly ≈ 4π
+    @test grid.Lz ≈ 9π
+
+    return nothing
+end
+
+function test_regular_rectilinear_correct_extent(FT)
+    grid = RegularRectilinearGrid(FT, size=(4, 6, 8), x=(1, 2), y=(π, 3π), z=(0, 4))
+
+    @test grid.Lx ≈ 1
+    @test grid.Ly ≈ 2π
+    @test grid.Lz ≈ 4
+
+    return nothing
+end
+
+function test_regular_rectilinear_correct_coordinate_lengths(FT)
+    grid = RegularRectilinearGrid(FT, size=(2, 3, 4), extent=(1, 1, 1), halo=(1, 1, 1),
+                                  topology=(Periodic, Bounded, Bounded))
+
+    Nx, Ny, Nz = size(grid)
+    Hx, Hy, Hz = halo_size(grid)
+
+    @test length(grid.xC) == Nx + 2Hx
+    @test length(grid.yC) == Ny + 2Hy
+    @test length(grid.zC) == Nz + 2Hz
+    @test length(grid.xF) == Nx + 2Hx
+    @test length(grid.yF) == Ny + 2Hy + 1
+    @test length(grid.zF) == Nz + 2Hz + 1
+
+    return nothing
+end
+
+function test_regular_rectilinear_correct_halo_size(FT)
+    grid = RegularRectilinearGrid(FT, size=(4, 6, 8), extent=(2π, 4π, 9π), halo=(1, 2, 3))
+
+    @test grid.Hx == 1
+    @test grid.Hy == 2
+    @test grid.Hz == 3
+
+    return nothing
+end
+
+function test_regular_rectilinear_correct_halo_faces(FT)
+    N = 4
+    H = 1
+    L = 2.0
+    Δ = L / N
+
+    topo = (Periodic, Bounded, Bounded)
+    grid = RegularRectilinearGrid(FT, topology=topo, size=(N, N, N), x=(0, L), y=(0, L), z=(0, L), halo=(H, H, H))
+
+    @test grid.xF[0] == - H * Δ
+    @test grid.yF[0] == - H * Δ
+    @test grid.zF[0] == - H * Δ
+
+    @test grid.xF[N+1] == L  # Periodic
+    @test grid.yF[N+2] == L + H * Δ
+    @test grid.zF[N+2] == L + H * Δ
+
+    return nothing
+end
+
+function test_regular_rectilinear_correct_first_cells(FT)
+    N = 4
+    H = 1
+    L = 4.0
+    Δ = L / N
+
+    grid = RegularRectilinearGrid(FT, size=(N, N, N), x=(0, L), y=(0, L), z=(0, L), halo=(H, H, H))
+
+    @test grid.xC[1] == Δ/2
+    @test grid.yC[1] == Δ/2
+    @test grid.zC[1] == Δ/2
+
+    return nothing
+end
+
+function test_regular_rectilinear_correct_end_faces(FT)
+    N = 4
+    L = 2.0
+    Δ = L / N
+
+    grid = RegularRectilinearGrid(FT, size=(N, N, N), x=(0, L), y=(0, L), z=(0, L), halo=(1, 1, 1),
+                                  topology=(Periodic, Bounded, Bounded))
+
+    @test grid.xF[N+1] == L
+    @test grid.yF[N+2] == L + Δ
+    @test grid.zF[N+2] == L + Δ
+
+    return nothing
+end
+
+function test_regular_rectilinear_ranges_have_correct_length(FT)
+    Nx, Ny, Nz = 8, 9, 10
+    Hx, Hy, Hz = 1, 2, 1
+
+    grid = RegularRectilinearGrid(FT, size=(Nx, Ny, Nz), extent=(1, 1, 1), halo=(Hx, Hy, Hz),
+                                  topology=(Bounded, Bounded, Bounded))
+
+    @test length(grid.xC) == Nx + 2Hx
+    @test length(grid.yC) == Ny + 2Hy
+    @test length(grid.zC) == Nz + 2Hz
+    @test length(grid.xF) == Nx + 1 + 2Hx
+    @test length(grid.yF) == Ny + 1 + 2Hy
+    @test length(grid.zF) == Nz + 1 + 2Hz
+
+    return nothing
+end
+
+# See: https://github.com/climate-machine/Oceananigans.jl/issues/480
+function test_regular_rectilinear_no_roundoff_error_in_ranges(FT)
+    Nx = Ny = 1
+    Nz = 64
+    Hz = 1
+
+    grid = RegularRectilinearGrid(FT, size=(Nx, Ny, Nz), extent=(1, 1, π/2), halo=(1, 1, Hz))
+
+    @test length(grid.zC) == Nz + 2Hz
+    @test length(grid.zF) == Nz + 2Hz + 1
+
+    return nothing
+end
+
+function test_regular_rectilinear_grid_properties_are_same_type(FT)
+    grid = RegularRectilinearGrid(FT, size=(10, 10, 10), extent=(1, 1//7, 2π))
+
+    @test grid.Lx isa FT
+    @test grid.Ly isa FT
+    @test grid.Lz isa FT
+    @test grid.Δx isa FT
+    @test grid.Δy isa FT
+    @test grid.Δz isa FT
+
+    @test eltype(grid.xF) == FT
+    @test eltype(grid.yF) == FT
+    @test eltype(grid.zF) == FT
+    @test eltype(grid.xC) == FT
+    @test eltype(grid.yC) == FT
+    @test eltype(grid.zC) == FT
+
+    return nothing
+end
+
+function test_xnode_ynode_znode_are_correct(FT)
+    N = 3
     grid = RegularRectilinearGrid(FT, size=(N, N, N), x=(0, π), y=(0, π), z=(0, π),
-                                topology=(Periodic, Periodic, Bounded))
+                                  topology=(Periodic, Periodic, Bounded))
 
     @test xnode(Center, 2, grid) ≈ FT(π/2)
     @test ynode(Center, 2, grid) ≈ FT(π/2)
@@ -28,87 +181,109 @@ function test_xnode_ynode_znode_are_correct(FT, N=3)
     return nothing
 end
 
-#####
-##### Regular rectilinear grids
-#####
+function test_regular_rectilinear_constructor_errors(FT)
+    @test isbitstype(typeof(RegularRectilinearGrid(FT, size=(16, 16, 16), extent=(1, 1, 1))))
 
-function regular_rectilinear_correct_size(FT)
-    grid = RegularRectilinearGrid(FT, size=(4, 6, 8), extent=(2π, 4π, 9π))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32,), extent=(1, 1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 64), extent=(1, 1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32, 16), extent=(1, 1, 1))
 
-    # Checking ≈ as the grid could be storing Float32 values.
-    return (grid.Nx ≈ 4  && grid.Ny ≈ 6  && grid.Nz ≈ 8 &&
-            grid.Lx ≈ 2π && grid.Ly ≈ 4π && grid.Lz ≈ 9π)
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32.0), extent=(1, 1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(20.1, 32, 32), extent=(1, 1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, nothing, 32), extent=(1, 1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, "32", 32), extent=(1, 1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32), extent=(1, nothing, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32), extent=(1, "1", 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32), extent=(1, 1, 1), halo=(1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32), extent=(1, 1, 1), halo=(1.0, 1, 1))
+
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=2)
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), y=[1, 2])
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), z=(-π, π))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=1, y=2, z=3)
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(0, 1), y=(0, 2), z=4)
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(-1//2, 1), y=(1//7, 5//7), z=("0", "1"))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(-1//2, 1), y=(1//7, 5//7), z=(1, 2, 3))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(1, 0), y=(1//7, 5//7), z=(1, 2))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(0, 1), y=(1, 5), z=(π, -π))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(0, 1), y=(1, 5), z=(π, -π))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), extent=(1, 2, 3), x=(0, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), extent=(1, 2, 3), x=(0, 1), y=(1, 5), z=(-π, π))
+
+    @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), extent=(1, 1, 1), topology=(Periodic, Periodic, Flux))
+
+    @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Flat, Periodic, Periodic), size=(16, 16, 16), extent=1)
+    @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Periodic, Flat, Periodic), size=(16, 16, 16), extent=(1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Periodic, Periodic, Flat), size=(16, 16, 16), extent=(1, 1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Periodic, Periodic, Flat), size=(16, 16),     extent=(1, 1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Periodic, Periodic, Flat), size=16,           extent=(1, 1, 1))
+
+    @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Periodic, Flat, Flat), size=16, extent=(1, 1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Flat, Periodic, Flat), size=16, extent=(1, 1))
+    @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Flat, Flat, Periodic), size=(16, 16), extent=1)
+
+    @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Flat, Flat, Flat), size=16, extent=1)
+
+    return nothing
 end
 
-function regular_rectilinear_correct_extent(FT)
-    grid = RegularRectilinearGrid(FT, size=(4, 6, 8), x=(1, 2), y=(π, 3π), z=(0, 4))
-    return (grid.Lx ≈ 1 && grid.Ly ≈ 2π  && grid.Lz ≈ 4)
+function flat_size_regular_rectilinear_grid(FT; topology, size, extent)
+    grid = RegularRectilinearGrid(FT; size=size, topology=topology, extent=extent)
+    return grid.Nx, grid.Ny, grid.Nz
 end
 
-function regular_rectilinear_correct_coordinate_lengths(FT)
-    grid = RegularRectilinearGrid(FT, size=(2, 3, 4), extent=(1, 1, 1), halo=(1, 1, 1),
-                                topology=(Periodic, Bounded, Bounded))
-
-    return (
-            length(grid.xC) == 4 &&
-            length(grid.yC) == 5 &&
-            length(grid.zC) == 6 &&
-            length(grid.xF) == 4 &&
-            length(grid.yF) == 6 &&
-            length(grid.zF) == 7
-           )
+function flat_halo_regular_rectilinear_grid(FT; topology, size, halo, extent)
+    grid = RegularRectilinearGrid(FT; size=size, halo=halo, topology=topology, extent=extent)
+    return grid.Hx, grid.Hy, grid.Hz
 end
 
-function regular_rectilinear_correct_halo_size(FT)
-    grid = RegularRectilinearGrid(FT, size=(4, 6, 8), extent=(2π, 4π, 9π), halo=(1, 2, 3))
-    return (grid.Hx == 1  && grid.Hy == 2  && grid.Hz == 3)
+function flat_extent_regular_rectilinear_grid(FT; topology, size, extent)
+    grid = RegularRectilinearGrid(FT; size=size, topology=topology, extent=extent)
+    return grid.Lx, grid.Ly, grid.Lz
 end
 
-function regular_rectilinear_correct_halo_faces(FT)
-    N, H, L = 4, 1, 2.0
-    Δ = L / N
-    grid = RegularRectilinearGrid(FT, size=(N, N, N), x=(0, L), y=(0, L), z=(0, L), halo=(H, H, H))
-    return grid.xF[0] == - H * Δ && grid.yF[0] == - H * Δ && grid.zF[0] == - H * Δ
-end
 
-function regular_rectilinear_correct_first_cells(FT)
-    N, H, L = 4, 1, 4.0
-    Δ = L / N
-    grid = RegularRectilinearGrid(FT, size=(N, N, N), x=(0, L), y=(0, L), z=(0, L), halo=(H, H, H))
-    return grid.xC[1] == Δ/2 && grid.yC[1] == Δ/2 && grid.zC[1] == Δ/2
-end
+function test_flat_size_regular_rectilinear_grid(FT)
+    @test flat_size_regular_rectilinear_grid(FT, topology=(Flat, Periodic, Periodic), size=(2, 3), extent=(1, 1)) === (1, 2, 3)
+    @test flat_size_regular_rectilinear_grid(FT, topology=(Periodic, Flat, Bounded),  size=(2, 3), extent=(1, 1)) === (2, 1, 3)
+    @test flat_size_regular_rectilinear_grid(FT, topology=(Periodic, Bounded, Flat),  size=(2, 3), extent=(1, 1)) === (2, 3, 1)
 
-function regular_rectilinear_correct_end_faces(FT)
-    N, L = 4, 2.0
-    Δ = L / N
-    grid = RegularRectilinearGrid(FT, size=(N, N, N), x=(0, L), y=(0, L), z=(0, L), halo=(1, 1, 1),
-                                topology=(Periodic, Bounded, Bounded))
-    return grid.xF[end] == L && grid.yF[end] == L + Δ && grid.zF[end] == L + Δ
-end
+    @test flat_size_regular_rectilinear_grid(FT, topology=(Flat, Periodic, Periodic), size=(2, 3), extent=(1, 1)) === (1, 2, 3)
+    @test flat_size_regular_rectilinear_grid(FT, topology=(Periodic, Flat, Bounded),  size=(2, 3), extent=(1, 1)) === (2, 1, 3)
+    @test flat_size_regular_rectilinear_grid(FT, topology=(Periodic, Bounded, Flat),  size=(2, 3), extent=(1, 1)) === (2, 3, 1)
 
-function regular_rectilinear_ranges_have_correct_length(FT)
-    Nx, Ny, Nz = 8, 9, 10
-    Hx, Hy, Hz = 1, 2, 1
+    @test flat_size_regular_rectilinear_grid(FT, topology=(Periodic, Flat, Flat), size=2, extent=1) === (2, 1, 1)
+    @test flat_size_regular_rectilinear_grid(FT, topology=(Flat, Periodic, Flat), size=2, extent=1) === (1, 2, 1)
+    @test flat_size_regular_rectilinear_grid(FT, topology=(Flat, Flat, Bounded),  size=2, extent=1) === (1, 1, 2)
 
-    grid = RegularRectilinearGrid(FT, size=(Nx, Ny, Nz), extent=(1, 1, 1), halo=(Hx, Hy, Hz),
-                                topology=(Bounded, Bounded, Bounded))
+    @test flat_size_regular_rectilinear_grid(FT, topology=(Flat, Flat, Flat), size=(), extent=()) === (1, 1, 1)
 
-    return (length(grid.xC) == Nx + 2Hx && length(grid.xF) == Nx + 1 + 2Hx &&
-            length(grid.yC) == Ny + 2Hy && length(grid.yF) == Ny + 1 + 2Hy &&
-            length(grid.zC) == Nz + 2Hz && length(grid.zF) == Nz + 1 + 2Hz)
-end
+    @test flat_halo_regular_rectilinear_grid(FT, topology=(Flat, Periodic, Periodic), size=(1, 1), extent=(1, 1), halo=nothing) === (0, 1, 1)
+    @test flat_halo_regular_rectilinear_grid(FT, topology=(Periodic, Flat, Bounded),  size=(1, 1), extent=(1, 1), halo=nothing) === (1, 0, 1)
+    @test flat_halo_regular_rectilinear_grid(FT, topology=(Periodic, Bounded, Flat),  size=(1, 1), extent=(1, 1), halo=nothing) === (1, 1, 0)
 
-# See: https://github.com/climate-machine/Oceananigans.jl/issues/480
-function regular_rectilinear_no_roundoff_error_in_ranges(FT)
-    Nx, Ny, Nz, Hz = 1, 1, 64, 1
-    grid = RegularRectilinearGrid(FT, size=(Nx, Ny, Nz), extent=(1, 1, π/2), halo=(1, 1, Hz))
-    return length(grid.zC) == Nz + 2Hz && length(grid.zF) == Nz + 1 + 2Hz
-end
+    @test flat_halo_regular_rectilinear_grid(FT, topology=(Flat, Periodic, Periodic), size=(1, 1), extent=(1, 1), halo=(2, 3)) === (0, 2, 3)
+    @test flat_halo_regular_rectilinear_grid(FT, topology=(Periodic, Flat, Bounded),  size=(1, 1), extent=(1, 1), halo=(2, 3)) === (2, 0, 3)
+    @test flat_halo_regular_rectilinear_grid(FT, topology=(Periodic, Bounded, Flat),  size=(1, 1), extent=(1, 1), halo=(2, 3)) === (2, 3, 0)
 
-function regular_rectilinear_grid_properties_are_same_type(FT)
-    grid = RegularRectilinearGrid(FT, size=(10, 10, 10), extent=(1, 1//7, 2π))
-    return all(isa.([grid.Lx, grid.Ly, grid.Lz, grid.Δx, grid.Δy, grid.Δz], FT)) &&
-           all(eltype.([grid.xF, grid.yF, grid.zF, grid.xC, grid.yC, grid.zC]) .== FT)
+    @test flat_halo_regular_rectilinear_grid(FT, topology=(Periodic, Flat, Flat), size=1, extent=1, halo=2) === (2, 0, 0)
+    @test flat_halo_regular_rectilinear_grid(FT, topology=(Flat, Periodic, Flat), size=1, extent=1, halo=2) === (0, 2, 0)
+    @test flat_halo_regular_rectilinear_grid(FT, topology=(Flat, Flat, Bounded),  size=1, extent=1, halo=2) === (0, 0, 2)
+
+    @test flat_halo_regular_rectilinear_grid(FT, topology=(Flat, Flat, Flat), size=(), extent=(), halo=()) === (0, 0, 0)
+
+    @test flat_extent_regular_rectilinear_grid(FT, topology=(Flat, Periodic, Periodic), size=(2, 3), extent=(1, 1)) == (0, 1, 1)
+    @test flat_extent_regular_rectilinear_grid(FT, topology=(Periodic, Flat, Periodic), size=(2, 3), extent=(1, 1)) == (1, 0, 1)
+    @test flat_extent_regular_rectilinear_grid(FT, topology=(Periodic, Periodic, Flat), size=(2, 3), extent=(1, 1)) == (1, 1, 0)
+
+    @test flat_extent_regular_rectilinear_grid(FT, topology=(Periodic, Flat, Flat), size=2, extent=1) == (1, 0, 0)
+    @test flat_extent_regular_rectilinear_grid(FT, topology=(Flat, Periodic, Flat), size=2, extent=1) == (0, 1, 0)
+    @test flat_extent_regular_rectilinear_grid(FT, topology=(Flat, Flat, Periodic), size=2, extent=1) == (0, 0, 1)
+
+    @test flat_extent_regular_rectilinear_grid(FT, topology=(Flat, Flat, Flat), size=(), extent=()) == (0, 0, 0)
+
+    return nothing
 end
 
 #####
@@ -117,8 +292,24 @@ end
 
 function vertically_stretched_grid_properties_are_same_type(FT, arch)
     grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, 16), x=(0,1), y=(0,1), zF=collect(0:16))
-    return all(isa.([grid.Lx, grid.Ly, grid.Lz, grid.Δx, grid.Δy], FT)) &&
-           all(eltype.([grid.Δzᵃᵃᶜ, grid.Δzᵃᵃᶠ, grid.xᶠᵃᵃ, grid.yᵃᶠᵃ, grid.zᵃᵃᶠ, grid.xᶜᵃᵃ, grid.yᵃᶜᵃ, grid.zᵃᵃᶜ]) .== FT)
+
+    @test grid.Lx isa FT
+    @test grid.Ly isa FT
+    @test grid.Lz isa FT
+    @test grid.Δx isa FT
+    @test grid.Δy isa FT
+
+    @test eltype(grid.xᶠᵃᵃ) == FT
+    @test eltype(grid.xᶜᵃᵃ) == FT
+    @test eltype(grid.yᵃᶠᵃ) == FT
+    @test eltype(grid.yᵃᶜᵃ) == FT
+    @test eltype(grid.zᵃᵃᶠ) == FT
+    @test eltype(grid.zᵃᵃᶜ) == FT
+
+    @test eltype(grid.Δzᵃᵃᶜ) == FT
+    @test eltype(grid.Δzᵃᵃᶠ) == FT
+
+    return nothing
 end
 
 function run_architecturally_correct_stretched_grid_tests(FT, arch, zF)
@@ -135,8 +326,10 @@ end
 
 function run_correct_constant_grid_spacings_tests(FT, Nz)
     grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=collect(0:Nz))
+
     @test all(grid.Δzᵃᵃᶜ .== 1)
     @test all(grid.Δzᵃᵃᶠ .== 1)
+
     return nothing
 end
 
@@ -180,21 +373,6 @@ function run_correct_tanh_grid_spacings_tests(FT, Nz)
    return nothing
 end
 
-function flat_size_regular_rectilinear_grid(FT; topology, size, extent)
-    grid = RegularRectilinearGrid(FT; size=size, topology=topology, extent=extent)
-    return grid.Nx, grid.Ny, grid.Nz
-end
-
-function flat_halo_regular_rectilinear_grid(FT; topology, size, halo, extent)
-    grid = RegularRectilinearGrid(FT; size=size, halo=halo, topology=topology, extent=extent)
-    return grid.Hx, grid.Hy, grid.Hz
-end
-
-function flat_extent_regular_rectilinear_grid(FT; topology, size, extent)
-    grid = RegularRectilinearGrid(FT; size=size, topology=topology, extent=extent)
-    return grid.Lx, grid.Ly, grid.Lz
-end
-
 #####
 ##### Test the tests
 #####
@@ -204,11 +382,9 @@ end
 
     @testset "Grid utils" begin
         @info "  Testing grid utilities..."
+
         @test total_extent(Periodic, 1, 0.2, 1.0) == 1.2
         @test total_extent(Bounded, 1, 0.2, 1.0) == 1.4
-        for FT in float_types
-            test_xnode_ynode_znode_are_correct(FT)
-        end
     end
 
     @testset "Regular rectilinear grid" begin
@@ -218,16 +394,17 @@ end
             @info "    Testing grid initialization..."
 
             for FT in float_types
-                @test regular_rectilinear_correct_size(FT)
-                @test regular_rectilinear_correct_extent(FT)
-                @test regular_rectilinear_correct_coordinate_lengths(FT)
-                @test regular_rectilinear_correct_halo_size(FT)
-                @test regular_rectilinear_correct_halo_faces(FT)
-                @test regular_rectilinear_correct_first_cells(FT)
-                @test regular_rectilinear_correct_end_faces(FT)
-                @test regular_rectilinear_ranges_have_correct_length(FT)
-                @test regular_rectilinear_no_roundoff_error_in_ranges(FT)
-                @test regular_rectilinear_grid_properties_are_same_type(FT)
+                test_regular_rectilinear_correct_size(FT)
+                test_regular_rectilinear_correct_extent(FT)
+                test_regular_rectilinear_correct_coordinate_lengths(FT)
+                test_regular_rectilinear_correct_halo_size(FT)
+                test_regular_rectilinear_correct_halo_faces(FT)
+                test_regular_rectilinear_correct_first_cells(FT)
+                test_regular_rectilinear_correct_end_faces(FT)
+                test_regular_rectilinear_ranges_have_correct_length(FT)
+                test_regular_rectilinear_no_roundoff_error_in_ranges(FT)
+                test_regular_rectilinear_grid_properties_are_same_type(FT)
+                test_xnode_ynode_znode_are_correct(FT)
             end
         end
 
@@ -235,48 +412,7 @@ end
             @info "    Testing grid constructor errors..."
 
             for FT in float_types
-                @test isbitstype(typeof(RegularRectilinearGrid(FT, size=(16, 16, 16), extent=(1, 1, 1))))
-
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32,), extent=(1, 1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 64), extent=(1, 1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32, 16), extent=(1, 1, 1))
-
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32.0), extent=(1, 1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(20.1, 32, 32), extent=(1, 1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, nothing, 32), extent=(1, 1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, "32", 32), extent=(1, 1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32), extent=(1, nothing, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32), extent=(1, "1", 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32), extent=(1, 1, 1), halo=(1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(32, 32, 32), extent=(1, 1, 1), halo=(1.0, 1, 1))
-
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=2)
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), y=[1, 2])
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), z=(-π, π))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=1, y=2, z=3)
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(0, 1), y=(0, 2), z=4)
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(-1//2, 1), y=(1//7, 5//7), z=("0", "1"))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(-1//2, 1), y=(1//7, 5//7), z=(1, 2, 3))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(1, 0), y=(1//7, 5//7), z=(1, 2))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(0, 1), y=(1, 5), z=(π, -π))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), x=(0, 1), y=(1, 5), z=(π, -π))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), extent=(1, 2, 3), x=(0, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), extent=(1, 2, 3), x=(0, 1), y=(1, 5), z=(-π, π))
-
-                @test_throws ArgumentError RegularRectilinearGrid(FT, size=(16, 16, 16), extent=(1, 1, 1), topology=(Periodic, Periodic, Flux))
-
-                @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Flat, Periodic, Periodic), size=(16, 16, 16), extent=1)
-                @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Periodic, Flat, Periodic), size=(16, 16, 16), extent=(1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Periodic, Periodic, Flat), size=(16, 16, 16), extent=(1, 1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Periodic, Periodic, Flat), size=(16, 16),     extent=(1, 1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Periodic, Periodic, Flat), size=16,           extent=(1, 1, 1))
-
-                @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Periodic, Flat, Flat), size=16, extent=(1, 1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Flat, Periodic, Flat), size=16, extent=(1, 1))
-                @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Flat, Flat, Periodic), size=(16, 16), extent=1)
-
-                @test_throws ArgumentError RegularRectilinearGrid(FT, topology=(Flat, Flat, Flat), size=16, extent=1)
+                test_regular_rectilinear_constructor_errors(FT)
             end
         end
 
@@ -284,43 +420,7 @@ end
             @info "    Testing construction of grids with Flat dimensions..."
 
             for FT in float_types
-                @test flat_size_regular_rectilinear_grid(FT; topology=(Flat, Periodic, Periodic), size=(2, 3), extent=(1, 1)) === (1, 2, 3)
-                @test flat_size_regular_rectilinear_grid(FT; topology=(Periodic, Flat, Bounded),  size=(2, 3), extent=(1, 1)) === (2, 1, 3)
-                @test flat_size_regular_rectilinear_grid(FT; topology=(Periodic, Bounded, Flat),  size=(2, 3), extent=(1, 1)) === (2, 3, 1)
-
-                @test flat_size_regular_rectilinear_grid(FT; topology=(Flat, Periodic, Periodic), size=(2, 3), extent=(1, 1)) === (1, 2, 3)
-                @test flat_size_regular_rectilinear_grid(FT; topology=(Periodic, Flat, Bounded),  size=(2, 3), extent=(1, 1)) === (2, 1, 3)
-                @test flat_size_regular_rectilinear_grid(FT; topology=(Periodic, Bounded, Flat),  size=(2, 3), extent=(1, 1)) === (2, 3, 1)
-
-                @test flat_size_regular_rectilinear_grid(FT; topology=(Periodic, Flat, Flat), size=2, extent=1) === (2, 1, 1)
-                @test flat_size_regular_rectilinear_grid(FT; topology=(Flat, Periodic, Flat), size=2, extent=1) === (1, 2, 1)
-                @test flat_size_regular_rectilinear_grid(FT; topology=(Flat, Flat, Bounded),  size=2, extent=1) === (1, 1, 2)
-
-                @test flat_size_regular_rectilinear_grid(FT; topology=(Flat, Flat, Flat), size=(), extent=()) === (1, 1, 1)
-
-                @test flat_halo_regular_rectilinear_grid(FT; topology=(Flat, Periodic, Periodic), size=(1, 1), extent=(1, 1), halo=nothing) === (0, 1, 1)
-                @test flat_halo_regular_rectilinear_grid(FT; topology=(Periodic, Flat, Bounded),  size=(1, 1), extent=(1, 1), halo=nothing) === (1, 0, 1)
-                @test flat_halo_regular_rectilinear_grid(FT; topology=(Periodic, Bounded, Flat),  size=(1, 1), extent=(1, 1), halo=nothing) === (1, 1, 0)
-
-                @test flat_halo_regular_rectilinear_grid(FT; topology=(Flat, Periodic, Periodic), size=(1, 1), extent=(1, 1), halo=(2, 3)) === (0, 2, 3)
-                @test flat_halo_regular_rectilinear_grid(FT; topology=(Periodic, Flat, Bounded),  size=(1, 1), extent=(1, 1), halo=(2, 3)) === (2, 0, 3)
-                @test flat_halo_regular_rectilinear_grid(FT; topology=(Periodic, Bounded, Flat),  size=(1, 1), extent=(1, 1), halo=(2, 3)) === (2, 3, 0)
-
-                @test flat_halo_regular_rectilinear_grid(FT; topology=(Periodic, Flat, Flat), size=1, extent=1, halo=2) === (2, 0, 0)
-                @test flat_halo_regular_rectilinear_grid(FT; topology=(Flat, Periodic, Flat), size=1, extent=1, halo=2) === (0, 2, 0)
-                @test flat_halo_regular_rectilinear_grid(FT; topology=(Flat, Flat, Bounded),  size=1, extent=1, halo=2) === (0, 0, 2)
-
-                @test flat_halo_regular_rectilinear_grid(FT; topology=(Flat, Flat, Flat), size=(), extent=(), halo=()) === (0, 0, 0)
-
-                @test flat_extent_regular_rectilinear_grid(FT; topology=(Flat, Periodic, Periodic), size=(2, 3), extent=(1, 1)) == (0, 1, 1)
-                @test flat_extent_regular_rectilinear_grid(FT; topology=(Periodic, Flat, Periodic), size=(2, 3), extent=(1, 1)) == (1, 0, 1)
-                @test flat_extent_regular_rectilinear_grid(FT; topology=(Periodic, Periodic, Flat), size=(2, 3), extent=(1, 1)) == (1, 1, 0)
-
-                @test flat_extent_regular_rectilinear_grid(FT; topology=(Periodic, Flat, Flat), size=2, extent=1) == (1, 0, 0)
-                @test flat_extent_regular_rectilinear_grid(FT; topology=(Flat, Periodic, Flat), size=2, extent=1) == (0, 1, 0)
-                @test flat_extent_regular_rectilinear_grid(FT; topology=(Flat, Flat, Periodic), size=2, extent=1) == (0, 0, 1)
-
-                @test flat_extent_regular_rectilinear_grid(FT; topology=(Flat, Flat, Flat), size=(), extent=()) == (0, 0, 0)
+                test_flat_size_regular_rectilinear_grid(FT)
             end
         end
 


### PR DESCRIPTION
This PR adds tests for `RegularLatitudeLongitudeGrid` which uncovered a couple of stupid bugs in the process.

Sorry everyone. I guess we shouldn't be approving important PRs without tests in the future.

I've somehow convinced myself that we need `Nλ + 2Hλ + 1` grid points in longitude even when it's periodic (tests don't pass otherwise), but not sure why so maybe let's hold off on merging just yet.

This PR should fix things in PR #1404.

Also, I didn't like `test_grids.jl` so I refactored it.