### PR TITLE
Fixes bug in FourierTridiagonalPoissonSolver that swapped `ΔzF` and `ΔzC`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.54.0"
+version = "0.54.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/numerical_implementation/poisson_solvers.md
+++ b/docs/src/numerical_implementation/poisson_solvers.md
@@ -94,11 +94,11 @@ and recalling that Fourier transforms do ``\partial_x \rightarrow ik_x`` and ``\
 Discretizing the ``\partial_z^2`` derivative and equating the term inside the brackets to zero we arrive at
 ``N_x\times N_y`` symmetric tridiagonal systems of ``N_z`` linear equations for the Fourier modes:
 ```math
-\frac{\tilde{\phi}_{mn,k-1}}{\Delta z^F_{k-1}}
-- \left\lbrace \frac{1}{\Delta z^F_{k-1}} + \frac{1}{\Delta z^F_k} + \Delta z^C_k (k_x^2 + k_y^2) \right\rbrace
+\frac{\tilde{\phi}_{mn,k-1}}{\Delta z^C_k}
+- \left\lbrace \frac{1}{\Delta z^C_k} + \frac{1}{\Delta z^C_{k+1}} + \Delta z^F_k (k_x^2 + k_y^2) \right\rbrace
   \tilde{\phi}_{mnk}
-+ \frac{\tilde{\phi}_{mn,k+1}}{\Delta z^F_k}
-= \Delta z^C_k \tilde{\mathscr{F}}_{mnk} \, .
++ \frac{\tilde{\phi}_{mn,k+1}}{\Delta z^C_{k+1}}
+= \Delta z^F_k \tilde{\mathscr{F}}_{mnk} \, .
 ```
 
 ## Cosine transforms on the GPU

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -25,7 +25,7 @@ export
     ℑxyᶜᶜᵃ, ℑxyᶠᶜᵃ, ℑxyᶠᶠᵃ, ℑxyᶜᶠᵃ, ℑxzᶜᵃᶜ, ℑxzᶠᵃᶜ, ℑxzᶠᵃᶠ, ℑxzᶜᵃᶠ, ℑyzᵃᶜᶜ, ℑyzᵃᶠᶜ, ℑyzᵃᶠᶠ, ℑyzᵃᶜᶠ,
     ℑxyzᶜᶜᶠ, ℑxyzᶜᶠᶜ, ℑxyzᶠᶜᶜ, ℑxyzᶜᶠᶠ, ℑxyzᶠᶜᶠ, ℑxyzᶠᶠᶜ,
     divᶜᶜᶜ, div_xyᶜᶜᵃ, div_xzᶜᵃᶜ, div_yzᵃᶜᶜ, ζ₃ᶠᶠᵃ,
-    ∇², ∇²hᶜᶜᵃ, ∇²hᶠᶜᵃ, ∇²hᶜᶠᵃ, ∇⁴hᶜᶜᵃ, ∇⁴hᶠᶜᵃ, ∇⁴hᶜᶠᵃ
+    ∇²ᶜᶜᶜ, ∇²hᶜᶜᶜ, ∇²hᶠᶜᶜ, ∇²hᶜᶠᶜ
 
 using Oceananigans.Grids
 

--- a/src/Operators/derivative_operators.jl
+++ b/src/Operators/derivative_operators.jl
@@ -25,14 +25,15 @@
 ##### Operators of the form A*δ(q) where A is an area and q is some quantity.
 #####
 
-@inline Ax_∂xᶜᵃᵃ(i, j, k, grid::ARG, u) = Axᵃᵃᶠ(i, j, k, grid) * ∂xᶜᵃᵃ(i, j, k, grid, u)
-@inline Ax_∂xᶠᵃᵃ(i, j, k, grid::ARG, c) = Axᵃᵃᶠ(i, j, k, grid) * ∂xᶠᵃᵃ(i, j, k, grid, c)
+@inline Ax_∂xᶜᶜᶜ(i, j, k, grid::ARG, u) = Axᶜᶜᶜ(i, j, k, grid) * ∂xᶜᶜᵃ(i, j, k, grid, u)
+@inline Ax_∂xᶠᶠᶜ(i, j, k, grid::ARG, v) = Axᶠᶠᶜ(i, j, k, grid) * ∂xᶠᶠᵃ(i, j, k, grid, v)
+@inline Ax_∂xᶠᶜᶜ(i, j, k, grid::ARG, c) = Axᶠᶜᶜ(i, j, k, grid) * ∂xᶠᶜᵃ(i, j, k, grid, c)
 
