### PR TITLE
Adds information about Δz on show function for VerticallyStretchedGrid

### DIFF
--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -174,11 +174,14 @@ short_show(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, 
     "VerticallyStretchedRectilinearGrid{$FT, $TX, $TY, $TZ}(Nx=$(grid.Nx), Ny=$(grid.Ny), Nz=$(grid.Nz))"
 
 function show(io::IO, g::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
+    Δz_min = minimum(view(g.Δzᵃᵃᶜ, 1:g.Nz))
+    Δz_max = maximum(view(g.Δzᵃᵃᶜ, 1:g.Nz))
     print(io, "VerticallyStretchedRectilinearGrid{$FT, $TX, $TY, $TZ}\n",
               "                   domain: $(domain_string(g))\n",
               "                 topology: ", (TX, TY, TZ), '\n',
               "  resolution (Nx, Ny, Nz): ", (g.Nx, g.Ny, g.Nz), '\n',
-              "   halo size (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz))
+              "   halo size (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz), '\n',
+              "grid spacing (Δx, Δy, Δz): (", g.Δx, ", ", g.Δy, ", [min=", Δz_min, ", max=", Δz_max,"])",)
 end
 
 Adapt.adapt_structure(to, grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =


### PR DESCRIPTION
This changes the behavior of `show()` for VerticallyStretchedGrids to

```julia
VerticallyStretchedRectilinearGrid{Float64, Periodic, Periodic, Bounded}
                   domain: x ∈ [0.0, 500.0], y ∈ [0.0, 23.4375], z ∈ [0.0, 100.0]
                 topology: (Periodic, Periodic, Bounded)
  resolution (Nx, Ny, Nz): (128, 1, 32)
   halo size (Hx, Hy, Hz): (1, 1, 1)
grid spacing (Δx, Δy, Δz): (3.90625, 23.4375, [min=0.97654576571653, max=5.174919985099578])
```

This is very clear but also a bit on the verbose side. Another option would be

```julia
VerticallyStretchedRectilinearGrid{Float64, Periodic, Periodic, Bounded}
                   domain: x ∈ [0.0, 500.0], y ∈ [0.0, 23.4375], z ∈ [0.0, 100.0]
                 topology: (Periodic, Periodic, Bounded)
  resolution (Nx, Ny, Nz): (128, 1, 32)
   halo size (Hx, Hy, Hz): (1, 1, 1)
grid spacing (Δx, Δy, Δz): (3.90625, 23.4375, [0.97654576571653, 5.174919985099578])
```

and then the `min` and `max` are implicit. I'm happy to change to whatever is preferred.

CC @ali-ramadhan 