### PR TITLE
Fix NonDimensionalImcompressible typo

### DIFF
--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -166,7 +166,7 @@ progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
                         prettytime(sim.Δt.Δt))
 
 simulation = Simulation(model, Δt=wizard, stop_time=24hours,
-                        iteration_interval=1, progress=progress)
+                        iteration_interval=20, progress=progress)
 
 # We add a basic `JLD2OutputWriter` that writes velocities and both
 # the two-dimensional and horizontally-averaged plankton concentration,

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -165,9 +165,8 @@ progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
                         prettytime(sim.model.clock.time),
                         prettytime(sim.Δt.Δt))
 
-#simulation = Simulation(model, Δt=wizard, stop_time=24hours,
-simulation = Simulation(model, Δt=1minutes, stop_time=24hours,
-                        iteration_interval=20)#, progress=progress)
+simulation = Simulation(model, Δt=wizard, stop_time=24hours,
+                        iteration_interval=1, progress=progress)
 
 # We add a basic `JLD2OutputWriter` that writes velocities and both
 # the two-dimensional and horizontally-averaged plankton concentration,

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -42,7 +42,8 @@
 
 # ## The grid
 #
-# We use a two-dimensional grid with 64² points and 1 m grid spacing:
+# We use a two-dimensional grid with 64² points and 1 m grid spacing and assign `Flat`
+# to the `y` direction:
 
 using Oceananigans
 using Oceananigans.Units: minutes, hour, hours, day

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -165,8 +165,9 @@ progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
                         prettytime(sim.model.clock.time),
                         prettytime(sim.Δt.Δt))
 
-simulation = Simulation(model, Δt=wizard, stop_time=24hours,
-                        iteration_interval=20, progress=progress)
+#simulation = Simulation(model, Δt=wizard, stop_time=24hours,
+simulation = Simulation(model, Δt=1minutes, stop_time=24hours,
+                        iteration_interval=20)#, progress=progress)
 
 # We add a basic `JLD2OutputWriter` that writes velocities and both
 # the two-dimensional and horizontally-averaged plankton concentration,

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -47,7 +47,7 @@
 using Oceananigans
 using Oceananigans.Units: minutes, hour, hours, day
 
-grid = RegularRectilinearGrid(size=(64, 1, 64), extent=(64, 1, 64))
+grid = RegularRectilinearGrid(size=(64, 64), extent=(64, 64), topology=(Periodic, Flat, Bounded))
 
 # ## Boundary conditions
 #

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -23,11 +23,9 @@
 using Oceananigans
 using Oceananigans.Units: hours, meters, kilometers
 
-Lz = 400meters
-
-grid = RegularRectilinearGrid(size = (128),
-                            x = (0, 1000kilometers),
-                            topology = (Bounded, Flat, Flat))
+grid = RegularRectilinearGrid(size = (128, 1, 1),
+                            x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),
+                            topology = (Bounded, Periodic, Bounded))
 
 # and Coriolis parameter appropriate for the mid-latitudes on Earth,
 
@@ -72,7 +70,7 @@ set!(model, v=vᵍ, η=ηⁱ)
 #
 # We pick a time-step that resolves the surface dynamics,
 
-gravity_wave_speed = sqrt(g * Lz) # hydrostatic (shallow water) gravity wave speed
+gravity_wave_speed = sqrt(g * grid.Lz) # hydrostatic (shallow water) gravity wave speed
 
 wave_propagation_time_scale = model.grid.Δx / gravity_wave_speed
 
@@ -85,7 +83,7 @@ simulation = Simulation(model, Δt = 0.1 * wave_propagation_time_scale, stop_ite
 output_fields = merge(model.velocities, (η=model.free_surface.η,))
 
 simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
-                                                      schedule = IterationInterval(1),
+                                                      schedule = IterationInterval(10),
                                                       prefix = "geostrophic_adjustment",
                                                       force = true)
 

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -25,14 +25,9 @@ using Oceananigans.Units: hours, meters, kilometers
 
 Lz = 400meters
 
-grid = RegularRectilinearGrid(size = (128, 1),
-                            x = (0, 1000kilometers), y = (0, 1),
-                            topology = (Bounded, Periodic, Flat))
-#=                            
-grid = RegularRectilinearGrid(size = (128, 1, 1),
-                            x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),
-                            topology = (Bounded, Periodic, Bounded))
-=#
+grid = RegularRectilinearGrid(size = (128),
+                            x = (0, 1000kilometers),
+                            topology = (Bounded, Flat, Flat))
 
 # and Coriolis parameter appropriate for the mid-latitudes on Earth,
 
@@ -96,7 +91,6 @@ simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
 
 run!(simulation)
 
-#=
 # ## Visualizing the results
 
 using JLD2, Plots, Printf
@@ -132,4 +126,3 @@ end
 close(file)
 
 mp4(anim, "geostrophic_adjustment.mp4", fps = 15) # hide
-=#

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -24,9 +24,15 @@ using Oceananigans
 using Oceananigans.Units: hours, meters, kilometers
 
 Lz = 400meters
-grid = RegularRectilinearGrid(size = (128),
-                            x = (0, 1000kilometers),
-                            topology = (Bounded, Flat, Flat))
+
+grid = RegularRectilinearGrid(size = (128, 1),
+                            x = (0, 1000kilometers), y = (0, 1),
+                            topology = (Bounded, Periodic, Flat))
+#=                            
+grid = RegularRectilinearGrid(size = (128, 1, 1),
+                            x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),
+                            topology = (Bounded, Periodic, Bounded))
+=#
 
 # and Coriolis parameter appropriate for the mid-latitudes on Earth,
 
@@ -71,7 +77,7 @@ set!(model, v=vᵍ, η=ηⁱ)
 #
 # We pick a time-step that resolves the surface dynamics,
 
-gravity_wave_speed = sqrt(g * grid.Lz) # hydrostatic (shallow water) gravity wave speed
+gravity_wave_speed = sqrt(g * Lz) # hydrostatic (shallow water) gravity wave speed
 
 wave_propagation_time_scale = model.grid.Δx / gravity_wave_speed
 
