### PR TITLE
Fixes show for VerticallyStretchedRectilinearGrid on GPUs

### DIFF
--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -272,8 +272,8 @@ short_show(grid::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, 
     "VerticallyStretchedRectilinearGrid{$FT, $TX, $TY, $TZ}(Nx=$(grid.Nx), Ny=$(grid.Ny), Nz=$(grid.Nz))"
 
 function show(io::IO, g::VerticallyStretchedRectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
-    Δz_min = minimum(view(g.Δzᵃᵃᶜ, 1:g.Nz))
-    Δz_max = maximum(view(g.Δzᵃᵃᶜ, 1:g.Nz))
+    Δz_min = minimum(view(parent(g.Δzᵃᵃᶜ), g.Hz+1:g.Nz+g.Hz))
+    Δz_max = maximum(view(parent(g.Δzᵃᵃᶜ), g.Hz+1:g.Nz+g.Hz))
     print(io, "VerticallyStretchedRectilinearGrid{$FT, $TX, $TY, $TZ}\n",
               "                   domain: $(domain_string(g))\n",
               "                 topology: ", (TX, TY, TZ), '\n',

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -554,7 +554,15 @@ end
         # Testing show function
         topo = (Periodic, Periodic, Periodic)
         grid = RegularRectilinearGrid(topology=topo, size=(3, 7, 9), x=(0, 1), y=(-π, π), z=(0, 2π))
-        show(grid); println();
+
+        @test try
+            show(grid)
+            true
+        catch err
+            error("error in show(::RegularRectilinearGrid)")
+            false
+        end
+
         @test grid isa RegularRectilinearGrid
     end
 
@@ -585,8 +593,16 @@ end
 
             # Testing show function
             Nz = 20
-            grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z_faces=collect(0:Nz).^2)
-            show(grid); println();
+            grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(1, 1, Nz-1), x=(0, 1), y=(0, 1), z_faces=collect(0:Nz).^2)
+            
+            @test try
+                show(grid)
+                true
+            catch err
+                error("error in show(::VerticallyStretchedRectilinearGrid)")
+                false
+            end
+            
             @test grid isa VerticallyStretchedRectilinearGrid
         end
     end
@@ -601,7 +617,15 @@ end
 
         # Testing show function
         grid = RegularLatitudeLongitudeGrid(size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
-        show(grid); println();
+        
+        @test try
+            show(grid)
+            true
+        catch err
+            error("error in show(::RegularLatitudeLongitudeGrid)")
+            false
+        end
+
         @test grid isa RegularLatitudeLongitudeGrid
     end
 
@@ -614,7 +638,15 @@ end
 
         # Testing show function
         grid = ConformalCubedSphereFaceGrid(size=(10, 10, 1), z=(0, 1))
-        show(grid); println();
+        
+        @test try
+            show(grid)
+            true
+        catch err
+            error("error in show(::ConformalCubedSphereFaceGrid)")
+            false
+        end
+
         @test grid isa ConformalCubedSphereFaceGrid
     end
 

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -556,6 +556,7 @@ end
         
         grid = RegularRectilinearGrid(topology=topo, size=(3, 7, 9), x=(0, 1), y=(-π, π), z=(0, 2π))
 
+        CUDA.allowscalar(false)
         @test try
             show(grid)
             return true
@@ -563,7 +564,8 @@ end
             println("error in show(::RegularRectilinearGrid)")
             return false
         end
-
+        CUDA.allowscalar(true)
+        
         @test grid isa RegularRectilinearGrid
     end
 
@@ -596,6 +598,7 @@ end
             Nz = 20
             grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(1, 1, Nz-1), x=(0, 1), y=(0, 1), z_faces=collect(0:Nz).^2)
             
+            CUDA.allowscalar(false)
             @test try
                 show(grid)
                 return true
@@ -604,6 +607,7 @@ end
                 println(sprint(showerror, err))
                 return false
             end
+            CUDA.allowscalar(true)
             
             @test grid isa VerticallyStretchedRectilinearGrid
         end
@@ -620,6 +624,7 @@ end
         # Testing show function
         grid = RegularLatitudeLongitudeGrid(size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
     
+        CUDA.allowscalar(false)
         @test try
             show(grid)
             return true
@@ -628,6 +633,7 @@ end
             println(sprint(showerror, err))
             return false
         end
+        CUDA.allowscalar(true)
 
         @test grid isa RegularLatitudeLongitudeGrid
     end
@@ -642,6 +648,7 @@ end
         # Testing show function
         grid = ConformalCubedSphereFaceGrid(architecture=arch, size=(10, 10, 1), z=(0, 1))
     
+        CUDA.allowscalar(false)
         @test try
             show(grid)
             return true
@@ -650,6 +657,7 @@ end
             println(sprint(showerror, err))
             return false
         end
+        CUDA.allowscalar(true)
 
         @test grid isa ConformalCubedSphereFaceGrid
     end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -554,19 +554,17 @@ end
         # Testing show function
         topo = (Periodic, Periodic, Periodic)
         
-        for arch in archs
-            grid = RegularRectilinearGrid(architecture=arch, topology=topo, size=(3, 7, 9), x=(0, 1), y=(-π, π), z=(0, 2π))
+        grid = RegularRectilinearGrid(topology=topo, size=(3, 7, 9), x=(0, 1), y=(-π, π), z=(0, 2π))
 
-            @test try
-                show(grid)
-                true
-            catch err
-                println("error in show(::RegularRectilinearGrid)")
-                false
-            end
-
-            @test grid isa RegularRectilinearGrid
+        @test try
+            show(grid)
+            true
+        catch err
+            println("error in show(::RegularRectilinearGrid)")
+            false
         end
+
+        @test grid isa RegularRectilinearGrid
     end
 
     @testset "Vertically stretched rectilinear grid" begin
@@ -620,20 +618,18 @@ end
         end
 
         # Testing show function
-        for arch in archs
-            grid = RegularLatitudeLongitudeGrid(architecture=arch, size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
-        
-            @test try
-                show(grid)
-                return true
-            catch err
-                println("error in show(::RegularLatitudeLongitudeGrid)")
-                println(sprint(showerror, err))
-                return false
-            end
-
-            @test grid isa RegularLatitudeLongitudeGrid
+        grid = RegularLatitudeLongitudeGrid(size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
+    
+        @test try
+            show(grid)
+            return true
+        catch err
+            println("error in show(::RegularLatitudeLongitudeGrid)")
+            println(sprint(showerror, err))
+            return false
         end
+
+        @test grid isa RegularLatitudeLongitudeGrid
     end
 
     @testset "Conformal cubed sphere face grid" begin

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -585,7 +585,7 @@ end
 
             # Testing show function
             Nz = 20
-            grid = VerticallyStretchedRectilinearGrid(size=(1, 1, Nz), x=(0, 1), y=(0, 1), z_faces=collect(0:Nz).^2)
+            grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z_faces=collect(0:Nz).^2)
             show(grid); println();
             @test grid isa VerticallyStretchedRectilinearGrid
         end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -553,17 +553,20 @@ end
 
         # Testing show function
         topo = (Periodic, Periodic, Periodic)
-        grid = RegularRectilinearGrid(topology=topo, size=(3, 7, 9), x=(0, 1), y=(-π, π), z=(0, 2π))
+        
+        for arch in archs
+            grid = RegularRectilinearGrid(architecture=arch, topology=topo, size=(3, 7, 9), x=(0, 1), y=(-π, π), z=(0, 2π))
 
-        @test try
-            show(grid)
-            true
-        catch err
-            error("error in show(::RegularRectilinearGrid)")
-            false
+            @test try
+                show(grid)
+                true
+            catch err
+                println("error in show(::RegularRectilinearGrid)")
+                false
+            end
+
+            @test grid isa RegularRectilinearGrid
         end
-
-        @test grid isa RegularRectilinearGrid
     end
 
     @testset "Vertically stretched rectilinear grid" begin
@@ -599,7 +602,7 @@ end
                 show(grid)
                 true
             catch err
-                error("error in show(::VerticallyStretchedRectilinearGrid)")
+                println("error in show(::VerticallyStretchedRectilinearGrid)")
                 false
             end
             
@@ -616,17 +619,19 @@ end
         end
 
         # Testing show function
-        grid = RegularLatitudeLongitudeGrid(size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
+        for arch in archs
+            grid = RegularLatitudeLongitudeGrid(architecture=arch, size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
         
-        @test try
-            show(grid)
-            true
-        catch err
-            error("error in show(::RegularLatitudeLongitudeGrid)")
-            false
-        end
+            @test try
+                show(grid)
+                true
+            catch err
+                println("error in show(::RegularLatitudeLongitudeGrid)")
+                false
+            end
 
-        @test grid isa RegularLatitudeLongitudeGrid
+            @test grid isa RegularLatitudeLongitudeGrid
+        end
     end
 
     @testset "Conformal cubed sphere face grid" begin
@@ -637,17 +642,19 @@ end
         end
 
         # Testing show function
-        grid = ConformalCubedSphereFaceGrid(size=(10, 10, 1), z=(0, 1))
+        for arch in archs
+            grid = ConformalCubedSphereFaceGrid(architecture=arch, size=(10, 10, 1), z=(0, 1))
         
-        @test try
-            show(grid)
-            true
-        catch err
-            error("error in show(::ConformalCubedSphereFaceGrid)")
-            false
-        end
+            @test try
+                show(grid)
+                true
+            catch err
+                println("error in show(::ConformalCubedSphereFaceGrid)")
+                false
+            end
 
-        @test grid isa ConformalCubedSphereFaceGrid
+            @test grid isa ConformalCubedSphereFaceGrid
+        end
     end
 
     @testset "Conformal cubed sphere face grid from file" begin

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -556,15 +556,13 @@ end
         
         grid = RegularRectilinearGrid(topology=topo, size=(3, 7, 9), x=(0, 1), y=(-π, π), z=(0, 2π))
 
-        CUDA.allowscalar(false)
         @test try
-            show(grid)
+            CUDA.@disallowscalar show(grid)
             return true
         catch err
             println("error in show(::RegularRectilinearGrid)")
             return false
         end
-        CUDA.allowscalar(true)
         
         @test grid isa RegularRectilinearGrid
     end
@@ -598,16 +596,14 @@ end
             Nz = 20
             grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(1, 1, Nz-1), x=(0, 1), y=(0, 1), z_faces=collect(0:Nz).^2)
             
-            CUDA.allowscalar(false)
             @test try
-                show(grid)
+                CUDA.@disallowscalar show(grid)
                 return true
             catch err
                 println("error in show(::VerticallyStretchedRectilinearGrid)")
                 println(sprint(showerror, err))
                 return false
             end
-            CUDA.allowscalar(true)
             
             @test grid isa VerticallyStretchedRectilinearGrid
         end
@@ -624,16 +620,14 @@ end
         # Testing show function
         grid = RegularLatitudeLongitudeGrid(size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
     
-        CUDA.allowscalar(false)
         @test try
-            show(grid)
+            CUDA.@disallowscalar show(grid)
             return true
         catch err
             println("error in show(::RegularLatitudeLongitudeGrid)")
             println(sprint(showerror, err))
             return false
         end
-        CUDA.allowscalar(true)
 
         @test grid isa RegularLatitudeLongitudeGrid
     end
@@ -648,16 +642,14 @@ end
         # Testing show function
         grid = ConformalCubedSphereFaceGrid(architecture=arch, size=(10, 10, 1), z=(0, 1))
     
-        CUDA.allowscalar(false)
         @test try
-            show(grid)
+            CUDA.@disallowscalar show(grid)
             return true
         catch err
             println("error in show(::ConformalCubedSphereFaceGrid)")
             println(sprint(showerror, err))
             return false
         end
-        CUDA.allowscalar(true)
 
         @test grid isa ConformalCubedSphereFaceGrid
     end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -239,7 +239,6 @@ function flat_extent_regular_rectilinear_grid(FT; topology, size, extent)
     return grid.Lx, grid.Ly, grid.Lz
 end
 
-
 function test_flat_size_regular_rectilinear_grid(FT)
     @test flat_size_regular_rectilinear_grid(FT, topology=(Flat, Periodic, Periodic), size=(2, 3), extent=(1, 1)) === (1, 2, 3)
     @test flat_size_regular_rectilinear_grid(FT, topology=(Periodic, Flat, Bounded),  size=(2, 3), extent=(1, 1)) === (2, 1, 3)
@@ -598,11 +597,11 @@ end
             
             @test try
                 CUDA.@disallowscalar show(grid)
-                return true
+                true
             catch err
                 println("error in show(::VerticallyStretchedRectilinearGrid)")
                 println(sprint(showerror, err))
-                return false
+                false
             end
             
             @test grid isa VerticallyStretchedRectilinearGrid
@@ -622,11 +621,11 @@ end
     
         @test try
             CUDA.@disallowscalar show(grid)
-            return true
+            true
         catch err
             println("error in show(::RegularLatitudeLongitudeGrid)")
             println(sprint(showerror, err))
-            return false
+            false
         end
 
         @test grid isa RegularLatitudeLongitudeGrid
@@ -644,11 +643,11 @@ end
     
         @test try
             CUDA.@disallowscalar show(grid)
-            return true
+            true
         catch err
             println("error in show(::ConformalCubedSphereFaceGrid)")
             println(sprint(showerror, err))
-            return false
+            false
         end
 
         @test grid isa ConformalCubedSphereFaceGrid

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -558,10 +558,10 @@ end
 
         @test try
             show(grid)
-            true
+            return true
         catch err
             println("error in show(::RegularRectilinearGrid)")
-            false
+            return false
         end
 
         @test grid isa RegularRectilinearGrid
@@ -640,20 +640,18 @@ end
         end
 
         # Testing show function
-        for arch in archs
-            grid = ConformalCubedSphereFaceGrid(architecture=arch, size=(10, 10, 1), z=(0, 1))
-        
-            @test try
-                show(grid)
-                return true
-            catch err
-                println("error in show(::ConformalCubedSphereFaceGrid)")
-                println(sprint(showerror, err))
-                return false
-            end
-
-            @test grid isa ConformalCubedSphereFaceGrid
+        grid = ConformalCubedSphereFaceGrid(architecture=arch, size=(10, 10, 1), z=(0, 1))
+    
+        @test try
+            show(grid)
+            return true
+        catch err
+            println("error in show(::ConformalCubedSphereFaceGrid)")
+            println(sprint(showerror, err))
+            return false
         end
+
+        @test grid isa ConformalCubedSphereFaceGrid
     end
 
     @testset "Conformal cubed sphere face grid from file" begin

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -600,10 +600,11 @@ end
             
             @test try
                 show(grid)
-                true
+                return true
             catch err
                 println("error in show(::VerticallyStretchedRectilinearGrid)")
-                false
+                println(sprint(showerror, err))
+                return false
             end
             
             @test grid isa VerticallyStretchedRectilinearGrid
@@ -624,10 +625,11 @@ end
         
             @test try
                 show(grid)
-                true
+                return true
             catch err
                 println("error in show(::RegularLatitudeLongitudeGrid)")
-                false
+                println(sprint(showerror, err))
+                return false
             end
 
             @test grid isa RegularLatitudeLongitudeGrid
@@ -647,10 +649,11 @@ end
         
             @test try
                 show(grid)
-                true
+                return true
             catch err
                 println("error in show(::ConformalCubedSphereFaceGrid)")
-                false
+                println(sprint(showerror, err))
+                return false
             end
 
             @test grid isa ConformalCubedSphereFaceGrid

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -556,11 +556,12 @@ end
         grid = RegularRectilinearGrid(topology=topo, size=(3, 7, 9), x=(0, 1), y=(-π, π), z=(0, 2π))
 
         @test try
-            CUDA.@disallowscalar show(grid)
-            return true
+            CUDA.@disallowscalar show(grid); println()
+            true
         catch err
             println("error in show(::RegularRectilinearGrid)")
-            return false
+            println(sprint(showerror, err))
+            false
         end
         
         @test grid isa RegularRectilinearGrid
@@ -596,7 +597,7 @@ end
             grid = VerticallyStretchedRectilinearGrid(architecture=arch, size=(1, 1, Nz-1), x=(0, 1), y=(0, 1), z_faces=collect(0:Nz).^2)
             
             @test try
-                CUDA.@disallowscalar show(grid)
+                CUDA.@disallowscalar show(grid); println()
                 true
             catch err
                 println("error in show(::VerticallyStretchedRectilinearGrid)")
@@ -620,7 +621,7 @@ end
         grid = RegularLatitudeLongitudeGrid(size=(36, 32, 1), longitude=(-180, 180), latitude=(-80, 80), z=(0, 1))
     
         @test try
-            CUDA.@disallowscalar show(grid)
+            CUDA.@disallowscalar show(grid); println()
             true
         catch err
             println("error in show(::RegularLatitudeLongitudeGrid)")
@@ -639,10 +640,10 @@ end
         end
 
         # Testing show function
-        grid = ConformalCubedSphereFaceGrid(architecture=arch, size=(10, 10, 1), z=(0, 1))
+        grid = ConformalCubedSphereFaceGrid(size=(10, 10, 1), z=(0, 1))
     
         @test try
-            CUDA.@disallowscalar show(grid)
+            CUDA.@disallowscalar show(grid); println()
             true
         catch err
             println("error in show(::ConformalCubedSphereFaceGrid)")


### PR DESCRIPTION
This PR uses a view into the underlying array of grid spacings rather than a view into the OffsetArray of grid spacings in `Base.show` for `VerticallyStretchedRectilinearGrid`. This should allow `maximum` and `minimum` to run without errors and allow `VerticallyStretchedRectilinearGrid` to be printed on the GPU.

Would be best to add a test, cc @navidcy

Closes #1637 .