### PR TITLE
Improved and simplified BinaryOperation with "stubborn" location inference

### DIFF
--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -54,9 +54,9 @@ include("averages_of_operations.jl")
 # Make some operators!
 
 # Some unaries:
-import Base: sqrt, sin, cos, exp, tanh, -, +, /, ^, *
+import Base: sqrt, sin, cos, exp, tanh, -, +, /, ^, *, identity
 
-@unary sqrt sin cos exp tanh
+@unary sqrt sin cos exp tanh identity
 @unary -
 
 @binary +

--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -40,7 +40,6 @@ Base.parent(op::AbstractOperation) = op
 # AbstractOperation macros add their associated functions to this list
 const operators = Set()
 
-include("at.jl")
 include("grid_validation.jl")
 
 include("unary_operations.jl")
@@ -54,9 +53,12 @@ include("averages_of_operations.jl")
 # Make some operators!
 
 # Some unaries:
-import Base: sqrt, sin, cos, exp, tanh, -, +, /, ^, *, identity
+import Base: sqrt, sin, cos, exp, tanh, -, +, /, ^, *
 
-@unary sqrt sin cos exp tanh identity
+# A very special UnaryOperation
+@inline interpolate_operation(x) = x
+
+@unary sqrt sin cos exp tanh interpolate_operation
 @unary -
 
 @binary +
@@ -78,4 +80,7 @@ eval(define_multiary_operator(:*))
 push!(operators, :*)
 push!(multiary_operators, :*)
 
+include("at.jl")
+
 end # module
+

--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -55,10 +55,7 @@ include("averages_of_operations.jl")
 # Some unaries:
 import Base: sqrt, sin, cos, exp, tanh, -, +, /, ^, *
 
-# A very special UnaryOperation
-@inline interpolate_operation(x) = x
-
-@unary sqrt sin cos exp tanh interpolate_operation
+@unary sqrt sin cos exp tanh
 @unary -
 
 @binary +

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -26,7 +26,10 @@ insert_location!(anything, location) = nothing
 @inbounds identity(i, j, k, grid, a::Number) = a
 @inbounds identity(i, j, k, grid, a::AbstractField) = @inbounds a[i, j, k]
 
-interpolate_operation(L, x::AbstractField) = _unary_operation(L, identity, x, location(x), x.grid)
+function interpolate_operation(L, x::AbstractField)
+    L == location(x) && return x # Don't interpolate unecessarily
+    return _unary_operation(L, identity, x, location(x), x.grid)
+end
 
 """
     @at location abstract_operation
@@ -39,9 +42,6 @@ macro at(location, abstract_operation)
 
     # We wrap it all in an interpolator to help "stubborn" binary operations
     # arrive in the right place.
-    #expr = Expr(:block)
-    #push!(expr.args, :(interpolate_operation($(esc(location)), $(esc(abstract_operation)))))
-
     wrapped_operation = quote
         interpolate_operation($(esc(location)), $(esc(abstract_operation)))
     end

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -30,5 +30,8 @@ Modify the `abstract_operation` so that it returns values at
 """
 macro at(location, abstract_operation)
     insert_location!(abstract_operation, location)
-    return esc(abstract_operation)
+
+    # We wrap it all in an interpolator to help "stubborn" binary operations
+    # arrive in the right place.
+    return :(interpolate_operation($(esc(location)), $(esc(abstract_operation))))
 end

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -33,5 +33,10 @@ macro at(location, abstract_operation)
 
     # We wrap it all in an interpolator to help "stubborn" binary operations
     # arrive in the right place.
