### PR TITLE
Adds missing `\cdot` in isotropic viscosity in Docs/Numerical Implementation/Spatial Operators

### DIFF
--- a/docs/src/numerical_implementation/spatial_operators.md
+++ b/docs/src/numerical_implementation/spatial_operators.md
@@ -102,7 +102,7 @@ as, e.g,
 ```math
 \renewcommand{\div}[1] {\boldsymbol{\nabla} \boldsymbol{\cdot} \left ( #1 \right )}
 \begin{align}
-\boldsymbol{u} \cdot \nabla u & = \div{u \boldsymbol{u}} - u ( \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{u} ) \nonumber \\
+\boldsymbol{u} \boldsymbol{\cdot} \boldsymbol{\nabla} u & = \div{u \boldsymbol{u}} - u ( \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{u} ) \nonumber \\
     & = \div{u \boldsymbol{u}} \, ,
 \end{align}
 ```
@@ -111,7 +111,7 @@ be discretized differently for each direction.
 
 For example, the ``x``-momentum advection operator is discretized as
 ```math
-\boldsymbol{u} \cdot \nabla u
+\boldsymbol{u} \boldsymbol{\cdot} \boldsymbol{\nabla} u
 = \frac{1}{\overline{V}^x} \left[
     \delta_x^{faa} \left( \overline{A_x u}^{caa} \overline{u}^{caa} \right)
   + \delta_y^{afa} \left( \overline{A_y v}^{aca} \overline{u}^{aca} \right)
@@ -129,7 +129,7 @@ back onto the cell faces.
 
 An isotropic viscosity operator acting on vertical momentum is discretized via
 ```math
-    \boldsymbol{\nabla} \left ( \nu_e \boldsymbol{\nabla} w \right )
+    \boldsymbol{\nabla} \boldsymbol{\cdot} \left ( \nu_e \boldsymbol{\nabla} w \right )
     = \frac{1}{V} \left[
           \delta_x^{faa} \left( \nu_e \overline{A_x}^{caa} \partial_x^{caa} w \right)
         + \delta_y^{afa} \left( \nu_e \overline{A_y}^{aca} \partial_y^{aca} w \right)

--- a/docs/src/numerical_implementation/spatial_operators.md
+++ b/docs/src/numerical_implementation/spatial_operators.md
@@ -131,9 +131,9 @@ An isotropic viscosity operator acting on vertical momentum is discretized via
 ```math
     \boldsymbol{\nabla} \boldsymbol{\cdot} \left ( \nu_e \boldsymbol{\nabla} w \right )
     = \frac{1}{V} \left[
-          \delta_x^{faa} \left( \nu_e \overline{A_x}^{caa} \partial_x^{caa} w \right)
-        + \delta_y^{afa} \left( \nu_e \overline{A_y}^{aca} \partial_y^{aca} w \right)
-        + \delta_z^{aaf} \left( \nu_e \overline{A_z}^{aac} \partial_z^{aac} w \right)
+          \delta_x^{faa} ( \nu_e \overline{A_x}^{caa} \partial_x^{caa} w )
+        + \delta_y^{afa} ( \nu_e \overline{A_y}^{aca} \partial_y^{aca} w )
+        + \delta_z^{aaf} ( \nu_e \overline{A_z}^{aac} \partial_z^{aac} w )
     \right ] \, ,
 ```
 where ``\nu`` is the kinematic viscosity.
@@ -141,10 +141,10 @@ where ``\nu`` is the kinematic viscosity.
 An isotropic diffusion operator acting on a tracer ``c``, on the other hand, is discretized via
 ```math
    \boldsymbol{\nabla} \boldsymbol{\cdot} \left ( \kappa_e \boldsymbol{\nabla} c \right )
-    = \frac{1}{V} \left[
-        \delta_x^{caa} \left( \kappa_e A_x \partial_x^{faa} c \right)
-      + \delta_y^{aca} \left( \kappa_e A_y \partial_y^{afa} c \right)
-      + \delta_z^{aac} \left( \kappa_e A_z \partial_z^{aaf} c \right)
+    = \frac{1}{V} \left[ \phantom{\overline{A_x}^{caa}}
+        \delta_x^{caa} ( \kappa_e A_x \partial_x^{faa} c )
+      + \delta_y^{aca} ( \kappa_e A_y \partial_y^{afa} c )
+      + \delta_z^{aac} ( \kappa_e A_z \partial_z^{aaf} c )
     \right] \, .
 ```
 


### PR DESCRIPTION
PR title self-explanatory ;)