### PR TITLE
Hydrostatic model explicit vs. implicit free surface benchmarks + some small fixes

### DIFF
--- a/benchmark/benchmark_hydrostatic_model.jl
+++ b/benchmark/benchmark_hydrostatic_model.jl
@@ -27,7 +27,7 @@ grids = Dict(
 
 free_surfaces = Dict(
     :ExplicitFreeSurface => ExplicitFreeSurface(),
-    :ImplicitFreeSurface => ImplicitFreeSurface()
+    :ImplicitFreeSurface => ImplicitFreeSurface(maximum_iterations=1, tolerance=-Inf)  # Force it to take exactly 1 iteration.
 )
 
 function benchmark_hydrostatic_model(Arch, grid_type, free_surface_type)
@@ -42,7 +42,7 @@ function benchmark_hydrostatic_model(Arch, grid_type, free_surface_type)
     time_step!(model, 1) # warmup
 
     trial = @benchmark begin
-        time_step!($model, 1)
+        CUDA.@sync blocking=true time_step!($model, 1)
     end samples=10
 
     return trial
@@ -55,13 +55,13 @@ Architectures = has_cuda() ? [CPU, GPU] : [CPU]
 grid_types = [
     :RegularRectilinearGrid,
     :RegularLatitudeLongitudeGrid,
-    # ConformalCubedSphereFaceGrid,
+    :ConformalCubedSphereFaceGrid,
     :ConformalCubedSphereGrid
 ]
 
 free_surface_types = [
     :ExplicitFreeSurface,
-    # :ImplicitFreeSurface
+    :ImplicitFreeSurface
 ]
 
 # Run and summarize benchmarks

--- a/benchmark/benchmark_hydrostatic_model.jl
+++ b/benchmark/benchmark_hydrostatic_model.jl
@@ -1,0 +1,74 @@
+using BenchmarkTools
+using CUDA
+using DataDeps
+using Oceananigans
+using Benchmarks
+
+# Need a grid
+
+ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"
+
+dd = DataDep("cubed_sphere_32_grid",
+    "Conformal cubed sphere grid with 32×32 grid points on each face",
+    "https://github.com/CliMA/OceananigansArtifacts.jl/raw/main/cubed_sphere_grids/cubed_sphere_32_grid.jld2"
+)
+
+DataDeps.register(dd)
+
+# Benchmark function
+
+# All grids have 6 * 32^2 = 6144 grid points.
+grids = Dict(
+    :RegularRectilinearGrid => RegularRectilinearGrid(size=(128, 48, 1), extent=(1, 1, 1)),
+    :RegularLatitudeLongitudeGrid => RegularLatitudeLongitudeGrid(size=(128, 48, 1), longitude=(-180, 180), latitude=(-80, 80), z=(-1, 0)),
+    :ConformalCubedSphereFaceGrid => ConformalCubedSphereFaceGrid(size=(128, 48, 1), z=(-1, 0)),
+    :ConformalCubedSphereGrid => ConformalCubedSphereGrid(datadep"cubed_sphere_32_grid/cubed_sphere_32_grid.jld2", Nz=1, z=(-1, 0))
+)
+
+free_surfaces = Dict(
+    :ExplicitFreeSurface => ExplicitFreeSurface(),
+    :ImplicitFreeSurface => ImplicitFreeSurface()
+)
+
+function benchmark_hydrostatic_model(Arch, grid_type, free_surface_type)
+
+    model = HydrostaticFreeSurfaceModel(
+              architecture = Arch(),
+                      grid = grids[grid_type],
+        momentum_advection = VectorInvariant(),
+              free_surface = free_surfaces[free_surface_type]
+    )
+
+    time_step!(model, 1) # warmup
+
+    trial = @benchmark begin
+        time_step!($model, 1)
+    end samples=10
+
+    return trial
+end
+
+# Benchmark parameters
+
+Architectures = has_cuda() ? [CPU, GPU] : [CPU]
+
+grid_types = [
+    :RegularRectilinearGrid,
+    :RegularLatitudeLongitudeGrid,
+    # ConformalCubedSphereFaceGrid,
+    :ConformalCubedSphereGrid
+]
+
+free_surface_types = [
+    :ExplicitFreeSurface,
+    # :ImplicitFreeSurface
+]
+
+# Run and summarize benchmarks
+
+print_system_info()
+suite = run_benchmarks(benchmark_hydrostatic_model; Architectures, grid_types, free_surface_types)
+
+df = benchmarks_dataframe(suite)
+# sort!(df, [:Architectures, :Float_types, :Ns], by=(string, string, identity))
+benchmarks_pretty_table(df, title="Hydrostatic model benchmarks")

--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -17,7 +17,7 @@ const CubedSphereData = CubedSphereFaces{<:OffsetArray}
 
 const CubedSphereField = AbstractField{X, Y, Z, <:Union{Nothing, AbstractArchitecture}, <:ConformalCubedSphereGrid} where {X, Y, Z}
 const CubedSphereFaceField = AbstractField{X, Y, Z, A, <:ConformalCubedSphereFaceGrid} where {X, Y, Z, A}
-const CubedSphereReducedField = ReducedField{X, Y, Z, A, D, <:ConformalCubedSphereFaceGrid} where {X, Y, Z, A, D}
+const CubedSphereReducedField = ReducedField{X, Y, Z, A, D, <:ConformalCubedSphereGrid} where {X, Y, Z, A, D}
 
 # There must be a way to dispatch in one function without ambiguity with `new_data.jl`...
 

--- a/src/CubedSpheres/cubed_sphere_halo_filling.jl
+++ b/src/CubedSpheres/cubed_sphere_halo_filling.jl
@@ -4,7 +4,6 @@ import Oceananigans.BoundaryConditions:
 import Oceananigans.Models.HydrostaticFreeSurfaceModels: fill_horizontal_velocity_halos!
 
 # These filling functions won't work so let's not use them.
-
  fill_west_halo!(c, bc::CubedSphereExchangeBC, args...; kwargs...) = nothing
  fill_east_halo!(c, bc::CubedSphereExchangeBC, args...; kwargs...) = nothing
 fill_south_halo!(c, bc::CubedSphereExchangeBC, args...; kwargs...) = nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
@@ -45,9 +45,9 @@ function FreeSurface(free_surface::ImplicitFreeSurface{Nothing}, velocities, arc
 
     implicit_step_solver = PreconditionedConjugateGradientSolver(implicit_free_surface_linear_operation!,
                                                                  template_field = η,
-                                                                 maximum_iterations = grid.Nx * grid.Ny,
+                                                                 maximum_iterations = grid.Nx * grid.Ny;
                                                                  free_surface.solver_settings...)
-    
+
     implicit_step_right_hand_side = ReducedField(Center, Center, Nothing, arch, grid; dims=3)
 
     return ImplicitFreeSurface(η,

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -1,8 +1,10 @@
 module Models
 
 export
-    IncompressibleModel, NonDimensionalIncompressibleModel, HydrostaticFreeSurfaceModel, ShallowWaterModel,
-    ExplicitFreeSurface, VectorInvariant, HydrostaticSphericalCoriolis, VectorInvariantEnstrophyConserving,
+    IncompressibleModel, NonDimensionalIncompressibleModel, ShallowWaterModel,
+    HydrostaticFreeSurfaceModel, VectorInvariant,
+    ExplicitFreeSurface, ImplicitFreeSurface,
+    HydrostaticSphericalCoriolis, VectorInvariantEnstrophyConserving,
     PrescribedVelocityFields
 
 using Oceananigans: AbstractModel
@@ -17,7 +19,8 @@ using .IncompressibleModels: IncompressibleModel, NonDimensionalIncompressibleMo
 using .ShallowWaterModels: ShallowWaterModel
 
 using .HydrostaticFreeSurfaceModels:
-    HydrostaticFreeSurfaceModel, ExplicitFreeSurface, VectorInvariant,
+    HydrostaticFreeSurfaceModel, VectorInvariant,
+    ExplicitFreeSurface, ImplicitFreeSurface,
     HydrostaticSphericalCoriolis, VectorInvariantEnstrophyConserving,
     PrescribedVelocityFields
 

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -58,8 +58,9 @@ export
     # Models
     IncompressibleModel, NonDimensionalIncompressibleModel, HydrostaticFreeSurfaceModel, fields,
 
-    # Hydrostatic free surface model
-    ExplicitFreeSurface, VectorInvariant, HydrostaticSphericalCoriolis, VectorInvariantEnstrophyConserving,
+    # Hydrostatic free surface model stuff
+    VectorInvariant, ExplicitFreeSurface, ImplicitFreeSurface,
+    HydrostaticSphericalCoriolis, VectorInvariantEnstrophyConserving,
     PrescribedVelocityFields,
 
     # Time stepping


### PR DESCRIPTION
Should run these benchmarks again once everything works on the GPU.

Notes:
1. Lat-lon grid seems slower than the single cubed sphere face, which is weird. Maybe the cost of computing the grid metrics on the fly is actually adding up to a significant overhead?
2. Cubed sphere grid performs better than it should (less than 6x slower than 1 face), but allocates a lot of memory.
3. Explicit vs. implicit free surface solver performance is problem-dependent so for the purposes of this benchmarks every implicit solver is forced to take 1 iteration.

```
                                                             Hydrostatic model benchmarks
┌───────────────┬──────────────────────────────┬─────────────────────┬───────────┬───────────┬───────────┬───────────┬────────────┬─────────┬─────────┐
│ Architectures │                   grid_types │  free_surface_types │       min │    median │      mean │       max │     memory │  allocs │ samples │
├───────────────┼──────────────────────────────┼─────────────────────┼───────────┼───────────┼───────────┼───────────┼────────────┼─────────┼─────────┤
│           CPU │       RegularRectilinearGrid │ ExplicitFreeSurface │  3.127 ms │  3.632 ms │  3.665 ms │  4.225 ms │ 263.23 KiB │    1726 │      10 │
│           CPU │ RegularLatitudeLongitudeGrid │ ExplicitFreeSurface │  9.765 ms │ 10.370 ms │ 10.428 ms │ 11.847 ms │ 290.50 KiB │    1984 │      10 │
│           CPU │ ConformalCubedSphereFaceGrid │ ExplicitFreeSurface │  5.986 ms │  9.676 ms │ 10.276 ms │ 16.990 ms │ 151.66 KiB │    1994 │      10 │
│           CPU │     ConformalCubedSphereGrid │ ExplicitFreeSurface │ 24.817 ms │ 28.235 ms │ 30.393 ms │ 45.743 ms │   2.12 MiB │   41751 │      10 │
├───────────────┼──────────────────────────────┼─────────────────────┼───────────┼───────────┼───────────┼───────────┼────────────┼─────────┼─────────┤
│           CPU │       RegularRectilinearGrid │ ImplicitFreeSurface │  6.418 ms │  6.925 ms │  7.147 ms │  9.625 ms │ 578.41 KiB │    3545 │      10 │
│           CPU │ RegularLatitudeLongitudeGrid │ ImplicitFreeSurface │ 15.913 ms │ 16.438 ms │ 17.028 ms │ 20.042 ms │ 656.92 KiB │    4306 │      10 │
│           CPU │ ConformalCubedSphereFaceGrid │ ImplicitFreeSurface │  9.899 ms │ 10.666 ms │ 10.976 ms │ 13.104 ms │ 412.36 KiB │    4658 │      10 │
└───────────────┴──────────────────────────────┴─────────────────────┴───────────┴───────────┴───────────┴───────────┴────────────┴─────────┴─────────┘
```

```
Oceananigans v0.55.1
Julia Version 1.5.3
Commit 788b2c77c1 (2020-11-09 13:37 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-9.0.1 (ORCJIT, skylake)
```