-@inline Ay_∂yᵃᶜᵃ(i, j, k, grid::ARG, v) = Ayᵃᵃᶠ(i, j, k, grid) * ∂yᵃᶜᵃ(i, j, k, grid, v)
-@inline Ay_∂yᵃᶠᵃ(i, j, k, grid::ARG, c) = Ayᵃᵃᶠ(i, j, k, grid) * ∂yᵃᶠᵃ(i, j, k, grid, c)
+@inline Ay_∂yᶠᶠᶜ(i, j, k, grid::ARG, u) = Ayᶠᶠᶜ(i, j, k, grid) * ∂yᶠᶠᵃ(i, j, k, grid, u)
+@inline Ay_∂yᶜᶜᶜ(i, j, k, grid::ARG, v) = Ayᶜᶜᶜ(i, j, k, grid) * ∂yᶜᶜᵃ(i, j, k, grid, v)
+@inline Ay_∂yᶜᶠᶜ(i, j, k, grid::ARG, c) = Ayᶜᶠᶜ(i, j, k, grid) * ∂yᶜᶠᵃ(i, j, k, grid, c)
 
-@inline Az_∂zᵃᵃᶜ(i, j, k, grid::ARG, w) = Azᵃᵃᵃ(i, j, k, grid) * ∂zᵃᵃᶜ(i, j, k, grid, w)
-@inline Az_∂zᵃᵃᶠ(i, j, k, grid::ARG, c) = Azᵃᵃᵃ(i, j, k, grid) * ∂zᵃᵃᶠ(i, j, k, grid, c)
+@inline Az_∂zᶜᶜᶠ(i, j, k, grid::ARG, c) = Azᶜᶜᵃ(i, j, k, grid) * ∂zᵃᵃᶠ(i, j, k, grid, c)
 
 #####
 ##### Second derivatives

--- a/src/Operators/divergence_operators.jl
+++ b/src/Operators/divergence_operators.jl
@@ -12,9 +12,9 @@ Calculates the divergence ∇·U of a vector field U = (u, v, w),
 which will end up at the cell centers `ccc`.
 """
 @inline function divᶜᶜᶜ(i, j, k, grid, u, v, w)
-    return 1/Vᵃᵃᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_ψᵃᵃᶠ, u) +
-                                    δyᵃᶜᵃ(i, j, k, grid, Ay_ψᵃᵃᶠ, v) +
-                                    δzᵃᵃᶜ(i, j, k, grid, Az_ψᵃᵃᵃ, w))
+    return 1/Vᶜᶜᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_uᶠᶜᶜ, u) +
+                                    δyᵃᶜᵃ(i, j, k, grid, Ay_vᶜᶠᶜ, v) +
+                                    δzᵃᵃᶜ(i, j, k, grid, Az_wᶜᶜᵃ, w))
 end
 
 """

--- a/src/Operators/laplacian_operators.jl
+++ b/src/Operators/laplacian_operators.jl
@@ -2,19 +2,19 @@
 ##### Horizontal Laplacians
 #####
 
-@inline function ∇²hᶜᶜᵃ(i, j, k, grid, c)
-    return 1/Vᵃᵃᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_∂xᶠᵃᵃ, c) +
-                                    δyᵃᶜᵃ(i, j, k, grid, Ay_∂yᵃᶠᵃ, c))
+@inline function ∇²hᶜᶜᶜ(i, j, k, grid, c)
+    return 1/Vᶜᶜᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_∂xᶠᶜᶜ, c) +
+                                    δyᵃᶜᵃ(i, j, k, grid, Ay_∂yᶜᶠᶜ, c))
 end
 