-    return :(interpolate_operation($(esc(location)), $(esc(abstract_operation))))
+    wrapped_operation = quote
+        local interpolate = Oceananigans.AbstractOperations.interpolate_operation
+        interpolate($(esc(location)), $(esc(abstract_operation)))
+    end
+
+    return wrapped_operation
 end

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -15,10 +15,6 @@ struct BinaryOperation{X, Y, Z, O, A, B, IA, IB, G} <: AbstractOperation{X, Y, Z
     where `▶a` and `▶b` interpolate `a` and `b` to (X, Y, Z).
     """
     function BinaryOperation{X, Y, Z}(op, a, b, ▶a, ▶b, grid) where {X, Y, Z}
-
-        any((X, Y, Z) .=== Nothing) && throw(ArgumentError("Nothing locations are invalid! " *
-                                                           "Cannot construct BinaryOperation at ($X, $Y, $Z)."))
-
         return new{X, Y, Z, typeof(op), typeof(a), typeof(b), typeof(▶a), typeof(▶b),
                    typeof(grid)}(op, a, b, ▶a, ▶b, grid)
     end

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -1,10 +1,5 @@
 const binary_operators = Set()
 
-"""
-    BinaryOperation{X, Y, Z, O, A, B, IA, IB, G} <: AbstractOperation{X, Y, Z, G}
-
-An abstract representation of a binary operation on `AbstractField`s.
-"""
 struct BinaryOperation{X, Y, Z, O, A, B, IA, IB, G} <: AbstractOperation{X, Y, Z, G}
       op :: O
        a :: A

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -1,37 +1,35 @@
 const binary_operators = Set()
 
 """
-    BinaryOperation{X, Y, Z, O, A, B, IA, IB, IΩ, G} <: AbstractOperation{X, Y, Z, G}
+    BinaryOperation{X, Y, Z, O, A, B, IA, IB, G} <: AbstractOperation{X, Y, Z, G}
 
 An abstract representation of a binary operation on `AbstractField`s.
 """
-struct BinaryOperation{X, Y, Z, O, A, B, IA, IB, IΩ, G} <: AbstractOperation{X, Y, Z, G}
+struct BinaryOperation{X, Y, Z, O, A, B, IA, IB, G} <: AbstractOperation{X, Y, Z, G}
       op :: O
        a :: A
        b :: B
       ▶a :: IA
       ▶b :: IB
-     ▶op :: IΩ
     grid :: G
 
     """
-        BinaryOperation{X, Y, Z}(op, a, b, ▶a, ▶b, ▶op, grid)
+        BinaryOperation{X, Y, Z}(op, a, b, ▶a, ▶b, grid)
 
-    Returns an abstract representation of the binary operation `op(▶a(a), ▶b(b))`,
-    followed by interpolation by `▶op` to `(X, Y, Z)`, where `▶a` and `▶b` interpolate
-    `a` and `b` to a common location.
+    Returns an abstract representation of the binary operation `op(▶a(a), ▶b(b))`.
+    where `▶a` and `▶b` interpolate `a` and `b` to (X, Y, Z).
     """
-    function BinaryOperation{X, Y, Z}(op, a, b, ▶a, ▶b, ▶op, grid) where {X, Y, Z}
+    function BinaryOperation{X, Y, Z}(op, a, b, ▶a, ▶b, grid) where {X, Y, Z}
 
         any((X, Y, Z) .=== Nothing) && throw(ArgumentError("Nothing locations are invalid! " *
                                                            "Cannot construct BinaryOperation at ($X, $Y, $Z)."))
 
         return new{X, Y, Z, typeof(op), typeof(a), typeof(b), typeof(▶a), typeof(▶b),
-                   typeof(▶op), typeof(grid)}(op, a, b, ▶a, ▶b, ▶op, grid)
+                   typeof(grid)}(op, a, b, ▶a, ▶b, grid)
     end
 end
 
-@inline Base.getindex(β::BinaryOperation, i, j, k) = β.▶op(i, j, k, β.grid, β.op, β.▶a, β.▶b, β.a, β.b)
+@inline Base.getindex(β::BinaryOperation, i, j, k) = @inbounds β.op(β.▶a(i, j, k, β.grid, β.a), β.▶b(i, j, k, β.grid, β.b))
 
 #####
 ##### BinaryOperation construction
@@ -39,18 +37,20 @@ end
 
 """Create a binary operation for `op` acting on `a` and `b` with locations `La` and `Lb`.
 The operator acts at `Lab` and the result is interpolated to `Lc`."""
-function _binary_operation(Lc, op, a, b, La, Lb, Lab, grid)
-     ▶a = interpolation_operator(La, Lab)
-     ▶b = interpolation_operator(Lb, Lab)
-    ▶op = interpolation_operator(Lab, Lc)
-    return BinaryOperation{Lc[1], Lc[2], Lc[3]}(op, a, b, ▶a, ▶b, ▶op, grid)
+function _binary_operation(Lc, op, a, b, La, Lb, grid)
+     ▶a = interpolation_operator(La, Lc)
+     ▶b = interpolation_operator(Lb, Lc)
+    return BinaryOperation{Lc[1], Lc[2], Lc[3]}(op, a, b, ▶a, ▶b, grid)
 end
 
-const LocationType = Union{Type{Face}, Type{Center}}
+const ConcreteLocationType = Union{Type{Face}, Type{Center}}
 
-choose_location(L1::LocationType, L2::LocationType) = L1
-choose_location(L1::LocationType, L2) = L1
-choose_location(L1, L2::LocationType) = L2
+# Precedence rules for choosing operation location:
+choose_location(La, Lb, Lc) = Lc                                    # Fallback to the specification Lc, but also...
+choose_location(::Type{Face},   ::Type{Face},   Lc) = Face          # keep common locations; and
+choose_location(::Type{Center}, ::Type{Center}, Lc) = Center        #
+choose_location(La::ConcreteLocationType, ::Type{Nothing}, Lc) = La # don't interpolate unspecified locations.
+choose_location(::Type{Nothing}, Lb::ConcreteLocationType, Lc) = Lb #
 
 """Return an expression that defines an abstract `BinaryOperator` named `op` for `AbstractField`."""
 function define_binary_operator(op)
@@ -62,38 +62,30 @@ function define_binary_operator(op)
         local FunctionField = Oceananigans.Fields.FunctionField
         local AF = AbstractField
 
-        @inline $op(i, j, k, grid::AbstractGrid, ▶a, ▶b, a, b) =
-            @inbounds $op(▶a(i, j, k, grid, a), ▶b(i, j, k, grid, b))
-
         """
-            $($op)(Lc, Lab, a, b)
+            $($op)(Lc, a, b)
 
-        Returns an abstract representation of the operator `$($op)` acting on `a` and `b` at
-        location `Lab`, and subsequently interpolated to location `Lc`.
+        Returns an abstract representation of the operator `$($op)` acting on `a` and `b`.
+        The operation occurs at location(a) except for Nothing dimensions. In that case,
+        the location of the dimension in question is supplied either by location(b) or
+        if that is also Nothing, Lc.
         """
-        function $op(Lc::Tuple, Lop::Tuple, a, b)
-            La = location(a)
-            Lb = location(b)
-            grid = Oceananigans.AbstractOperations.validate_grid(a, b)
-            return Oceananigans.AbstractOperations._binary_operation(Lc, $op, a, b, La, Lb, Lop, grid)
-        end
-
         function $op(Lc::Tuple, a, b)
             La = location(a)
             Lb = location(b)
+            Lab = choose_location.(La, Lb, Lc)
 
-            LX = choose_location(La[1], Lb[1])
-            LY = choose_location(La[2], Lb[2])
-            LZ = choose_location(La[3], Lb[3])
+            grid = Oceananigans.AbstractOperations.validate_grid(a, b)
 
-            Lab = (LX, LY, LZ)
-
-            return $op(Lc, Lab, a, b)
+            return Oceananigans.AbstractOperations._binary_operation(Lab, $op, a, b, La, Lb, grid)
         end
 
+        # Numbers are not fields...
+        $op(Lc::Tuple, a::Number, b::Number) = $op(a, b)
+
         # Sugar for mixing in functions of (x, y, z)
-        $op(Lc::Tuple, a::Function, b::AbstractField) = $op(Lc, FunctionField(Lc, a, b.grid), b)
-        $op(Lc::Tuple, a::AbstractField, b::Function) = $op(Lc, a, FunctionField(Lc, b, a.grid))
+        $op(Lc::Tuple, f::Function, b::AbstractField) = $op(Lc, FunctionField(location(b), f, b.grid), b)
+        $op(Lc::Tuple, a::AbstractField, f::Function) = $op(Lc, a, FunctionField(location(a), f, a.grid))
 
         # Sugary versions with default locations
         $op(a::AF, b::AF) = $op(location(a), a, b)
@@ -198,5 +190,5 @@ end
 "Adapt `BinaryOperation` to work on the GPU via CUDAnative and CUDAdrv."
 Adapt.adapt_structure(to, binary::BinaryOperation{X, Y, Z}) where {X, Y, Z} =
     BinaryOperation{X, Y, Z}(Adapt.adapt(to, binary.op), Adapt.adapt(to, binary.a),  Adapt.adapt(to, binary.b),
-                             Adapt.adapt(to, binary.▶a), Adapt.adapt(to, binary.▶b), Adapt.adapt(to, binary.▶op),
-                             binary.grid)
+                             Adapt.adapt(to, binary.▶a), Adapt.adapt(to, binary.▶b), Adapt.adapt(to, binary.grid))
+                             

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -20,7 +20,7 @@ struct BinaryOperation{X, Y, Z, O, A, B, IA, IB, G} <: AbstractOperation{X, Y, Z
     end
 end
 
-@inline Base.getindex(β::BinaryOperation, i, j, k) = @inbounds β.op(β.▶a(i, j, k, β.grid, β.a), β.▶b(i, j, k, β.grid, β.b))
+@inline Base.getindex(β::BinaryOperation, i, j, k) = β.op(i, j, k, β.grid, β.▶a, β.▶b, β.a, β.b)
 
 #####
 ##### BinaryOperation construction
@@ -52,6 +52,9 @@ function define_binary_operator(op)
         local location = Oceananigans.Fields.location
         local FunctionField = Oceananigans.Fields.FunctionField
         local AF = AbstractField
+
+        @inline $op(i, j, k, grid::AbstractGrid, ▶a, ▶b, a, b) =
+            @inbounds $op(▶a(i, j, k, grid, a), ▶b(i, j, k, grid, b))
 
         """
             $($op)(Lc, a, b)

--- a/src/AbstractOperations/derivatives.jl
+++ b/src/AbstractOperations/derivatives.jl
@@ -1,10 +1,5 @@
 using Oceananigans.Operators: interpolation_code
 
-"""
-    Derivative{X, Y, Z, D, A, I, G} <: AbstractOperation{X, Y, Z, G}
-
-An abstract representation of a derivative of an `AbstractField`.
-"""
 struct Derivative{X, Y, Z, D, A, I, G} <: AbstractOperation{X, Y, Z, G}
        ∂ :: D
      arg :: A
@@ -122,4 +117,4 @@ compute_at!(∂::Derivative, time) = compute_at!(∂.arg, time)
 "Adapt `Derivative` to work on the GPU via CUDAnative and CUDAdrv."
 Adapt.adapt_structure(to, deriv::Derivative{X, Y, Z}) where {X, Y, Z} =
     Derivative{X, Y, Z}(Adapt.adapt(to, deriv.∂), Adapt.adapt(to, deriv.arg),
-                        Adapt.adapt(to, deriv.▶), deriv.grid)
+                        Adapt.adapt(to, deriv.▶), Adapt.adapt(to, deriv.grid))

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -162,4 +162,4 @@ end
 "Adapt `MultiaryOperation` to work on the GPU via CUDAnative and CUDAdrv."
 Adapt.adapt_structure(to, multiary::MultiaryOperation{X, Y, Z}) where {X, Y, Z} =
     MultiaryOperation{X, Y, Z}(Adapt.adapt(to, multiary.op), Adapt.adapt(to, multiary.args),
-                               Adapt.adapt(to, multiary.▶),  multiary.grid)
+                               Adapt.adapt(to, multiary.▶),  Adapt.adapt(to, multiary.grid))

