### PR TITLE
Change nomenclature of vertical direction for Buoyancy()

### DIFF
--- a/src/BuoyancyModels/buoyancy.jl
+++ b/src/BuoyancyModels/buoyancy.jl
@@ -1,28 +1,28 @@
 struct Buoyancy{M, G}
-                        model :: M
-    gravitational_unit_vector :: G
+                   model :: M
+    vertical_unit_vector :: G
 end
 
 struct VerticalDirection end
 
-function Buoyancy(; model, gravitational_unit_vector=VerticalDirection())
-    ĝ = gravitational_unit_vector
+function Buoyancy(; model, vertical_unit_vector=VerticalDirection())
+    ĝ = vertical_unit_vector
     ĝ isa VerticalDirection || length(ĝ) == 3 ||
-        throw(ArgumentError("gravitational_unit_vector must have length 3"))
+        throw(ArgumentError("vertical_unit_vector must have length 3"))
 
     if !isa(ĝ, VerticalDirection)
         gx, gy, gz = ĝ
 
         gx^2 + gy^2 + gz^2 ≈ 1 ||
-            throw(ArgumentError("gravitational_unit_vector must be a unit vector with g[1]² + g[2]² + g[3]² = 1"))
+            throw(ArgumentError("vertical_unit_vector must be a unit vector with g[1]² + g[2]² + g[3]² = 1"))
     end
 
     return Buoyancy(model, ĝ)
 end
 
-@inline ĝ_x(buoyancy) = @inbounds buoyancy.gravitational_unit_vector[1]
-@inline ĝ_y(buoyancy) = @inbounds buoyancy.gravitational_unit_vector[2]
-@inline ĝ_z(buoyancy) = @inbounds buoyancy.gravitational_unit_vector[3]
+@inline ĝ_x(buoyancy) = @inbounds buoyancy.vertical_unit_vector[1]
+@inline ĝ_y(buoyancy) = @inbounds buoyancy.vertical_unit_vector[2]
+@inline ĝ_z(buoyancy) = @inbounds buoyancy.vertical_unit_vector[3]
 
 @inline ĝ_x(::Buoyancy{M, VerticalDirection}) where M = 0
 @inline ĝ_y(::Buoyancy{M, VerticalDirection}) where M = 0

--- a/src/BuoyancyModels/buoyancy.jl
+++ b/src/BuoyancyModels/buoyancy.jl
@@ -49,8 +49,8 @@ end
 @inline ĝ_y(buoyancy) = @inbounds buoyancy.vertical_unit_vector[2]
 @inline ĝ_z(buoyancy) = @inbounds buoyancy.vertical_unit_vector[3]
 
-@inline ĝ_x(::Buoyancy{M, VerticalDirection}) where M = 0
-@inline ĝ_y(::Buoyancy{M, VerticalDirection}) where M = 0
+@inline ĝ_x(::Buoyancy{M, ZDirection}) where M = 0
+@inline ĝ_y(::Buoyancy{M, ZDirection}) where M = 0
 @inline ĝ_z(::Buoyancy{M, VerticalDirection}) where M = 1
 
 #####

--- a/src/BuoyancyModels/buoyancy.jl
+++ b/src/BuoyancyModels/buoyancy.jl
@@ -6,7 +6,7 @@ end
 struct ZDirection end
 
 """
-    Buoyancy(; model, vertical_unit_vector=VerticalDirection())
+    Buoyancy(; model, vertical_unit_vector=ZDirection())
 
 Uses a given buoyancy `model` to create buoyancy in a model. The optional keyword argument 
 `vertical_unit_vector` can be used to specify the direction opposite to the gravitational
@@ -32,10 +32,10 @@ model = IncompressibleModel(
 """
 function Buoyancy(; model, vertical_unit_vector=ZDirection())
     ĝ = vertical_unit_vector
-    ĝ isa VerticalDirection || length(ĝ) == 3 ||
+    ĝ isa ZDirection || length(ĝ) == 3 ||
         throw(ArgumentError("vertical_unit_vector must have length 3"))
 
-    if !isa(ĝ, VerticalDirection)
+    if !isa(ĝ, ZDirection)
         gx, gy, gz = ĝ
 
         gx^2 + gy^2 + gz^2 ≈ 1 ||
@@ -51,7 +51,7 @@ end
 
 @inline ĝ_x(::Buoyancy{M, ZDirection}) where M = 0
 @inline ĝ_y(::Buoyancy{M, ZDirection}) where M = 0
-@inline ĝ_z(::Buoyancy{M, VerticalDirection}) where M = 1
+@inline ĝ_z(::Buoyancy{M, ZDirection}) where M = 1
 
 #####
 ##### For convinience

