### PR TITLE
Fix field `norm` tests for `p=Inf`

### DIFF
--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -70,7 +70,7 @@ function run_field_reduction_tests(FT, arch)
             @test norm(ϕ, 0) == norm(ϕ_vals, 0)
             @test norm(ϕ, 1) == norm(ϕ_vals, 1)
             @test norm(ϕ, 4) == norm(ϕ_vals, 4)
-            @test norm(ϕ, ∞) == norm(ϕ_vals, ∞)
+            @test norm(ϕ, Inf) == norm(ϕ_vals, Inf)
             
             @test minimum(∛, ϕ) == minimum(∛, ϕ_vals)
             @test maximum(abs, ϕ) == maximum(abs, ϕ_vals)


### PR DESCRIPTION
I guess you need to use `Inf` instead of `∞` which isn't an actual `Float64` in Julia.

We accidently merged a failing test from PR #1557 into the main branch: https://buildkite.com/clima/oceananigans/builds/1935#32b55ec6-724f-4c5d-951f-bf6735923583