### PR TITLE
Buildkite with Julia v1.5.4

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  JULIA_VERSION: "1.5.3"
+  JULIA_VERSION: "1.5.4"
   JULIA_MINOR_VERSION: "1.5"
   SVERDRUP_HOME: "/data5/glwagner"
   TARTARUS_HOME: "/storage7/buildkite-agent"


### PR DESCRIPTION
Updates buildkite to use Julia v1.5.4.

Closes #1461.