### PR TITLE
Fixes AnisotropicMinimumDissipation bug with `buoyancy=nothing`

### DIFF
--- a/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
+++ b/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
@@ -54,7 +54,7 @@ julia> closure = AnisotropicMinimumDissipation()
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.08333333333333333
     Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: 0.08333333333333333
-                        Buoyancy modification multiplier Cb: 0.0
+                        Buoyancy modification multiplier Cb: nothing
                 Background diffusivit(ies) for tracer(s), κ: 1.46e-7
              Background kinematic viscosity for momentum, ν: 1.05e-6
 ```

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
@@ -44,7 +44,10 @@ Keyword arguments
     - `Cκ` : Poincaré constant for tracer eddy diffusivities. If one number or function, the same
              number or function is applied to all tracers. If a `NamedTuple`, it must possess
              a field specifying the Poncaré constant for every tracer.
-    - `Cb` : Buoyancy modification multiplier (`Cb = nothing` turns it off, `Cb = 1` was used by [Abkar16](@cite))
+    - `Cb` : Buoyancy modification multiplier (`Cb = nothing` turns it off, `Cb = 1` was used by [Abkar16](@cite)).
+             *Note*: that we _do not_ subtract the horizontally-average component before computing this
+             buoyancy modification term. This implementation differs from [Abkar16](@cite)'s proposal
+             and the impact of this approximation has not been tested or validated.
     - `ν`  : Constant background viscosity for momentum.
     - `κ`  : Constant background diffusivity for tracer. If a single number, the same background
              diffusivity is applied to all tracers. If a `NamedTuple`, it must possess a field
@@ -104,6 +107,8 @@ function AnisotropicMinimumDissipation(FT=Float64; C=1/12, Cν=nothing, Cκ=noth
                                        Cb=nothing, ν=ν₀, κ=κ₀)
     Cν = Cν === nothing ? C : Cν
     Cκ = Cκ === nothing ? C : Cκ
+    
+    !isnothing(Cb) && warn("AnisotropicMinimumDissipation with buoyancy modification is unvalidated.")
 
     return AnisotropicMinimumDissipation{FT}(Cν, Cκ, Cb, ν, κ)
 end

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
@@ -65,7 +65,7 @@ julia> pretty_diffusive_closure = AnisotropicMinimumDissipation(C=1/2)
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.5
     Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: 0.5
-                        Buoyancy modification multiplier Cb:
+                        Buoyancy modification multiplier Cb: nothing
                 Background diffusivit(ies) for tracer(s), κ: 1.46e-7
              Background kinematic viscosity for momentum, ν: 1.05e-6
 
@@ -78,7 +78,7 @@ julia> fancy_closure = AnisotropicMinimumDissipation(Cκ=surface_enhanced_tracer
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.08333333333333333
     Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: surface_enhanced_tracer_C
-                        Buoyancy modification multiplier Cb:
+                        Buoyancy modification multiplier Cb: nothing
                 Background diffusivit(ies) for tracer(s), κ: 1.46e-7
              Background kinematic viscosity for momentum, ν: 1.05e-6
 
@@ -86,7 +86,7 @@ julia> tracer_specific_closure = AnisotropicMinimumDissipation(Cκ=(c₁=1/12, c
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.08333333333333333
     Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: (c₁ = 0.08333333333333333, c₂ = 0.16666666666666666)
-                        Buoyancy modification multiplier Cb:
+                        Buoyancy modification multiplier Cb: nothing
                 Background diffusivit(ies) for tracer(s), κ: 1.46e-7
              Background kinematic viscosity for momentum, ν: 1.05e-6
 ```

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
@@ -108,7 +108,7 @@ function AnisotropicMinimumDissipation(FT=Float64; C=1/12, Cν=nothing, Cκ=noth
     Cν = Cν === nothing ? C : Cν
     Cκ = Cκ === nothing ? C : Cκ
     
-    !isnothing(Cb) && warn("AnisotropicMinimumDissipation with buoyancy modification is unvalidated.")
+    !isnothing(Cb) && @warn "AnisotropicMinimumDissipation with buoyancy modification is unvalidated."
 
     return AnisotropicMinimumDissipation{FT}(Cν, Cκ, Cb, ν, κ)
 end

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
@@ -5,15 +5,17 @@ Parameters for the "anisotropic minimum dissipation" turbulence closure for larg
 proposed originally by [Rozema15](@cite) and [Abkar16](@cite), and then modified
 by [Verstappen18](@cite), and finally described and validated for by [Vreugdenhil18](@cite).
 """
-struct AnisotropicMinimumDissipation{FT, PK, PN, K} <: AbstractEddyViscosityClosure
+struct AnisotropicMinimumDissipation{FT, PK, PN, K, PB} <: AbstractEddyViscosityClosure
     Cν :: PN
     Cκ :: PK
-    Cb :: FT
+    Cb :: PB
      ν :: FT
      κ :: K
 
-    function AnisotropicMinimumDissipation{FT}(Cν, Cκ, Cb, ν, κ) where FT
-        return new{FT, typeof(Cκ), typeof(Cν), typeof(κ)}(Cν, Cκ, Cb, ν, convert_diffusivity(FT, κ))
+    function AnisotropicMinimumDissipation{FT}(Cν::PN, Cκ::PK, Cb::PB, ν, κ) where {FT, PN, PK, PB}
+        κ = convert_diffusivity(FT, κ)
+        K = typeof(κ)
+        return new{FT, PK, PN, K, PB}(Cν, Cκ, Cb, ν, κ)
     end
 end
 
@@ -42,14 +44,14 @@ Keyword arguments
     - `Cκ` : Poincaré constant for tracer eddy diffusivities. If one number or function, the same
              number or function is applied to all tracers. If a `NamedTuple`, it must possess
              a field specifying the Poncaré constant for every tracer.
-    - `Cb` : Buoyancy modification multiplier (`Cb = 0` turns it off, `Cb = 1` turns it on)
+    - `Cb` : Buoyancy modification multiplier (`Cb = nothing` turns it off, `Cb = 1` was used by [Abkar16](@cite))
     - `ν`  : Constant background viscosity for momentum.
     - `κ`  : Constant background diffusivity for tracer. If a single number, the same background
              diffusivity is applied to all tracers. If a `NamedTuple`, it must possess a field
              specifying a background diffusivity for every tracer.
 
 By default: `C = Cν = Cκ` = 1/12, which is appropriate for a finite-volume method employing a
-second-order advection scheme, `Cb` = 0, which terms off the buoyancy modification term,
+second-order advection scheme, `Cb = nothing`, which terms off the buoyancy modification term,
 the molecular viscosity of seawater at 20 deg C and 35 psu is used for `ν`, and
 the molecular diffusivity of heat in seawater at 20 deg C and 35 psu is used for `κ`.
 
@@ -58,11 +60,12 @@ the molecular diffusivity of heat in seawater at 20 deg C and 35 psu is used for
 Example
 =======
 
+```julia
 julia> pretty_diffusive_closure = AnisotropicMinimumDissipation(C=1/2)
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.5
     Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: 0.5
-                        Buoyancy modification multiplier Cb: 0.0
+                        Buoyancy modification multiplier Cb:
                 Background diffusivit(ies) for tracer(s), κ: 1.46e-7
              Background kinematic viscosity for momentum, ν: 1.05e-6
 
@@ -75,7 +78,7 @@ julia> fancy_closure = AnisotropicMinimumDissipation(Cκ=surface_enhanced_tracer
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.08333333333333333
     Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: surface_enhanced_tracer_C
-                        Buoyancy modification multiplier Cb: 0.0
+                        Buoyancy modification multiplier Cb:
                 Background diffusivit(ies) for tracer(s), κ: 1.46e-7
              Background kinematic viscosity for momentum, ν: 1.05e-6
 
@@ -83,9 +86,10 @@ julia> tracer_specific_closure = AnisotropicMinimumDissipation(Cκ=(c₁=1/12, c
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.08333333333333333
     Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: (c₁ = 0.08333333333333333, c₂ = 0.16666666666666666)
-                        Buoyancy modification multiplier Cb: 0.0
+                        Buoyancy modification multiplier Cb:
                 Background diffusivit(ies) for tracer(s), κ: 1.46e-7
              Background kinematic viscosity for momentum, ν: 1.05e-6
+```
 
 References
 ==========
@@ -97,7 +101,7 @@ Verstappen, R. (2018), "How much eddy dissipation is needed to counterbalance th
     Computers & Fluids 176, pp. 276-284.
 """
 function AnisotropicMinimumDissipation(FT=Float64; C=1/12, Cν=nothing, Cκ=nothing,
-                                                 Cb=0.0, ν=ν₀, κ=κ₀)
+                                       Cb=nothing, ν=ν₀, κ=κ₀)
     Cν = Cν === nothing ? C : Cν
     Cκ = Cκ === nothing ? C : Cκ
 
