### PR TITLE
Changes zF to z_faces for VerticallyStretchedGrid

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.55.1"
+version = "0.56.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/benchmark/benchmark_fourier_tridiagonal_poisson_solver.jl
+++ b/benchmark/benchmark_fourier_tridiagonal_poisson_solver.jl
@@ -8,7 +8,7 @@ using Oceananigans.Solvers
 # Benchmark function
 
 function benchmark_fourier_tridiagonal_poisson_solver(Arch, N, topo)
-    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), topology=topo, size=(N, N, N), x=(0, 1), y=(0, 1), zF=collect(0:N))
+    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), topology=topo, size=(N, N, N), x=(0, 1), y=(0, 1), z_faces=collect(0:N))
     solver = FourierTridiagonalPoissonSolver(Arch(), grid)
 
     solve_poisson_equation!(solver) # warmup

--- a/benchmark/benchmark_vertically_stretched_incompressible_model.jl
+++ b/benchmark/benchmark_vertically_stretched_incompressible_model.jl
@@ -6,7 +6,7 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_vertically_stretched_incompressible_model(Arch, FT, N)
-    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), size=(N, N, N), x=(0, 1), y=(0, 1), zF=collect(0:N))
+    grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), size=(N, N, N), x=(0, 1), y=(0, 1), z_faces=collect(0:N))
     model = IncompressibleModel(architecture=Arch(), float_type=FT, grid=grid)
 
     time_step!(model, 1) # warmup

--- a/src/Grids/regular_rectilinear_grid.jl
+++ b/src/Grids/regular_rectilinear_grid.jl
@@ -215,7 +215,6 @@ therefore ignored) prior to constructing the new `RegularRectilinearGrid`.
 """
 function with_halo(new_halo, old_grid::RegularRectilinearGrid)
 
-    FT = eltype(old_grid)
     Nx, Ny, Nz = size = (old_grid.Nx, old_grid.Ny, old_grid.Nz)
     topo = topology(old_grid)
 
@@ -229,7 +228,7 @@ function with_halo(new_halo, old_grid::RegularRectilinearGrid)
     new_halo = pop_flat_elements(new_halo, topo)
 
     new_grid = RegularRectilinearGrid(eltype(old_grid); size=size, x=x, y=y, z=z,
-                                    topology=topo, halo=new_halo)
+                                      topology=topo, halo=new_halo)
 
     return new_grid
 end

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -1,4 +1,6 @@
-struct VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, R, A} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
+struct VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, R, A, Arch} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
+
+    architecture :: Arch
 
     # Number of grid points in (x,y,z).
     Nx :: Int
@@ -34,12 +36,12 @@ struct VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, R, A} <: AbstractRecti
 end
 
 """
