### PR TITLE
Bump to 0.55.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.54.2"
+version = "0.55.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Release notes:

* Tests and fixes for `FFTBasedPoissonSolver` for topologies with `Flat` dimensions (#1560)
* Improved `AbstractOperations` that are much more likely to compile on the GPU, with better "location inference" for `BinaryOperation` (#1595, #1599)