@@ -84,12 +90,13 @@ simulation = Simulation(model, Δt = 0.1 * wave_propagation_time_scale, stop_ite
 output_fields = merge(model.velocities, (η=model.free_surface.η,))
 
 simulation.output_writers[:fields] = JLD2OutputWriter(model, output_fields,
-                                                      schedule = IterationInterval(10),
+                                                      schedule = IterationInterval(1),
                                                       prefix = "geostrophic_adjustment",
                                                       force = true)
 
 run!(simulation)
 
+#=
 # ## Visualizing the results
 
 using JLD2, Plots, Printf
@@ -125,3 +132,4 @@ end
 close(file)
 
 mp4(anim, "geostrophic_adjustment.mp4", fps = 15) # hide
+=#

--- a/examples/geostrophic_adjustment.jl
+++ b/examples/geostrophic_adjustment.jl
@@ -23,9 +23,10 @@
 using Oceananigans
 using Oceananigans.Units: hours, meters, kilometers
 
-grid = RegularRectilinearGrid(size = (128, 1, 1),
-                            x = (0, 1000kilometers), y = (0, 1), z = (-400meters, 0),
-                            topology = (Bounded, Periodic, Bounded))
+Lz = 400meters
+grid = RegularRectilinearGrid(size = (128),
+                            x = (0, 1000kilometers),
+                            topology = (Bounded, Flat, Flat))
 
 # and Coriolis parameter appropriate for the mid-latitudes on Earth,
 

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -21,7 +21,7 @@
 using Oceananigans
 
 grid = RegularRectilinearGrid(size=(128, 128), x=(-π, π), z=(-π, π),
-                            topology=(Periodic, Flat, Periodic))
+                              topology=(Periodic, Flat, Periodic))
 
 # ## Internal wave parameters
 #

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -20,8 +20,8 @@
 
 using Oceananigans
 
-grid = RegularRectilinearGrid(size=(128, 1, 128), x=(-π, π), y=(-π, π), z=(-π, π),
-                            topology=(Periodic, Periodic, Periodic))
+grid = RegularRectilinearGrid(size=(128, 128), x=(-π, π), z=(-π, π),
+                            topology=(Periodic, Flat, Periodic))
 
 # ## Internal wave parameters
 #

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -16,7 +16,7 @@
 # ## The physical domain
 #
 # First, we pick a resolution and domain size. We use a two-dimensional domain
-# that's periodic in ``(x, y, z)``:
+# that's periodic in ``(x, z)`` and is `Flat` in ``y``:
 
 using Oceananigans
 

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -17,7 +17,7 @@
 using Oceananigans
 
 grid = RegularRectilinearGrid(size=(64, 64), x=(-5, 5), z=(-5, 5),
-                                  topology=(Periodic, Flat, Bounded))
+                              topology=(Periodic, Flat, Bounded))
 
 # # The basic state
 #

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -16,8 +16,8 @@
 
 using Oceananigans
 
-grid = RegularRectilinearGrid(size=(64, 1, 64), x=(-5, 5), y=(0, 1), z=(-5, 5),
-                                  topology=(Periodic, Periodic, Bounded))
+grid = RegularRectilinearGrid(size=(64, 64), x=(-5, 5), z=(-5, 5),
+                                  topology=(Periodic, Flat, Bounded))
 
 # # The basic state
 #

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -12,7 +12,8 @@
 
 # ## The physical domain
 #
-# We simulate Kelvin-Helmholtz instability in two-dimensions in ``x, z``,
+# We simulate Kelvin-Helmholtz instability in two-dimensions in ``x, z``
+# and therefore assign `Flat` to the `y` direction,
 
 using Oceananigans
 

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -37,6 +37,12 @@ using Oceananigans
 
 grid = RegularRectilinearGrid(size=(128), z=(-0.5, 0.5), topology=(Flat, Flat, Bounded))
 
+# The default topology is `(Periodic, Periodic, Bounded)`` but since we only want to solve
+# a one-dimensional problem, we assign the `x` and `y` dimensions to `Flat`.  
+# We could specify each of them to be either `Periodic` or `Bounded` but that will define
+# a halo in each of those directions, and that is numerically more costly.  
+# Note that we only specify the extent and size for the `Bounded` dimension.
+#
 # We next specify a model with an `IsotropicDiffusivity`, which models either
 # molecular or turbulent diffusion,
 

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -35,7 +35,7 @@ using Oceananigans
 # Below, we build a regular rectilinear grid with 128 grid points in the `z`-direction,
 # where `z` spans from `z = -0.5` to `z = 0.5`,
 
-grid = RegularRectilinearGrid(size=(1, 1, 128), x=(0, 1), y=(0, 1), z=(-0.5, 0.5))
+grid = RegularRectilinearGrid(size=(128), z=(-0.5, 0.5), topology=(Flat, Flat, Bounded))
 
 # We next specify a model with an `IsotropicDiffusivity`, which models either
 # molecular or turbulent diffusion,

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -24,7 +24,8 @@
 
 using Oceananigans
 