-@inline function ∇²hᶠᶜᵃ(i, j, k, grid, u)
-    return 1/Vᵃᵃᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, Ax_∂xᶜᵃᵃ, u) +
-                                    δyᵃᶜᵃ(i, j, k, grid, Ay_∂yᵃᶠᵃ, u))
+@inline function ∇²hᶠᶜᶜ(i, j, k, grid, u)
+    return 1/Vᶠᶜᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, Ax_∂xᶜᶜᶜ, u) +
+                                    δyᵃᶜᵃ(i, j, k, grid, Ay_∂yᶠᶠᶜ, u))
 end
 
-@inline function ∇²hᶜᶠᵃ(i, j, k, grid, u)
-    return 1/Vᵃᵃᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_∂xᶠᵃᵃ, u) +
-                                    δyᵃᶠᵃ(i, j, k, grid, Ay_∂yᵃᶜᵃ, u))
+@inline function ∇²hᶜᶠᶜ(i, j, k, grid, v)
+    return 1/Vᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_∂xᶠᶠᶜ, v) +
+                                    δyᵃᶠᵃ(i, j, k, grid, Ay_∂yᶜᶜᶜ, v))
 end
 
 @inline ∇²hᶜᶜᵃ(i, j, k, grid, F::FU, args...) where FU <: Function = ∂²xᶜᵃᵃ(i, j, k, grid, F, args...) + ∂²yᵃᶜᵃ(i, j, k, grid, F, args...)
@@ -34,16 +34,8 @@ Calculates the Laplacian of c via
 
 which will end up at the location `ccc`.
 """
-@inline function ∇²(i, j, k, grid, c)
-    return 1/Vᵃᵃᶠ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, Ax_∂xᶜᵃᵃ, c) +
-                                    δyᵃᶠᵃ(i, j, k, grid, Ay_∂yᵃᶜᵃ, c) +
-                                    δzᵃᵃᶠ(i, j, k, grid, Az_∂zᵃᵃᶜ, c))
+@inline function ∇²ᶜᶜᶜ(i, j, k, grid, c)
+    return 1/Vᶜᶜᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_∂xᶠᶜᶜ, c) +
+                                    δyᵃᶜᵃ(i, j, k, grid, Ay_∂yᶜᶠᶜ, c) +
+                                    δzᵃᵃᶜ(i, j, k, grid, Az_∂zᶜᶜᶠ, c))
 end
-
-#####
-##### Horizontal biharmonic operators
-#####
-
-@inline ∇⁴hᶜᶜᵃ(i, j, k, grid, c) = ∇²hᶜᶜᵃ(i, j, k, grid, ∇²hᶜᶜᵃ, c)
-@inline ∇⁴hᶠᶜᵃ(i, j, k, grid, c) = ∇²hᶠᶜᵃ(i, j, k, grid, ∇²hᶠᶜᵃ, c)
-@inline ∇⁴hᶜᶠᵃ(i, j, k, grid, c) = ∇²hᶜᶠᵃ(i, j, k, grid, ∇²hᶜᶠᵃ, c)

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -14,13 +14,13 @@ end
     Nz = grid.Nz
 
     # Using a homogeneous Neumann (zero Gradient) boundary condition:
-    D[i, j, 1] = - 1 / ΔzC(i, j, 2, grid) - ΔzF(i, j, 1, grid) * (λx[i] + λy[j])
+    D[i, j, 1] = - 1 / Δzᵃᵃᶠ(i, j, 2, grid) - Δzᵃᵃᶜ(i, j, 1, grid) * (λx[i] + λy[j])
 
     @unroll for k in 2:Nz-1
-        D[i, j, k] = - (1 / ΔzC(i, j, k+1, grid) + 1 / ΔzC(i, j, k, grid)) - ΔzF(i, j, k, grid) * (λx[i] + λy[j])
+        D[i, j, k] = - (1 / Δzᵃᵃᶠ(i, j, k+1, grid) + 1 / Δzᵃᵃᶠ(i, j, k, grid)) - Δzᵃᵃᶜ(i, j, k, grid) * (λx[i] + λy[j])
     end
 
-    D[i, j, Nz] = -1 / ΔzC(i, j, Nz, grid) - ΔzF(i, j, Nz, grid) * (λx[i] + λy[j])
+    D[i, j, Nz] = -1 / Δzᵃᵃᶠ(i, j, Nz, grid) - Δzᵃᵃᶜ(i, j, Nz, grid) * (λx[i] + λy[j])
 end
 
 function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
@@ -42,7 +42,7 @@ function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
 
     # Lower and upper diagonals are the same
     CUDA.@allowscalar begin
-        lower_diagonal = arch_array(arch, [1 / ΔzC(1, 1, k, grid) for k in 2:Nz])
+        lower_diagonal = arch_array(arch, [1 / Δzᵃᵃᶠ(1, 1, k, grid) for k in 2:Nz])
         upper_diagonal = lower_diagonal
     end
 
@@ -96,7 +96,7 @@ end
 @kernel function calculate_pressure_source_term_fourier_tridiagonal_solver!(RHS, grid, Δt, U★)
     i, j, k = @index(Global, NTuple)
 
-    @inbounds RHS[i, j, k] = ΔzF(i, j, k, grid) * divᶜᶜᶜ(i, j, k, grid, U★.u, U★.v, U★.w) / Δt
+    @inbounds RHS[i, j, k] = Δzᵃᵃᶜ(i, j, k, grid) * divᶜᶜᶜ(i, j, k, grid, U★.u, U★.v, U★.w) / Δt
 end
 
 """

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Operators: Δzᵃᵃᶜ
+using Oceananigans.Operators: Δzᵃᵃᶜ, Δzᵃᵃᶠ
 
 struct FourierTridiagonalPoissonSolver{A, G, B, S, β, T}
                   architecture :: A

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -14,7 +14,7 @@ end
     Nz = grid.Nz
 
     # Using a homogeneous Neumann (zero Gradient) boundary condition:
