### PR TITLE
Support FieldSlicer for function output that returns AbstractField

### DIFF
--- a/src/OutputWriters/fetch_output.jl
+++ b/src/OutputWriters/fetch_output.jl
@@ -1,18 +1,21 @@
 using CUDA
 
 using Oceananigans.Fields: AbstractField, compute_at!, slice_parent
-using Oceananigans.LagrangianParticleTracking: LagrangianParticles
-
-fetch_output(output, model, field_slicer) = output(model)
+using Oceananigans.LagrangianParticleTracking: LagrangianParticles'
 
 # Needed to support `fetch_output` with `model::Nothing`.
 time(model) = model.clock.time
 time(::Nothing) = nothing
 
-function fetch_output(field::AbstractField, model, field_slicer)
+function compute_and_slice_output(field::AbstractField, model, field_slicer)
     compute_at!(field, time(model))
     return slice_parent(field_slicer, field)
 end
+
+compute_and_slice_output(output, model, field_slicer) = output
+
+fetch_output(output, model, field_slicer) = compute_and_slice_output(output(model), model, field_slicer)
+fetch_output(field::AbstractField, model, field_slicer) = compute_and_slice_output(field, model, field_slicer)
 
 function fetch_output(lagrangian_particles::LagrangianParticles, model, field_slicer)
     particle_properties = lagrangian_particles.properties

--- a/src/OutputWriters/fetch_output.jl
+++ b/src/OutputWriters/fetch_output.jl
@@ -1,7 +1,7 @@
 using CUDA
 
 using Oceananigans.Fields: AbstractField, compute_at!, slice_parent
-using Oceananigans.LagrangianParticleTracking: LagrangianParticles'
+using Oceananigans.LagrangianParticleTracking: LagrangianParticles
 
 # Needed to support `fetch_output` with `model::Nothing`.
 time(model) = model.clock.time

--- a/test/test_jld2_output_writer.jl
+++ b/test/test_jld2_output_writer.jl
@@ -45,7 +45,7 @@ function jld2_field_output(model)
     return FT(u₀) == u₁ && FT(v₀) == v₁ && FT(w₀) == w₁
 end
 
-function jld2_sliced_field_output(model)
+function jld2_sliced_field_output(model, outputs=model.velocities)
 
     model.clock.iteration = 0
     model.clock.time = 0.0
@@ -57,12 +57,12 @@ function jld2_sliced_field_output(model)
     simulation = Simulation(model, Δt=1.0, stop_iteration=1)
 
     simulation.output_writers[:velocities] =
-        JLD2OutputWriter(model, model.velocities,
-                                      schedule = TimeInterval(1),
-                                 field_slicer = FieldSlicer(i=1:2, j=1:2:4, k=:),
-                                          dir = ".",
-                                       prefix = "test",
-                                        force = true)
+        JLD2OutputWriter(model, outputs,
+                             schedule = TimeInterval(1),
+                         field_slicer = FieldSlicer(i=1:2, j=1:2:4, k=:),
+                                  dir = ".",
+                               prefix = "test",
+                                force = true)
 
     run!(simulation)
 
@@ -174,6 +174,9 @@ for arch in archs
 
         @test jld2_field_output(model)
         @test jld2_sliced_field_output(model)
+        @test jld2_sliced_field_output(model, (u = model -> model.velocities.u,
+                                               v = model -> model.velocities.v,
+                                               w = model -> model.velocities.w))
 
         run_jld2_file_splitting_tests(arch)
 


### PR DESCRIPTION
Resolves #1629 

TODO:

- [x] Perhaps a test?
- [x] OK from @ali-ramadhan that we bypass compute_and_slice_output for `LagrangianParticles`

cc @tomchor