-    VerticallyStretchedRectilinearGrid([FT=Float64]; architecture=CPU(), size, zF,
+    VerticallyStretchedRectilinearGrid([FT=Float64]; architecture=CPU(), size, z_faces,
                                         x = nothing, y = nothing,
                                         topology = (Periodic, Periodic, Bounded), halo = nothing)
 
 Creates a `VerticallyStretchedRectilinearGrid` with `size = (Nx, Ny, Nz)` grid points and
-a vertical grid specified by `zF`.
+a vertical grid specified by `z_faces`.
 
 Keyword arguments
 =================
@@ -58,7 +60,7 @@ Keyword arguments
 - `architecture`: Specifies whether the array of vertical coordinates, interfaces, and spacings
                   are stored on the CPU or GPU. Default: `architecture = CPU()`.
 
-- `zF`: An array or function of vertical index `k` that specifies the location of cell faces
+- `z_faces`: An array or function of vertical index `k` that specifies the location of cell faces
         in the `z-`direction for indices `k=1` through `k=Nz+1`, where `Nz` is the third element
         of `size`.
 
@@ -102,7 +104,7 @@ Grid properties
 function VerticallyStretchedRectilinearGrid(FT = Float64;
                                             architecture = CPU(),
                                             size,
-                                            zF,
+                                            z_faces,
                                             x = nothing,
                                             y = nothing,
                                             halo = nothing,
@@ -119,7 +121,7 @@ function VerticallyStretchedRectilinearGrid(FT = Float64;
     Hx, Hy, Hz = halo
 
     # Initialize vertically-stretched arrays on CPU
-    Lz, zᵃᵃᶠ, zᵃᵃᶜ, Δzᵃᵃᶜ, Δzᵃᵃᶠ = generate_stretched_vertical_grid(FT, topology[3], Nz, Hz, zF)
+    Lz, zᵃᵃᶠ, zᵃᵃᶜ, Δzᵃᵃᶜ, Δzᵃᵃᶠ = generate_stretched_vertical_grid(FT, topology[3], Nz, Hz, z_faces)
 
     # Construct uniform horizontal grid
     Lh, Nh, Hh, X₁ = (Lx, Ly), size[1:2], halo[1:2], (x[1], y[1])
@@ -169,7 +171,11 @@ function VerticallyStretchedRectilinearGrid(FT = Float64;
     Δzᵃᵃᶜ = OffsetArray(arch_array(architecture, Δzᵃᵃᶜ.parent), Δzᵃᵃᶜ.offsets...)
     Δzᵃᵃᶠ = OffsetArray(arch_array(architecture, Δzᵃᵃᶠ.parent), Δzᵃᵃᶠ.offsets...)
 
-    return VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, typeof(xᶠᵃᵃ), typeof(zᵃᵃᶠ)}(
+    R = typeof(xᶠᵃᵃ)
+    A = typeof(zᵃᵃᶠ)
+    Arch = typeof(architecture)
+
+    return VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, R, A, Arch}(architecture,
         Nx, Ny, Nz, Hx, Hy, Hz, Lx, Ly, Lz, Δx, Δy, Δzᵃᵃᶜ, Δzᵃᵃᶠ, xᶜᵃᵃ, yᵃᶜᵃ, zᵃᵃᶜ, xᶠᵃᵃ, yᵃᶠᵃ, zᵃᵃᶠ)
 end
 
@@ -186,13 +192,13 @@ lower_exterior_Δzᵃᵃᶜ(::Type{Bounded}, zFi, Hz) = [zFi[2]  - zFi[1] for k 
 upper_exterior_Δzᵃᵃᶜ(z_topo,          zFi, Hz) = [zFi[k + 1] - zFi[k] for k = 1:Hz]
 upper_exterior_Δzᵃᵃᶜ(::Type{Bounded}, zFi, Hz) = [zFi[end]   - zFi[end - 1] for k = 1:Hz]
 
-function generate_stretched_vertical_grid(FT, z_topo, Nz, Hz, zF_generator)
+function generate_stretched_vertical_grid(FT, z_topo, Nz, Hz, z_faces)
 
     # Ensure correct type for zF and derived quantities
     interior_zF = zeros(FT, Nz+1)
 
     for k = 1:Nz+1
-        interior_zF[k] = get_z_face(zF_generator, k)
+        interior_zF[k] = get_z_face(z_faces, k)
     end
 
     Lz = interior_zF[Nz+1] - interior_zF[1]
@@ -225,9 +231,28 @@ end
 # We cannot reconstruct a VerticallyStretchedRectilinearGrid without the zF_generator.
 # So the best we can do is tell the user what they should have done.
 function with_halo(new_halo, old_grid::VerticallyStretchedRectilinearGrid)
-    new_halo != halo_size(old_grid) &&
-        @error "You need to construct your VerticallyStretchedRectilinearGrid with the keyword argument halo=$new_halo"
-    return old_grid
+
+    Nx, Ny, Nz = size = (old_grid.Nx, old_grid.Ny, old_grid.Nz)
+    topo = topology(old_grid)
+
+    x = x_domain(old_grid)
+    y = y_domain(old_grid)
+    z = z_domain(old_grid)
+
+    # Remove elements of size and new_halo in Flat directions as expected by grid
+    # constructor
+    size = pop_flat_elements(size, topo)
+    new_halo = pop_flat_elements(new_halo, topo)
+
+    new_grid = VerticallyStretchedRectilinearGrid(eltype(old_grid);
+                                                  architecture = old_grid.architecture,
+                                                  size = size,
+                                                  x = x, y = y,
+                                                  z_faces = old_grid.zᵃᵃᶠ,
+                                                  topology = topo,
+                                                  halo = new_halo)
+
+    return new_grid
 end
 
 @inline x_domain(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TX, grid.Nx, grid.xᶠᵃᵃ)
@@ -249,7 +274,11 @@ function show(io::IO, g::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) whe
 end
 
 Adapt.adapt_structure(to, grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
-    VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ, typeof(grid.xᶠᵃᵃ), typeof(Adapt.adapt(to, grid.zᵃᵃᶠ))}(
+    VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ,
+                                       typeof(grid.xᶠᵃᵃ),
+                                       typeof(Adapt.adapt(to, grid.zᵃᵃᶠ))
+                                       Nothing}(
+        nothing,
         grid.Nx, grid.Ny, grid.Nz,
         grid.Hx, grid.Hy, grid.Hz,
         grid.Lx, grid.Ly, grid.Lz,

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -228,8 +228,17 @@ function generate_stretched_vertical_grid(FT, z_topo, Nz, Hz, z_faces)
     return Lz, zF, zC, ΔzF, ΔzC
 end
 
-# We cannot reconstruct a VerticallyStretchedRectilinearGrid without the zF_generator.
-# So the best we can do is tell the user what they should have done.
+"""
+    with_halo(new_halo, old_grid::VerticallyStretchedRectilinearGrid)
+
+Returns a new `VerticallyStretchedRectilinearGrid` with the same properties as
+`old_grid` but with halos set to `new_halo`.
+
+Note that in contrast to the constructor for `VerticallyStretchedRectilinearGrid`,
+`new_halo` is expected to be a 3-`Tuple` by `with_halo`. The elements
+of `new_halo` corresponding to `Flat` directions are removed (and are
+therefore ignored) prior to constructing the new `VerticallyStretchedRectilinearGrid`.
+"""
 function with_halo(new_halo, old_grid::VerticallyStretchedRectilinearGrid)
 
     Nx, Ny, Nz = size = (old_grid.Nx, old_grid.Ny, old_grid.Nz)

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -276,7 +276,7 @@ end
 Adapt.adapt_structure(to, grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
     VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ,
                                        typeof(grid.xᶠᵃᵃ),
-                                       typeof(Adapt.adapt(to, grid.zᵃᵃᶠ))
+                                       typeof(Adapt.adapt(to, grid.zᵃᵃᶠ)),
                                        Nothing}(
         nothing,
         grid.Nx, grid.Ny, grid.Nz,

--- a/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
+++ b/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
@@ -19,7 +19,7 @@ function run_ocean_large_eddy_simulation_regression_test(arch, grid_type, closur
         grid = RegularRectilinearGrid(size=(N, N, N), extent=(L, L, L))
     elseif grid_type == :vertically_unstretched
         zF = range(-L, 0, length=N+1)
-        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(N, N, N), x=(0, L), y=(0, L), zF=zF)
+        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(N, N, N), x=(0, L), y=(0, L), z_faces=zF)
     end
 
     # Boundary conditions

--- a/test/regression_tests/rayleigh_benard_regression_test.jl
+++ b/test/regression_tests/rayleigh_benard_regression_test.jl
@@ -29,7 +29,7 @@ function run_rayleigh_benard_regression_test(arch, grid_type)
         grid = RegularRectilinearGrid(size=(Nx, Ny, Nz), extent=(Lx, Ly, Lz))
     elseif grid_type == :vertically_unstretched
         zF = range(-Lz, 0, length=Nz+1)
-        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), zF=zF)
+        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), z_faces=zF)
     end
 
     # Force salinity as a passive tracer (βS=0)

--- a/test/regression_tests/thermal_bubble_regression_test.jl
+++ b/test/regression_tests/thermal_bubble_regression_test.jl
@@ -7,7 +7,7 @@ function run_thermal_bubble_regression_test(arch, grid_type)
         grid = RegularRectilinearGrid(size=(Nx, Ny, Nz), extent=(Lx, Ly, Lz))
     elseif grid_type == :vertically_unstretched
         zF = range(-Lz, 0, length=Nz+1)
-        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), zF=zF)
+        grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, Lx), y=(0, Ly), z_faces=zF)
     end
 
     closure = IsotropicDiffusivity(ν=4e-2, κ=4e-2)

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -17,7 +17,7 @@ end
 
 TestModel_VerticallyStrectedRectGrid(arch, FT, ν=1.0, Δx=0.5) =
     IncompressibleModel(
-          grid = VerticallyStretchedRectilinearGrid(FT, architecture = arch, size=(3, 3, 3), x=(0, 3Δx), y=(0, 3Δx), zF=0:Δx:3Δx,),
+          grid = VerticallyStretchedRectilinearGrid(FT, architecture = arch, size=(3, 3, 3), x=(0, 3Δx), y=(0, 3Δx), z_faces=0:Δx:3Δx,),
        closure = IsotropicDiffusivity(FT, ν=ν, κ=ν),
   architecture = arch,
     float_type = FT
@@ -103,7 +103,7 @@ function accurate_advective_cfl_on_regular_grid(arch, FT)
 end
 
 function accurate_advective_cfl_on_stretched_grid(arch, FT)
-    grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(4, 4, 8), x=(0, 100), y=(0, 100), zF=[k^2 for k in 0:8])
+    grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(4, 4, 8), x=(0, 100), y=(0, 100), z_faces=[k^2 for k in 0:8])
     model = IncompressibleModel(grid=grid, architecture=arch)
 
     Δt = FT(15.5)

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -295,7 +295,7 @@ end
 #####
 
 function test_vertically_stretched_grid_properties_are_same_type(FT, arch)
