### PR TITLE
Curvilinear diffusion validation experiments

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -9,7 +9,7 @@ using Oceananigans.Buoyancy: validate_buoyancy, SeawaterBuoyancy, g_Earth
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions, TracerBoundaryConditions
 using Oceananigans.Fields: Field, CenterField, tracernames, VelocityFields, TracerFields
 using Oceananigans.Forcings: model_forcing
-using Oceananigans.Grids: with_halo
+using Oceananigans.Grids: with_halo, AbstractRectilinearGrid, AbstractCurvilinearGrid, AbstractHorizontallyCurvilinearGrid
 using Oceananigans.Models.IncompressibleModels: extract_boundary_conditions
 using Oceananigans.TimeSteppers: Clock, TimeStepper
 using Oceananigans.TurbulenceClosures: ν₀, κ₀, with_tracers, DiffusivityFields, IsotropicDiffusivity
@@ -101,6 +101,8 @@ function HydrostaticFreeSurfaceModel(; grid,
          throw(ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
     end
 
+    validate_momentum_advection(momentum_advection, grid)
+
     tracers = tupleit(tracers) # supports tracers=:c keyword argument (for example)
     validate_buoyancy(buoyancy, tracernames(tracers))
 
@@ -157,3 +159,9 @@ function validate_velocity_boundary_conditions(velocities)
                                                               must be `nothing`!")
     return nothing
 end
+
+momentum_advection_squawk(momentum_advection, grid) = error("$(typeof(momentum_advection)) is not supported with $(typeof(grid))")
+
+validate_momentum_advection(momentum_advection, grid) = nothing
+validate_momentum_advection(momentum_advection::VectorInvariant, grid::AbstractRectilinearGrid) = momentum_advection_squawk(momentum_advection, grid)
+validate_momentum_advection(momentum_advection::VectorInvariant, grid::AbstractHorizontallyCurvilinearGrid) = nothing

--- a/src/TurbulenceClosures/turbulence_closure_implementations/horizontally_curvilinear_anistropic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/horizontally_curvilinear_anistropic_diffusivity.jl
@@ -50,14 +50,14 @@ calculate_diffusivities!(K, arch, grid, closure::HorizontallyCurvilinearAnisotro
 end
 
 @inline ∂ⱼ_2ν_Σ₁ⱼ(i, j, k, grid, clock, closure::HorizontallyCurvilinearAnisotropicDiffusivity, U, args...) = (
-      δxᶠᵃᵃ(i, j, k, grid, ν_δᶜᶜᶜ, clock, closure.νh, U.u, U.v) / Δxᶠᶜᵃ(i, j, k, grid)
+    + δxᶠᵃᵃ(i, j, k, grid, ν_δᶜᶜᶜ, clock, closure.νh, U.u, U.v) / Δxᶠᶜᵃ(i, j, k, grid)
     - δyᵃᶜᵃ(i, j, k, grid, ν_ζᶠᶠᶜ, clock, closure.νh, U.u, U.v) / Δyᶠᶜᵃ(i, j, k, grid)
     + δzᵃᵃᶜ(i, j, k, grid, ν_uzᶠᶜᶠ, clock, closure.νz, U.u)     / Δzᵃᵃᶜ(i, j, k, grid)
 )
 
 @inline ∂ⱼ_2ν_Σ₂ⱼ(i, j, k, grid, clock, closure::HorizontallyCurvilinearAnisotropicDiffusivity, U, args...) = (
-      δyᵃᶠᵃ(i, j, k, grid, ν_δᶜᶜᶜ, clock, closure.νh, U.u, U.v) / Δyᶜᶠᵃ(i, j, k, grid)
     + δxᶜᵃᵃ(i, j, k, grid, ν_ζᶠᶠᶜ, clock, closure.νh, U.u, U.v) / Δxᶜᶠᵃ(i, j, k, grid)
+    + δyᵃᶠᵃ(i, j, k, grid, ν_δᶜᶜᶜ, clock, closure.νh, U.u, U.v) / Δyᶜᶠᵃ(i, j, k, grid)
     + δzᵃᵃᶜ(i, j, k, grid, ν_vzᶜᶠᶠ, clock, closure.νz, U.v)     / Δzᵃᵃᶜ(i, j, k, grid)
 )
 

--- a/validation/curvilinear_diffusion/longitudinal_tracer_diffusion.jl
+++ b/validation/curvilinear_diffusion/longitudinal_tracer_diffusion.jl
@@ -1,0 +1,101 @@
+# # Meridional diffusion
+
+using Oceananigans
+using Oceananigans.TurbulenceClosures: HorizontallyCurvilinearAnisotropicDiffusivity
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel
+
+using Statistics
+using JLD2
+using Printf
+using GLMakie
+
+include("../solid_body_rotation/hydrostatic_prescribed_velocity_fields.jl")
+
+Nx = 360
+
+# A spherical domain
+grid = RegularLatitudeLongitudeGrid(size = (Nx, 1, 1),
+                                    radius = 1,
+                                    latitude = (-60, 60),
+                                    longitude = (-180, 180),
+                                    z = (-1, 0))
+
+model = HydrostaticFreeSurfaceModel(grid = grid,
+                                    architecture = CPU(),
+                                    tracers = :c,
+                                    velocities = PrescribedVelocityFields(grid), # quiescent
+                                    closure = HorizontallyCurvilinearAnisotropicDiffusivity(κh=1),
+                                    buoyancy = nothing)
+
+# Tracer patch for visualization
+Gaussian(λ, ϕ, L) = exp(-(λ^2 + ϕ^2) / 2L^2)
+
+# Tracer patch parameters
+L = 12 # degree
+
+cᵢ(λ, ϕ, z) = Gaussian(λ, 0, L)
+
+set!(model, c=cᵢ)
+
+c = model.tracers.c
+
+function progress(s)
+    c = s.model.tracers.c
+    @info "Maximum(c) = $(maximum(c)), time = $(s.model.clock.time) / $(s.stop_time)"
+    return nothing
+end
+
+ϕᵃᶜᵃ_max = maximum(abs, ynodes(Center, grid))
+Δx_min = grid.radius * cosd(ϕᵃᶜᵃ_max) * deg2rad(grid.Δλ)
+Δy_min = grid.radius * deg2rad(grid.Δϕ)
+Δ_min = min(Δx_min, Δy_min)
+
+# Time-scale for gravity wave propagation across the smallest grid cell
+cell_diffusion_time_scale = Δ_min^2
+
+simulation = Simulation(model,
+                        Δt = 0.01cell_diffusion_time_scale,
+                        stop_time = 100cell_diffusion_time_scale,
+                        iteration_interval = 100,
+                        progress = progress)
+                                                         
+output_fields = model.tracers
+
+output_prefix = "longitudinal_tracer_diffusion_Nx$(grid.Nx)"
+
+simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
+                                                      schedule = TimeInterval(cell_diffusion_time_scale / 10),
+                                                      prefix = output_prefix,
+                                                      force = true)
+
+run!(simulation)
+
+file = jldopen(simulation.output_writers[:fields].filepath)
+
+iterations = parse.(Int, keys(file["timeseries/t"]))
+
+for iter in iterations
+    c = file["timeseries/c/$iter"][:, 1, 1]
+    @show maximum(c)
+end
+
+λ = xnodes(Center, grid)
+
+iter = Node(0)
+
+plot_title = @lift "Diffusion on a circle of constant longitude, t = $(file["timeseries/t/" * string($iter)])"
+
+c = @lift file["timeseries/c/" * string($iter)][:, 1, 1]
+
+fig = Figure(resolution = (1080, 540))
+
+ax = fig[1, 1] = Axis(fig, ylabel = "c(λ)", xlabel = "λ")
+
+lines!(ax, λ, c, color=:black)
+
+supertitle = fig[0, :] = Label(fig, plot_title, textsize=30)
+
+record(fig, "longitudinal_tracer_diffusion_Nx$(grid.Nx).mp4", iterations, framerate=30) do i
+    @info "Animating iteration $i/$(iterations[end])..."
+    iter[] = i
+end

--- a/validation/curvilinear_diffusion/longitudinal_tracer_diffusion.jl
+++ b/validation/curvilinear_diffusion/longitudinal_tracer_diffusion.jl
@@ -9,7 +9,7 @@ using JLD2
 using Printf
 using GLMakie
 
-include("../solid_body_rotation/hydrostatic_prescribed_velocity_fields.jl")
+include(joinpath(@__DIR__, "..", "solid_body_rotation", "hydrostatic_prescribed_velocity_fields.jl"))
 
 Nx = 360
 

--- a/validation/curvilinear_diffusion/longitudinal_tracer_diffusion.jl
+++ b/validation/curvilinear_diffusion/longitudinal_tracer_diffusion.jl
@@ -54,7 +54,7 @@ end
 cell_diffusion_time_scale = Δ_min^2
 
 simulation = Simulation(model,
-                        Δt = 0.01cell_diffusion_time_scale,
+                        Δt = 0.1cell_diffusion_time_scale,
                         stop_time = 100cell_diffusion_time_scale,
                         iteration_interval = 100,
                         progress = progress)
@@ -64,7 +64,7 @@ output_fields = model.tracers
 output_prefix = "longitudinal_tracer_diffusion_Nx$(grid.Nx)"
 
 simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
-                                                      schedule = TimeInterval(cell_diffusion_time_scale / 10),
+                                                      schedule = TimeInterval(cell_diffusion_time_scale),
                                                       prefix = output_prefix,
                                                       force = true)
 
@@ -83,7 +83,7 @@ end
 
 iter = Node(0)
 
-plot_title = @lift "Diffusion on a circle of constant longitude, t = $(file["timeseries/t/" * string($iter)])"
+title = @lift "Tracer diffusion on a parallel, t = $(file["timeseries/t/" * string($iter)])"
 
 c = @lift file["timeseries/c/" * string($iter)][:, 1, 1]
 
@@ -92,8 +92,6 @@ fig = Figure(resolution = (1080, 540))
 ax = fig[1, 1] = Axis(fig, ylabel = "c(λ)", xlabel = "λ")
 
 lines!(ax, λ, c, color=:black)
-
-supertitle = fig[0, :] = Label(fig, plot_title, textsize=30)
 
 record(fig, "longitudinal_tracer_diffusion_Nx$(grid.Nx).mp4", iterations, framerate=30) do i
     @info "Animating iteration $i/$(iterations[end])..."

--- a/validation/curvilinear_diffusion/meridional_diffusion.jl
+++ b/validation/curvilinear_diffusion/meridional_diffusion.jl
@@ -1,8 +1,9 @@
 # # Meridional diffusion
 
 using Oceananigans
+lines!(cax, c, ϕ, color = :black)
 using Oceananigans.TurbulenceClosures: HorizontallyCurvilinearAnisotropicDiffusivity
-using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel, VectorInvariant
 
 using Statistics
 using JLD2
@@ -22,9 +23,10 @@ grid = RegularLatitudeLongitudeGrid(size = (1, Ny, 1),
 
 model = HydrostaticFreeSurfaceModel(grid = grid,
                                     architecture = CPU(),
+                                    momentum_advection = VectorInvariant(),
                                     tracers = :c,
-                                    velocities = PrescribedVelocityFields(grid), # quiescent
-                                    closure = HorizontallyCurvilinearAnisotropicDiffusivity(κh=1),
+                                    coriolis = nothing,
+                                    closure = HorizontallyCurvilinearAnisotropicDiffusivity(κh=1, νh=1),
                                     buoyancy = nothing)
 
 # Tracer patch for visualization
@@ -36,7 +38,7 @@ L = 4 # degree
 
 cᵢ(λ, ϕ, z) = Gaussian(0, ϕ - ϕ₀, L)
 
-set!(model, c=cᵢ)
+set!(model, c=cᵢ, u=cᵢ)
 
 c = model.tracers.c
 
@@ -55,18 +57,17 @@ end
 cell_diffusion_time_scale = Δ_min^2
 
 simulation = Simulation(model,
-                        Δt = 0.01cell_diffusion_time_scale,
+                        Δt = 0.1cell_diffusion_time_scale,
                         stop_time = 100cell_diffusion_time_scale,
                         iteration_interval = 100,
                         progress = progress)
                                                          
-#output_fields = merge(model.velocities, model.tracers, (η=model.free_surface.η,))
-output_fields = model.tracers
+output_fields = merge(model.velocities, model.tracers)
 
-output_prefix = "meridional_tracer_diffusion_Ny$(grid.Ny)"
+output_prefix = "meridional_diffusion_Ny$(grid.Ny)"
 
 simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
-                                                      schedule = TimeInterval(cell_diffusion_time_scale / 10),
+                                                      schedule = TimeInterval(cell_diffusion_time_scale),
                                                       prefix = output_prefix,
                                                       force = true)
 
@@ -76,29 +77,36 @@ file = jldopen(simulation.output_writers[:fields].filepath)
 
 iterations = parse.(Int, keys(file["timeseries/t"]))
 
-for iter in iterations
-    c = file["timeseries/c/$iter"][1, :, 1]
-    @show maximum(c)
-end
-
 ϕ = ynodes(Center, grid)
 
 iter = Node(0)
 
 plot_title = "hi"
 
+u = @lift file["timeseries/u/" * string($iter)][1, :, 1]
 c = @lift file["timeseries/c/" * string($iter)][1, :, 1]
 
+set_theme!(Theme(fontsize = 30))
 
-fig = Figure(resolution = (540, 1080))
+fig = Figure(resolution = (1920, 1080))
 
-ax = fig[1, 1] = Axis(fig, xlabel = "U(ϕ)", ylabel = "ϕ")
+c_title = @lift @sprintf("Tracer diffusion on a meridian, t = %.2e", file["timeseries/t/" * string($iter)])
+u_title = @lift @sprintf("Momentum diffusion on a meridian, t = %.2e", file["timeseries/t/" * string($iter)])
 
-lines!(ax, c, ϕ, color=:black)
+cax = fig[1, 1] = Axis(fig,
+                       xlabel = "c(ϕ)",
+                       ylabel = "ϕ",
+                       title = c_title)
 
-supertitle = fig[0, :] = Label(fig, plot_title, textsize=30)
+uax = fig[1, 2] = Axis(fig,
+                       xlabel = "u(ϕ)",
+                       ylabel = "ϕ",
+                       title = u_title)
 
-record(fig, "meridional_tracer_diffusion_Ny$(grid.Ny).mp4", iterations, framerate=30) do i
+lines!(cax, c, ϕ, color = :black)
+lines!(uax, u, ϕ, color = :black)
+
+record(fig, "meridional_diffusion_Ny$(grid.Ny).mp4", iterations, framerate = 30) do i
     @info "Animating iteration $i/$(iterations[end])..."
     iter[] = i
 end

--- a/validation/curvilinear_diffusion/meridional_diffusion.jl
+++ b/validation/curvilinear_diffusion/meridional_diffusion.jl
@@ -10,7 +10,7 @@ using JLD2
 using Printf
 using GLMakie
 
-include("../solid_body_rotation/hydrostatic_prescribed_velocity_fields.jl")
+include(joinpath(@__DIR__, "..", "solid_body_rotation", "hydrostatic_prescribed_velocity_fields.jl"))
 
 Ny = 320
 

--- a/validation/curvilinear_diffusion/meridional_tracer_diffusion.jl
+++ b/validation/curvilinear_diffusion/meridional_tracer_diffusion.jl
@@ -1,0 +1,104 @@
+# # Meridional diffusion
+
+using Oceananigans
+using Oceananigans.TurbulenceClosures: HorizontallyCurvilinearAnisotropicDiffusivity
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel
+
+using Statistics
+using JLD2
+using Printf
+using GLMakie
+
+include("../solid_body_rotation/hydrostatic_prescribed_velocity_fields.jl")
+
+Ny = 320
+
+# A spherical domain
+grid = RegularLatitudeLongitudeGrid(size = (1, Ny, 1),
+                                    radius = 1,
+                                    latitude = (-80, 80),
+                                    longitude = (-180, 180),
+                                    z = (-1, 0))
+
+model = HydrostaticFreeSurfaceModel(grid = grid,
+                                    architecture = CPU(),
+                                    tracers = :c,
+                                    velocities = PrescribedVelocityFields(grid), # quiescent
+                                    closure = HorizontallyCurvilinearAnisotropicDiffusivity(κh=1),
+                                    buoyancy = nothing)
+
+# Tracer patch for visualization
+Gaussian(λ, ϕ, L) = exp(-(λ^2 + ϕ^2) / 2L^2)
+
+# Tracer patch parameters
+L = 4 # degree
+ϕ₀ = 0 # degrees
+
+cᵢ(λ, ϕ, z) = Gaussian(0, ϕ - ϕ₀, L)
+
+set!(model, c=cᵢ)
+
+c = model.tracers.c
+
+function progress(s)
+    c = s.model.tracers.c
+    @info "Maximum(c) = $(maximum(c)), time = $(s.model.clock.time) / $(s.stop_time)"
+    return nothing
+end
+
+ϕᵃᶜᵃ_max = maximum(abs, ynodes(Center, grid))
+Δx_min = grid.radius * cosd(ϕᵃᶜᵃ_max) * deg2rad(grid.Δλ)
+Δy_min = grid.radius * deg2rad(grid.Δϕ)
+Δ_min = min(Δx_min, Δy_min)
+
+# Time-scale for gravity wave propagation across the smallest grid cell
+cell_diffusion_time_scale = Δ_min^2
+
+simulation = Simulation(model,
+                        Δt = 0.01cell_diffusion_time_scale,
+                        stop_time = 100cell_diffusion_time_scale,
+                        iteration_interval = 100,
+                        progress = progress)
+                                                         
+#output_fields = merge(model.velocities, model.tracers, (η=model.free_surface.η,))
+output_fields = model.tracers
+
+output_prefix = "meridional_tracer_diffusion_Ny$(grid.Ny)"
+
+simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
+                                                      schedule = TimeInterval(cell_diffusion_time_scale / 10),
+                                                      prefix = output_prefix,
+                                                      force = true)
+
+run!(simulation)
+
+file = jldopen(simulation.output_writers[:fields].filepath)
+
+iterations = parse.(Int, keys(file["timeseries/t"]))
+
+for iter in iterations
+    c = file["timeseries/c/$iter"][1, :, 1]
+    @show maximum(c)
+end
+
+ϕ = ynodes(Center, grid)
+
+iter = Node(0)
+
+plot_title = "hi"
+
+c = @lift file["timeseries/c/" * string($iter)][1, :, 1]
+
+
+fig = Figure(resolution = (540, 1080))
+
+ax = fig[1, 1] = Axis(fig, xlabel = "U(ϕ)", ylabel = "ϕ")
+
+lines!(ax, c, ϕ, color=:black)
+
+supertitle = fig[0, :] = Label(fig, plot_title, textsize=30)
+
+record(fig, "meridional_tracer_diffusion_Ny$(grid.Ny).mp4", iterations, framerate=30) do i
+    @info "Animating iteration $i/$(iterations[end])..."
+    iter[] = i
+end

