### PR TITLE
slight modification of vertically stretched grid

### DIFF
--- a/benchmark/benchmark_fourier_tridiagonal_poisson_solver.jl
+++ b/benchmark/benchmark_fourier_tridiagonal_poisson_solver.jl
@@ -8,7 +8,7 @@ using Oceananigans.Solvers
 # Benchmark function
 
 function benchmark_fourier_tridiagonal_poisson_solver(Arch, N, topo)
-    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), topology=topo, size=(N, N, N), x=(0, 1), y=(0, 1), zF=collect(0:N))
+    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), topology=topo, size=(N, N, N), x=(0, 1), y=(0, 1), z=(0, N), z_stretch=collect(0:N))
     solver = FourierTridiagonalPoissonSolver(Arch(), grid)
 
     solve_poisson_equation!(solver) # warmup

--- a/benchmark/benchmark_vertically_stretched_incompressible_model.jl
+++ b/benchmark/benchmark_vertically_stretched_incompressible_model.jl
@@ -6,7 +6,7 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_vertically_stretched_incompressible_model(Arch, FT, N)
-    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), size=(N, N, N), x=(0, 1), y=(0, 1), zF=collect(0:N))
+    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), size=(N, N, N), x=(0, 1), y=(0, 1), z=(0, N), z_stretch=collect(0:N))
     model = IncompressibleModel(architecture=Arch(), float_type=FT, grid=grid)
 
     time_step!(model, 1) # warmup

--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -114,12 +114,14 @@ function validate_regular_grid_domain(TX, TY, TZ, FT, extent, x, y, z)
     return FT(Lx), FT(Ly), FT(Lz), FT.(x), FT.(y), FT.(z)
 end
 
-function validate_vertically_stretched_grid_xy(TX, TY, FT, x, y)
+function validate_vertically_stretched_grid_xy(TX, TY, TZ, FT, x, y, z)
     x = validate_dimension_specification(TX, x, :x)
     y = validate_dimension_specification(TY, y, :y)
+    z = validate_dimension_specification(TZ, z, :z)
 
     Lx = x[2] - x[1]
     Ly = y[2] - y[1]
+    Lz = z[2] - z[1]
 
-    return FT(Lx), FT(Ly), FT.(x), FT.(y)
+    return FT(Lx), FT(Ly), FT(Lz), FT.(x), FT.(y), FT.(z)
 end

--- a/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
+++ b/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
@@ -19,7 +19,7 @@ function run_ocean_large_eddy_simulation_regression_test(arch, grid_type, closur
         grid = RegularRectilinearGrid(size=(N, N, N), extent=(L, L, L))
     elseif grid_type == :vertically_unstretched
         zF = range(-L, 0, length=N+1)
-        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(N, N, N), x=(0, L), y=(0, L), zF=zF)
+        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(N, N, N), x=(0, L), y=(0, L), z=(-L, 0), z_stretch=zF)
     end
 
     # Boundary conditions

--- a/test/regression_tests/rayleigh_benard_regression_test.jl
+++ b/test/regression_tests/rayleigh_benard_regression_test.jl
@@ -29,7 +29,7 @@ function run_rayleigh_benard_regression_test(arch, grid_type)
         grid = RegularRectilinearGrid(size=(Nx, Ny, Nz), extent=(Lx, Ly, Lz))
     elseif grid_type == :vertically_unstretched
         zF = range(-Lz, 0, length=Nz+1)
-        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), zF=zF)
+        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), z=(-Lz, 0), z_stretch=zF)
     end
 
     # Force salinity as a passive tracer (βS=0)

--- a/test/regression_tests/thermal_bubble_regression_test.jl
+++ b/test/regression_tests/thermal_bubble_regression_test.jl
@@ -25,7 +25,7 @@ function run_thermal_bubble_regression_test(arch, grid_type)
     model.tracers.T.data[i1:i2, j1:j2, k1:k2] .+= 0.01
 
     regression_data_filepath = joinpath(dirname(@__FILE__), "data", "thermal_bubble_regression.nc")
-
+    
     ####
     #### Uncomment the block below to generate regression data.
     ####

--- a/test/regression_tests/thermal_bubble_regression_test.jl
+++ b/test/regression_tests/thermal_bubble_regression_test.jl
@@ -7,7 +7,7 @@ function run_thermal_bubble_regression_test(arch, grid_type)
         grid = RegularRectilinearGrid(size=(Nx, Ny, Nz), extent=(Lx, Ly, Lz))
     elseif grid_type == :vertically_unstretched
         zF = range(-Lz, 0, length=Nz+1)
