### PR TITLE
Use (λ, φ) (`\lambda`, `\varphi`) for geographical coordinates

### DIFF
--- a/examples/spherical_splash.jl
+++ b/examples/spherical_splash.jl
@@ -45,13 +45,13 @@ model = HydrostaticFreeSurfaceModel(grid = grid,
 #
 # We make a splash by imposing a Gaussian height field,
 
-Gaussian(λ, ϕ, L) = exp(-(λ^2 + ϕ^2) / 2L^2)
+Gaussian(λ, φ, L) = exp(-(λ^2 + φ^2) / 2L^2)
 
 a = 0.01 # splash amplitude
 L = 10 # degree
-ϕ₀ = 5 # degrees
+φ₀ = 5 # degrees
 
-splash(λ, ϕ, z) = a * Gaussian(λ, ϕ - ϕ₀, L)
+splash(λ, φ, z) = a * Gaussian(λ, φ - φ₀, L)
 
 set!(model, η=splash)
 
@@ -66,15 +66,15 @@ g = model.free_surface.gravitational_acceleration
 gravity_wave_speed = sqrt(g * grid.Lz) # hydrostatic (shallow water) gravity wave speed
 
 # Time-scale for gravity wave propagation across the smallest grid cell
-wave_propagation_time_scale = min(grid.radius * cosd(maximum(abs, grid.ϕᵃᶜᵃ)) * deg2rad(grid.Δλ),
-                                  grid.radius * deg2rad(grid.Δϕ)) / gravity_wave_speed
+wave_propagation_time_scale = min(grid.radius * cosd(maximum(abs, grid.φᵃᶜᵃ)) * deg2rad(grid.Δλ),
+                                  grid.radius * deg2rad(grid.Δφ)) / gravity_wave_speed
 
 simulation = Simulation(model,
                         Δt = 0.05wave_propagation_time_scale,
                         stop_iteration = 4000,
                         iteration_interval = 100,
                         progress = s -> @info "Iteration = $(s.model.clock.iteration) / $(s.stop_iteration)")
-                                                         
+
 
 # ## Output
 #
@@ -96,10 +96,10 @@ run!(simulation)
 using JLD2, Printf, Oceananigans.Grids, GLMakie
 using Oceananigans.Utils: hours
 
-λ, ϕ, r = nodes(model.free_surface.η, reshape=true)
+λ, φ, r = nodes(model.free_surface.η, reshape=true)
 
 λ = λ .+ 180  # Convert to λ ∈ [0°, 360°]
-ϕ = 90 .- ϕ   # Convert to ϕ ∈ [0°, 180°] (0° at north pole)
+φ = 90 .- φ   # Convert to φ ∈ [0°, 180°] (0° at north pole)
 
 file = jldopen(simulation.output_writers[:fields].filepath)
 
@@ -114,9 +114,9 @@ v = @lift file["timeseries/v/" * string($iter)][:, :, 1]
 η = @lift file["timeseries/η/" * string($iter)][:, :, 1]
 
 # Plot on the unit sphere to align with the spherical wireframe.
-x3 = @. cosd(λ) * sind(ϕ)
-y3 = @. sind(λ) * sind(ϕ)
-z3 = @. cosd(ϕ) * λ ./ λ
+x3 = @. cosd(λ) * sind(φ)
+y3 = @. sind(λ) * sind(φ)
+z3 = @. cosd(φ) * λ ./ λ
 
 x = @lift (1 .+ 20 .* file["timeseries/η/" * string($iter)][:, :, 1]) .* x3[:, :, 1]
 y = @lift (1 .+ 20 .* file["timeseries/η/" * string($iter)][:, :, 1]) .* y3[:, :, 1]

--- a/src/Coriolis/hydrostatic_spherical_coriolis.jl
+++ b/src/Coriolis/hydrostatic_spherical_coriolis.jl
@@ -27,10 +27,10 @@ By default, `rotation_rate` is assumed to be Earth's.
 HydrostaticSphericalCoriolis(FT::DataType=Float64; rotation_rate=Ω_Earth, scheme::S=VectorInvariantEnergyConserving()) where S =
     HydrostaticSphericalCoriolis{S, FT}(rotation_rate, scheme)
 
-@inline ϕᶠᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.ϕᵃᶠᵃ[j]
+@inline φᶠᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.φᵃᶠᵃ[j]
 
 @inline fᶠᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid, coriolis::HydrostaticSphericalCoriolis) =