--- a/src/AbstractOperations/show_abstract_operations.jl
+++ b/src/AbstractOperations/show_abstract_operations.jl
@@ -48,7 +48,7 @@ end
 function tree_show(binary::BinaryOperation{X, Y, Z}, depth, nesting) where {X, Y, Z}
     padding = get_tree_padding(depth, nesting)
 
-    return string(binary.op, " at ", show_location(X, Y, Z), " via ", show_interp(binary.▶op), '\n',
+    return string(binary.op, " at ", show_location(X, Y, Z), '\n',
                   padding, "├── ", tree_show(binary.a, depth+1, nesting+1), '\n',
                   padding, "└── ", tree_show(binary.b, depth+1, nesting))
 end

--- a/src/AbstractOperations/unary_operations.jl
+++ b/src/AbstractOperations/unary_operations.jl
@@ -1,11 +1,5 @@
 const unary_operators = Set()
 
-"""
-    UnaryOperation{X, Y, Z, O, A, I, G} <: AbstractOperation{X, Y, Z, G}
-
-An abstract representation of a unary operation on an `AbstractField`; or a function
-`f(x)` with on argument acting on `x::AbstractField`.
-"""
 struct UnaryOperation{X, Y, Z, O, A, I, G} <: AbstractOperation{X, Y, Z, G}
       op :: O
      arg :: A
@@ -131,4 +125,4 @@ compute_at!(υ::UnaryOperation, time) = compute_at!(υ.arg, time)
 "Adapt `UnaryOperation` to work on the GPU via CUDAnative and CUDAdrv."
 Adapt.adapt_structure(to, unary::UnaryOperation{X, Y, Z}) where {X, Y, Z} =
     UnaryOperation{X, Y, Z}(Adapt.adapt(to, unary.op), Adapt.adapt(to, unary.arg),
-                            Adapt.adapt(to, unary.▶), unary.grid)
+                            Adapt.adapt(to, unary.▶), Adapt.adapt(to, unary.grid))