@@ -148,14 +152,19 @@ end
 @inline function νᶜᶜᶜ(i, j, k, grid::AbstractGrid{FT}, closure::AMD, buoyancy, U, C) where FT
     ijk = (i, j, k, grid)
     q = norm_tr_∇uᶜᶜᶜ(ijk..., U.u, U.v, U.w)
+    Cb = closure.Cb
 
     if q == 0 # SGS viscosity is zero when strain is 0
         νˢᵍˢ = zero(FT)
     else
         r = norm_uᵢₐ_uⱼₐ_Σᵢⱼᶜᶜᶜ(ijk..., closure, U.u, U.v, U.w)
-        ζ = norm_wᵢ_bᵢᶜᶜᶜ(ijk..., closure, buoyancy, U.w, C) / Δᶠzᶜᶜᶜ(ijk...)
+
+        # So-called buoyancy modification term:
+        Cb_ζ = Cb_norm_wᵢ_bᵢᶜᶜᶜ(ijk..., Cb, closure, buoyancy, U.w, C) / Δᶠzᶜᶜᶜ(ijk...)
+
         δ² = 3 / (1 / Δᶠxᶜᶜᶜ(ijk...)^2 + 1 / Δᶠyᶜᶜᶜ(ijk...)^2 + 1 / Δᶠzᶜᶜᶜ(ijk...)^2)