-    D[i, j, 1] = - 1 / Δzᵃᵃᶠ(i, j, 2, grid) - Δzᵃᵃᶜ(i, j, 1, grid) * (λx[i] + λy[j])
+    D[i, j, 1] = -1 / Δzᵃᵃᶠ(i, j, 2, grid) - Δzᵃᵃᶜ(i, j, 1, grid) * (λx[i] + λy[j])
 
     @unroll for k in 2:Nz-1
         D[i, j, k] = - (1 / Δzᵃᵃᶠ(i, j, k+1, grid) + 1 / Δzᵃᵃᶠ(i, j, k, grid)) - Δzᵃᵃᶜ(i, j, k, grid) * (λx[i] + λy[j])

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -116,10 +116,10 @@ function set_source_term!(solver::FourierTridiagonalPoissonSolver, source_term)
     grid = solver.grid
     arch = solver.architecture
 
-    source_term = solver.batched_tridiagonal_solver.f
-    source_term .= source_term
+    solver_rhs = solver.batched_tridiagonal_solver.f
+    solver_rhs .= source_term
 
-    event = launch!(arch, grid, :xyz, multiply_by_Δzᵃᵃᶜ!, source_term, grid, dependencies=Event(device(arch)))
+    event = launch!(arch, grid, :xyz, multiply_by_Δzᵃᵃᶜ!, solver_rhs, grid, dependencies=Event(device(arch)))
     wait(device(arch), event)
                     
     return nothing

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -54,12 +54,13 @@ function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
 
     # Set up batched tridiagonal solver
     rhs_storage = arch_array(arch, zeros(complex(eltype(grid)), size(grid)...))
