### PR TITLE
Updating examples to include `Flat`

### DIFF
--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -166,7 +166,7 @@ progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
                         prettytime(sim.Δt.Δt))
 
 simulation = Simulation(model, Δt=wizard, stop_time=24hours,
-                        iteration_interval=1, progress=progress)
+                        iteration_interval=20, progress=progress)
 
 # We add a basic `JLD2OutputWriter` that writes velocities and both
 # the two-dimensional and horizontally-averaged plankton concentration,

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -165,9 +165,8 @@ progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
                         prettytime(sim.model.clock.time),
                         prettytime(sim.Δt.Δt))
 
-#simulation = Simulation(model, Δt=wizard, stop_time=24hours,
-simulation = Simulation(model, Δt=1minutes, stop_time=24hours,
-                        iteration_interval=20)#, progress=progress)
+simulation = Simulation(model, Δt=wizard, stop_time=24hours,
+                        iteration_interval=1, progress=progress)
 
 # We add a basic `JLD2OutputWriter` that writes velocities and both
 # the two-dimensional and horizontally-averaged plankton concentration,

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -42,7 +42,8 @@
 
 # ## The grid
 #
-# We use a two-dimensional grid with 64² points and 1 m grid spacing:
+# We use a two-dimensional grid with 64² points and 1 m grid spacing and assign `Flat`
+# to the `y` direction:
 
 using Oceananigans
 using Oceananigans.Units: minutes, hour, hours, day

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -165,8 +165,9 @@ progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
                         prettytime(sim.model.clock.time),
                         prettytime(sim.Δt.Δt))
 
-simulation = Simulation(model, Δt=wizard, stop_time=24hours,
-                        iteration_interval=20, progress=progress)
+#simulation = Simulation(model, Δt=wizard, stop_time=24hours,
+simulation = Simulation(model, Δt=1minutes, stop_time=24hours,
+                        iteration_interval=20)#, progress=progress)
 
 # We add a basic `JLD2OutputWriter` that writes velocities and both
 # the two-dimensional and horizontally-averaged plankton concentration,

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -47,7 +47,7 @@
 using Oceananigans
 using Oceananigans.Units: minutes, hour, hours, day
 
-grid = RegularRectilinearGrid(size=(64, 1, 64), extent=(64, 1, 64))
+grid = RegularRectilinearGrid(size=(64, 64), extent=(64, 64), topology=(Periodic, Flat, Bounded))
 
 # ## Boundary conditions
 #

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -23,11 +23,9 @@
 using Oceananigans
 using Oceananigans.Units: hours, meters, kilometers
 
-Lz = 400meters
-
-grid = RegularRectilinearGrid(size = (128),
-                            x = (0, 1000kilometers),
-                            topology = (Bounded, Flat, Flat))
+grid = RegularRectilinearGrid(size = (128, 1, 1),
+                            x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),
+                            topology = (Bounded, Periodic, Bounded))
 
 # and Coriolis parameter appropriate for the mid-latitudes on Earth,
 
@@ -72,7 +70,7 @@ set!(model, v=vᵍ, η=ηⁱ)
 #
 # We pick a time-step that resolves the surface dynamics,
 
-gravity_wave_speed = sqrt(g * Lz) # hydrostatic (shallow water) gravity wave speed
+gravity_wave_speed = sqrt(g * grid.Lz) # hydrostatic (shallow water) gravity wave speed
 
 wave_propagation_time_scale = model.grid.Δx / gravity_wave_speed
 
@@ -85,7 +83,7 @@ simulation = Simulation(model, Δt = 0.1 * wave_propagation_time_scale, stop_ite
 output_fields = merge(model.velocities, (η=model.free_surface.η,))
 
 simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
-                                                      schedule = IterationInterval(1),
+                                                      schedule = IterationInterval(10),
                                                       prefix = "geostrophic_adjustment",
                                                       force = true)
 

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -25,14 +25,9 @@ using Oceananigans.Units: hours, meters, kilometers
 
 Lz = 400meters
 
-grid = RegularRectilinearGrid(size = (128, 1),
-                            x = (0, 1000kilometers), y = (0, 1),
-                            topology = (Bounded, Periodic, Flat))
-#=                            
-grid = RegularRectilinearGrid(size = (128, 1, 1),
-                            x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),
-                            topology = (Bounded, Periodic, Bounded))
-=#
+grid = RegularRectilinearGrid(size = (128),
+                            x = (0, 1000kilometers),
+                            topology = (Bounded, Flat, Flat))
 
 # and Coriolis parameter appropriate for the mid-latitudes on Earth,
 
@@ -96,7 +91,6 @@ simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
 
 run!(simulation)
 