-    grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, 16), x=(0,1), y=(0,1), zF=collect(0:16))
+    grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, 16), x=(0,1), y=(0,1), z_faces=collect(0:16))
 
     @test grid.Lx isa FT
     @test grid.Ly isa FT
@@ -317,7 +317,7 @@ function test_vertically_stretched_grid_properties_are_same_type(FT, arch)
 end
 
 function test_architecturally_correct_stretched_grid(FT, arch, zF)
-    grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, length(zF)-1), x=(0, 1), y=(0, 1), zF=zF)
+    grid = VerticallyStretchedRectilinearGrid(FT, architecture=arch, size=(1, 1, length(zF)-1), x=(0, 1), y=(0, 1), z_faces=zF)
 
     ArrayType = array_type(arch)
     @test grid.zᵃᵃᶠ  isa OffsetArray{FT, 1, <:ArrayType}
@@ -329,7 +329,7 @@ function test_architecturally_correct_stretched_grid(FT, arch, zF)
 end
 
 function test_correct_constant_grid_spacings(FT, Nz)
-    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=collect(0:Nz))
+    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z_faces=collect(0:Nz))
 
     @test all(grid.Δzᵃᵃᶜ .== 1)
     @test all(grid.Δzᵃᵃᶠ .== 1)