--- a/validation/curvilinear_diffusion/spot_tracer_diffusion.jl
+++ b/validation/curvilinear_diffusion/spot_tracer_diffusion.jl
@@ -9,7 +9,7 @@ using JLD2
 using Printf
 using GLMakie
 
-include("../solid_body_rotation/hydrostatic_prescribed_velocity_fields.jl")
+include(joinpath(@__DIR__, "..", "solid_body_rotation", "hydrostatic_prescribed_velocity_fields.jl"))
 
 Nx = 360
 Ny = 120

--- a/validation/curvilinear_diffusion/spot_tracer_diffusion.jl
+++ b/validation/curvilinear_diffusion/spot_tracer_diffusion.jl
@@ -1,0 +1,110 @@
+# # Meridional diffusion
+
+using Oceananigans
+using Oceananigans.TurbulenceClosures: HorizontallyCurvilinearAnisotropicDiffusivity
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel
+
+using Statistics
+using JLD2
+using Printf
+using GLMakie
+
+include("../solid_body_rotation/hydrostatic_prescribed_velocity_fields.jl")
+
+Nx = 360
+Ny = 120
+latitude = (-60, 60)
+longitude = (-180, 180)
+
+# A spherical domain
+grid = RegularLatitudeLongitudeGrid(size = (Nx, Ny, 1),
+                                    radius = 1,
+                                    latitude = latitude,
+                                    longitude = longitude,
+                                    z = (-1, 0))
+
+model = HydrostaticFreeSurfaceModel(grid = grid,
+                                    architecture = CPU(),
+                                    tracers = :c,
+                                    velocities = PrescribedVelocityFields(grid), # quiescent
+                                    closure = HorizontallyCurvilinearAnisotropicDiffusivity(κh=1),
+                                    buoyancy = nothing)
+
+# Tracer patch for visualization
+Gaussian(λ, ϕ, L) = exp(-(λ^2 + ϕ^2) / 2L^2)
+
+# Tracer patch parameters
+L = 4 # degree
+ϕ₀ = 0 # degrees
+
+cᵢ(λ, ϕ, z) = Gaussian(0, ϕ - ϕ₀, L)
+
+set!(model, c=cᵢ)
+
+c = model.tracers.c
+
+function progress(s)
+    c = s.model.tracers.c
+    @info "Maximum(c) = $(maximum(c)), time = $(s.model.clock.time) / $(s.stop_time)"
+    return nothing
+end
+
+ϕᵃᶜᵃ_max = maximum(abs, ynodes(Center, grid))
+Δx_min = grid.radius * cosd(ϕᵃᶜᵃ_max) * deg2rad(grid.Δλ)
+Δy_min = grid.radius * deg2rad(grid.Δϕ)
+Δ_min = min(Δx_min, Δy_min)
+
+# Time-scale for gravity wave propagation across the smallest grid cell
+cell_diffusion_time_scale = Δ_min^2
+
+simulation = Simulation(model,
+                        Δt = 0.01cell_diffusion_time_scale,
+                        stop_time = 1cell_diffusion_time_scale,
+                        iteration_interval = 100,
+                        progress = progress)
+                                                         
+#output_fields = merge(model.velocities, model.tracers, (η=model.free_surface.η,))
+output_fields = model.tracers
+
+output_prefix = "spot_tracer_diffusion_Nx$(grid.Nx)_Ny$(grid.Ny)"
+
+simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
+                                                      schedule = TimeInterval(cell_diffusion_time_scale / 10),
+                                                      prefix = output_prefix,
+                                                      force = true)
+
+run!(simulation)
+
+file = jldopen(simulation.output_writers[:fields].filepath)
+
+iterations = parse.(Int, keys(file["timeseries/t"]))
+
+for iter in iterations
+    c = file["timeseries/c/$iter"][1, :, 1]
+    @show maximum(c)
+end
+
+λ = xnodes(Center, grid)
+ϕ = ynodes(Center, grid)
+
+λ = repeat(reshape(λ, Nx, 1), 1, Ny)
+ϕ = repeat(reshape(ϕ, 1, Ny), Nx, 1)
+
+iter = Node(0)
+
+plot_title = "hi"
+
+c = @lift file["timeseries/c/" * string($iter)][:, :, 1]
+
+fig = Figure(resolution = (1080, 1080))
+
+ax = fig[1, 1] = Axis(fig, xlabel = "λ", ylabel = "ϕ")
+
+contourf!(ax, λ, ϕ, c, color=:black)
+
+supertitle = fig[0, :] = Label(fig, plot_title, textsize=30)
+
+record(fig, "spot_tracer_diffusion_Nx$(grid.Nx)_Ny$(grid.Ny)", iterations, framerate=30) do i
+    @info "Animating iteration $i/$(iterations[end])..."
+    iter[] = i
+end