-#=
 # ## Visualizing the results
 
 using JLD2, Plots, Printf
@@ -132,4 +126,3 @@ end
 close(file)
 
 mp4(anim, "geostrophic_adjustment.mp4", fps = 15) # hide
-=#

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -24,9 +24,15 @@ using Oceananigans
 using Oceananigans.Units: hours, meters, kilometers
 
 Lz = 400meters
-grid = RegularRectilinearGrid(size = (128),
-                            x = (0, 1000kilometers),
-                            topology = (Bounded, Flat, Flat))
+
+grid = RegularRectilinearGrid(size = (128, 1),
+                            x = (0, 1000kilometers), y = (0, 1),
+                            topology = (Bounded, Periodic, Flat))
+#=                            
+grid = RegularRectilinearGrid(size = (128, 1, 1),
+                            x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),
+                            topology = (Bounded, Periodic, Bounded))
+=#
 
 # and Coriolis parameter appropriate for the mid-latitudes on Earth,
 
@@ -71,7 +77,7 @@ set!(model, v=vᵍ, η=ηⁱ)
 #
 # We pick a time-step that resolves the surface dynamics,
 
-gravity_wave_speed = sqrt(g * grid.Lz) # hydrostatic (shallow water) gravity wave speed
+gravity_wave_speed = sqrt(g * Lz) # hydrostatic (shallow water) gravity wave speed
 
 wave_propagation_time_scale = model.grid.Δx / gravity_wave_speed
 
@@ -84,12 +90,13 @@ simulation = Simulation(model, Δt = 0.1 * wave_propagation_time_scale, stop_ite
 output_fields = merge(model.velocities, (η=model.free_surface.η,))
 
 simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
-                                                      schedule = IterationInterval(10),
+                                                      schedule = IterationInterval(1),
                                                       prefix = "geostrophic_adjustment",
                                                       force = true)
 
 run!(simulation)
 
+#=
 # ## Visualizing the results
 
 using JLD2, Plots, Printf
@@ -125,3 +132,4 @@ end
 close(file)
 
 mp4(anim, "geostrophic_adjustment.mp4", fps = 15) # hide
+=#

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -23,9 +23,10 @@
 using Oceananigans
 using Oceananigans.Units: hours, meters, kilometers
 
-grid = RegularRectilinearGrid(size = (128, 1, 1),
-                            x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),
-                            topology = (Bounded, Periodic, Bounded))
+Lz = 400meters
+grid = RegularRectilinearGrid(size = (128),
+                            x = (0, 1000kilometers),
+                            topology = (Bounded, Flat, Flat))
 
 # and Coriolis parameter appropriate for the mid-latitudes on Earth,
 

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -21,7 +21,7 @@
 using Oceananigans
 
 grid = RegularRectilinearGrid(size=(128, 128), x=(-π, π), z=(-π, π),
-                            topology=(Periodic, Flat, Periodic))
+                              topology=(Periodic, Flat, Periodic))
 
 # ## Internal wave parameters
 #

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -20,8 +20,8 @@
 
 using Oceananigans
 
-grid = RegularRectilinearGrid(size=(128, 1, 128), x=(-π, π), y=(-π, π), z=(-π, π),
-                            topology=(Periodic, Periodic, Periodic))
+grid = RegularRectilinearGrid(size=(128, 128), x=(-π, π), z=(-π, π),
+                            topology=(Periodic, Flat, Periodic))
 
 # ## Internal wave parameters
 #

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -16,7 +16,7 @@
 # ## The physical domain
 #
 # First, we pick a resolution and domain size. We use a two-dimensional domain
-# that's periodic in ``(x, y, z)``:
+# that's periodic in ``(x, z)`` and is `Flat` in ``y``:
 
 using Oceananigans
 

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -17,7 +17,7 @@
 using Oceananigans
 
 grid = RegularRectilinearGrid(size=(64, 64), x=(-5, 5), z=(-5, 5),
-                                  topology=(Periodic, Flat, Bounded))
+                              topology=(Periodic, Flat, Bounded))
 
 # # The basic state
 #

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -16,8 +16,8 @@
 
 using Oceananigans
 
-grid = RegularRectilinearGrid(size=(64, 1, 64), x=(-5, 5), y=(0, 1), z=(-5, 5),
-                                  topology=(Periodic, Periodic, Bounded))
+grid = RegularRectilinearGrid(size=(64, 64), x=(-5, 5), z=(-5, 5),
+                                  topology=(Periodic, Flat, Bounded))
 
 # # The basic state
 #

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -12,7 +12,8 @@
 
 # ## The physical domain
 #