--- a/src/Fields/abstract_field.jl
+++ b/src/Fields/abstract_field.jl
@@ -102,7 +102,7 @@ end
 ##### AbstractField functionality
 #####
 
-@inline location(a) = nothing
+@inline location(a) = (Nothing, Nothing, Nothing)
 
 "Returns the location `(X, Y, Z)` of an `AbstractField{X, Y, Z}`."
 @inline location(::AbstractField{X, Y, Z}) where {X, Y, Z} = (X, Y, Z) # note no instantiation

--- a/src/Fields/zero_field.jl
+++ b/src/Fields/zero_field.jl
@@ -1,3 +1,3 @@
-struct ZeroField{X, Y, Z} <: AbstractField{X, Y, Z, Nothing, Nothing, Nothing} end
+struct ZeroField <: AbstractField{Nothing, Nothing, Nothing, Nothing, Nothing} end
 
 @inline Base.getindex(::ZeroField, i, j, k) = 0

--- a/src/Fields/zero_field.jl
+++ b/src/Fields/zero_field.jl
@@ -1,3 +1,3 @@
-struct ZeroField <: AbstractField{Nothing, Nothing, Nothing, Nothing, Nothing} end
+struct ZeroField{X, Y, Z} <: AbstractField{X, Y, Z, Nothing, Nothing, Nothing} end
 
 @inline Base.getindex(::ZeroField, i, j, k) = 0