-    2 * coriolis.rotation_rate * hack_sind(ϕᶠᶠᵃ(i, j, k, grid))
+    2 * coriolis.rotation_rate * hack_sind(φᶠᶠᵃ(i, j, k, grid))
 
 @inline z_f_cross_U(i, j, k, grid::AbstractGrid{FT}, coriolis::HydrostaticSphericalCoriolis, U) where FT = zero(FT)
 
@@ -59,7 +59,7 @@ const VIEnergy = HydrostaticSphericalCoriolis{<:VectorInvariantEnergyConserving}
     @inbounds - ℑyᵃᶜᵃ(i, j, k, grid, f_ℑx_vᶠᶠᵃ, coriolis, U[2]) / Δxᶠᶜᵃ(i, j, k, grid)
 
 @inline y_f_cross_U(i, j, k, grid::RegularLatitudeLongitudeGrid, coriolis::VIEnergy, U) =
-    @inbounds + ℑxᶜᵃᵃ(i, j, k, grid, f_ℑy_uᶠᶠᵃ, coriolis, U[1]) / Δyᶜᶠᵃ(i, j, k, grid)  
+    @inbounds + ℑxᶜᵃᵃ(i, j, k, grid, f_ℑy_uᶠᶠᵃ, coriolis, U[1]) / Δyᶜᶠᵃ(i, j, k, grid)
 
 #####
 ##### Show

--- a/src/Grids/regular_latitude_longitude_grid.jl
+++ b/src/Grids/regular_latitude_longitude_grid.jl
@@ -11,12 +11,12 @@ struct RegularLatitudeLongitudeGrid{FT, TX, TY, TZ, A} <: AbstractHorizontallyCu
         Ly :: FT
         Lz :: FT
         Δλ :: FT
-        Δϕ :: FT
+        Δφ :: FT
         Δz :: FT
       λᶠᵃᵃ :: A
       λᶜᵃᵃ :: A
-      ϕᵃᶠᵃ :: A
-      ϕᵃᶜᵃ :: A
+      φᵃᶠᵃ :: A
+      φᵃᶜᵃ :: A
       zᵃᵃᶠ :: A
       zᵃᵃᶜ :: A
     radius :: FT