-# We simulate Kelvin-Helmholtz instability in two-dimensions in ``x, z``,
+# We simulate Kelvin-Helmholtz instability in two-dimensions in ``x, z``
+# and therefore assign `Flat` to the `y` direction,
 
 using Oceananigans
 

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -37,6 +37,12 @@ using Oceananigans
 
 grid = RegularRectilinearGrid(size=(128), z=(-0.5, 0.5), topology=(Flat, Flat, Bounded))
 
+# The default topology is `(Periodic, Periodic, Bounded)`` but since we only want to solve
+# a one-dimensional problem, we assign the `x` and `y` dimensions to `Flat`.  
+# We could specify each of them to be either `Periodic` or `Bounded` but that will define
+# a halo in each of those directions, and that is numerically more costly.  
+# Note that we only specify the extent and size for the `Bounded` dimension.
+#
 # We next specify a model with an `IsotropicDiffusivity`, which models either
 # molecular or turbulent diffusion,
 

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -35,7 +35,7 @@ using Oceananigans
 # Below, we build a regular rectilinear grid with 128 grid points in the `z`-direction,
 # where `z` spans from `z = -0.5` to `z = 0.5`,
 
-grid = RegularRectilinearGrid(size=(1, 1, 128), x=(0, 1), y=(0, 1), z=(-0.5, 0.5))
+grid = RegularRectilinearGrid(size=(128), z=(-0.5, 0.5), topology=(Flat, Flat, Bounded))
 
 # We next specify a model with an `IsotropicDiffusivity`, which models either
 # molecular or turbulent diffusion,

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -37,7 +37,7 @@ using Oceananigans
 
 grid = RegularRectilinearGrid(size=(128), z=(-0.5, 0.5), topology=(Flat, Flat, Bounded))
 
-# The default topology is `(Periodic, Periodic, Bounded)`` but since we only want to solve
+# The default topology is `(Periodic, Periodic, Bounded)` but since we only want to solve
 # a one-dimensional problem, we assign the `x` and `y` dimensions to `Flat`.  
 # We could specify each of them to be either `Periodic` or `Bounded` but that will define
 # a halo in each of those directions, and that is numerically more costly.  

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -24,7 +24,8 @@
 
 using Oceananigans
 