--- a/src/BuoyancyModels/buoyancy.jl
+++ b/src/BuoyancyModels/buoyancy.jl
@@ -30,7 +30,7 @@ model = IncompressibleModel(
 )
 ```
 """
-function Buoyancy(; model, vertical_unit_vector=VerticalDirection())
+function Buoyancy(; model, vertical_unit_vector=ZDirection())
     ĝ = vertical_unit_vector
     ĝ isa VerticalDirection || length(ĝ) == 3 ||
         throw(ArgumentError("vertical_unit_vector must have length 3"))

--- a/src/BuoyancyModels/buoyancy.jl
+++ b/src/BuoyancyModels/buoyancy.jl
@@ -3,7 +3,7 @@ struct Buoyancy{M, G}
     vertical_unit_vector :: G
 end
 
-struct VerticalDirection end
+struct ZDirection end
 
 """
     Buoyancy(; model, vertical_unit_vector=VerticalDirection())

--- a/src/BuoyancyModels/buoyancy.jl
+++ b/src/BuoyancyModels/buoyancy.jl
@@ -5,6 +5,31 @@ end
 
 struct VerticalDirection end
 
+"""
+    Buoyancy(; model, vertical_unit_vector=VerticalDirection())
+
+Uses a given buoyancy `model` to create buoyancy in a model. The optional keyword argument 
+`vertical_unit_vector` can be used to specify the direction opposite to the gravitational
+acceleration (which we take here to mean the "vertical" direction).
+
+Example
+=======
+
+```julia
+using Oceananigans
+
+grid = RegularRectilinearGrid(size=(1, 8, 8), extent=(1, 1000, 100))
+θ = 45 # degrees
+g̃ = (0, sind(θ), cosd(θ))
+
+buoyancy = Buoyancy(model=BuoyancyTracer(), vertical_unit_vector=g̃)
+model = IncompressibleModel(
+                   grid = grid,
+               buoyancy = buoyancy,
+                tracers = :b,
+)
+```
+"""
 function Buoyancy(; model, vertical_unit_vector=VerticalDirection())
     ĝ = vertical_unit_vector
     ĝ isa VerticalDirection || length(ĝ) == 3 ||

--- a/src/BuoyancyModels/g_dot_b.jl
+++ b/src/BuoyancyModels/g_dot_b.jl
@@ -2,6 +2,6 @@
 @inline y_dot_g_b(i, j, k, grid, buoyancy, C) = ĝ_y(buoyancy) * buoyancy_perturbation(i, j, k, grid, buoyancy.model, C)
 @inline z_dot_g_b(i, j, k, grid, buoyancy, C) = ĝ_z(buoyancy) * buoyancy_perturbation(i, j, k, grid, buoyancy.model, C)
 
-@inline x_dot_g_b(i, j, k, grid,  ::Buoyancy{M, VerticalDirection}, C) where M = 0
-@inline y_dot_g_b(i, j, k, grid,  ::Buoyancy{M, VerticalDirection}, C) where M = 0
-@inline z_dot_g_b(i, j, k, grid, b::Buoyancy{M, VerticalDirection}, C) where M = buoyancy_perturbation(i, j, k, grid, b.model, C)
+@inline x_dot_g_b(i, j, k, grid,  ::Buoyancy{M, ZDirection}, C) where M = 0
+@inline y_dot_g_b(i, j, k, grid,  ::Buoyancy{M, ZDirection}, C) where M = 0
+@inline z_dot_g_b(i, j, k, grid, b::Buoyancy{M, ZDirection}, C) where M = buoyancy_perturbation(i, j, k, grid, b.model, C)

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -249,7 +249,7 @@ function stratified_fluid_remains_at_rest_with_tilted_gravity_buoyancy_tracer(ar
     grid = RegularRectilinearGrid(FT, topology=topo, size=(1, N, N), extent=(L, L, L))
 
     g̃ = (0, sind(θ), cosd(θ))
-    buoyancy = Buoyancy(model=BuoyancyTracer(), gravitational_unit_vector=g̃)
+    buoyancy = Buoyancy(model=BuoyancyTracer(), vertical_unit_vector=g̃)
 
     y_bc = GradientBoundaryCondition(N² * g̃[2])
     z_bc = GradientBoundaryCondition(N² * g̃[3])
@@ -301,7 +301,7 @@ function stratified_fluid_remains_at_rest_with_tilted_gravity_temperature_tracer
     grid = RegularRectilinearGrid(FT, topology=topo, size=(1, N, N), extent=(L, L, L))
 
     g̃ = (0, sind(θ), cosd(θ))
-    buoyancy = Buoyancy(model=SeawaterBuoyancy(), gravitational_unit_vector=g̃)
+    buoyancy = Buoyancy(model=SeawaterBuoyancy(), vertical_unit_vector=g̃)
 
     α  = buoyancy.model.equation_of_state.α
     g₀ = buoyancy.model.gravitational_acceleration


### PR DESCRIPTION
Closes https://github.com/CliMA/Oceananigans.jl/issues/1496

I went ahead and created the PR that makes the change from `gravitational_unit_vector` to `vertical_unit_vector` as discussed in #1496, but I'm still open to suggestions if people agree on a better name. I also created a docstring for the user-facing `Buoyancy()` function that explains what `vertical_unit_vector` is.