@@ -30,10 +30,10 @@ function RegularLatitudeLongitudeGrid(FT=Float64; size, latitude, longitude, z, 
     λ₁, λ₂ = longitude
     @assert -180 <= λ₁ < λ₂ <= 180
 
-    ϕ₁, ϕ₂ = latitude
-    @assert -90 <= ϕ₁ < ϕ₂ <= 90
+    φ₁, φ₂ = latitude
+    @assert -90 <= φ₁ < φ₂ <= 90
 
-    (ϕ₁ == -90 || ϕ₂ == 90) &&
+    (φ₁ == -90 || φ₂ == 90) &&
         @warn "Are you sure you want to use a latitude-longitude grid with a grid point at the pole?"
 
     z₁, z₂ = z
@@ -44,51 +44,51 @@ function RegularLatitudeLongitudeGrid(FT=Float64; size, latitude, longitude, z, 
     TZ = Bounded
     topo = (TX, TY, TZ)
 
-    Nλ, Nϕ, Nz = N = validate_size(TX, TY, TZ, size)
-    Hλ, Hϕ, Hz = H = validate_halo(TX, TY, TZ, halo)
+    Nλ, Nφ, Nz = N = validate_size(TX, TY, TZ, size)
+    Hλ, Hφ, Hz = H = validate_halo(TX, TY, TZ, halo)
 
     Lλ = λ₂ - λ₁
-    Lϕ = ϕ₂ - ϕ₁
+    Lφ = φ₂ - φ₁
     Lz = z₂ - z₁
 
-            Λ₁ = (λ₁, ϕ₁, z₁)
-            L  = (Lλ, Lϕ, Lz)
-    Δλ, Δϕ, Δz = Δ = @. L / N
+            Λ₁ = (λ₁, φ₁, z₁)
+            L  = (Lλ, Lφ, Lz)
+    Δλ, Δφ, Δz = Δ = @. L / N
 
     # Calculate end points for cell faces and centers
-    λF₋, ϕF₋, zF₋ = ΛF₋ = @. Λ₁ - H * Δ
-    λF₊, ϕF₊, zF₊ = ΛF₊ = @. ΛF₋ + total_extent(topo, H, Δ, L)
+    λF₋, φF₋, zF₋ = ΛF₋ = @. Λ₁ - H * Δ
+    λF₊, φF₊, zF₊ = ΛF₊ = @. ΛF₋ + total_extent(topo, H, Δ, L)
 
-    λC₋, ϕC₋, zC₋ = ΛC₋ = @. ΛF₋ + Δ / 2
-    λC₊, ϕC₊, zC₊ = ΛC₊ = @. ΛC₋ + L + Δ * (2H - 1)
+    λC₋, φC₋, zC₋ = ΛC₋ = @. ΛF₋ + Δ / 2
+    λC₊, φC₊, zC₊ = ΛC₊ = @. ΛC₋ + L + Δ * (2H - 1)
 
-    TFλ, TFϕ, TFz = total_length.(Face, topo, N, H)
-    TCλ, TCϕ, TCz = total_length.(Center, topo, N, H)
+    TFλ, TFφ, TFz = total_length.(Face, topo, N, H)
+    TCλ, TCφ, TCz = total_length.(Center, topo, N, H)
 
     λᶠᵃᵃ = range(λF₋, λF₊, length = TFλ)
-    ϕᵃᶠᵃ = range(ϕF₋, ϕF₊, length = TFϕ)
+    φᵃᶠᵃ = range(φF₋, φF₊, length = TFφ)
     zᵃᵃᶠ = range(zF₋, zF₊, length = TFz)
 
     λᶜᵃᵃ = range(λC₋, λC₊, length = TCλ)
-    ϕᵃᶜᵃ = range(ϕC₋, ϕC₊, length = TCϕ)
+    φᵃᶜᵃ = range(φC₋, φC₊, length = TCφ)
     zᵃᵃᶜ = range(zC₋, zC₊, length = TCz)
 
     λᶠᵃᵃ = OffsetArray(λᶠᵃᵃ, -Hλ)
-    ϕᵃᶠᵃ = OffsetArray(ϕᵃᶠᵃ, -Hϕ)
+    φᵃᶠᵃ = OffsetArray(φᵃᶠᵃ, -Hφ)
     zᵃᵃᶠ = OffsetArray(zᵃᵃᶠ, -Hz)
 
     λᶜᵃᵃ = OffsetArray(λᶜᵃᵃ, -Hλ)
-    ϕᵃᶜᵃ = OffsetArray(ϕᵃᶜᵃ, -Hϕ)
+    φᵃᶜᵃ = OffsetArray(φᵃᶜᵃ, -Hφ)
     zᵃᵃᶜ = OffsetArray(zᵃᵃᶜ, -Hz)
 
-    return RegularLatitudeLongitudeGrid{FT, TX, TY, TZ, typeof(λᶠᵃᵃ)}(Nλ, Nϕ, Nz, Hλ, Hϕ, Hz, Lλ, Lϕ, Lz, Δλ, Δϕ, Δz, λᶠᵃᵃ, λᶜᵃᵃ, ϕᵃᶠᵃ, ϕᵃᶜᵃ, zᵃᵃᶠ, zᵃᵃᶜ, radius)
+    return RegularLatitudeLongitudeGrid{FT, TX, TY, TZ, typeof(λᶠᵃᵃ)}(Nλ, Nφ, Nz, Hλ, Hφ, Hz, Lλ, Lφ, Lz, Δλ, Δφ, Δz, λᶠᵃᵃ, λᶜᵃᵃ, φᵃᶠᵃ, φᵃᶜᵃ, zᵃᵃᶠ, zᵃᵃᶜ, radius)
 end
 
 function domain_string(grid::RegularLatitudeLongitudeGrid)
     λ₁, λ₂ = domain(topology(grid, 1), grid.Nx, grid.λᶠᵃᵃ)
-    ϕ₁, ϕ₂ = domain(topology(grid, 2), grid.Ny, grid.ϕᵃᶠᵃ)
+    φ₁, φ₂ = domain(topology(grid, 2), grid.Ny, grid.φᵃᶠᵃ)
     z₁, z₂ = domain(topology(grid, 3), grid.Nz, grid.zᵃᵃᶠ)
-    return "longitude λ ∈ [$λ₁, $λ₂], latitude ∈ [$ϕ₁, $ϕ₂], z ∈ [$z₁, $z₂]"
+    return "longitude λ ∈ [$λ₁, $λ₂], latitude ∈ [$φ₁, $φ₂], z ∈ [$z₁, $z₂]"
 end
 
 function show(io::IO, g::RegularLatitudeLongitudeGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
@@ -97,7 +97,7 @@ function show(io::IO, g::RegularLatitudeLongitudeGrid{FT, TX, TY, TZ}) where {FT
               "                 topology: ", (TX, TY, TZ), '\n',
               "  resolution (Nx, Ny, Nz): ", (g.Nx, g.Ny, g.Nz), '\n',
               "   halo size (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz), '\n',
-              "grid spacing (Δλ, Δϕ, Δz): ", (g.Δλ, g.Δϕ, g.Δz))
+              "grid spacing (Δλ, Δφ, Δz): ", (g.Δλ, g.Δφ, g.Δz))
 end
 
 #####
@@ -108,15 +108,15 @@ end
 @inline xnode(::Type{Center}, i, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.λᶜᵃᵃ[i]
 @inline xnode(::Type{Face},   i, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.λᶠᵃᵃ[i]
 
-@inline ynode(::Type{Center}, j, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.ϕᵃᶜᵃ[j]
-@inline ynode(::Type{Face},   j, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.ϕᵃᶠᵃ[j]
+@inline ynode(::Type{Center}, j, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.φᵃᶜᵃ[j]
+@inline ynode(::Type{Face},   j, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.φᵃᶠᵃ[j]
 
 @inline znode(::Type{Center}, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.zᵃᵃᶠ[k]
 @inline znode(::Type{Face},   k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.zᵃᵃᶜ[k]
 
 all_x_nodes(::Type{Center}, grid::RegularLatitudeLongitudeGrid) = grid.λᶜᵃᵃ
 all_x_nodes(::Type{Face},   grid::RegularLatitudeLongitudeGrid) = grid.λᶠᵃᵃ
-all_y_nodes(::Type{Center}, grid::RegularLatitudeLongitudeGrid) = grid.ϕᵃᶜᵃ
-all_y_nodes(::Type{Face},   grid::RegularLatitudeLongitudeGrid) = grid.ϕᵃᶠᵃ
+all_y_nodes(::Type{Center}, grid::RegularLatitudeLongitudeGrid) = grid.φᵃᶜᵃ
+all_y_nodes(::Type{Face},   grid::RegularLatitudeLongitudeGrid) = grid.φᵃᶠᵃ
 all_z_nodes(::Type{Center}, grid::RegularLatitudeLongitudeGrid) = grid.zᵃᵃᶜ
 all_z_nodes(::Type{Face},   grid::RegularLatitudeLongitudeGrid) = grid.zᵃᵃᶠ

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -17,8 +17,8 @@ The staggering is denoted by the locations "Center" and "Face":
       reference cells.
 
 The three-dimensional location of an object is defined by a 3-tuple of locations, and
-denoted by a triplet of superscripts. For example, an object `ϕ` whose cell is located at
-(Center, Center, Face) is denoted `ϕᶜᶜᶠ`. `ᶜᶜᶠ` is Centered in `x`, `Centered` in `y`, and on
+denoted by a triplet of superscripts. For example, an object `φ` whose cell is located at
+(Center, Center, Face) is denoted `φᶜᶜᶠ`. `ᶜᶜᶠ` is Centered in `x`, `Centered` in `y`, and on
 reference cell interfaces in `z` (this is where the vertical velocity is located, for example).
 
 The super script `ᵃ` denotes "any" location.
@@ -133,15 +133,15 @@ using Oceananigans.Grids: Flat
 ##### Temporary place for grid spacings and areas for RegularLatitudeLongitudeGrid
 #####
 
-@inline hack_cosd(ϕ) = cos(π * ϕ / 180)
-@inline hack_sind(ϕ) = sin(π * ϕ / 180)
+@inline hack_cosd(φ) = cos(π * φ / 180)
+@inline hack_sind(φ) = sin(π * φ / 180)
 
-@inline Δxᶜᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.radius * hack_cosd(grid.ϕᵃᶠᵃ[j]) * deg2rad(grid.Δλ)
-@inline Δxᶠᶜᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.radius * hack_cosd(grid.ϕᵃᶜᵃ[j]) * deg2rad(grid.Δλ)
+@inline Δxᶜᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.radius * hack_cosd(grid.φᵃᶠᵃ[j]) * deg2rad(grid.Δλ)
+@inline Δxᶠᶜᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.radius * hack_cosd(grid.φᵃᶜᵃ[j]) * deg2rad(grid.Δλ)
 @inline Δxᶜᶜᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = Δxᶠᶜᵃ(i, j, k, grid)
 @inline Δxᶠᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = Δxᶜᶠᵃ(i, j, k, grid)
 
-@inline Δyᶜᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.radius * deg2rad(grid.Δϕ)
+@inline Δyᶜᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.radius * deg2rad(grid.Δφ)
 @inline Δyᶠᶜᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = Δyᶜᶠᵃ(i, j, k, grid)
 @inline Δyᶜᶜᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = Δyᶜᶠᵃ(i, j, k, grid)
 @inline Δyᶠᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = Δyᶜᶠᵃ(i, j, k, grid)
@@ -149,8 +149,8 @@ using Oceananigans.Grids: Flat
 @inline Δzᵃᵃᶜ(i, j, k, grid::RegularLatitudeLongitudeGrid) = grid.Δz
 @inline Δzᵃᵃᶠ(i, j, k, grid::RegularLatitudeLongitudeGrid) = grid.Δz
 
-@inline Azᶜᶜᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.radius^2 * deg2rad(grid.Δλ) * (hack_sind(grid.ϕᵃᶠᵃ[j+1]) - hack_sind(grid.ϕᵃᶠᵃ[j]))
-@inline Azᶠᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.radius^2 * deg2rad(grid.Δλ) * (hack_sind(grid.ϕᵃᶜᵃ[j])   - hack_sind(grid.ϕᵃᶜᵃ[j-1]))
+@inline Azᶜᶜᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.radius^2 * deg2rad(grid.Δλ) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+@inline Azᶠᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = @inbounds grid.radius^2 * deg2rad(grid.Δλ) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
 @inline Azᶠᶜᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = Azᶜᶜᵃ(i, j, k, grid)
 @inline Azᶜᶠᵃ(i, j, k, grid::RegularLatitudeLongitudeGrid) = Azᶠᶠᵃ(i, j, k, grid)
 

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -382,15 +382,15 @@ end
 #####
 
 function test_basic_lat_lon_bounded_domain(FT)
-    Nλ = Nϕ = 18
-    Hλ = Hϕ = 1
+    Nλ = Nφ = 18
+    Hλ = Hφ = 1
 
-    grid = RegularLatitudeLongitudeGrid(FT, size=(Nλ, Nϕ, 1), longitude=(-90, 90), latitude=(-45, 45), z=(0, 1), halo=(Hλ, Hϕ, 1))
+    grid = RegularLatitudeLongitudeGrid(FT, size=(Nλ, Nφ, 1), longitude=(-90, 90), latitude=(-45, 45), z=(0, 1), halo=(Hλ, Hφ, 1))
 
     @test topology(grid) == (Bounded, Bounded, Bounded)
 
     @test grid.Nx == Nλ
-    @test grid.Ny == Nϕ
+    @test grid.Ny == Nφ
     @test grid.Nz == 1
 
     @test grid.Lx == 180
@@ -398,47 +398,47 @@ function test_basic_lat_lon_bounded_domain(FT)
     @test grid.Lz == 1
 
     @test grid.Δλ == 10
-    @test grid.Δϕ == 5
+    @test grid.Δφ == 5
     @test grid.Δz == 1
 
     @test length(grid.λᶠᵃᵃ) == Nλ + 2Hλ + 1
     @test length(grid.λᶜᵃᵃ) == Nλ + 2Hλ
 
-    @test length(grid.ϕᵃᶠᵃ) == Nϕ + 2Hϕ + 1
-    @test length(grid.ϕᵃᶜᵃ) == Nϕ + 2Hϕ
+    @test length(grid.φᵃᶠᵃ) == Nφ + 2Hφ + 1
+    @test length(grid.φᵃᶜᵃ) == Nφ + 2Hφ
 
     @test grid.λᶠᵃᵃ[1] == -90
     @test grid.λᶠᵃᵃ[Nλ+1] == 90
 
-    @test grid.ϕᵃᶠᵃ[1] == -45
-    @test grid.ϕᵃᶠᵃ[Nϕ+1] == 45
+    @test grid.φᵃᶠᵃ[1] == -45
+    @test grid.φᵃᶠᵃ[Nφ+1] == 45
 
     @test grid.λᶠᵃᵃ[0] == -90 - grid.Δλ
     @test grid.λᶠᵃᵃ[Nλ+2] == 90 + grid.Δλ
 
-    @test grid.ϕᵃᶠᵃ[0] == -45 - grid.Δϕ
-    @test grid.ϕᵃᶠᵃ[Nϕ+2] == 45 + grid.Δϕ
+    @test grid.φᵃᶠᵃ[0] == -45 - grid.Δφ
+    @test grid.φᵃᶠᵃ[Nφ+2] == 45 + grid.Δφ
 
     @test all(diff(grid.λᶠᵃᵃ.parent) .== grid.Δλ)
     @test all(diff(grid.λᶜᵃᵃ.parent) .== grid.Δλ)
 
-    @test all(diff(grid.ϕᵃᶠᵃ.parent) .== grid.Δϕ)
-    @test all(diff(grid.ϕᵃᶜᵃ.parent) .== grid.Δϕ)
+    @test all(diff(grid.φᵃᶠᵃ.parent) .== grid.Δφ)
+    @test all(diff(grid.φᵃᶜᵃ.parent) .== grid.Δφ)
 
     return nothing
 end
 
 function test_basic_lat_lon_periodic_domain(FT)
     Nλ = 36
-    Nϕ = 32
-    Hλ = Hϕ = 1
+    Nφ = 32
+    Hλ = Hφ = 1
 
-    grid = RegularLatitudeLongitudeGrid(FT, size=(Nλ, Nϕ, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1), halo=(Hλ, Hϕ, 1))
+    grid = RegularLatitudeLongitudeGrid(FT, size=(Nλ, Nφ, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1), halo=(Hλ, Hφ, 1))
 
     @test topology(grid) == (Periodic, Bounded, Bounded)
 
     @test grid.Nx == Nλ
-    @test grid.Ny == Nϕ
+    @test grid.Ny == Nφ
     @test grid.Nz == 1
 
     @test grid.Lx == 360
@@ -446,32 +446,32 @@ function test_basic_lat_lon_periodic_domain(FT)
     @test grid.Lz == 1
 
     @test grid.Δλ == 10
-    @test grid.Δϕ == 5
+    @test grid.Δφ == 5
     @test grid.Δz == 1
 
     @test length(grid.λᶠᵃᵃ) == Nλ + 2Hλ
     @test length(grid.λᶜᵃᵃ) == Nλ + 2Hλ
 
-    @test length(grid.ϕᵃᶠᵃ) == Nϕ + 2Hϕ + 1
-    @test length(grid.ϕᵃᶜᵃ) == Nϕ + 2Hϕ
+    @test length(grid.φᵃᶠᵃ) == Nφ + 2Hφ + 1
+    @test length(grid.φᵃᶜᵃ) == Nφ + 2Hφ
 
     @test grid.λᶠᵃᵃ[1] == -180
     @test grid.λᶠᵃᵃ[Nλ] == 180 - grid.Δλ
 
-    @test grid.ϕᵃᶠᵃ[1] == -80
-    @test grid.ϕᵃᶠᵃ[Nϕ+1] == 80
+    @test grid.φᵃᶠᵃ[1] == -80
+    @test grid.φᵃᶠᵃ[Nφ+1] == 80
 
     @test grid.λᶠᵃᵃ[0] == -180 - grid.Δλ
     @test grid.λᶠᵃᵃ[Nλ+1] == 180
 
-    @test grid.ϕᵃᶠᵃ[0] == -80 - grid.Δϕ
-    @test grid.ϕᵃᶠᵃ[Nϕ+2] == 80 + grid.Δϕ
+    @test grid.φᵃᶠᵃ[0] == -80 - grid.Δφ
+    @test grid.φᵃᶠᵃ[Nφ+2] == 80 + grid.Δφ
 
     @test all(diff(grid.λᶠᵃᵃ.parent) .== grid.Δλ)
     @test all(diff(grid.λᶜᵃᵃ.parent) .== grid.Δλ)
 
-    @test all(diff(grid.ϕᵃᶠᵃ.parent) .== grid.Δϕ)
-    @test all(diff(grid.ϕᵃᶜᵃ.parent) .== grid.Δϕ)
+    @test all(diff(grid.φᵃᶠᵃ.parent) .== grid.Δφ)
+    @test all(diff(grid.φᵃᶜᵃ.parent) .== grid.Δφ)
 
     return nothing
 end

--- a/test/test_netcdf_output_writer.jl
+++ b/test/test_netcdf_output_writer.jl
@@ -687,15 +687,15 @@ function test_netcdf_regular_lat_lon_grid_output(arch)
 
     @test ds["xC"][1] == grid.λᶜᵃᵃ[1]
     @test ds["xF"][1] == grid.λᶠᵃᵃ[1]
-    @test ds["yC"][1] == grid.ϕᵃᶜᵃ[1]
-    @test ds["yF"][1] == grid.ϕᵃᶠᵃ[1]
+    @test ds["yC"][1] == grid.φᵃᶜᵃ[1]
+    @test ds["yF"][1] == grid.φᵃᶠᵃ[1]
     @test ds["zC"][1] == grid.zᵃᵃᶜ[1]
     @test ds["zF"][1] == grid.zᵃᵃᶠ[1]
 
     @test ds["xC"][end] == grid.λᶜᵃᵃ[Nx]
     @test ds["xF"][end] == grid.λᶠᵃᵃ[Nx]
-    @test ds["yC"][end] == grid.ϕᵃᶜᵃ[Ny]
-    @test ds["yF"][end] == grid.ϕᵃᶠᵃ[Ny+1]  # y is Bounded
+    @test ds["yC"][end] == grid.φᵃᶜᵃ[Ny]
+    @test ds["yF"][end] == grid.φᵃᶠᵃ[Ny+1]  # y is Bounded
     @test ds["zC"][end] == grid.zᵃᵃᶜ[Nz]
     @test ds["zF"][end] == grid.zᵃᵃᶠ[Nz+1]  # z is Bounded
 

--- a/validation/barotropic_gyre/barotropic_gyre.jl
+++ b/validation/barotropic_gyre/barotropic_gyre.jl
@@ -67,7 +67,7 @@ u_bcs = UVelocityBoundaryConditions(grid,
 
 v_bcs = VVelocityBoundaryConditions(grid,
                                     bottom = v_bottom_drag_bc)
-                                        
+
 @show const νh₀ = 5e3 * (60 / grid.Nx)^2
 
 @inline νh(λ, φ, z, t) = νh₀ * cos(π * φ / 180)
@@ -91,8 +91,8 @@ g = model.free_surface.gravitational_acceleration
 gravity_wave_speed = sqrt(g * grid.Lz) # hydrostatic (shallow water) gravity wave speed
 
 # Time-scale for gravity wave propagation across the smallest grid cell
-wave_propagation_time_scale = min(grid.radius * cosd(maximum(abs, grid.ϕᵃᶜᵃ)) * deg2rad(grid.Δλ),
-                                  grid.radius * deg2rad(grid.Δϕ)) / gravity_wave_speed
+wave_propagation_time_scale = min(grid.radius * cosd(maximum(abs, grid.φᵃᶜᵃ)) * deg2rad(grid.Δλ),
+                                  grid.radius * deg2rad(grid.Δφ)) / gravity_wave_speed
 
 mutable struct Progress
     interval_start_time :: Float64
@@ -117,7 +117,7 @@ simulation = Simulation(model,
                         stop_time = 1years,
                         iteration_interval = 100,
                         progress = Progress(time_ns()))
-                                                         
+
 output_fields = merge(model.velocities, (η=model.free_surface.η,))
 
 output_prefix = "barotropic_gyre_Nx$(grid.Nx)_Ny$(grid.Ny)"


### PR DESCRIPTION
This PR changes `RegularLatitudeLongitudeGrid` to use (λ, φ) (`\lambda`, `\varphi`) for spherical/geographical coordinates as agreed on in #1437.

This is a breaking change so I'm hoping to get it into v0.54.0 along with PR #1489.

Resolves #1437