-grid = RegularRectilinearGrid(size=(128, 128), extent=(2π, 2π), topology=(Periodic, Periodic, Flat))
+grid = RegularRectilinearGrid(size=(128, 128), extent=(2π, 2π), 
+                            topology=(Periodic, Periodic, Flat))
 
 model = IncompressibleModel(timestepper = :RungeKutta3,
                               advection = UpwindBiasedFifthOrder(),
@@ -144,7 +145,7 @@ anim = @animate for (i, iteration) in enumerate(iterations)
     s_plot = contourf(xs, ys, clamp.(s_snapshot', 0, s_lim);
                        color = :thermal,
                       levels = s_levels,
-                       clims = (0, s_lim),
+                       clims = (0., s_lim),
                       kwargs...)
 
     plot(ω_plot, s_plot, title=["Vorticity" "Speed"], layout=(1, 2), size=(1200, 500))

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -20,7 +20,7 @@
 
 # We instantiate the model with an isotropic diffusivity. We use a grid with 128² points,
 # a fifth-order advection scheme, third-order Runge-Kutta time-stepping,
-# and a small isotropic viscosity.
+# and a small isotropic viscosity.  Note that we assign `Flat` to the `z` direction.
 
 using Oceananigans
 

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -80,7 +80,7 @@ s_field = ComputedField(s)
 
 progress(sim) = @info "Iteration: $(sim.model.clock.iteration), time: $(round(Int, sim.model.clock.time))"
 
-simulation = Simulation(model, Δt=0.2, stop_time=50, iteration_interval=1, progress=progress)
+simulation = Simulation(model, Δt=0.2, stop_time=50, iteration_interval=100, progress=progress)
 
 # ## Output
 #

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -24,7 +24,7 @@
 
 using Oceananigans
 
-grid = RegularRectilinearGrid(size=(128, 128, 1), extent=(2π, 2π, 2π))
+grid = RegularRectilinearGrid(size=(128, 128), extent=(2π, 2π), topology=(Periodic, Periodic, Flat))
 
 model = IncompressibleModel(timestepper = :RungeKutta3,
                               advection = UpwindBiasedFifthOrder(),
@@ -79,7 +79,7 @@ s_field = ComputedField(s)
 
 progress(sim) = @info "Iteration: $(sim.model.clock.iteration), time: $(round(Int, sim.model.clock.time))"
 
-simulation = Simulation(model, Δt=0.2, stop_time=50, iteration_interval=100, progress=progress)
+simulation = Simulation(model, Δt=0.2, stop_time=50, iteration_interval=1, progress=progress)
 
 # ## Output
 #

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -25,7 +25,7 @@
 using Oceananigans
 
 grid = RegularRectilinearGrid(size=(128, 128), extent=(2π, 2π), 
-                            topology=(Periodic, Periodic, Flat))
+                              topology=(Periodic, Periodic, Flat))
 
 model = IncompressibleModel(timestepper = :RungeKutta3,
                               advection = UpwindBiasedFifthOrder(),

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -4,7 +4,8 @@ export
     Center, Face,
     AbstractTopology, Periodic, Bounded, Flat, topology,
     AbstractGrid, halo_size,
-    AbstractRectilinearGrid, RegularRectilinearGrid, VerticallyStretchedRectilinearGrid, RegularLatitudeLongitudeGrid,
+    AbstractRectilinearGrid, RegularRectilinearGrid, 
+    VerticallyStretchedRectilinearGrid, ZonallyStretchedRectilinearGrid, RegularLatitudeLongitudeGrid,
     ConformalCubedSphereFaceGrid, ConformalCubedSphereGrid,
     xnode, ynode, znode, xnodes, ynodes, znodes, nodes,
     xC, xF, yC, yF, zC, zF
@@ -108,6 +109,7 @@ include("automatic_halo_sizing.jl")
 include("input_validation.jl")
 include("regular_rectilinear_grid.jl")
 include("vertically_stretched_rectilinear_grid.jl")
+include("zonally_stretched_rectilinear_grid.jl")
 include("regular_latitude_longitude_grid.jl")
 include("conformal_cubed_sphere_face_grid.jl")
 

--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -123,3 +123,13 @@ function validate_vertically_stretched_grid_xy(TX, TY, FT, x, y)
 
     return FT(Lx), FT(Ly), FT.(x), FT.(y)
 end
+
+function validate_zonally_stretched_grid_yz(TY, TZ, FT, y, z)
+    y = validate_dimension_specification(TY, y, :y)
+    z = validate_dimension_specification(TZ, z, :z)
+
+    Ly = y[2] - y[1]
+    Lz = z[2] - z[1]
+
+    return FT(Ly), FT(Lz), FT.(y), FT.(z)
+end

--- a/src/Grids/zonally_stretched_rectilinear_grid.jl
+++ b/src/Grids/zonally_stretched_rectilinear_grid.jl
@@ -1,0 +1,233 @@
+"""
+    ZonallyStretchedRectilinearGrid{FT, TX, TY, TZ, R, A} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
+
+A rectilinear grid with with constant grid spacings `Δy` and `Δz`, and
+non-uniform or stretched zonal grid spacing `Δx` between cell centers and cell faces,
+topology `{TX, TY, TZ}`, and coordinate ranges of type `R` (where a range can be used) and
+`A` (where an array is needed).
+"""
+struct ZonallyStretchedRectilinearGrid{FT, TX, TY, TZ, R, A} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
+
+    # Number of grid points in (x,y,z).
+    Nx :: Int
+    Ny :: Int
+    Nz :: Int
+
+    # Halo size in (x,y,z).
+    Hx :: Int
+    Hy :: Int
+    Hz :: Int
+
+    # Domain size [m].
+    Lx :: FT
+    Ly :: FT
+    Lz :: FT
+
+    # Grid spacing [m].
+    Δxᶜᵃᵃ :: A
+    Δxᶠᵃᵃ :: A
+       Δy :: FT
+       Δz :: FT
+
+    # Range of coordinates at the centers of the cells.
+    xᶜᵃᵃ :: A
+    yᵃᶜᵃ :: R
+    zᵃᵃᶜ :: R
+
+    # Range of grid coordinates at the faces of the cells.
+    # Note: there are Nx+1 faces in the x-dimension, Ny+1 in the y, and Nz+1 in the z.
+    xᶠᵃᵃ :: A
+    yᵃᶠᵃ :: R
+    zᵃᵃᶠ :: R
+end
+
+# FJP: since this is for ShallowWater, should the default in z be Flat?
+function ZonallyStretchedRectilinearGrid(FT=Float64; architecture = CPU(),
+                                              size, xF, y, z,
+                                              halo = (1, 1, 1),
+                                          topology = (Bounded, Periodic, Periodic))
+
+    TX, TY, TZ = validate_topology(topology)
+    size = validate_size(TX, TY, TZ, size)
+    halo = validate_halo(TX, TY, TZ, halo)
+    Lx, Ly, x, y = validate_zonally_stretched_grid_yz(TY, TZ, FT, y, z)
+
+    Nx, Ny, Nz = size
+    Hx, Hy, Hz = halo
+
+    # Initialize zonally-stretched arrays on CPU
+    Lx, xᶠᵃᵃ, xᶜᵃᵃ, Δxᶜᵃᵃ, Δxᶠᵃᵃ = generate_stretched_zonal_grid(FT, topology[3], Nx, Hx, xF)
+
+    # Construct uniform horizontal grid
+    # FJP: don't want to force the grid to be uniform in the vertical slice!
+    Lh, Nh, Hh, X₁ = (Lx, Ly), size[1:2], halo[1:2], (x[1], y[1])
+    Δx, Δy = Δh = Lh ./ Nh
+
+    # Face-node limits in x, y, z
+    xF₋, yF₋ = XF₋ = @. X₁ - Hh * Δh
+    xF₊, yF₊ = XF₊ = @. XF₋ + total_extent(topology[1:2], Hh, Δh, Lh)
+
+    # Center-node limits in x, y, z
+    xC₋, yC₋ = XC₋ = @. XF₋ + Δh / 2
+    xC₊, yC₊ = XC₊ = @. XC₋ + Lh + Δh * (2Hh - 1)
+
+    # Total length of Center and Face quantities
+    TFx, TFy, TFz = total_length.(Face, topology, size, halo)
+    TCx, TCy, TCz = total_length.(Center, topology, size, halo)
+
+    # Include halo points in coordinate arrays
+    xᶠᵃᵃ = range(xF₋, xF₊; length = TFx)
+    yᵃᶠᵃ = range(yF₋, yF₊; length = TFy)
+
+    xᶜᵃᵃ = range(xC₋, xC₊; length = TCx)
+    yᵃᶜᵃ = range(yC₋, yC₊; length = TCy)
+
+    xᶜᵃᵃ = OffsetArray(xᶜᵃᵃ,  -Hx)
+    yᵃᶜᵃ = OffsetArray(yᵃᶜᵃ,  -Hy)
+    zᵃᵃᶜ = OffsetArray(zᵃᵃᶜ,  -Hz)
+
+    xᶠᵃᵃ = OffsetArray(xᶠᵃᵃ,  -Hx)
+    yᵃᶠᵃ = OffsetArray(yᵃᶠᵃ,  -Hy)
+    zᵃᵃᶠ = OffsetArray(zᵃᵃᶠ,  -Hz)
+
+    Δzᵃᵃᶠ = OffsetArray(Δzᵃᵃᶠ, -Hz)
+    Δzᵃᵃᶜ = OffsetArray(Δzᵃᵃᶜ, -Hz)
+
+    # Needed for pressure solver solution to be divergence-free.
+    # Will figure out why later...
+    Δzᵃᵃᶠ[Nz] = Δzᵃᵃᶠ[Nz-1]
+
+    # Seems needed to avoid out-of-bounds error in viscous dissipation
+    # operators wanting to access Δzᵃᵃᶠ[Nz+2].
+    Δzᵃᵃᶠ = OffsetArray(cat(Δzᵃᵃᶠ[0], Δzᵃᵃᶠ..., Δzᵃᵃᶠ[Nz], dims=1), -Hz-1)
+
+    # Convert to appropriate array type for arch
+    zᵃᵃᶠ  = OffsetArray(arch_array(architecture,  zᵃᵃᶠ.parent),  zᵃᵃᶠ.offsets...)
+    zᵃᵃᶜ  = OffsetArray(arch_array(architecture,  zᵃᵃᶜ.parent),  zᵃᵃᶜ.offsets...)
+    Δzᵃᵃᶜ = OffsetArray(arch_array(architecture, Δzᵃᵃᶜ.parent), Δzᵃᵃᶜ.offsets...)
+    Δzᵃᵃᶠ = OffsetArray(arch_array(architecture, Δzᵃᵃᶠ.parent), Δzᵃᵃᶠ.offsets...)
+
+    return VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, typeof(xᶠᵃᵃ), typeof(zᵃᵃᶠ)}(
+        Nx, Ny, Nz, Hx, Hy, Hz, Lx, Ly, Lz, Δx, Δy, Δzᵃᵃᶜ, Δzᵃᵃᶠ, xᶜᵃᵃ, yᵃᶜᵃ, zᵃᵃᶜ, xᶠᵃᵃ, yᵃᶠᵃ, zᵃᵃᶠ)
+end
+
+#####
+##### Vertically stretched grid utilities
+#####
+
+get_z_face(z::Function, k) = z(k)
+get_z_face(z::AbstractVector, k) = z[k]
+
+lower_exterior_Δzᵃᵃᶜ(z_topo,          zFi, Hz) = [zFi[end - Hz + k] - zFi[end - Hz + k - 1] for k = 1:Hz]
+lower_exterior_Δzᵃᵃᶜ(::Type{Bounded}, zFi, Hz) = [zFi[2]  - zFi[1] for k = 1:Hz]
+
+upper_exterior_Δzᵃᵃᶜ(z_topo,          zFi, Hz) = [zFi[k + 1] - zFi[k] for k = 1:Hz]
+upper_exterior_Δzᵃᵃᶜ(::Type{Bounded}, zFi, Hz) = [zFi[end]   - zFi[end - 1] for k = 1:Hz]
+
+function generate_stretched_zonal_grid(FT, x_topo, Nx, Hx, xF_generator)
+
+    # Ensure correct type for xF and derived quantities
+    interior_xF = zeros(FT, Nx+1)
+
+    for i = 1:Nx+1
+        interior_xF[i] = get_x_face(xF_generator, i)
+    end
+
+    Lx = interior_xF[Nx+1] - interior_xF[1]
+
+    # Build halo regions
+    ΔxF₋ = lower_exterior_Δxᶜᵃᵃ(x_topo, interior_xF, Hx)
+    ΔxF₊ = lower_exterior_Δxᶜᵃᵃ(x_topo, interior_xF, Hx)
+
+    x¹, xᴺ⁺¹ = interior_xF[1], interior_xF[Nx+1]
+
+    xF₋ = [x¹   - sum(ΔxF₋[i:Hx]) for i = 1:Hx] # locations of faces in lower halo
+    xF₊ = [xᴺ⁺¹ + ΔxF₊[i]         for i = 1:Hx] # locations of faces in width of top halo region
+
+    xF = vcat(xF₋, interior_xF, xF₊)
+
+    # Build cell centers, cell center spacings, and cell interface spacings
+    TCx = total_length(Center, x_topo, Nx, Hx)
+     xC = [ (xF[i + 1] + xF[i]) / 2 for i = 1:TCx ]
+    ΔxC = [  xC[i] - xC[i - 1]      for i = 2:TCx ]
+
+    # Trim face locations for periodic domains
+    TFx = total_length(Face, x_topo, Nx, Hx)
+    xF = xF[1:TFx]
+
+    #FJP: what if Flat????
+    ΔxF = [xF[i + 1] - xF[i] for i = 1:TFx-1]
+
+    return Lx, xF, xC, ΔxF, ΔxC
+end
+
+# We cannot reconstruct a VerticallyStretchedRectilinearGrid without the zF_generator.
+# So the best we can do is tell the user what they should have done.
+function with_halo(new_halo, old_grid::VerticallyStretchedRectilinearGrid)
+    new_halo != halo_size(old_grid) &&
+        @error "You need to construct your VerticallyStretchedRectilinearGrid with the keyword argument halo=$new_halo"
+    return old_grid
+end
+
+@inline x_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TX, grid.Nx, grid.xᶠᵃᵃ)
+@inline y_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TY, grid.Ny, grid.yᵃᶠᵃ)
+@inline z_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TZ, grid.Nz, grid.zᵃᵃᶠ)
+
+short_show(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
+    "VerticallyStretchedRectilinearGrid{$FT, $TX, $TY, $TZ}(Nx=$(grid.Nx), Ny=$(grid.Ny), Nz=$(grid.Nz))"
+
+function show(io::IO, g::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
+    Δz_min = minimum(view(g.Δzᵃᵃᶜ, 1:g.Nz))
+    Δz_max = maximum(view(g.Δzᵃᵃᶜ, 1:g.Nz))
+    print(io, "VerticallyStretchedRectilinearGrid{$FT, $TX, $TY, $TZ}\n",
+              "                   domain: $(domain_string(g))\n",
+              "                 topology: ", (TX, TY, TZ), '\n',
+              "  resolution (Nx, Ny, Nz): ", (g.Nx, g.Ny, g.Nz), '\n',
+              "   halo size (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz), '\n',
+              "grid spacing (Δx, Δy, Δz): (", g.Δx, ", ", g.Δy, ", [min=", Δz_min, ", max=", Δz_max,"])",)
+end
+
+Adapt.adapt_structure(to, grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
+    VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, typeof(grid.xᶠᵃᵃ), typeof(Adapt.adapt(to, grid.zᵃᵃᶠ))}(
+        grid.Nx, grid.Ny, grid.Nz,
+        grid.Hx, grid.Hy, grid.Hz,
+        grid.Lx, grid.Ly, grid.Lz,
+        grid.Δx, grid.Δy,
+        Adapt.adapt(to, grid.Δzᵃᵃᶜ),
+        Adapt.adapt(to, grid.Δzᵃᵃᶠ),
+        grid.xᶜᵃᵃ, grid.yᵃᶜᵃ,
+        Adapt.adapt(to, grid.zᵃᵃᶜ),
+        grid.xᶠᵃᵃ, grid.yᵃᶠᵃ,
+        Adapt.adapt(to, grid.zᵃᵃᶠ))
+
+#####
+##### Should merge with grid_utils.jl at some point
+#####
+
+@inline xnode(::Type{Center}, i, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.xᶜᵃᵃ[i]
+@inline xnode(::Type{Face}, i, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.xᶠᵃᵃ[i]
+
+@inline ynode(::Type{Center}, j, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.yᵃᶜᵃ[j]
+@inline ynode(::Type{Face}, j, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.yᵃᶠᵃ[j]
+
+@inline znode(::Type{Center}, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.zᵃᵃᶜ[k]
+@inline znode(::Type{Face}, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.zᵃᵃᶠ[k]
+
+
+all_x_nodes(::Type{Center}, grid::VerticallyStretchedRectilinearGrid) = grid.xᶜᵃᵃ
+all_x_nodes(::Type{Face}, grid::VerticallyStretchedRectilinearGrid) = grid.xᶠᵃᵃ
+all_y_nodes(::Type{Center}, grid::VerticallyStretchedRectilinearGrid) = grid.yᵃᶜᵃ
+all_y_nodes(::Type{Face}, grid::VerticallyStretchedRectilinearGrid) = grid.yᵃᶠᵃ
+all_z_nodes(::Type{Center}, grid::VerticallyStretchedRectilinearGrid) = grid.zᵃᵃᶜ
+all_z_nodes(::Type{Face}, grid::VerticallyStretchedRectilinearGrid) = grid.zᵃᵃᶠ
+
+
+
+#
+# Get minima of grid
+#
+
+min_Δx(grid::VerticallyStretchedRectilinearGrid) = grid.Δx
+min_Δy(grid::VerticallyStretchedRectilinearGrid) = grid.Δy
+min_Δz(grid::VerticallyStretchedRectilinearGrid) = minimum(view(grid.Δzᵃᵃᶜ, 1:grid.Nz))
+

--- a/src/Models/IncompressibleModels/non_dimensional_model.jl
+++ b/src/Models/IncompressibleModels/non_dimensional_model.jl
@@ -1,7 +1,7 @@
 using Oceananigans.BuoyancyModels
 
 """
-    NonDimensionalImcompressibleModel(; N, L, Re, Pr=0.7, Ro=Inf, float_type=Float64, kwargs...)
+    NonDimensionalIncompressibleModel(; N, L, Re, Pr=0.7, Ro=Inf, float_type=Float64, kwargs...)
 
 Construct a "Non-dimensional" `Model` with resolution `N`, domain extent `L`,
 precision `float_type`, and the four non-dimensional numbers:
@@ -20,7 +20,7 @@ Note that `N`, `L`, and `Re` are required.
 
 Additional `kwargs` are passed to the regular `IncompressibleModel` constructor.
 """
-function NonDimensionalImcompressibleModel(; grid, float_type=Float64, Re, Pr=0.7, Ro=Inf,
+function NonDimensionalIncompressibleModel(; grid, float_type=Float64, Re, Pr=0.7, Ro=Inf,
     buoyancy = BuoyancyTracer(),
     coriolis = FPlane(float_type, f=1/Ro),
      closure = IsotropicDiffusivity(float_type, ν=1/Re, κ=1/(Pr*Re)),

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -1,6 +1,6 @@
 module Models
 
-export IncompressibleModel, NonDimensionalImcompressibleModel, HydrostaticFreeSurfaceModel, ShallowWaterModel
+export IncompressibleModel, NonDimensionalIncompressibleModel, HydrostaticFreeSurfaceModel, ShallowWaterModel
 
 using Oceananigans: AbstractModel
 
@@ -10,7 +10,7 @@ include("IncompressibleModels/IncompressibleModels.jl")
 include("HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl")
 include("ShallowWaterModels/ShallowWaterModels.jl")
 
-using .IncompressibleModels: IncompressibleModel, NonDimensionalImcompressibleModel
+using .IncompressibleModels: IncompressibleModel, NonDimensionalIncompressibleModel
 using .HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel
 using .ShallowWaterModels: ShallowWaterModel
 

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -2,32 +2,23 @@ using Oceananigans.Grids: Center, Face
 
 """
 Notes:
-
 This file defines grid lengths, areas, and volumes for staggered structured grids.
-
 Each "reference cell" is associated with an index i, j, k.
 The "location" of each reference cell is roughly the geometric centroid of the reference cell.
-
 On the staggered grid, there are 7 cells additional to the "reference cell"
 that are staggered with respect to the reference cell in x, y, and/or z.
 The staggering is denoted by the locations "Center" and "Face":
-
     - "Center" is shared with the reference cell;
     - "Face" lies between reference cell centers, roughly at the interface between
       reference cells.
-
 The three-dimensional location of an object is defined by a 3-tuple of locations, and
 denoted by a triplet of superscripts. For example, an object `ϕ` whose cell is located at
 (Center, Center, Face) is denoted `ϕᶜᶜᶠ`. `ᶜᶜᶠ` is Centered in `x`, `Centered` in `y`, and on
 reference cell interfaces in `z` (this is where the vertical velocity is located, for example).
-
 The super script `ᵃ` denotes "any" location.
-
 The operators in this file fall into three categories:
-
 1. Operators needed for an algorithm valid on rectilinear grids with
    at most a stretched vertical dimension and regular horizontal dimensions.
-
 2. Operators needed for an algorithm on a grid that is curvilinear in the horizontal
    at rectilinear (possibly stretched) in the vertical.
 """
@@ -59,10 +50,12 @@ The operators in this file fall into three categories:
 
 using Oceananigans.Grids: Flat
 
-@inline Δx(i, j, k,  grid::RegularRectilinearGrid{FT, Flat})         where FT           = one(FT)
-@inline Δy(i, j, k,  grid::RegularRectilinearGrid{FT, TX, Flat})     where {FT, TX}     = one(FT)
-@inline ΔzC(i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
-@inline ΔzF(i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
+@inline Δx(   i, j, k, grid::RegularRectilinearGrid{FT, Flat})         where FT           = one(FT)
+@inline Δy(   i, j, k, grid::RegularRectilinearGrid{FT, TX, Flat})     where {FT, TX}     = one(FT)
+@inline ΔzC(  i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
+@inline ΔzF(  i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
+@inline Δzᵃᵃᶠ(i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
+@inline Δzᵃᵃᶜ(i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
 
 #####
 ##### Areas for horizontally-regular algorithms
@@ -87,15 +80,15 @@ using Oceananigans.Grids: Flat
 ##### Grid lengths for horizontally-curvilinear, vertically-rectilinear algorithms
 #####
 
-@inline Δxᶜᶜᵃ(i, j, k, grid::ARG) = grid.Δx
-@inline Δxᶜᶠᵃ(i, j, k, grid::ARG) = grid.Δx
-@inline Δxᶠᶠᵃ(i, j, k, grid::ARG) = grid.Δx
-@inline Δxᶠᶜᵃ(i, j, k, grid::ARG) = grid.Δx
+@inline Δxᶜᶜᵃ(i, j, k, grid::ARG) = Δx(i, j, k, grid)
+@inline Δxᶜᶠᵃ(i, j, k, grid::ARG) = Δx(i, j, k, grid)
+@inline Δxᶠᶠᵃ(i, j, k, grid::ARG) = Δx(i, j, k, grid)
+@inline Δxᶠᶜᵃ(i, j, k, grid::ARG) = Δx(i, j, k, grid)
 
-@inline Δyᶜᶜᵃ(i, j, k, grid::ARG) = grid.Δy
-@inline Δyᶠᶜᵃ(i, j, k, grid::ARG) = grid.Δy
-@inline Δyᶜᶠᵃ(i, j, k, grid::ARG) = grid.Δy
-@inline Δyᶠᶠᵃ(i, j, k, grid::ARG) = grid.Δy
+@inline Δyᶜᶜᵃ(i, j, k, grid::ARG) = Δy(i, j, k, grid)
+@inline Δyᶠᶜᵃ(i, j, k, grid::ARG) = Δy(i, j, k, grid)
+@inline Δyᶜᶠᵃ(i, j, k, grid::ARG) = Δy(i, j, k, grid)
+@inline Δyᶠᶠᵃ(i, j, k, grid::ARG) = Δy(i, j, k, grid)
 
 #####
 ##### Areas for algorithms that generalize to horizontally-curvilinear, vertically-rectilinear grids

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -23,6 +23,8 @@ than `max_Δt` and no less than `min_Δt`.
 TimeStepWizard(; cfl=0.1, diffusive_cfl=Inf, max_change=2.0, min_change=0.5, max_Δt=Inf, min_Δt=0.0, Δt=0.01) =
         TimeStepWizard{typeof(Δt)}(cfl, diffusive_cfl, max_change, min_change, max_Δt, min_Δt, Δt)
 
+using Oceananigans.Grids: topology
+
 """
     update_Δt!(wizard, model)
 

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -29,7 +29,6 @@ minimum_grid_spacing(Δx, ::Type{Flat}) = Inf
 
 function cell_diffusion_timescale(closure::IsotropicDiffusivity, diffusivities, grid)
     Δ = min_Δxyz(grid)
-
     max_κ = maximum_numeric_diffusivity(closure.κ)
     max_ν = maximum_numeric_diffusivity(closure.ν)
     return min(Δ^2 / max_ν, Δ^2 / max_κ)

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -2,8 +2,6 @@
 using Oceananigans.Grids: min_Δx, min_Δy, min_Δz
 using Oceananigans.Grids: topology
 
-min_Δxy(grid) = min(min_Δx(grid), min_Δy(grid))
-
 function min_Δxyz(grid)
     topo = topology(grid)
 

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -1,5 +1,4 @@
 # Timescale for diffusion across one cell
-using Oceananigans.Grids: min_Δx, min_Δy, min_Δz
 using Oceananigans.Grids: topology
 
 function min_Δxyz(grid)

--- a/src/Utils/cell_advection_timescale.jl
+++ b/src/Utils/cell_advection_timescale.jl
@@ -29,8 +29,6 @@ function cell_advection_timescale(u, v, w, grid::VerticallyStretchedRectilinearG
 
     Δx = minimum_grid_spacing(grid.Δx,    topo[1])
     Δy = minimum_grid_spacing(grid.Δy,    topo[2])
-    #FJP: this line fails when run on gpu 
-    #FJP: see test_diagnostics.jl for an example
     Δz = minimum_grid_spacing(grid.Δzᵃᵃᶠ, topo[3])
 
     return min(Δx/umax, Δy/vmax, Δz/wmax)

--- a/src/Utils/cell_advection_timescale.jl
+++ b/src/Utils/cell_advection_timescale.jl
@@ -25,7 +25,3 @@ cell_advection_timescale(model) =
                              model.velocities.v.data.parent,
                              model.velocities.w.data.parent,
                              model.grid)
-
-
-
-

--- a/src/Utils/cell_advection_timescale.jl
+++ b/src/Utils/cell_advection_timescale.jl
@@ -4,7 +4,7 @@ minimum_grid_spacing(Δx, TX          ) = minimum(Δx)
 minimum_grid_spacing(Δx, ::Type{Flat}) = Inf
 
 "Returns the time-scale for advection on a regular grid across a single grid cell."
-function cell_advection_timescale(u, v, w, grid)
+function cell_advection_timescale(u, v, w, grid::RegularRectilinearGrid)
 
     umax = maximum(abs, u)
     vmax = maximum(abs, v)
@@ -19,6 +19,22 @@ function cell_advection_timescale(u, v, w, grid)
     return min(Δx/umax, Δy/vmax, Δz/wmax)
 end
 
+function cell_advection_timescale(u, v, w, grid::VerticallyStretchedRectilinearGrid)
+
+    umax = maximum(abs, u)
+    vmax = maximum(abs, v)
+    wmax = maximum(abs, w)
+
+    topo = topology(grid)
+
+    Δx = minimum_grid_spacing(grid.Δx,    topo[1])
+    Δy = minimum_grid_spacing(grid.Δy,    topo[2])
+    #FJP: this line fails when run on gpu 
+    #FJP: see test_diagnostics.jl for an example
+    Δz = minimum_grid_spacing(grid.Δzᵃᵃᶠ, topo[3])
+
+    return min(Δx/umax, Δy/vmax, Δz/wmax)
+end
 
 cell_advection_timescale(model) =
     cell_advection_timescale(model.velocities.u.data.parent,

--- a/src/Utils/cell_advection_timescale.jl
+++ b/src/Utils/cell_advection_timescale.jl
@@ -1,14 +1,20 @@
-using Oceananigans.Grids: min_Δx, min_Δy, min_Δz
+using Oceananigans.Grids: topology
+
+minimum_grid_spacing(Δx, TX          ) = minimum(Δx)
+minimum_grid_spacing(Δx, ::Type{Flat}) = Inf
 
 "Returns the time-scale for advection on a regular grid across a single grid cell."
 function cell_advection_timescale(u, v, w, grid)
+
     umax = maximum(abs, u)
     vmax = maximum(abs, v)
     wmax = maximum(abs, w)
 
-    Δx = min_Δx(grid)
-    Δy = min_Δy(grid)
-    Δz = min_Δz(grid)
+    topo = topology(grid)
+
+    Δx = minimum_grid_spacing(grid.Δx, topo[1])
+    Δy = minimum_grid_spacing(grid.Δy, topo[2])
+    Δz = minimum_grid_spacing(grid.Δz, topo[3])
 
     return min(Δx/umax, Δy/vmax, Δz/wmax)
 end
@@ -19,3 +25,7 @@ cell_advection_timescale(model) =
                              model.velocities.v.data.parent,
                              model.velocities.w.data.parent,
                              model.grid)
+
+
+
+

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -64,7 +64,9 @@ end
     @info "  Testing $topo model construction..."
         for arch in archs, FT in float_types                
             grid = RegularRectilinearGrid(FT, topology=topo, size=(), extent=())
-            model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)        
+            model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)
+            
+            @test model isa HydrostaticFreeSurfaceModel
         end
     end
 
@@ -77,6 +79,8 @@ end
         @testset "$topo model construction" begin
             @info "  Testing $topo model construction..."
             for arch in archs, FT in float_types
+                arch isa GPU && topo == (Flat, Bounded, Flat) && continue
+                
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(1), extent=(1))
                 model = HydrostaticFreeSurfaceModel(grid=grid, gravitational_acceleration=1, architecture=arch)        
 

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -58,6 +58,51 @@ end
         @test_throws TypeError HydrostaticFreeSurfaceModel(architecture=GPU, grid=grid)
     end
 
+    topo = ( (Flat,      Flat,     Flat) )
+   
+    @testset "$topo model construction" begin
+    @info "  Testing $topo model construction..."
+        for arch in archs, FT in float_types                
+            grid = RegularRectilinearGrid(FT, topology=topo, size=(), extent=())
+            model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)        
+        end
+    end
+
+    topos = (
+             (Bounded,   Flat,     Flat),    
+             (Flat,      Bounded,  Flat),
+            )
+
+    for topo in topos
+        @testset "$topo model construction" begin
+            @info "  Testing $topo model construction..."
+            for arch in archs, FT in float_types
+                grid = RegularRectilinearGrid(FT, topology=topo, size=(1), extent=(1))
+                model = HydrostaticFreeSurfaceModel(grid=grid, gravitational_acceleration=1, architecture=arch)        
+
+                @test model isa HydrostaticFreeSurfaceModel
+            end
+        end
+    end
+
+    topos = (
+             (Periodic, Periodic,  Flat),
+             (Periodic,  Bounded,  Flat),
+             (Bounded,   Bounded,  Flat),
+            )
+
+    for topo in topos
+        @testset "$topo model construction" begin
+            @info "  Testing $topo model construction..."
+            for arch in archs, FT in float_types
+                grid = RegularRectilinearGrid(FT, topology=topo, size=(1, 1), extent=(1, 2))
+                model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)
+
+                @test model isa HydrostaticFreeSurfaceModel
+            end
+        end
+    end
+
     topos = (
              (Periodic, Periodic,  Bounded),
              (Periodic,  Bounded,  Bounded),
@@ -71,11 +116,7 @@ end
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(1, 1, 1), extent=(1, 2, 3))
                 model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)
 
-                # Just testing that the model was constructed with no errors/crashes.
                 @test model isa HydrostaticFreeSurfaceModel
-
-                # Test that the grid didn't get mangled (sort of)
-                @test size(grid) === size(model.grid)
             end
         end
     end

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -79,10 +79,8 @@ end
         @testset "$topo model construction" begin
             @info "  Testing $topo model construction..."
             for arch in archs, FT in float_types
-                arch isa GPU && topo == (Flat, Bounded, Flat) && continue
-                
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(1), extent=(1))
-                model = HydrostaticFreeSurfaceModel(grid=grid, gravitational_acceleration=1, architecture=arch)        
+                model = HydrostaticFreeSurfaceModel(grid=grid, architecture=arch)        
 
                 @test model isa HydrostaticFreeSurfaceModel
             end

--- a/test/test_incompressible_models.jl
+++ b/test/test_incompressible_models.jl
@@ -85,9 +85,9 @@
         @info "  Testing non-dimensional model construction..."
         for arch in archs, FT in float_types
             grid = RegularRectilinearGrid(FT, size=(16, 16, 2), extent=(3, 2, 1))
-            model = NonDimensionalImcompressibleModel(architecture=arch, float_type=FT, grid=grid, Re=1, Pr=1, Ro=Inf)
+            model = NonDimensionalIncompressibleModel(architecture=arch, float_type=FT, grid=grid, Re=1, Pr=1, Ro=Inf)
 
-            # Just testing that a NonDimensionalImcompressibleModel was constructed with no errors/crashes.
+            # Just testing that a NonDimensionalIncompressibleModel was constructed with no errors/crashes.
             @test model isa IncompressibleModel
         end
     end

--- a/test/test_shallow_water_models.jl
+++ b/test/test_shallow_water_models.jl
@@ -64,7 +64,9 @@ end
     @info "  Testing $topo model construction..."
         for arch in archs, FT in float_types                
             grid = RegularRectilinearGrid(FT, topology=topo, size=(), extent=())
-            model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch)        
+            model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch) 
+            
+            @test model isa HydrostaticFreeSurfaceModel
         end
     end
 
@@ -80,7 +82,9 @@ end
                 arch isa GPU && topo == (Flat, Bounded, Flat) && continue
         
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(1), extent=(1))
-                model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch)        
+                model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch) 
+                
+                @test model isa HydrostaticFreeSurfaceModel
             end
         end
     end
@@ -101,10 +105,6 @@ end
                 model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch)
 
                 @test model isa ShallowWaterModel
-
-                #too_big_grid = RegularRectilinearGrid(FT, topology=topo, size=(1, 1, 2), extent=(1, 2, 3))
-
-                #@test_throws ArgumentError ShallowWaterModel(grid=too_big_grid, gravitational_acceleration=1, architecture=arch)
             end
         end
     end

--- a/test/test_shallow_water_models.jl
+++ b/test/test_shallow_water_models.jl
@@ -58,7 +58,7 @@ end
         @test_throws TypeError ShallowWaterModel(architecture=GPU, grid=grid, gravitational_acceleration=1)
     end
 
-    topo = ( (Flat,      Flat,     Flat) )
+    topo = ( Flat,      Flat,     Flat )
    
     @testset "$topo model construction" begin
     @info "  Testing $topo model construction..."
@@ -66,7 +66,7 @@ end
             grid = RegularRectilinearGrid(FT, topology=topo, size=(), extent=())
             model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch) 
             
-            @test model isa HydrostaticFreeSurfaceModel
+            @test model isa ShallowWaterModel
         end
     end
 
@@ -79,12 +79,12 @@ end
         @testset "$topo model construction" begin
             @info "  Testing $topo model construction..."
             for arch in archs, FT in float_types
-                arch isa GPU && topo == (Flat, Bounded, Flat) && continue
+                #arch isa GPU && topo == (Flat, Bounded, Flat) && continue
         
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(1), extent=(1))
                 model = ShallowWaterModel(grid=grid, gravitational_acceleration=1, architecture=arch) 
                 
-                @test model isa HydrostaticFreeSurfaceModel
+                @test model isa ShallowWaterModel
             end
         end
     end

--- a/validation/lid_driven_cavity/lid_driven_cavity.jl
+++ b/validation/lid_driven_cavity/lid_driven_cavity.jl
@@ -45,9 +45,8 @@ function simulate_lid_driven_cavity(; Re, N, end_time)
     cfl = AdvectiveCFL(wizard)
     dcfl = DiffusiveCFL(wizard)
 
-    #simulation = Simulation(model, Δt=wizard, stop_time=end_time, progress=print_progress,
-    simulation = Simulation(model, Δt=0.0001, stop_time=end_time, #progress=print_progress,
-                            iteration_interval=1, parameters=(cfl=cfl, dcfl=dcfl))
+    simulation = Simulation(model, Δt=wizard, stop_time=end_time, progress=print_progress,
+                            iteration_interval=20, parameters=(cfl=cfl, dcfl=dcfl))
 
     simulation.output_writers[:fields] = field_output_writer
 

--- a/validation/lid_driven_cavity/lid_driven_cavity.jl
+++ b/validation/lid_driven_cavity/lid_driven_cavity.jl
@@ -1,27 +1,22 @@
 using Printf
 using Logging
-
 using Oceananigans
-using Oceananigans: Face, Center
-using Oceananigans.Diagnostics
-using Oceananigans.OutputWriters
-using Oceananigans.AbstractOperations
 
 Logging.global_logger(OceananigansLogger())
 
 function simulate_lid_driven_cavity(; Re, N, end_time)
     topology = (Flat, Bounded, Bounded)
-    domain = (x=(0, 1), y=(0, 1), z=(0, 1))
-    grid = RegularRectilinearGrid(topology=topology, size=(1, N, N); domain...)
+    domain = (y=(0, 1), z=(0, 1))
+    grid = RegularRectilinearGrid(topology=topology, size=(N, N); domain...)
 
     v_bcs = VVelocityBoundaryConditions(grid,
-           top = ValueBoundaryCondition(1.0),
-        bottom = ValueBoundaryCondition(0.0)
+           top = ValueBoundaryCondition(1),
+        bottom = ValueBoundaryCondition(0)
     )
 
     w_bcs = WVelocityBoundaryConditions(grid,
-        north = ValueBoundaryCondition(0.0),
-        south = ValueBoundaryCondition(0.0)
+        north = ValueBoundaryCondition(0),
+        south = ValueBoundaryCondition(0)
     )
 
     model = IncompressibleModel(
@@ -34,24 +29,15 @@ function simulate_lid_driven_cavity(; Re, N, end_time)
     )
 
     u, v, w = model.velocities
-    ζ_op = ∂y(w) - ∂z(v)
-    ζ = Field(Center, Face, Face, model.architecture, model.grid, TracerBoundaryConditions(grid))
-    ζ_computation = Computation(ζ_op, ζ)
+    ζ = ComputedField(∂y(w) - ∂z(v))
 
-    fields = Dict(
-        "v" => model.velocities.v,
-        "w" => model.velocities.w,
-        "ζ" => model -> ζ_computation(model)
-    )
-
-    dims = Dict("ζ" => ("xC", "yF", "zF"))
+    fields = (; v, w, ζ)
     global_attributes = Dict("Re" => Re)
     output_attributes = Dict("ζ" => Dict("longname" => "vorticity", "units" => "1/s"))
 
     field_output_writer =
-        NetCDFOutputWriter(model, fields, filename="lid_driven_cavity_Re$Re.nc", schedule=TimeInterval(0.1),
-                           global_attributes=global_attributes, output_attributes=output_attributes,
-                           dimensions=dims)
+        NetCDFOutputWriter(model, fields, filepath="lid_driven_cavity_Re$Re.nc", schedule=TimeInterval(0.1),
+                           global_attributes=global_attributes, output_attributes=output_attributes)
 
     max_Δt = 0.25 * model.grid.Δy^2 * Re / 2  # Make sure not to violate diffusive CFL.
     wizard = TimeStepWizard(cfl=0.1, Δt=1e-6, max_change=1.1, max_Δt=max_Δt)
@@ -59,8 +45,9 @@ function simulate_lid_driven_cavity(; Re, N, end_time)
     cfl = AdvectiveCFL(wizard)
     dcfl = DiffusiveCFL(wizard)
 
-    simulation = Simulation(model, Δt=wizard, stop_time=end_time, progress=print_progress,
-                            iteration_interval=20, parameters=(cfl=cfl, dcfl=dcfl))
+    #simulation = Simulation(model, Δt=wizard, stop_time=end_time, progress=print_progress,
+    simulation = Simulation(model, Δt=0.0001, stop_time=end_time, #progress=print_progress,
+                            iteration_interval=1, parameters=(cfl=cfl, dcfl=dcfl))
 
     simulation.output_writers[:fields] = field_output_writer
 
@@ -77,8 +64,8 @@ function print_progress(simulation)
     progress = 100 * (model.clock.time / simulation.stop_time)
 
     # Find maximum velocities.
-    vmax = maximum(abs, interior(model.velocities.v))
-    wmax = maximum(abs, interior(model.velocities.w))
+    vmax = maximum(abs, model.velocities.v)
+    wmax = maximum(abs, model.velocities.w)
 
     i, t = model.clock.iteration, model.clock.time
     @info @sprintf("[%06.2f%%] i: %d, t: %.3f, U_max: (%.2e, %.2e), CFL: %.2e, dCFL: %.2e, next Δt: %.2e",
@@ -87,11 +74,11 @@ function print_progress(simulation)
     return nothing
 end
 
- simulate_lid_driven_cavity(Re=100,   N=128, end_time=15)
- simulate_lid_driven_cavity(Re=400,   N=128, end_time=20)
- simulate_lid_driven_cavity(Re=1000,  N=128, end_time=25)
- simulate_lid_driven_cavity(Re=3200,  N=128, end_time=50)
- simulate_lid_driven_cavity(Re=5000,  N=256, end_time=50)
- simulate_lid_driven_cavity(Re=7500,  N=256, end_time=75)
- simulate_lid_driven_cavity(Re=10000, N=256, end_time=100)
+simulate_lid_driven_cavity(Re=100,   N=128, end_time=15)
+simulate_lid_driven_cavity(Re=400,   N=128, end_time=20)
+simulate_lid_driven_cavity(Re=1000,  N=128, end_time=25)
+simulate_lid_driven_cavity(Re=3200,  N=128, end_time=50)
+simulate_lid_driven_cavity(Re=5000,  N=256, end_time=50)
+simulate_lid_driven_cavity(Re=7500,  N=256, end_time=75)
+simulate_lid_driven_cavity(Re=10000, N=256, end_time=100)
 


### PR DESCRIPTION
I noticed that almost everywhere we mentioned the NonDimensional model we had `Imcompressible` instead of `Incompressible`.  It was only correct in one spot. Even though it was more effort to change the typos I thought this would be for the better.