### PR TITLE
Small typos

### DIFF
--- a/docs/src/numerical_implementation/spatial_operators.md
+++ b/docs/src/numerical_implementation/spatial_operators.md
@@ -123,9 +123,9 @@ An isotropic viscosity operator acting on vertical momentum is discretized via
 ```math
     \bm{\nabla} \left ( \nu_e \bm{\nabla} w \right )
     = \frac{1}{V} \left[
-          \delta_x^{faa} \left( \nu_e \overline{A_x}^{caa} \delta_x^{caa} w \right)
-        + \delta_y^{afa} \left( \nu_e \overline{A_y}^{aca} \delta_y^{aca} w \right)
-        + \delta_z^{aaf} \left( \nu_e \overline{A_z}^{aac} \delta_z^{aac} w \right)
+          \delta_x^{faa} \left( \nu_e \overline{A_x}^{caa} \partial_x^{caa} w \right)
+        + \delta_y^{afa} \left( \nu_e \overline{A_y}^{aca} \partial_y^{aca} w \right)
+        + \delta_z^{aaf} \left( \nu_e \overline{A_z}^{aac} \partial_z^{aac} w \right)
     \right ] \, ,
 ```
 where ``\nu`` is the kinematic viscosity.
@@ -134,9 +134,9 @@ An isotropic diffusion operator acting on a tracer ``c``, on the other hand, is 
 ```math
    \bm{\nabla} \bm{\cdot} \left ( \kappa_e \bm{\nabla} c \right ) =
     = \frac{1}{V} \left[
-        \delta_x^{caa} \left( \kappa_e A_x \delta_x^{faa} c \right)
-      + \delta_y^{aca} \left( \kappa_e A_y \delta_y^{afa} c \right)
-      + \delta_z^{aac} \left( \kappa_e A_z \delta_z^{aaf} c \right)
+        \delta_x^{caa} \left( \kappa_e A_x \partial_x^{faa} c \right)
+      + \delta_y^{aca} \left( \kappa_e A_y \partial_y^{afa} c \right)
+      + \delta_z^{aac} \left( \kappa_e A_z \partial_z^{aaf} c \right)
     \right] \, .
 ```
 

--- a/docs/src/numerical_implementation/time_stepping.md
+++ b/docs/src/numerical_implementation/time_stepping.md
@@ -57,7 +57,7 @@ where ``\chi`` is a parameter. Ascher et al. (1995) claim that ``\chi = \tfrac{1
 Combining the equations for ``\bm{u}^\star`` and the time integral of the momentum equation yields
 ```math
     \tag{eq:fractional-step}
-    \bm{u}^{n+1} - \bm{u}^\star = - \Delta t \bm{\nabla} \phi_{\rm{non}}^{n+1} \, \rm{d} t \, .
+    \bm{u}^{n+1} - \bm{u}^\star = - \Delta t \bm{\nabla} \phi_{\rm{non}}^{n+1} \, .
 ```
 Taking the divergence of fractional step equation and requiring that 
 ``\bm{\nabla} \bm{\cdot} \bm{u}^{n+1} = 0`` yields a Poisson equation for the potential 


### PR DESCRIPTION
Fixing two small doc typos in 

  spatial_operators:  difference should be a gradient
  

  time_stepping: errant dt