--- a/test/test_abstract_operations_computed_field.jl
+++ b/test/test_abstract_operations_computed_field.jl
@@ -544,8 +544,6 @@ end
 
                     u, v, w, T, S = fields(model)
 
-                    @test_throws ArgumentError @at (Nothing, Nothing, Center) T * S
-
                     for ϕ in (u, v, w, T, S)
                         for op in (sin, cos, sqrt, exp, tanh)
                             @test op(ϕ) isa UnaryOperation
@@ -661,12 +659,7 @@ end
                     @info "      Testing operations with AveragedField..."
 
                     T, S = model.tracers
-
                     TS = AveragedField(T * S, dims=(1, 2))
-
-                    @test_throws ArgumentError @at (Nothing, Nothing, Center) T * S
-                    @test_throws ArgumentError TS * S
-
                     @test operations_with_averaged_field(model)
                 end
 

--- a/test/test_abstract_operations_computed_field.jl
+++ b/test/test_abstract_operations_computed_field.jl
@@ -725,21 +725,12 @@ end
                     @test try compute!(ComputedField(horizontal_tke      )); true; catch; false; end
                     @test try compute!(ComputedField(twice_tke           )); true; catch; false; end
 
-                    if arch isa CPU
-                        @test try compute!(ComputedField(horizontal_tke_ccc  )); true; catch; false; end
-                        @test try compute!(ComputedField(tke                 )); true; catch; false; end
-                        @test try compute!(ComputedField(tke_ccc             )); true; catch; false; end
+                    @test try compute!(ComputedField(horizontal_tke_ccc  )); true; catch; false; end
+                    @test try compute!(ComputedField(tke                 )); true; catch; false; end
+                    @test try compute!(ComputedField(tke_ccc             )); true; catch; false; end
 
