### PR TITLE
Implements `similar(f::Field)` and `similar(r::ReducedField)`

### DIFF
--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -46,9 +46,10 @@ function Field(X, Y, Z, arch, grid,
     return Field{X, Y, Z}(data, grid, bcs)
 end
 
-#####
-##### Convenience constructor for Field that uses a 3-tuple of locations rather than a list of locations:
-#####
+function Base.similar(f::Field{X, Y, Z}) where {X, Y, Z}
+    arch = architecture(f.data)
+    return Field(X, Y, Z, arch, f.grid, f.boundary_conditions)
+end
 
 # Type "destantiation": convert Face() to Face and Center() to Center if needed.
 destantiate(X) = typeof(X)

--- a/src/Fields/reduced_field.jl
+++ b/src/Fields/reduced_field.jl
@@ -132,7 +132,10 @@ function ReducedField(Xr, Yr, Zr, arch, grid; dims, data=nothing,
     return ReducedField{X, Y, Z}(data, grid, dims, boundary_conditions)
 end
 
-ReducedField(loc::Tuple, args...; kwargs...) = ReducedField(loc..., args...; kwargs...)
+function Base.similar(r::ReducedField{X, Y, Z}) where {X, Y, Z}
+    arch = architecture(r.data)
+    return ReducedField(X, Y, Z, arch, r.grid; dims=r.dims, boundary_conditions=r.boundary_conditions)
+end
 
 #####
 ##### ReducedField utils

--- a/src/Fields/reduced_field.jl
+++ b/src/Fields/reduced_field.jl
@@ -132,6 +132,8 @@ function ReducedField(Xr, Yr, Zr, arch, grid; dims, data=nothing,
     return ReducedField{X, Y, Z}(data, grid, dims, boundary_conditions)
 end
 
+ReducedField(Lr, arch, grid; dims, kwargs...) = ReducedField(Lr..., arch, grid; dims=dims, kwargs...)
+
 function Base.similar(r::ReducedField{X, Y, Z}) where {X, Y, Z}
     arch = architecture(r.data)
     return ReducedField(X, Y, Z, arch, r.grid; dims=r.dims, boundary_conditions=r.boundary_conditions)

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -8,6 +8,14 @@ has size `(Tx, Ty, Tz)`.
 """
 correct_field_size(a, g, FieldType, Tx, Ty, Tz) = size(parent(FieldType(a, g))) == (Tx, Ty, Tz)
 
+function run_similar_field_tests(f)
+    g = similar(f)
+    @test typeof(f) == typeof(g)
+    @test typeof(f) == typeof(g)
+    @test f.boundary_conditions == g.boundary_conditions
+    return nothing
+end
+
 """
      correct_field_value_was_set(N, L, ftf, val)
 
@@ -238,5 +246,21 @@ end
         end
 
         @test FieldSlicer() isa FieldSlicer
+
+        @info "    Testing similar(f) for f::Union(Field, ReducedField)..."
+
+        grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
+
+        for X in (Center, Face), Y in (Center, Face), Z in (Center, Face)
+            for arch in archs
+                f = Field(X, Y, Z, arch, grid)
+                run_similar_field_tests(f)
+
+                for dims in (3, (1, 2), (1, 2, 3))
+                    f = ReducedField(X, Y, Z, arch, grid, dims=dims)
+                    run_similar_field_tests(f)
+                end
+            end
+        end
     end
 end


### PR DESCRIPTION
Calling `similar(f)` returns a field at the same location and with identical boundary conditions as `f` for `f::Field` and `f::ReducedField`.

cc @christophernhill 