### PR TITLE
Warn users about untested pressure solvers with flat topologies

### DIFF
--- a/src/Solvers/fft_based_poisson_solver.jl
+++ b/src/Solvers/fft_based_poisson_solver.jl
@@ -10,6 +10,10 @@ end
 function FFTBasedPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
     topo = (TX, TY, TZ) =  topology(grid)
 
+    if Flat in topo
+        @warn "Pressure solvers with Flat topologies are not yet tested. Use at your own risk!"
+    end
+
     λx = poisson_eigenvalues(grid.Nx, grid.Lx, 1, TX())
     λy = poisson_eigenvalues(grid.Ny, grid.Ly, 2, TY())
     λz = poisson_eigenvalues(grid.Nz, grid.Lz, 3, TZ())

--- a/src/Solvers/fft_based_poisson_solver.jl
+++ b/src/Solvers/fft_based_poisson_solver.jl
@@ -11,7 +11,7 @@ function FFTBasedPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
     topo = (TX, TY, TZ) =  topology(grid)
 
     if Flat in topo
-        @warn "Pressure solvers with Flat topologies are not yet tested. Use at your own risk!"
+        @warn "Pressure solvers with Flat topologies are not yet tested and have bugs. Use at your own risk!"
     end
 
     λx = poisson_eigenvalues(grid.Nx, grid.Lx, 1, TX())

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -21,8 +21,13 @@ end
 end
 
 function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
-    TX, TY, TZ = topology(grid)
+    TX, TY, TZ = topo = topology(grid)
+
     TZ != Bounded && error("FourierTridiagonalPoissonSolver can only be used with a Bounded z topology.")
+
+    if Flat in topo
+        @warn "Pressure solvers with Flat topologies are not yet tested. Use at your own risk!"
+    end
 
     Nx, Ny, Nz = size(grid)
 

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -26,7 +26,7 @@ function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
     TZ != Bounded && error("FourierTridiagonalPoissonSolver can only be used with a Bounded z topology.")
 
     if Flat in topo
-        @warn "Pressure solvers with Flat topologies are not yet tested. Use at your own risk!"
+        @warn "Pressure solvers with Flat topologies are not yet tested and have bugs. Use at your own risk!"
     end
 
     Nx, Ny, Nz = size(grid)


### PR DESCRIPTION
Pair programming with @francispoulin we figured out that the pressure solvers are not tested for `Flat` topologies which might be causing #1554. This PR just adds a warning about this until the pressure solvers properly support `Flat`.

Resolves #1554 (?)