-                        computed_tke = ComputedField(tke_ccc)
-                        @test (compute!(computed_tke); all(interior(computed_tke)[2:3, 2:3, 2:3] .== 9/2))
-                    else
-                        @test_skip try compute!(ComputedField(horizontal_tke_ccc  )); true; catch; false; end
-                        @test_skip try compute!(ComputedField(tke                 )); true; catch; false; end
-                        @test_skip try compute!(ComputedField(tke_ccc             )); true; catch; false; end
-
-                        computed_tke = ComputedField(tke_ccc)
-                        @test_skip (compute!(computed_tke); all(interior(computed_tke)[2:3, 2:3, 2:3] .== 9/2))
-                    end
+                    computed_tke = ComputedField(tke_ccc)
+                    @test (compute!(computed_tke); all(interior(computed_tke)[2:3, 2:3, 2:3] .== 9/2))
                 end
 
                 @testset "Computations with ComputedFields [$FT, $(typeof(arch))]" begin

--- a/test/test_abstract_operations_computed_field.jl
+++ b/test/test_abstract_operations_computed_field.jl
@@ -687,13 +687,7 @@ end
                     @info "      Testing computations with AveragedField [$FT, $(typeof(arch))]..."
 
                     @test computations_with_averaged_field_derivative(model)
-
-                    # These don't work on the GPU right now
-                    if arch isa CPU
-                        @test computations_with_averaged_fields(model)
-                    else
-                        @test_skip computations_with_averaged_fields(model)
-                    end
+                    @test computations_with_averaged_fields(model)
                 end
 
                 @testset "Computations with ComputedFields [$FT, $(typeof(arch))]" begin


### PR DESCRIPTION
This PR changes the structure of BinaryOperations and the way that locations are inferred when constructing them.

Before this PR, BinaryOperations stored three interpolation operators: two for each argument, and a third interpolation function applied after the binary operation was computed. The motivation for this design was to ensure that products of fields were always computed at their shared location, while allowing abstract operations to be built at user-specified locations. In other words, users might want something like

```julia
using Oceananigans
grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
model = IncompressibleModel(architecture=CPU(), grid=grid)
u, v, w = model.velocities

uu = @at (Center, Center, Center) u * u

# output
BinaryOperation at (Center, Center, Center)
├── grid: RegularRectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
└── tree: 
    * at (Center, Center, Center) via ℑxᶜᵃᵃ
    ├── Field located at (Face, Center, Center)
    └── Field located at (Face, Center, Center)
```