-        νˢᵍˢ = - Cᴾᵒⁱⁿ(i, j, k, grid, closure.Cν) * δ² * (r - closure.Cb * ζ) / q
+
+        νˢᵍˢ = - Cᴾᵒⁱⁿ(i, j, k, grid, closure.Cν) * δ² * (r - Cb_ζ) / q
     end
 
     return max(zero(FT), νˢᵍˢ) + closure.ν
@@ -304,7 +313,9 @@ end
     )
 end
 
-@inline function norm_wᵢ_bᵢᶜᶜᶜ(i, j, k, grid, closure, buoyancy, w, C)
+@inline Cb_norm_wᵢ_bᵢᶜᶜᶜ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, args...) where FT = zero(FT)
+
+@inline function Cb_norm_wᵢ_bᵢᶜᶜᶜ(i, j, k, grid, Cb, closure, buoyancy, w, C)
     ijk = (i, j, k, grid)
 
     wx_bx = (ℑxzᶜᵃᶜ(ijk..., norm_∂x_w, w)
@@ -316,7 +327,7 @@ end
     wz_bz = (norm_∂z_w(ijk..., w)
              * Δᶠzᶜᶜᶜ(ijk...) * ℑzᵃᵃᶜ(ijk..., ∂zᵃᵃᶠ, buoyancy_perturbation, buoyancy.model, C))
 
-    return wx_bx + wy_by + wz_bz
+    return Cb * (wx_bx + wy_by + wz_bz)
 end
 
 @inline function norm_uᵢⱼ_cⱼ_cᵢᶜᶜᶜ(i, j, k, grid, closure, u, v, w, c)

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -193,9 +193,11 @@ end
 
 Planes = (FPlane, NonTraditionalFPlane, BetaPlane, NonTraditionalBetaPlane)
 
+BuoyancyModifiedAnisotropicMinimumDissipation(FT) = AnisotropicMinimumDissipation(FT, Cb=1.0)
+
 Closures = (IsotropicDiffusivity, AnisotropicDiffusivity,
             AnisotropicBiharmonicDiffusivity, TwoDimensionalLeith,
-            SmagorinskyLilly, AnisotropicMinimumDissipation)
+            SmagorinskyLilly, AnisotropicMinimumDissipation, BuoyancyModifiedAnisotropicMinimumDissipation)
 
 advection_schemes = (nothing,
                      CenteredSecondOrder(),

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -21,11 +21,15 @@ function time_stepping_works_with_coriolis(arch, FT, Coriolis)
     return true # Test that no errors/crashes happen when time stepping.
 end
 
-function time_stepping_works_with_closure(arch, FT, Closure)
+function time_stepping_works_with_closure(arch, FT, Closure;
+                                          buoyancy=Buoyancy(model=SeawaterBuoyancy(float_type)))
+
     # Use halos of size 2 to accomadate time stepping with AnisotropicBiharmonicDiffusivity.
     grid = RegularRectilinearGrid(FT; size=(1, 1, 1), halo=(2, 2, 2), extent=(1, 2, 3))
 
-    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, closure=Closure(FT))
+    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT,
+                                closure=Closure(FT), buoyancy=buoyancy)
+
     time_step!(model, 1, euler=true)
 
     return true  # Test that no errors/crashes happen when time stepping.
