### PR TITLE
Checkpoint at the end of `run!`

### DIFF
--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -2,7 +2,7 @@ using Glob
 
 using Oceananigans.Utils: initialize_schedule!, align_time_step
 using Oceananigans.Fields: set!
-using Oceananigans.OutputWriters: WindowedTimeAverage, checkpoint_superprefix
+using Oceananigans.OutputWriters: Checkpointer, WindowedTimeAverage, checkpoint_superprefix
 using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, RungeKutta3TimeStepper, update_state!, next_time, unit_time
 
 using Oceananigans: AbstractModel, run_diagnostic!, write_output!
@@ -189,5 +189,8 @@ function run!(sim; pickup=false)
         sim.run_time += time_after - time_before
     end
 
+    # Checkpoint at the end of `run!`
+    [write_output!(writer, sim.model) for writer in values(sim.output_writers) if writer isa Checkpointer]
+    
     return nothing
 end


### PR DESCRIPTION
Not sure if this is something we want to do by default, probably makes sense to make it a `Checkpointer` property, but it's useful as you might want to checkpoint a final time at the end of the simulation (preserving a 3D state) and when running on clusters with time limits, you want to checkpoint one final time before the job's time limit is up (to avoid repeating computational work on subsequent jobs). 