--- a/validation/solid_body_rotation/solid_body_tracer_advection.jl
+++ b/validation/solid_body_rotation/solid_body_tracer_advection.jl
@@ -95,10 +95,10 @@ function run_solid_body_tracer_advection(; architecture = CPU(),
 
     set!(model, c=cᵢ, d=dᵢ, e=eᵢ)
 
-    @show ϕᵃᶜᵃ_max = maximum(abs, ynodes(Center, grid))
-    @show Δx_min = grid.radius * cosd(ϕᵃᶜᵃ_max) * deg2rad(grid.Δλ)
-    @show Δy_min = grid.radius * deg2rad(grid.Δϕ)
-    @show Δ_min = min(Δx_min, Δy_min)
+    ϕᵃᶜᵃ_max = maximum(abs, ynodes(Center, grid))
+    Δx_min = grid.radius * cosd(ϕᵃᶜᵃ_max) * deg2rad(grid.Δλ)
+    Δy_min = grid.radius * deg2rad(grid.Δϕ)
+    Δ_min = min(Δx_min, Δy_min)
 
     # Time-scale for tracer advection across the smallest grid cell
     @show advection_time_scale = Δ_min / U


### PR DESCRIPTION
This PR implements validation experiments for `HorizontallyCurvilinearAnisotropicDissipation`.

There are three experiments:

1. `validation/curvilinear_diffusion/meridional_diffusion.jl`: Diffusion of a tracer and zonal momentum along a meridian
2. `validation/curvilinear_diffusion/longitudinal_tracer_diffusion.jl`: Diffusion of a tracer along a circle of constant latitude. We would need a non-trivial `NormalFlow` boundary condition to diffuse meridional momentum, so I didn't implement momentum diffusion for this experiment.
3. `validation/curvilinear_diffusion/spot_tracer_diffusion.jl`: Diffusion of a Gaussian spot in longitude and latitude.

# Meridional diffusion 

https://user-images.githubusercontent.com/15271942/109988157-42787180-7cd5-11eb-8dfe-b6f173c6c623.mp4

# Longitudinal tracer diffusion

https://user-images.githubusercontent.com/15271942/109988246-5a4ff580-7cd5-11eb-8f91-f089a3760c7f.mp4

# Spot tracer diffusion

https://user-images.githubusercontent.com/15271942/109988291-650a8a80-7cd5-11eb-81a7-762b65a8d39f.mp4

I propose we merge these and, like the other curvilinear validation experiments, save a quantitative validation for the future. For tracers, quantitative validation requires writing down analytical solutions to the diffusion equation on a spherical surface. For momentum, we cannot yet implement quantitative validation experiments, because our diffusion operator is not correct for the diffusion of a vector on a spherical surface (cc @jm-c, @kburns).