-grid = RegularRectilinearGrid(size=(128, 128), extent=(2π, 2π), topology=(Periodic, Periodic, Flat))
+grid = RegularRectilinearGrid(size=(128, 128), extent=(2π, 2π), 
+                            topology=(Periodic, Periodic, Flat))
 
 model = IncompressibleModel(timestepper = :RungeKutta3,
                               advection = UpwindBiasedFifthOrder(),
@@ -144,7 +145,7 @@ anim = @animate for (i, iteration) in enumerate(iterations)
     s_plot = contourf(xs, ys, clamp.(s_snapshot', 0, s_lim);
                        color = :thermal,
                       levels = s_levels,
-                       clims = (0, s_lim),
+                       clims = (0., s_lim),
                       kwargs...)
 
     plot(ω_plot, s_plot, title=["Vorticity" "Speed"], layout=(1, 2), size=(1200, 500))

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -20,7 +20,7 @@
 
 # We instantiate the model with an isotropic diffusivity. We use a grid with 128² points,
 # a fifth-order advection scheme, third-order Runge-Kutta time-stepping,
-# and a small isotropic viscosity.
+# and a small isotropic viscosity.  Note that we assign `Flat` to the `z` direction.
 
 using Oceananigans
 

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -80,7 +80,7 @@ s_field = ComputedField(s)
 
 progress(sim) = @info "Iteration: $(sim.model.clock.iteration), time: $(round(Int, sim.model.clock.time))"
 
-simulation = Simulation(model, Δt=0.2, stop_time=50, iteration_interval=1, progress=progress)
+simulation = Simulation(model, Δt=0.2, stop_time=50, iteration_interval=100, progress=progress)
 
 # ## Output
 #

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -24,7 +24,7 @@
 
 using Oceananigans
 
-grid = RegularRectilinearGrid(size=(128, 128, 1), extent=(2π, 2π, 2π))
+grid = RegularRectilinearGrid(size=(128, 128), extent=(2π, 2π), topology=(Periodic, Periodic, Flat))
 
 model = IncompressibleModel(timestepper = :RungeKutta3,
                               advection = UpwindBiasedFifthOrder(),
@@ -79,7 +79,7 @@ s_field = ComputedField(s)
 
 progress(sim) = @info "Iteration: $(sim.model.clock.iteration), time: $(round(Int, sim.model.clock.time))"
 
-simulation = Simulation(model, Δt=0.2, stop_time=50, iteration_interval=100, progress=progress)
+simulation = Simulation(model, Δt=0.2, stop_time=50, iteration_interval=1, progress=progress)
 
 # ## Output
 #

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -25,7 +25,7 @@
 using Oceananigans
 
 grid = RegularRectilinearGrid(size=(128, 128), extent=(2π, 2π), 
-                            topology=(Periodic, Periodic, Flat))
+                              topology=(Periodic, Periodic, Flat))
 
 model = IncompressibleModel(timestepper = :RungeKutta3,
                               advection = UpwindBiasedFifthOrder(),

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -2,32 +2,23 @@ using Oceananigans.Grids: Center, Face
 
 """
 Notes:
-
 This file defines grid lengths, areas, and volumes for staggered structured grids.
-
 Each "reference cell" is associated with an index i, j, k.
 The "location" of each reference cell is roughly the geometric centroid of the reference cell.
-
 On the staggered grid, there are 7 cells additional to the "reference cell"
 that are staggered with respect to the reference cell in x, y, and/or z.
 The staggering is denoted by the locations "Center" and "Face":
-
     - "Center" is shared with the reference cell;
     - "Face" lies between reference cell centers, roughly at the interface between
       reference cells.
-
 The three-dimensional location of an object is defined by a 3-tuple of locations, and
 denoted by a triplet of superscripts. For example, an object `ϕ` whose cell is located at
 (Center, Center, Face) is denoted `ϕᶜᶜᶠ`. `ᶜᶜᶠ` is Centered in `x`, `Centered` in `y`, and on
 reference cell interfaces in `z` (this is where the vertical velocity is located, for example).
-
 The super script `ᵃ` denotes "any" location.
-
 The operators in this file fall into three categories:
-
 1. Operators needed for an algorithm valid on rectilinear grids with
    at most a stretched vertical dimension and regular horizontal dimensions.
-
 2. Operators needed for an algorithm on a grid that is curvilinear in the horizontal
    at rectilinear (possibly stretched) in the vertical.
 """
@@ -59,10 +50,12 @@ The operators in this file fall into three categories:
 
 using Oceananigans.Grids: Flat
 
-@inline Δx(i, j, k,  grid::RegularRectilinearGrid{FT, Flat})         where FT           = one(FT)
-@inline Δy(i, j, k,  grid::RegularRectilinearGrid{FT, TX, Flat})     where {FT, TX}     = one(FT)
-@inline ΔzC(i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
-@inline ΔzF(i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
+@inline Δx(   i, j, k, grid::RegularRectilinearGrid{FT, Flat})         where FT           = one(FT)
+@inline Δy(   i, j, k, grid::RegularRectilinearGrid{FT, TX, Flat})     where {FT, TX}     = one(FT)
+@inline ΔzC(  i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
+@inline ΔzF(  i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
+@inline Δzᵃᵃᶠ(i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
+@inline Δzᵃᵃᶜ(i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
 
 #####
 ##### Areas for horizontally-regular algorithms
@@ -87,15 +80,15 @@ using Oceananigans.Grids: Flat
 ##### Grid lengths for horizontally-curvilinear, vertically-rectilinear algorithms
 #####
 
-@inline Δxᶜᶜᵃ(i, j, k, grid::ARG) = grid.Δx
-@inline Δxᶜᶠᵃ(i, j, k, grid::ARG) = grid.Δx
-@inline Δxᶠᶠᵃ(i, j, k, grid::ARG) = grid.Δx
-@inline Δxᶠᶜᵃ(i, j, k, grid::ARG) = grid.Δx
+@inline Δxᶜᶜᵃ(i, j, k, grid::ARG) = Δx(i, j, k, grid)
+@inline Δxᶜᶠᵃ(i, j, k, grid::ARG) = Δx(i, j, k, grid)
+@inline Δxᶠᶠᵃ(i, j, k, grid::ARG) = Δx(i, j, k, grid)
+@inline Δxᶠᶜᵃ(i, j, k, grid::ARG) = Δx(i, j, k, grid)
 
-@inline Δyᶜᶜᵃ(i, j, k, grid::ARG) = grid.Δy
-@inline Δyᶠᶜᵃ(i, j, k, grid::ARG) = grid.Δy
-@inline Δyᶜᶠᵃ(i, j, k, grid::ARG) = grid.Δy
-@inline Δyᶠᶠᵃ(i, j, k, grid::ARG) = grid.Δy
+@inline Δyᶜᶜᵃ(i, j, k, grid::ARG) = Δy(i, j, k, grid)
+@inline Δyᶠᶜᵃ(i, j, k, grid::ARG) = Δy(i, j, k, grid)
+@inline Δyᶜᶠᵃ(i, j, k, grid::ARG) = Δy(i, j, k, grid)
+@inline Δyᶠᶠᵃ(i, j, k, grid::ARG) = Δy(i, j, k, grid)
 
 #####
 ##### Areas for algorithms that generalize to horizontally-curvilinear, vertically-rectilinear grids

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -23,6 +23,8 @@ than `max_Δt` and no less than `min_Δt`.
 TimeStepWizard(; cfl=0.1, diffusive_cfl=Inf, max_change=2.0, min_change=0.5, max_Δt=Inf, min_Δt=0.0, Δt=0.01) =
         TimeStepWizard{typeof(Δt)}(cfl, diffusive_cfl, max_change, min_change, max_Δt, min_Δt, Δt)
 
+using Oceananigans.Grids: topology
+
 """
     update_Δt!(wizard, model)
 

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -29,7 +29,6 @@ minimum_grid_spacing(Δx, ::Type{Flat}) = Inf
 
 function cell_diffusion_timescale(closure::IsotropicDiffusivity, diffusivities, grid)
     Δ = min_Δxyz(grid)
-
     max_κ = maximum_numeric_diffusivity(closure.κ)
     max_ν = maximum_numeric_diffusivity(closure.ν)
     return min(Δ^2 / max_ν, Δ^2 / max_κ)

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -2,8 +2,6 @@
 using Oceananigans.Grids: min_Δx, min_Δy, min_Δz
 using Oceananigans.Grids: topology
 
-min_Δxy(grid) = min(min_Δx(grid), min_Δy(grid))
-
 function min_Δxyz(grid)
     topo = topology(grid)
 

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -1,5 +1,4 @@
 # Timescale for diffusion across one cell
-using Oceananigans.Grids: min_Δx, min_Δy, min_Δz
 using Oceananigans.Grids: topology
 
 function min_Δxyz(grid)

--- a/src/Utils/cell_advection_timescale.jl
+++ b/src/Utils/cell_advection_timescale.jl
@@ -29,8 +29,6 @@ function cell_advection_timescale(u, v, w, grid::VerticallyStretchedRectilinearG
 
     Δx = minimum_grid_spacing(grid.Δx,    topo[1])
     Δy = minimum_grid_spacing(grid.Δy,    topo[2])
-    #FJP: this line fails when run on gpu 
-    #FJP: see test_diagnostics.jl for an example
     Δz = minimum_grid_spacing(grid.Δzᵃᵃᶠ, topo[3])
 
     return min(Δx/umax, Δy/vmax, Δz/wmax)

--- a/src/Utils/cell_advection_timescale.jl
+++ b/src/Utils/cell_advection_timescale.jl
@@ -25,7 +25,3 @@ cell_advection_timescale(model) =
                              model.velocities.v.data.parent,
                              model.velocities.w.data.parent,
                              model.grid)
-
-
-
-

--- a/src/Utils/cell_advection_timescale.jl
+++ b/src/Utils/cell_advection_timescale.jl
@@ -4,7 +4,7 @@ minimum_grid_spacing(Δx, TX          ) = minimum(Δx)
 minimum_grid_spacing(Δx, ::Type{Flat}) = Inf
 
 "Returns the time-scale for advection on a regular grid across a single grid cell."
-function cell_advection_timescale(u, v, w, grid)
+function cell_advection_timescale(u, v, w, grid::RegularRectilinearGrid)
 
     umax = maximum(abs, u)
     vmax = maximum(abs, v)
@@ -19,6 +19,22 @@ function cell_advection_timescale(u, v, w, grid)
     return min(Δx/umax, Δy/vmax, Δz/wmax)
 end
 
+function cell_advection_timescale(u, v, w, grid::VerticallyStretchedRectilinearGrid)
+
+    umax = maximum(abs, u)
+    vmax = maximum(abs, v)
+    wmax = maximum(abs, w)
+
+    topo = topology(grid)
+
+    Δx = minimum_grid_spacing(grid.Δx,    topo[1])
+    Δy = minimum_grid_spacing(grid.Δy,    topo[2])
+    #FJP: this line fails when run on gpu 
+    #FJP: see test_diagnostics.jl for an example
+    Δz = minimum_grid_spacing(grid.Δzᵃᵃᶠ, topo[3])
+
+    return min(Δx/umax, Δy/vmax, Δz/wmax)
+end
 
 cell_advection_timescale(model) =
     cell_advection_timescale(model.velocities.u.data.parent,

--- a/src/Utils/cell_advection_timescale.jl
+++ b/src/Utils/cell_advection_timescale.jl
@@ -1,14 +1,20 @@
-using Oceananigans.Grids: min_Δx, min_Δy, min_Δz
+using Oceananigans.Grids: topology
+
+minimum_grid_spacing(Δx, TX          ) = minimum(Δx)
+minimum_grid_spacing(Δx, ::Type{Flat}) = Inf
 
 "Returns the time-scale for advection on a regular grid across a single grid cell."
 function cell_advection_timescale(u, v, w, grid)
+
     umax = maximum(abs, u)
     vmax = maximum(abs, v)
     wmax = maximum(abs, w)
 
-    Δx = min_Δx(grid)
-    Δy = min_Δy(grid)
-    Δz = min_Δz(grid)
+    topo = topology(grid)
+
+    Δx = minimum_grid_spacing(grid.Δx, topo[1])
+    Δy = minimum_grid_spacing(grid.Δy, topo[2])
+    Δz = minimum_grid_spacing(grid.Δz, topo[3])
 
     return min(Δx/umax, Δy/vmax, Δz/wmax)
 end
@@ -19,3 +25,7 @@ cell_advection_timescale(model) =
                              model.velocities.v.data.parent,
                              model.velocities.w.data.parent,
                              model.grid)
+
+
+
+

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -64,7 +64,9 @@ end
     @info "  Testing $topo model construction..."
         for arch in archs, FT in float_types                
             grid = RegularRectilinearGrid(FT, topology=topo, size=(), extent=())
-            model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)        
+            model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)
+            
+            @test model isa HydrostaticFreeSurfaceModel
         end
     end
 
@@ -77,6 +79,8 @@ end
         @testset "$topo model construction" begin
             @info "  Testing $topo model construction..."
             for arch in archs, FT in float_types
+                arch isa GPU && topo == (Flat, Bounded, Flat) && continue
+                
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(1), extent=(1))
                 model = HydrostaticFreeSurfaceModel(grid=grid, gravitational_acceleration=1, architecture=arch)        
 

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -58,6 +58,51 @@ end
         @test_throws TypeError HydrostaticFreeSurfaceModel(architecture=GPU, grid=grid)
     end
 
+    topo = ( (Flat,      Flat,     Flat) )
+   
+    @testset "$topo model construction" begin
+    @info "  Testing $topo model construction..."
+        for arch in archs, FT in float_types                
+            grid = RegularRectilinearGrid(FT, topology=topo, size=(), extent=())
+            model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)        
+        end
+    end
+
+    topos = (
+             (Bounded,   Flat,     Flat),    
+             (Flat,      Bounded,  Flat),
+            )
+
+    for topo in topos
+        @testset "$topo model construction" begin
+            @info "  Testing $topo model construction..."
+            for arch in archs, FT in float_types
+                grid = RegularRectilinearGrid(FT, topology=topo, size=(1), extent=(1))
+                model = HydrostaticFreeSurfaceModel(grid=grid, gravitational_acceleration=1, architecture=arch)        
+
+                @test model isa HydrostaticFreeSurfaceModel
+            end
+        end
+    end
+
+    topos = (
+             (Periodic, Periodic,  Flat),
+             (Periodic,  Bounded,  Flat),
+             (Bounded,   Bounded,  Flat),
+            )
+
+    for topo in topos
+        @testset "$topo model construction" begin
+            @info "  Testing $topo model construction..."
+            for arch in archs, FT in float_types
+                grid = RegularRectilinearGrid(FT, topology=topo, size=(1, 1), extent=(1, 2))
+                model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)
+
+                @test model isa HydrostaticFreeSurfaceModel
+            end
+        end
+    end
+
     topos = (
              (Periodic, Periodic,  Bounded),
              (Periodic,  Bounded,  Bounded),
@@ -71,11 +116,7 @@ end
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(1, 1, 1), extent=(1, 2, 3))
                 model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)
 
-                # Just testing that the model was constructed with no errors/crashes.
                 @test model isa HydrostaticFreeSurfaceModel
-
-                # Test that the grid didn't get mangled (sort of)
-                @test size(grid) === size(model.grid)
             end
         end
     end

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -79,10 +79,8 @@ end
         @testset "$topo model construction" begin
             @info "  Testing $topo model construction..."
             for arch in archs, FT in float_types
-                arch isa GPU && topo == (Flat, Bounded, Flat) && continue
-                
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(1), extent=(1))
-                model = HydrostaticFreeSurfaceModel(grid=grid, gravitational_acceleration=1, architecture=arch)        
+                model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)        
 
                 @test model isa HydrostaticFreeSurfaceModel
             end

--- a/test/test_shallow_water_models.jl
+++ b/test/test_shallow_water_models.jl
@@ -64,7 +64,9 @@ end
     @info "  Testing $topo model construction..."
         for arch in archs, FT in float_types                
             grid = RegularRectilinearGrid(FT, topology=topo, size=(), extent=())
-            model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch)        
+            model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch) 
+            
+            @test model isa HydrostaticFreeSurfaceModel
         end
     end
 
@@ -80,7 +82,9 @@ end
                 arch isa GPU && topo == (Flat, Bounded, Flat) && continue
         
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(1), extent=(1))
-                model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch)        
+                model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch) 
+                
+                @test model isa HydrostaticFreeSurfaceModel
             end
         end
     end
@@ -101,10 +105,6 @@ end
                 model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch)
 
                 @test model isa ShallowWaterModel
-
-                #too_big_grid = RegularRectilinearGrid(FT, topology=topo, size=(1, 1, 2), extent=(1, 2, 3))
-
-                #@test_throws ArgumentError ShallowWaterModel(grid=too_big_grid, gravitational_acceleration=1, architecture=arch)
             end
         end
     end

--- a/test/test_shallow_water_models.jl
+++ b/test/test_shallow_water_models.jl
@@ -58,7 +58,7 @@ end
         @test_throws TypeError ShallowWaterModel(architecture=GPU, grid=grid, gravitational_acceleration=1)
     end
 
-    topo = ( (Flat,      Flat,     Flat) )
+    topo = ( Flat,      Flat,     Flat )
    
     @testset "$topo model construction" begin
     @info "  Testing $topo model construction..."
@@ -66,7 +66,7 @@ end
             grid = RegularRectilinearGrid(FT, topology=topo, size=(), extent=())
             model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch) 
             
-            @test model isa HydrostaticFreeSurfaceModel
+            @test model isa ShallowWaterModel
         end
     end
 
@@ -79,12 +79,12 @@ end
         @testset "$topo model construction" begin
             @info "  Testing $topo model construction..."
             for arch in archs, FT in float_types
-                arch isa GPU && topo == (Flat, Bounded, Flat) && continue
+                #arch isa GPU && topo == (Flat, Bounded, Flat) && continue
         
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(1), extent=(1))
                 model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch) 
                 
-                @test model isa HydrostaticFreeSurfaceModel
+                @test model isa ShallowWaterModel
             end
         end
     end

--- a/validation/lid_driven_cavity/lid_driven_cavity.jl
+++ b/validation/lid_driven_cavity/lid_driven_cavity.jl
@@ -45,9 +45,8 @@ function simulate_lid_driven_cavity(; Re, N, end_time)
     cfl = AdvectiveCFL(wizard)
     dcfl = DiffusiveCFL(wizard)
 
-    #simulation = Simulation(model, Δt=wizard, stop_time=end_time, progress=print_progress,
-    simulation = Simulation(model, Δt=0.0001, stop_time=end_time, #progress=print_progress,
-                            iteration_interval=1, parameters=(cfl=cfl, dcfl=dcfl))
+    simulation = Simulation(model, Δt=wizard, stop_time=end_time, progress=print_progress,
+                            iteration_interval=20, parameters=(cfl=cfl, dcfl=dcfl))
 
     simulation.output_writers[:fields] = field_output_writer
 

--- a/validation/lid_driven_cavity/lid_driven_cavity.jl
+++ b/validation/lid_driven_cavity/lid_driven_cavity.jl
@@ -1,27 +1,22 @@
 using Printf
 using Logging
-
 using Oceananigans
-using Oceananigans: Face, Center
-using Oceananigans.Diagnostics
-using Oceananigans.OutputWriters
-using Oceananigans.AbstractOperations
 
 Logging.global_logger(OceananigansLogger())
 
 function simulate_lid_driven_cavity(; Re, N, end_time)
     topology = (Flat, Bounded, Bounded)
-    domain = (x=(0, 1), y=(0, 1), z=(0, 1))
-    grid = RegularRectilinearGrid(topology=topology, size=(1, N, N); domain...)
+    domain = (y=(0, 1), z=(0, 1))
+    grid = RegularRectilinearGrid(topology=topology, size=(N, N); domain...)
 
     v_bcs = VVelocityBoundaryConditions(grid,
-           top = ValueBoundaryCondition(1.0),
-        bottom = ValueBoundaryCondition(0.0)
+           top = ValueBoundaryCondition(1),
+        bottom = ValueBoundaryCondition(0)
     )
 
     w_bcs = WVelocityBoundaryConditions(grid,
-        north = ValueBoundaryCondition(0.0),
-        south = ValueBoundaryCondition(0.0)
+        north = ValueBoundaryCondition(0),
+        south = ValueBoundaryCondition(0)
     )
 
     model = IncompressibleModel(
@@ -34,24 +29,15 @@ function simulate_lid_driven_cavity(; Re, N, end_time)
     )
 
     u, v, w = model.velocities
-    ζ_op = ∂y(w) - ∂z(v)
-    ζ = Field(Center, Face, Face, model.architecture, model.grid, TracerBoundaryConditions(grid))
-    ζ_computation = Computation(ζ_op, ζ)
+    ζ = ComputedField(∂y(w) - ∂z(v))
 
-    fields = Dict(
-        "v" => model.velocities.v,
-        "w" => model.velocities.w,
-        "ζ" => model -> ζ_computation(model)
-    )
-
-    dims = Dict("ζ" => ("xC", "yF", "zF"))
+    fields = (; v, w, ζ)
     global_attributes = Dict("Re" => Re)
     output_attributes = Dict("ζ" => Dict("longname" => "vorticity", "units" => "1/s"))
 
     field_output_writer =
-        NetCDFOutputWriter(model, fields, filename="lid_driven_cavity_Re$Re.nc", schedule=TimeInterval(0.1),
-                           global_attributes=global_attributes, output_attributes=output_attributes,
-                           dimensions=dims)
+        NetCDFOutputWriter(model, fields, filepath="lid_driven_cavity_Re$Re.nc", schedule=TimeInterval(0.1),
+                           global_attributes=global_attributes, output_attributes=output_attributes)
 
     max_Δt = 0.25 * model.grid.Δy^2 * Re / 2  # Make sure not to violate diffusive CFL.
     wizard = TimeStepWizard(cfl=0.1, Δt=1e-6, max_change=1.1, max_Δt=max_Δt)
@@ -59,8 +45,9 @@ function simulate_lid_driven_cavity(; Re, N, end_time)
     cfl = AdvectiveCFL(wizard)
     dcfl = DiffusiveCFL(wizard)
 
-    simulation = Simulation(model, Δt=wizard, stop_time=end_time, progress=print_progress,
-                            iteration_interval=20, parameters=(cfl=cfl, dcfl=dcfl))
+    #simulation = Simulation(model, Δt=wizard, stop_time=end_time, progress=print_progress,
+    simulation = Simulation(model, Δt=0.0001, stop_time=end_time, #progress=print_progress,
+                            iteration_interval=1, parameters=(cfl=cfl, dcfl=dcfl))
 
     simulation.output_writers[:fields] = field_output_writer
 
@@ -77,8 +64,8 @@ function print_progress(simulation)
     progress = 100 * (model.clock.time / simulation.stop_time)
 
     # Find maximum velocities.
-    vmax = maximum(abs, interior(model.velocities.v))
-    wmax = maximum(abs, interior(model.velocities.w))
+    vmax = maximum(abs, model.velocities.v)
+    wmax = maximum(abs, model.velocities.w)
 
     i, t = model.clock.iteration, model.clock.time
     @info @sprintf("[%06.2f%%] i: %d, t: %.3f, U_max: (%.2e, %.2e), CFL: %.2e, dCFL: %.2e, next Δt: %.2e",
@@ -87,11 +74,11 @@ function print_progress(simulation)
     return nothing
 end
 
- simulate_lid_driven_cavity(Re=100,   N=128, end_time=15)
- simulate_lid_driven_cavity(Re=400,   N=128, end_time=20)
- simulate_lid_driven_cavity(Re=1000,  N=128, end_time=25)
- simulate_lid_driven_cavity(Re=3200,  N=128, end_time=50)
- simulate_lid_driven_cavity(Re=5000,  N=256, end_time=50)
- simulate_lid_driven_cavity(Re=7500,  N=256, end_time=75)
- simulate_lid_driven_cavity(Re=10000, N=256, end_time=100)
+simulate_lid_driven_cavity(Re=100,   N=128, end_time=15)
+simulate_lid_driven_cavity(Re=400,   N=128, end_time=20)
+simulate_lid_driven_cavity(Re=1000,  N=128, end_time=25)
+simulate_lid_driven_cavity(Re=3200,  N=128, end_time=50)
+simulate_lid_driven_cavity(Re=5000,  N=256, end_time=50)
+simulate_lid_driven_cavity(Re=7500,  N=256, end_time=75)
+simulate_lid_driven_cavity(Re=10000, N=256, end_time=100)
 


### PR DESCRIPTION
Do we want to update the one and two dimensional examples to include `Flat`? 

If not then we can ignore this PR.  

If yes, then this is my attempt to do so.  The good news is that most of the one and two dimensional examples work very easily.  Unfortunately, a couple of them, geostrophic adjustment and convecting plankton, do not.  I don't know why at the moment and these should certainly be fixed before a merge happens.  If it happens.

The error get I get is `NaN` after (I believe) the first interval. So I suspect one of the tendencies is not being computed correctly.