### PR TITLE
Stop using `@hascuda` macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.54.1"
+version = "0.54.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -7,8 +7,6 @@ using Base: @propagate_inbounds
 import Adapt
 using CUDA
 
-using Oceananigans.Architectures: @hascuda
-
 using Oceananigans
 using Oceananigans.Architectures
 using Oceananigans.Grids

--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -1,7 +1,6 @@
 module Architectures
 
 export
-    @hascuda,
     AbstractArchitecture, AbstractCPUArchitecture, AbstractGPUArchitecture, CPU, GPU,
     device, architecture, array_type, arch_array
 
@@ -45,16 +44,6 @@ struct CPU <: AbstractCPUArchitecture end
 Run Oceananigans on a single NVIDIA CUDA GPU.
 """
 struct GPU <: AbstractGPUArchitecture end
-
-"""
-    @hascuda expr
-
-A macro to compile and execute `expr` only if CUDA is installed and available. Generally used to
-wrap expressions that can only be compiled if `CuArrays` and `CUDAnative` can be loaded.
-"""
-macro hascuda(expr)
-    return has_cuda() ? :($(esc(expr))) : :(nothing)
-end
 
 device(::AbstractCPUArchitecture) = KernelAbstractions.CPU()
 device(::AbstractGPUArchitecture) = KernelAbstractions.CUDADevice()

--- a/src/Fields/abstract_field.jl
+++ b/src/Fields/abstract_field.jl
@@ -145,9 +145,9 @@ total_size(f::AbstractField) = total_size(location(f), f.grid)
 
 @inline cpudata(a) = data(a)
 
-@hascuda const OffsetCuArray = OffsetArray{T, D, <:CuArray} where {T, D}
+const OffsetCuArray = OffsetArray{T, D, <:CuArray} where {T, D}
 
-@hascuda @inline cpudata(f::AbstractField{X, Y, Z, <:OffsetCuArray}) where {X, Y, Z} =
+@inline cpudata(f::AbstractField{X, Y, Z, <:OffsetCuArray}) where {X, Y, Z} =
     offset_data(Array(parent(f)), f.grid, location(f))
 
 "Returns `f.data.parent` for `f::Field`."

--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -47,57 +47,55 @@ set!(u::AbstractCPUField, f::Function) = interior(u) .= f.(nodes(u; reshape=true
 ##### set! for fields on the GPU
 #####
 
-@hascuda begin
-    const AbstractGPUField =
-        AbstractField{X, Y, Z, A, G} where {X, Y, Z, A<:OffsetArray{T, D, <:CuArray} where {T, D}, G}
+const AbstractGPUField =
+    AbstractField{X, Y, Z, A, G} where {X, Y, Z, A<:OffsetArray{T, D, <:CuArray} where {T, D}, G}
 
-    const AbstractReducedGPUField =
-        AbstractReducedField{X, Y, Z, A, G} where {X, Y, Z, A<:OffsetArray{T, D, <:CuArray} where {T, D}, G}
+const AbstractReducedGPUField =
+    AbstractReducedField{X, Y, Z, A, G} where {X, Y, Z, A<:OffsetArray{T, D, <:CuArray} where {T, D}, G}
 
-    """ Returns a field on the CPU with `nothing` boundary conditions. """
-    function similar_cpu_field(u)
-        FieldType = typeof(u).name.wrapper
-        return FieldType(location(u), CPU(), u.grid, nothing)
-    end
+""" Returns a field on the CPU with `nothing` boundary conditions. """
+function similar_cpu_field(u)
+    FieldType = typeof(u).name.wrapper
+    return FieldType(location(u), CPU(), u.grid, nothing)
+end
 
-    """ Set the GPU field `u` to the array `v`. """
-    function set!(u::AbstractGPUField, v::Array)
-        v_field = similar_cpu_field(u)
+""" Set the GPU field `u` to the array `v`. """
+function set!(u::AbstractGPUField, v::Array)
+    v_field = similar_cpu_field(u)
 
-        set!(v_field, v)
-        set!(u, v_field)
+    set!(v_field, v)
+    set!(u, v_field)
 
-        return nothing
-    end
+    return nothing
+end
 
-    """ Set the GPU field `u` to the CuArray `v`. """
-    function set!(u::AbstractGPUField, v::CuArray)
+""" Set the GPU field `u` to the CuArray `v`. """
+function set!(u::AbstractGPUField, v::CuArray)
 
-        launch!(GPU(), u.grid, :xyz, _set_gpu!, u.data, v, u.grid,
-                include_right_boundaries=true, location=location(u))
+    launch!(GPU(), u.grid, :xyz, _set_gpu!, u.data, v, u.grid,
+            include_right_boundaries=true, location=location(u))
 
-        return nothing
-    end
+    return nothing
+end
 
-    @kernel function _set_gpu!(u, v, grid)
-        i, j, k = @index(Global, NTuple)
-        @inbounds u[i, j, k] = v[i, j, k]
-    end
+@kernel function _set_gpu!(u, v, grid)
+    i, j, k = @index(Global, NTuple)
+    @inbounds u[i, j, k] = v[i, j, k]
+end
 
-    """ Set the CPU field `u` data to the GPU field data of `v`. """
-    set!(u::AbstractCPUField, v::AbstractGPUField) = u.data.parent .= Array(v.data.parent)
+""" Set the CPU field `u` data to the GPU field data of `v`. """
+set!(u::AbstractCPUField, v::AbstractGPUField) = u.data.parent .= Array(v.data.parent)
 
-    """ Set the GPU field `u` data to the CPU field data of `v`. """
-    set!(u::AbstractGPUField, v::AbstractCPUField) = copyto!(u.data.parent, v.data.parent)
+""" Set the GPU field `u` data to the CPU field data of `v`. """
+set!(u::AbstractGPUField, v::AbstractCPUField) = copyto!(u.data.parent, v.data.parent)
 
-    """ Set the GPU field `u` data to the function `f(x, y, z)`. """
-    function set!(u::AbstractGPUField, f::Function)
-        # Create a temporary field with bcs = nothing.
-        v_field = similar_cpu_field(u)
+""" Set the GPU field `u` data to the function `f(x, y, z)`. """
+function set!(u::AbstractGPUField, f::Function)
+    # Create a temporary field with bcs = nothing.
+    v_field = similar_cpu_field(u)
 
-        set!(v_field, f)
-        set!(u, v_field)
+    set!(v_field, f)
+    set!(u, v_field)
 
-        return nothing
-    end
+    return nothing
 end

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -212,7 +212,7 @@ function __init__()
         FFTW.set_num_threads(4*threads)
     end
 
-    @hascuda begin
+    if CUDA.has_cuda()
         @debug "CUDA-enabled GPU(s) detected:"
         for (gpu, dev) in enumerate(CUDA.devices())
             @debug "$dev: $(CUDA.name(dev))"

--- a/src/Solvers/Solvers.jl
+++ b/src/Solvers/Solvers.jl
@@ -12,7 +12,7 @@ using CUDA
 using KernelAbstractions
 using KernelAbstractions.Extras.LoopInfo: @unroll
 
-using Oceananigans.Architectures: device, @hascuda, CPU, GPU, array_type, arch_array
+using Oceananigans.Architectures: device, CPU, GPU, array_type, arch_array
 using Oceananigans.Utils
 using Oceananigans.Grids
 using Oceananigans.BoundaryConditions

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -10,7 +10,7 @@ export
 using CUDA
 using KernelAbstractions
 using Oceananigans: AbstractModel
-using Oceananigans.Architectures: @hascuda, device
+using Oceananigans.Architectures: device
 using Oceananigans.Fields: TendencyFields
 using Oceananigans.LagrangianParticleTracking: update_particle_properties!
 using Oceananigans.Utils: work_layout

--- a/src/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/TurbulenceClosures/TurbulenceClosures.jl
@@ -36,7 +36,7 @@ using Oceananigans.Fields
 using Oceananigans.BuoyancyModels
 using Oceananigans.Utils
 
-using Oceananigans.Architectures: AbstractArchitecture, device, @hascuda
+using Oceananigans.Architectures: AbstractArchitecture, device
 
 #####
 ##### Molecular viscosity and thermal diffusivity definitions

--- a/src/Utils/versioninfo.jl
+++ b/src/Utils/versioninfo.jl
@@ -5,7 +5,7 @@ using Oceananigans.Architectures
 
 function versioninfo_with_gpu()
     s = sprint(versioninfo)
-    @hascuda begin
+    if CUDA.has_cuda()
         gpu_name = CUDA.device() |> CUDA.name
         s = s * "  GPU: $gpu_name\n"
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,8 +53,7 @@ Logging.global_logger(OceananigansLogger())
 
 float_types = (Float32, Float64)
 
-         archs = (CPU(),)
-@hascuda archs = (GPU(),)
+archs = CUDA.has_cuda() ? (GPU(),) : (CPU(),)
 
 closures = (
     :IsotropicDiffusivity,

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -251,8 +251,10 @@ for arch in archs
         test_thermal_bubble_checkpointer_output(arch)
         test_checkpoint_output_with_function_bcs(arch)
 
-        @hascuda run_cross_architecture_checkpointer_tests(CPU(), GPU())
-        @hascuda run_cross_architecture_checkpointer_tests(GPU(), CPU())
+        if CUDA.has_cuda()
+            run_cross_architecture_checkpointer_tests(CPU(), GPU())
+            run_cross_architecture_checkpointer_tests(GPU(), CPU())
+        end
 
         run_checkpointer_cleanup_tests(arch)
     end

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -240,7 +240,7 @@ end
         ϕ = CenterField(CPU(), grid)
         @test cpudata(ϕ).parent isa Array
 
-        @hascuda begin
+        if CUDA.has_cuda()
             ϕ = CenterField(GPU(), grid)
             @test cpudata(ϕ).parent isa Array
         end


### PR DESCRIPTION
The `@hascuda` macro used to be necessary but with the addition of `CUDA.has_cuda()` I don't think it is anymore.

So this PR finally gets rid of the `@hascuda` macro.

It's been a source of errors for users, especially when using Oceananigans on clusters where some nodes have GPUs and others do not. So hopefully this PR will help reduce errors for users on clusters.