+
     btsolver = BatchedTridiagonalSolver(arch,
-                                        dl = lower_diagonal,
-                                         d = diagonal,
-                                        du = upper_diagonal,
-                                         f = rhs_storage,
-                                        grid = grid)
+                                        grid = grid,
+                                          dl = lower_diagonal,
+                                           d = diagonal,
+                                          du = upper_diagonal,
+                                           f = rhs_storage)
 
     # Need buffer for index permutations and transposes.
     buffer_needed = arch isa GPU && Bounded in (TX, TY) ? true : false

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Operators: Δzᵃᵃᶜ
+
 struct FourierTridiagonalPoissonSolver{A, G, B, S, β, T}
                   architecture :: A
                           grid :: G
@@ -11,13 +13,14 @@ end
     i, j = @index(Global, NTuple)
     Nz = grid.Nz
 
-    D[i, j, 1] = -1/ΔzF(i, j, 1, grid) - ΔzC(i, j, 1, grid) * (λx[i] + λy[j])
+    # Using a homogeneous Neumann (zero Gradient) boundary condition:
+    D[i, j, 1] = - 1 / ΔzC(i, j, 2, grid) - ΔzF(i, j, 1, grid) * (λx[i] + λy[j])
 
     @unroll for k in 2:Nz-1
-        D[i, j, k] = - (1/ΔzF(i, j, k-1, grid) + 1/ΔzF(i, j, k, grid)) - ΔzC(i, j, k, grid) * (λx[i] + λy[j])
+        D[i, j, k] = - (1 / ΔzC(i, j, k+1, grid) + 1 / ΔzC(i, j, k, grid)) - ΔzF(i, j, k, grid) * (λx[i] + λy[j])
     end
 
-    D[i, j, Nz] = -1/ΔzF(i, j, Nz-1, grid) - ΔzC(i, j, Nz, grid) * (λx[i] + λy[j])
+    D[i, j, Nz] = -1 / ΔzC(i, j, Nz, grid) - ΔzF(i, j, Nz, grid) * (λx[i] + λy[j])
 end
 
 function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
@@ -39,19 +42,24 @@ function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
 
     # Lower and upper diagonals are the same
     CUDA.@allowscalar begin
-        ld = arch_array(arch, [1/ΔzF(1, 1, k, grid) for k in 1:Nz-1])
-        ud = ld
+        lower_diagonal = arch_array(arch, [1 / ΔzC(1, 1, k, grid) for k in 2:Nz])
+        upper_diagonal = lower_diagonal
     end
 
     # Compute diagonal coefficients for each grid point