-        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), zF=zF)
+        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), z=(-Lz, 0), z_stretch=zF)
     end
 
     closure = IsotropicDiffusivity(ν=4e-2, κ=4e-2)

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -15,7 +15,7 @@ end
 
 TestModel_VerticallyStrectedRectGrid(arch, FT, ν=1.0, Δx=0.5) =
     IncompressibleModel(
-          grid = VerticallyStretchedRectilinearGrid(FT, architecture = arch, size=(3, 3, 3), x=(0, 3Δx), y=(0, 3Δx), zF=0:Δx:3Δx,),
+          grid = VerticallyStretchedRectilinearGrid(FT, architecture = arch, size=(3, 3, 3), x=(0, 3Δx), y=(0, 3Δx), z=(0, 3Δx), z_stretch=0:Δx:3Δx,),
        closure = IsotropicDiffusivity(FT, ν=ν, κ=ν),
   architecture = arch,
     float_type = FT

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -295,7 +295,7 @@ end
 #####
 
 function test_vertically_stretched_grid_properties_are_same_type(FT, arch)
-    grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, 16), x=(0,1), y=(0,1), zF=collect(0:16))
+    grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, 16), x=(0,1), y=(0,1), z=(0, 16), z_stretch=collect(0:16))
 
     @test grid.Lx isa FT
     @test grid.Ly isa FT
@@ -317,7 +317,7 @@ function test_vertically_stretched_grid_properties_are_same_type(FT, arch)
 end
 
 function test_architecturally_correct_stretched_grid(FT, arch, zF)
-    grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, length(zF)-1), x=(0, 1), y=(0, 1), zF=zF)
+    grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, length(zF)-1), x=(0, 1), y=(0, 1), z=(0, 1), z_stretch=zF)
 
     ArrayType = array_type(arch)
     @test grid.zᵃᵃᶠ  isa OffsetArray{FT, 1, <:ArrayType}
@@ -329,7 +329,7 @@ function test_architecturally_correct_stretched_grid(FT, arch, zF)
 end
 
 function test_correct_constant_grid_spacings(FT, Nz)
-    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=collect(0:Nz))
+    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=(0, Nz), z_stretch=collect(0:Nz))
 
     @test all(grid.Δzᵃᵃᶜ .== 1)
     @test all(grid.Δzᵃᵃᶠ .== 1)
@@ -338,7 +338,7 @@ function test_correct_constant_grid_spacings(FT, Nz)
 end
 
 function test_correct_quadratic_grid_spacings(FT, Nz)
-    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=collect(0:Nz).^2)
+    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=(0, Nz^2), z_stretch=collect(0:Nz).^2)
 
      zF(k) = (k-1)^2
      zC(k) = (k^2 + (k-1)^2) / 2
@@ -360,7 +360,7 @@ function test_correct_tanh_grid_spacings(FT, Nz)
     S = 3  # Stretching factor
     zF(k) = tanh(S * (2 * (k - 1) / Nz - 1)) / tanh(S)
 
-    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=zF)
+    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=(0, 1), z_stretch=zF)
 
      zC(k) = (zF(k) + zF(k+1)) / 2
     ΔzF(k) = zF(k+1) - zF(k)
@@ -593,7 +593,7 @@ end
 
             # Testing show function
             Nz = 20
-            grid = VerticallyStretchedRectilinearGrid(size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=collect(0:Nz).^2)
+            grid = VerticallyStretchedRectilinearGrid(size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=(0, Nz^2), z_stretch=collect(0:Nz).^2)
             show(grid); println();
             @test grid isa VerticallyStretchedRectilinearGrid
         end

--- a/test/test_netcdf_output_writer.jl
+++ b/test/test_netcdf_output_writer.jl
@@ -604,7 +604,7 @@ function test_netcdf_vertically_stretched_grid_output(arch)
     Nx = Ny = 8
     Nz = 16
     zF = [k^2 for k in 0:Nz]
-    grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, 1), y=(-π, π), zF=zF)
+    grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, 1), y=(-π, π), z=(0, Nz^2), z_stretch=zF)
 
     model = IncompressibleModel(architecture=arch, grid=grid)
 

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -146,7 +146,7 @@ end
 
 function vertically_stretched_poisson_solver_correct_answer(FT, arch, topo, Nx, Ny, zF)
     Nz = length(zF) - 1
-    vs_grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, topology=topo, size=(Nx, Ny, Nz), x=(0, 1), y=(0, 1), zF=zF)
+    vs_grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, topology=topo, size=(Nx, Ny, Nz), x=(0, 1), y=(0, 1), z=(0, 1), z_stretch=zF)
     solver = FourierTridiagonalPoissonSolver(arch, vs_grid)
 
     p_bcs = PressureBoundaryConditions(vs_grid)


### PR DESCRIPTION
Following up on @glwagner 's suggestion in #1532, here is  a slight modification to `VerticallyStretchedGrid`, which is consistent with what I'm proposing in that other PR.  I actually made a few changes here than I needed to, but these changes are cosmetic and have no impact on functionality.  

There are two significant differences.  

1. Like the other grids, we now specify `x,y,z` when defining the grid.  We can also add `extent` if people wanted, but it's not in place now.
2. What is called `zF_generator` in `master`, is now passed as a separate argument.  I also changed the name to `z_stetch` since this is what @tomchor used in his example and stretch seems more appropriate than generator.  Again, this is easily changed.

The grid tests all pass and not sure why other tests seem to fail.

What do people think about this difference?