@@ -274,6 +278,9 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                     @test time_stepping_works_with_closure(arch, FT, Closure)
                 end
             end
+
+            # AnisotropicMinimumDissipation can depend on buoyancy...
+            @test time_stepping_works_with_closure(arch, FT, AnisotropicMinimumDissipation; buoyancy=nothing)
         end
     end
 

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -22,7 +22,7 @@ function time_stepping_works_with_coriolis(arch, FT, Coriolis)
 end
 
 function time_stepping_works_with_closure(arch, FT, Closure;
-                                          buoyancy=Buoyancy(model=SeawaterBuoyancy(float_type)))
+                                          buoyancy=Buoyancy(model=SeawaterBuoyancy(FT)))
 
     # Use halos of size 2 to accomadate time stepping with AnisotropicBiharmonicDiffusivity.
     grid = RegularRectilinearGrid(FT; size=(1, 1, 1), halo=(2, 2, 2), extent=(1, 2, 3))


### PR DESCRIPTION
Trying to use `AnisotropicMinimumDissipation` with `buoyancy = nothing` threw an error because it tries to access `buoyancy.model`, which doesn't exist when `buoyancy = nothing`.

This PR fixes that bug and adds a few tests for time-stepping AMD with different buoyancy models, including `buoyancy=nothing`. The bug is fixed by adding a new default `Cb = nothing` (rather than `Cb = 0.0`), in which case the computation of the buoyancy modification term is elided entirely. This might speed up some models (but who knows by how much).

It is _still_ the case that users who specify a non-default `Cb` without a buoyancy model receive error that could be hard to interpret. We could `validate_closure` for this. I feel it's not worth the effort right now though because the buoyancy modification term is not implemented correctly anyways, and it seems that even if implemented correctly it may not improve the fidelity of simulations with buoyancy. A better solution might be to delete the code associated with the buoyancy modification term and simplify our lives.