-    D = arch_array(arch, zeros(Nx, Ny, Nz))
-    event = launch!(arch, grid, :xy, compute_diagonals!, D, grid, λx, λy,
+    diagonal = arch_array(arch, zeros(Nx, Ny, Nz))
+    event = launch!(arch, grid, :xy, compute_diagonals!, diagonal, grid, λx, λy,
                     dependencies=Event(device(arch)))
     wait(device(arch), event)
 
     # Set up batched tridiagonal solver
     rhs_storage = arch_array(arch, zeros(complex(eltype(grid)), size(grid)...))
-    btsolver = BatchedTridiagonalSolver(arch, dl=ld, d=D, du=ud, f=rhs_storage, grid=grid)
+    btsolver = BatchedTridiagonalSolver(arch,
+                                        dl = lower_diagonal,
+                                         d = diagonal,
+                                        du = upper_diagonal,
+                                         f = rhs_storage,
+                                        grid = grid)
 
     # Need buffer for index permutations and transposes.
     buffer_needed = arch isa GPU && Bounded in (TX, TY) ? true : false
@@ -82,4 +90,22 @@ function solve_poisson_equation!(solver::FourierTridiagonalPoissonSolver)
     ϕ .= ϕ .- mean(ϕ)
 
     return nothing
+end
+
+function set_source_term!(solver, R)
+    grid = solver.grid
+    arch = solver.architecture
+
+    source_term = solver.batched_tridiagonal_solver.f
+    source_term .= R
+
+    event = launch!(arch, grid, :xyz, multiply_by_Δzᵃᵃᶜ!, source_term, grid, dependencies=Event(device(arch)))
+    wait(device(arch), event)
+                    
+    return nothing
+end
+
+@kernel function multiply_by_Δzᵃᵃᶜ!(a, grid)
+    i, j, k = @index(Global, NTuple)
+    a[i, j, k] *= Δzᵃᵃᶜ(i, j, k, grid)
 end

--- a/src/Solvers/solve_for_pressure.jl
+++ b/src/Solvers/solve_for_pressure.jl
@@ -21,12 +21,6 @@ end
     @inbounds RHS[i, j, k] = divᶜᶜᶜ(i, j, k, grid, U★.u, U★.v, U★.w) / Δt
 end
 
-@kernel function calculate_pressure_source_term_fourier_tridiagonal_solver!(RHS, grid, Δt, U★)
-    i, j, k = @index(Global, NTuple)
-
-    @inbounds RHS[i, j, k] = ΔzC(i, j, k, grid) * divᶜᶜᶜ(i, j, k, grid, U★.u, U★.v, U★.w) / Δt
-end
-
 source_term_storage(solver::FFTBasedPoissonSolver) = solver.storage
 source_term_storage(solver::FourierTridiagonalPoissonSolver) = solver.batched_tridiagonal_solver.f
 

--- a/test/test_distributed_poisson_solvers.jl
+++ b/test/test_distributed_poisson_solvers.jl
@@ -26,15 +26,6 @@ function random_divergent_source_term(FT, arch, grid)
     return R
 end
 
-function compute_∇²!(∇²ϕ, ϕ, arch, grid)
-    fill_halo_regions!(ϕ, arch)
-    child_arch = child_architecture(arch)
-    event = launch!(child_arch, grid, :xyz, ∇²!, grid, ϕ.data, ∇²ϕ.data, dependencies=Event(device(child_arch)))
-    wait(device(child_arch), event)
-    fill_halo_regions!(∇²ϕ, arch)
-    return nothing
-end
-
 function divergence_free_poisson_solution_triply_periodic(grid_points, ranks)
     topo = (Periodic, Periodic, Periodic)
     full_grid = RegularRectilinearGrid(topology=topo, size=grid_points, extent=(1, 2, 3))

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Solvers: solve_for_pressure!, solve_poisson_equation!
+using Oceananigans.Solvers: solve_for_pressure!, solve_poisson_equation!, set_source_term!
 using Oceananigans.Solvers: poisson_eigenvalues
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: _compute_w_from_continuity!
 
@@ -64,14 +64,6 @@ function random_divergence_free_source_term(FT, arch, grid)
     wait(device(arch), event)
 
     return R
-end
-
-function compute_∇²!(∇²ϕ, ϕ, arch, grid)
-    fill_halo_regions!(ϕ, arch)
-    event = launch!(arch, grid, :xyz, ∇²!, grid, ϕ.data, ∇²ϕ.data, dependencies=Event(device(arch)))
-    wait(device(arch), event)
-    fill_halo_regions!(∇²ϕ, arch)
-    return nothing
 end
 
 #####
@@ -154,9 +146,8 @@ function vertically_stretched_poisson_solver_correct_answer(FT, arch, topo, Nx, 
     ∇²ϕ = CenterField(FT, arch, vs_grid, p_bcs)
 
     R = random_divergence_free_source_term(FT, arch, vs_grid)
-    F = CUDA.@allowscalar reshape(vs_grid.Δzᵃᵃᶠ[1:Nz], 1, 1, Nz) .* R  # RHS needs to be multiplied by ΔzC
-    solver.batched_tridiagonal_solver.f .= F
 
+    set_source_term!(solver, R)
     solve_poisson_equation!(solver)
 
     CUDA.@allowscalar interior(ϕ) .= real.(solver.storage)

--- a/test/test_preconditioned_conjugate_gradient_solver.jl
+++ b/test/test_preconditioned_conjugate_gradient_solver.jl
@@ -1,14 +1,9 @@
 using Statistics
 
-@kernel function ∇²!(grid, f, ∇²f)
-    i, j, k = @index(Global, NTuple)
-    @inbounds ∇²f[i, j, k] = ∇²(i, j, k, grid, f)
-end
-
 @kernel function implicit_η!(grid, f, implicit_η_f)
     ### Not sure what to call this
     ### it is for left hand side operator in
-    ### (-g∇ₕ² + 1/Δt )ϕⁿ⁺¹=ϕⁿ/Δt + ∇ₕHUˢᵗᵃʳ
+    ### (-g∇ₕ² + 1/Δt )ϕⁿ⁺¹ = ϕⁿ / Δt + ∇ₕHUˢᵗᵃʳ
 
     #
     # g= model.free_surface.gravitational_acceleration
@@ -21,7 +16,7 @@ end
     Δt = 9.81
 
     i, j, k = @index(Global, NTuple)
-    @inbounds implicit_η_f[i, j] = -g * ∇²(i, j, grid, f) + f[i,j]/Δt
+    @inbounds implicit_η_f[i, j] = -g * ∇²ᶜᶜᶜ(i, j, grid, f) + f[i, j] / Δt
 
     # need this for 2d vertically integrated ∇²hᶜᶜᵃ
 end

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -300,7 +300,7 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
 
             regular_grid = RegularRectilinearGrid(FT, size=(Nx, Ny, Nz), x=(0, 1), y=(0, 1), z=(-1, 1))
 
-            S = 0.01 # Stretching factor
+            S = 1.3 # Stretching factor
             hyperbolically_spaced_nodes(k) = tanh(S * (2 * (k - 1) / Nz - 1)) / tanh(S)
             hyperbolic_vs_grid = VerticallyStretchedRectilinearGrid(FT,
                                                                     architecture = arch,

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -88,17 +88,12 @@ end
     stepped. It just initializes a cube shaped hot bubble perturbation in the center of the 3D domain to induce a
     velocity field.
 """
-function incompressible_in_time(arch, FT, Nt, timestepper)
-    Nx, Ny, Nz = 32, 32, 32
-    Lx, Ly, Lz = 10, 10, 10
-
-    grid = RegularRectilinearGrid(FT, size=(Nx, Ny, Nz), extent=(Lx, Ly, Lz))
-    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, timestepper=timestepper)
-
+function incompressible_in_time(arch, grid, Nt, timestepper)
+    model = IncompressibleModel(grid=grid, architecture=arch, timestepper=timestepper)
     grid = model.grid
     u, v, w = model.velocities
 
-    div_U = CenterField(FT, arch, grid, TracerBoundaryConditions(grid))
+    div_U = CenterField(arch, grid, TracerBoundaryConditions(grid))
 
     # Just add a temperature perturbation so we get some velocity field.
     @. model.tracers.T.data[8:24, 8:24, 8:24] += 0.01
@@ -115,12 +110,14 @@ function incompressible_in_time(arch, FT, Nt, timestepper)
     max_abs_div = maximum(abs, interior(div_U))
     sum_div = sum(interior(div_U))
     sum_abs_div = sum(abs, interior(div_U))
-    @info "Velocity divergence after $Nt time steps [$(typeof(arch)), $FT, $timestepper]: " *
+
+    @info "Velocity divergence after $Nt time steps [$(typeof(arch)), $(typeof(grid)), $timestepper]: " *
           "min=$min_div, max=$max_div, max_abs_div=$max_abs_div, sum=$sum_div, abs_sum=$sum_abs_div"
 
     # We are comparing with 0 so we use absolute tolerances. They are a bit larger than eps(Float64) and eps(Float32)
     # because we are summing over the absolute value of many machine epsilons. A better atol value may be
-    # Nx*Ny*Nz*eps(FT) but it's much higher than the observed abs_sum_div.
+    # Nx*Ny*Nz*eps(eltype(grid)) but it's much higher than the observed max_abs_div, so out of a general abundance of caution
+    # we manually insert a smaller tolerance than we might need for this test.
     return isapprox(max_abs_div, 0, atol=5e-8)
 end
 
@@ -298,9 +295,28 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
     end
 
     @testset "Incompressibility" begin
-        @info "  Testing incompressibility..."
-        for arch in archs, FT in float_types, Nt in [1, 10, 100], timestepper in timesteppers
-            @test incompressible_in_time(arch, FT, Nt, timestepper)
+        for FT in float_types, arch in archs
+            Nx, Ny, Nz = 32, 32, 32
+            Lx, Ly, Lz = 10, 10, 10
+
+            regular_grid = RegularRectilinearGrid(FT, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), z=(0, Lz))
+
+            S = 1.3 # Stretching factor
+            zF(k) = tanh(S * (2 * (k - 1) / Nz - 1)) / tanh(S)
+            vertically_stretched_grid = VerticallyStretchedRectilinearGrid(FT,
+                                                                           architecture = arch,
+                                                                           size = (Nx, Ny, Nz),
+                                                                           x = (0, Lx),
+                                                                           y = (0, Ly),
+                                                                           zF = zF)
+
+            for grid in (regular_grid, vertically_stretched_grid)
+                @info "  Testing incompressibility [$FT, $(typeof(grid).name.wrapper)]..."
+
+                for Nt in [1, 10, 100], timestepper in timesteppers
+                    @test incompressible_in_time(arch, grid, Nt, timestepper)
+                end
+            end
         end
     end
 

--- a/test/utils_for_runtests.jl
+++ b/test/utils_for_runtests.jl
@@ -6,12 +6,21 @@ using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, RungeKutta3Tim
 
 @kernel function ∇²!(grid, f, ∇²f)
     i, j, k = @index(Global, NTuple)
-    @inbounds ∇²f[i, j, k] = ∇²(i, j, k, grid, f)
+    @inbounds ∇²f[i, j, k] = ∇²ᶜᶜᶜ(i, j, k, grid, f)
 end
 
 @kernel function divergence!(grid, u, v, w, div)
     i, j, k = @index(Global, NTuple)
     @inbounds div[i, j, k] = divᶜᶜᶜ(i, j, k, grid, u, v, w)
+end
+
+function compute_∇²!(∇²ϕ, ϕ, arch, grid)
+    fill_halo_regions!(ϕ, arch)
+    child_arch = child_architecture(arch)
+    event = launch!(child_arch, grid, :xyz, ∇²!, grid, ϕ.data, ∇²ϕ.data, dependencies=Event(device(child_arch)))
+    wait(device(child_arch), event)
+    fill_halo_regions!(∇²ϕ, arch)
+    return nothing
 end
 
 #####


### PR DESCRIPTION
This PR fixes a bug in the `FourierTridiagonalPoissonSolver` that almost certainly meant it produced incorrect answers. There were two concurrent bugs that cancelled each other out, which allowed tests to pass:

1. The Laplacian operator (previously called `∇²`, now called `∇²ᶜᶜᶜ`) was incorrect, because "Face" and "Center" superscripts were swapped. In other words, the Laplacian operator was correct for an object located at `(Face, Face, Face)`, rather than `(Center, Center, Center)` as it was being applied.
2. `ΔzF` and `ΔzC` were also swapped in derivation of the `FourierTridiagonalPoissonSolver`. This means that both the docs and the code were incorrect.

The tests passed because these two bugs effectively cancel each other out. This PR fixes both bugs. There still may be a lingering issue however, because the docs multiply the entire Poisson equation by the vertical grid spacing (which in the docs is written `ΔzC`, but should be `ΔzF`), including the source term. I didn't see immediately where to replace `ΔzC` with `ΔzF` in `solve_poisson_equation!`. The tests may pass anyways because there is no test that incompressibility is maintained on a stretched grid.

I also cleaned up the Laplacian operators a bit, and the grid spacing operators, and added a convenience function `set_source_term!` so that users don't have to know about the special formulation that `FourierTridiagonalPoissonSolver` uses.

TODO:

- [x] Update the docs
- [x] Test incompressibility on a stretched grid