which would compute `u * u` at `(Face, Center, Center)`, and subsequently interpolate to cell centers. The object `uu` would then be defined at cell centers.

The main issue of this design in terms of functionality is that it produces expression trees that interpolate "too eagerly". A common example is a turbulent kinetic energy computation:

```julia
U = AveragedField(u, dims=(1, 2))
V = AveragedField(v, dims=(1, 2))

tke = @at (Center, Center, Center) ((u - U)^2 + (v - V)^2 + w^2)
```

Inspection of this object reveals that while `u - U` does not interpolate, the squaring `(u - U)^2` would be performed at cell centers:

```julia
julia> tke.args[1].b
2

julia> tke.args[1].a
BinaryOperation at (Center, Center, Center)
├── grid: RegularRectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
└── tree: 
    - at (Center, Center, Center) via identity
    ├── Field located at (Face, Center, Center)
    └── AveragedField over dims=(1, 2) located at (⋅, ⋅, Center) of Field located at (Face, Center, Center)
```

This isn't what we want (usually): instead, we want both `u - U` and subsequent squaring in `(u - U)^2` to be performed at `(Face, Center, Center)`.

This PR addresses this issue by getting rid of the third interpolation in `BinaryOperation`, and changing how locations for `BinaryOperation` are inferred. Now, when locations are specified via `@at`, they are taken as a "suggestion" that only acts if the two elements of the binary operation have different _concrete_ locations such that a difference needs to be resolved. In other cases (such as a binary operation between fields at common locations, or a binary operation between a field and a number), the location of the members of the operation is preserved. In this way, `BinaryOperations` are "stubborn". 

We thus have results like

```julia
julia> *((Center, Center, Center), u, u)
BinaryOperation at (Face, Center, Center)
├── grid: RegularRectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
└── tree: 
    * at (Face, Center, Center)
    ├── Field located at (Face, Center, Center)
    └── Field located at (Face, Center, Center)
```

and

```julia
julia> tke = @at (Center, Center, Center) ((u - U)^2 + (v - V)^2 + w^2);

julia> tke.arg.args[1]
BinaryOperation at (Face, Center, Center)
├── grid: RegularRectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
└── tree: 
    ^ at (Face, Center, Center)
    ├── - at (Face, Center, Center)
    │   ├── Field located at (Face, Center, Center)
    │   └── AveragedField over dims=(1, 2) located at (⋅, ⋅, Center) of Field located at (Face, Center, Center)
    └── 2
```

An added benefit is that the `BinaryOperation` object is simpler. This could help compilation as well...

Of course, users do want to be able to specify the location of `BinaryOperations` for output. For this we change how `@at` works: now we wrap the entire user-prescribed expression in an interpolation operator that interpolates the result to the user-specified location. If the location of the underlying expression is already at the user-specified location, this is just an identity. But when the underlying operation is a "stubborn" `BinaryOperator`, we interpolate:

```julia
julia> uu = @at (Center, Center, Center) u * u
UnaryOperation at (Center, Center, Center)
├── grid: RegularRectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
└── tree: 
    identity at (Center, Center, Center) via ℑxᶜᵃᵃ
    └── * at (Face, Center, Center)
        ├── Field located at (Face, Center, Center)
        └── Field located at (Face, Center, Center)

julia> uu.arg
BinaryOperation at (Face, Center, Center)
├── grid: RegularRectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
└── tree: 
    * at (Face, Center, Center)
    ├── Field located at (Face, Center, Center)
    └── Field located at (Face, Center, Center)
```

This also means that operations between `ReducedField` and `Field` also end up at the right place, and we have no need to throw an error if a `BinaryOperation` has a `Nothing` location (in fact, this might be a useful abstraction for binary operations between `ReducedField`).