### PR TITLE
Fix `set!` for cubed sphere reduced fields

### DIFF
--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -6,7 +6,7 @@ using OffsetArrays: OffsetArray
 import Base: getindex, size, show, minimum, maximum
 import Statistics: mean
 
-import Oceananigans.Fields: AbstractField, AbstractDataField, AbstractReducedField, Field, minimum, maximum, mean, location
+import Oceananigans.Fields: AbstractField, AbstractDataField, AbstractReducedField, Field, ReducedField, minimum, maximum, mean, location
 import Oceananigans.Grids: new_data
 import Oceananigans.BoundaryConditions: FieldBoundaryConditions
 
@@ -24,6 +24,7 @@ const CubedSphereData = CubedSphereFaces{<:OffsetArray}
 
 # Flavors of CubedSphereField
 const CubedSphereField = Field{X, Y, Z, A, <:CubedSphereData} where {X, Y, Z, A}
+const CubedSphereReducedField = ReducedField{X, Y, Z, A, <:CubedSphereData} where {X, Y, Z, A}
 const CubedSphereAbstractField = AbstractField{X, Y, Z, A, <:ConformalCubedSphereGrid} where {X, Y, Z, A}
 const CubedSphereAbstractDataField = AbstractDataField{X, Y, Z, A, <:ConformalCubedSphereGrid} where {X, Y, Z, A}
 const CubedSphereAbstractReducedField = AbstractReducedField{X, Y, Z, A, D, <:ConformalCubedSphereFaceGrid} where {X, Y, Z, A, D}

--- a/src/CubedSpheres/cubed_sphere_set!.jl
+++ b/src/CubedSpheres/cubed_sphere_set!.jl
@@ -6,6 +6,9 @@ import Oceananigans.Fields: set!
 const CubedSphereCPUField = CubedSphereField{X, Y, Z, <:AbstractCPUArchitecture} where {X, Y, Z}
 const CubedSphereGPUField = CubedSphereField{X, Y, Z, <:AbstractGPUArchitecture} where {X, Y, Z}
 
+const CubedSphereCPUReducedField = CubedSphereReducedField{X, Y, Z, <:AbstractCPUArchitecture} where {X, Y, Z}
+const CubedSphereGPUReducedField = CubedSphereReducedField{X, Y, Z, <:AbstractGPUArchitecture} where {X, Y, Z}
+
 function set!(u::CubedSphereCPUField , v::CubedSphereCPUField)
     for (u_face, v_face) in zip(faces(u), faces(v))
         @. u_face.data.parent = v_face.data.parent
@@ -17,6 +20,11 @@ set!(field::CubedSphereCPUField, f::Function) = [set_face_field!(field_face, f) 
 set!(field::CubedSphereCPUField, f::Number) = [set_face_field!(field_face, f) for field_face in faces(field)]
 set!(field::CubedSphereGPUField, f::Function) = [set_face_field!(field_face, f) for field_face in faces(field)]
 set!(field::CubedSphereGPUField, f::Number) = [set_face_field!(field_face, f) for field_face in faces(field)]
+
+set!(field::CubedSphereCPUReducedField, f::Function) = [set_face_field!(field_face, f) for field_face in faces(field)]
+set!(field::CubedSphereCPUReducedField, f::Number) = [set_face_field!(field_face, f) for field_face in faces(field)]
+set!(field::CubedSphereGPUReducedField, f::Function) = [set_face_field!(field_face, f) for field_face in faces(field)]
+set!(field::CubedSphereGPUReducedField, f::Number) = [set_face_field!(field_face, f) for field_face in faces(field)]
 
 set_face_field!(field, a) = set!(field, a)
 

--- a/test/test_cubed_spheres.jl
+++ b/test/test_cubed_spheres.jl
@@ -47,15 +47,23 @@ include("data_dependencies.jl")
         @testset "CubedSphereData and CubedSphereFields [$(typeof(arch))]" begin
             @info "Testing CubedSphereData and CubedSphereFields [$(typeof(arch))]..."
             c = model.tracers.c
+            η = model.free_surface.η
+
             set!(c, 0)
+            set!(η, 0)
 
             CUDA.allowscalar(true)
             @test all(all(face_c .== 0) for face_c in faces(c))
+            @test all(all(face_η .== 0) for face_η in faces(η))
             CUDA.allowscalar(false)
 
             @test maximum(abs, c) == 0
             @test minimum(abs, c) == 0
             @test mean(c) == 0
+
+            @test maximum(abs, η) == 0
+            @test minimum(abs, η) == 0
+            @test mean(η) == 0
         end
 
         @testset "Constructing a HydrostaticFreeSurfaceModel [$(typeof(arch))]" begin
@@ -72,7 +80,7 @@ include("data_dependencies.jl")
             @info "Testing KernelComputedField on a ConformalCubedSphereGrid [$(typeof(arch))]..."
             ζ = VerticalVorticityField(model)
 
-            @test ζ isa KernelComputedField    
+            @test ζ isa KernelComputedField
 
             set!(model, u = (x, y, z) -> rand())
 


### PR DESCRIPTION
This PR fixes `set!` for `CubedSphereReducedField` for now which is used in the Rossby-Haurwitz validation experiment (and adds tests).