@@ -338,7 +338,7 @@ function test_correct_constant_grid_spacings(FT, Nz)
 end
 
 function test_correct_quadratic_grid_spacings(FT, Nz)
-    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=collect(0:Nz).^2)
+    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z_faces=collect(0:Nz).^2)
 
      zF(k) = (k-1)^2
      zC(k) = (k^2 + (k-1)^2) / 2
@@ -360,7 +360,7 @@ function test_correct_tanh_grid_spacings(FT, Nz)
     S = 3  # Stretching factor
     zF(k) = tanh(S * (2 * (k - 1) / Nz - 1)) / tanh(S)
 
-    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=zF)
+    grid = VerticallyStretchedRectilinearGrid(FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z_faces=zF)
 
      zC(k) = (zF(k) + zF(k+1)) / 2
     ΔzF(k) = zF(k+1) - zF(k)
@@ -593,7 +593,7 @@ end
 
             # Testing show function
             Nz = 20
-            grid = VerticallyStretchedRectilinearGrid(size=(1, 1, Nz), x=(0, 1), y=(0, 1), zF=collect(0:Nz).^2)
+            grid = VerticallyStretchedRectilinearGrid(size=(1, 1, Nz), x=(0, 1), y=(0, 1), z_faces=collect(0:Nz).^2)
             show(grid); println();
             @test grid isa VerticallyStretchedRectilinearGrid
         end

--- a/test/test_netcdf_output_writer.jl
+++ b/test/test_netcdf_output_writer.jl
@@ -604,7 +604,7 @@ function test_netcdf_vertically_stretched_grid_output(arch)
     Nx = Ny = 8
     Nz = 16
     zF = [k^2 for k in 0:Nz]
-    grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, 1), y=(-π, π), zF=zF)
+    grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(Nx, Ny, Nz), x=(0, 1), y=(-π, π), z_faces=zF)
 
     model = IncompressibleModel(architecture=arch, grid=grid)
 

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -147,7 +147,7 @@ function vertically_stretched_poisson_solver_correct_answer(FT, arch, topo, Nx, 
     Nz = length(zF) - 1
     sz = get_grid_size(topo..., Nx, Ny, Nz)
     xy_intervals = get_xy_interval_kwargs(topo...)
-    vs_grid = VerticallyStretchedRectilinearGrid(FT; architecture=arch, topology=topo, size=sz, zF=zF, xy_intervals...)
+    vs_grid = VerticallyStretchedRectilinearGrid(FT; architecture=arch, topology=topo, size=sz, z_faces=zF, xy_intervals...)
     solver = FourierTridiagonalPoissonSolver(arch, vs_grid)
 
     p_bcs = PressureBoundaryConditions(vs_grid)

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -307,14 +307,14 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                                                                     size = (Nx, Ny, Nz),
                                                                     x = (0, 1),
                                                                     y = (0, 1),
-                                                                    zF = hyperbolically_spaced_nodes)
+                                                                    z_faces = hyperbolically_spaced_nodes)
 
             regular_vs_grid = VerticallyStretchedRectilinearGrid(FT,
                                                                  architecture = arch,
                                                                  size = (Nx, Ny, Nz),
                                                                  x = (0, 1),
                                                                  y = (0, 1),
-                                                                 zF = collect(range(0, stop=1, length=Nz+1)))
+                                                                 z_faces = collect(range(0, stop=1, length=Nz+1)))
 
             for grid in (regular_grid, hyperbolic_vs_grid, regular_vs_grid)
                 @info "  Testing incompressibility [$FT, $(typeof(grid).name.wrapper)]..."


### PR DESCRIPTION
Also adds `architecture` property and fixes `with_halo(new_halo, old_grid::VerticallyStretchedRectilinearGrid)`.

This is a major breaking change to the API for `VerticallyStretchedRectilinearGrid`.

Resolves #1605 .

Need to bump version before merging.
