### PR TITLE
Extends `getindex` for `Nothing` locations to `AbstractField`

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -16,6 +16,7 @@ using Oceananigans.Grids
 using Oceananigans.BoundaryConditions
 
 include("abstract_field.jl")
+include("reduced_getindex_setindex.jl")
 include("field.jl")
 include("zero_field.jl")
 include("reduced_field.jl")

--- a/src/Fields/reduced_field.jl
+++ b/src/Fields/reduced_field.jl
@@ -2,50 +2,9 @@ using Adapt
 
 import Oceananigans.BoundaryConditions: fill_halo_regions!
 
-#####
-##### AbstractReducedField stuff
-#####
-
 abstract type AbstractReducedField{X, Y, Z, A, G, T, N} <: AbstractDataField{X, Y, Z, A, G, T} end
 
 const ARF = AbstractReducedField
-
-# Two-dimensional fields
-@inline Base.getindex( r::ARF{Nothing, Y, Z},    i, j, k) where {Y, Z} = @inbounds r.data[1, j, k]
-@inline Base.setindex!(r::ARF{Nothing, Y, Z}, d, i, j, k) where {Y, Z} = @inbounds r.data[1, j, k] = d
-@inline Base.getindex( r::ARF{X, Nothing, Z},    i, j, k) where {X, Z} = @inbounds r.data[i, 1, k]
-@inline Base.setindex!(r::ARF{X, Nothing, Z}, d, i, j, k) where {X, Z} = @inbounds r.data[i, 1, k] = d
-@inline Base.getindex( r::ARF{X, Y, Nothing},    i, j, k) where {X, Y} = @inbounds r.data[i, j, 1]
-@inline Base.setindex!(r::ARF{X, Y, Nothing}, d, i, j, k) where {X, Y} = @inbounds r.data[i, j, 1] = d
-
-@inline Base.getindex( r::ARF{Nothing, Y, Z},    j, k) where {Y, Z} = @inbounds r.data[1, j, k]
-@inline Base.setindex!(r::ARF{Nothing, Y, Z}, d, j, k) where {Y, Z} = @inbounds r.data[1, j, k] = d
-@inline Base.getindex( r::ARF{X, Nothing, Z},    i, k) where {X, Z} = @inbounds r.data[i, 1, k]
-@inline Base.setindex!(r::ARF{X, Nothing, Z}, d, i, k) where {X, Z} = @inbounds r.data[i, 1, k] = d
-@inline Base.getindex( r::ARF{X, Y, Nothing},    i, j) where {X, Y} = @inbounds r.data[i, j, 1]
-@inline Base.setindex!(r::ARF{X, Y, Nothing}, d, i, j) where {X, Y} = @inbounds r.data[i, j, 1] = d
-
-# One-dimensional fields
-@inline Base.getindex( r::ARF{X, Nothing, Nothing},    i, j, k) where X = @inbounds r.data[i, 1, 1]
-@inline Base.setindex!(r::ARF{X, Nothing, Nothing}, d, i, j, k) where X = @inbounds r.data[i, 1, 1] = d
-@inline Base.getindex( r::ARF{Nothing, Y, Nothing},    i, j, k) where Y = @inbounds r.data[1, j, 1]
-@inline Base.setindex!(r::ARF{Nothing, Y, Nothing}, d, i, j, k) where Y = @inbounds r.data[1, j, 1] = d
-@inline Base.getindex( r::ARF{Nothing, Nothing, Z},    i, j, k) where Z = @inbounds r.data[1, 1, k]
-@inline Base.setindex!(r::ARF{Nothing, Nothing, Z}, d, i, j, k) where Z = @inbounds r.data[1, 1, k] = d
-
-@inline Base.getindex( r::ARF{X, Nothing, Nothing},    i) where X = @inbounds r.data[i, 1, 1]
-@inline Base.setindex!(r::ARF{X, Nothing, Nothing}, d, i) where X = @inbounds r.data[i, 1, 1] = d
-@inline Base.getindex( r::ARF{Nothing, Y, Nothing},    j) where Y = @inbounds r.data[1, j, 1]
-@inline Base.setindex!(r::ARF{Nothing, Y, Nothing}, d, j) where Y = @inbounds r.data[1, j, 1] = d
-@inline Base.getindex( r::ARF{Nothing, Nothing, Z},    k) where Z = @inbounds r.data[1, 1, k]
-@inline Base.setindex!(r::ARF{Nothing, Nothing, Z}, d, k) where Z = @inbounds r.data[1, 1, k] = d
-
-# Zero-dimensional fields
-@inline Base.getindex( r::ARF{Nothing, Nothing, Nothing},    i, j, k) = @inbounds r.data[1, 1, 1]
-@inline Base.setindex!(r::ARF{Nothing, Nothing, Nothing}, d, i, j, k) = @inbounds r.data[1, 1, 1] = d
-
-@inline Base.getindex( r::ARF{Nothing, Nothing, Nothing},  ) = @inbounds r.data[1, 1, 1]
-@inline Base.setindex!(r::ARF{Nothing, Nothing, Nothing}, d) = @inbounds r.data[1, 1, 1] = d
 
 fill_halo_regions!(field::AbstractReducedField, arch, args...) =
     fill_halo_regions!(field.data, field.boundary_conditions, arch, field.grid, args...; reduced_dimensions=field.dims)

--- a/src/Fields/reduced_getindex_setindex.jl
+++ b/src/Fields/reduced_getindex_setindex.jl
@@ -1,40 +1,39 @@
-const AF = AbstractField
+const ADF = AbstractDataField
 
 # Two-dimensional fields
-@inline Base.getindex( r::AF{Nothing, Y, Z},    i, j, k) where {Y, Z} = @inbounds r.data[1, j, k]
-@inline Base.setindex!(r::AF{Nothing, Y, Z}, d, i, j, k) where {Y, Z} = @inbounds r.data[1, j, k] = d
-@inline Base.getindex( r::AF{X, Nothing, Z},    i, j, k) where {X, Z} = @inbounds r.data[i, 1, k]
-@inline Base.setindex!(r::AF{X, Nothing, Z}, d, i, j, k) where {X, Z} = @inbounds r.data[i, 1, k] = d
-@inline Base.getindex( r::AF{X, Y, Nothing},    i, j, k) where {X, Y} = @inbounds r.data[i, j, 1]
-@inline Base.setindex!(r::AF{X, Y, Nothing}, d, i, j, k) where {X, Y} = @inbounds r.data[i, j, 1] = d
+@inline Base.getindex( r::ADF{Nothing, Y, Z},    i, j, k) where {Y, Z} = @inbounds r.data[1, j, k]
+@inline Base.setindex!(r::ADF{Nothing, Y, Z}, d, i, j, k) where {Y, Z} = @inbounds r.data[1, j, k] = d
+@inline Base.getindex( r::ADF{X, Nothing, Z},    i, j, k) where {X, Z} = @inbounds r.data[i, 1, k]
+@inline Base.setindex!(r::ADF{X, Nothing, Z}, d, i, j, k) where {X, Z} = @inbounds r.data[i, 1, k] = d
+@inline Base.getindex( r::ADF{X, Y, Nothing},    i, j, k) where {X, Y} = @inbounds r.data[i, j, 1]
+@inline Base.setindex!(r::ADF{X, Y, Nothing}, d, i, j, k) where {X, Y} = @inbounds r.data[i, j, 1] = d
 
-@inline Base.getindex( r::AF{Nothing, Y, Z},    j, k) where {Y, Z} = @inbounds r.data[1, j, k]
-@inline Base.setindex!(r::AF{Nothing, Y, Z}, d, j, k) where {Y, Z} = @inbounds r.data[1, j, k] = d
-@inline Base.getindex( r::AF{X, Nothing, Z},    i, k) where {X, Z} = @inbounds r.data[i, 1, k]
-@inline Base.setindex!(r::AF{X, Nothing, Z}, d, i, k) where {X, Z} = @inbounds r.data[i, 1, k] = d
-@inline Base.getindex( r::AF{X, Y, Nothing},    i, j) where {X, Y} = @inbounds r.data[i, j, 1]
-@inline Base.setindex!(r::AF{X, Y, Nothing}, d, i, j) where {X, Y} = @inbounds r.data[i, j, 1] = d
+@inline Base.getindex( r::ADF{Nothing, Y, Z},    j, k) where {Y, Z} = @inbounds r.data[1, j, k]
+@inline Base.setindex!(r::ADF{Nothing, Y, Z}, d, j, k) where {Y, Z} = @inbounds r.data[1, j, k] = d
+@inline Base.getindex( r::ADF{X, Nothing, Z},    i, k) where {X, Z} = @inbounds r.data[i, 1, k]
+@inline Base.setindex!(r::ADF{X, Nothing, Z}, d, i, k) where {X, Z} = @inbounds r.data[i, 1, k] = d
+@inline Base.getindex( r::ADF{X, Y, Nothing},    i, j) where {X, Y} = @inbounds r.data[i, j, 1]
+@inline Base.setindex!(r::ADF{X, Y, Nothing}, d, i, j) where {X, Y} = @inbounds r.data[i, j, 1] = d
 
 # One-dimensional fields
-@inline Base.getindex( r::AF{X, Nothing, Nothing},    i, j, k) where X = @inbounds r.data[i, 1, 1]
-@inline Base.setindex!(r::AF{X, Nothing, Nothing}, d, i, j, k) where X = @inbounds r.data[i, 1, 1] = d
-@inline Base.getindex( r::AF{Nothing, Y, Nothing},    i, j, k) where Y = @inbounds r.data[1, j, 1]
-@inline Base.setindex!(r::AF{Nothing, Y, Nothing}, d, i, j, k) where Y = @inbounds r.data[1, j, 1] = d
-@inline Base.getindex( r::AF{Nothing, Nothing, Z},    i, j, k) where Z = @inbounds r.data[1, 1, k]
-@inline Base.setindex!(r::AF{Nothing, Nothing, Z}, d, i, j, k) where Z = @inbounds r.data[1, 1, k] = d
+@inline Base.getindex( r::ADF{X, Nothing, Nothing},    i, j, k) where X = @inbounds r.data[i, 1, 1]
+@inline Base.setindex!(r::ADF{X, Nothing, Nothing}, d, i, j, k) where X = @inbounds r.data[i, 1, 1] = d
+@inline Base.getindex( r::ADF{Nothing, Y, Nothing},    i, j, k) where Y = @inbounds r.data[1, j, 1]
+@inline Base.setindex!(r::ADF{Nothing, Y, Nothing}, d, i, j, k) where Y = @inbounds r.data[1, j, 1] = d
+@inline Base.getindex( r::ADF{Nothing, Nothing, Z},    i, j, k) where Z = @inbounds r.data[1, 1, k]
+@inline Base.setindex!(r::ADF{Nothing, Nothing, Z}, d, i, j, k) where Z = @inbounds r.data[1, 1, k] = d
 
-@inline Base.getindex( r::AF{X, Nothing, Nothing},    i) where X = @inbounds r.data[i, 1, 1]
-@inline Base.setindex!(r::AF{X, Nothing, Nothing}, d, i) where X = @inbounds r.data[i, 1, 1] = d
-@inline Base.getindex( r::AF{Nothing, Y, Nothing},    j) where Y = @inbounds r.data[1, j, 1]
-@inline Base.setindex!(r::AF{Nothing, Y, Nothing}, d, j) where Y = @inbounds r.data[1, j, 1] = d
-@inline Base.getindex( r::AF{Nothing, Nothing, Z},    k) where Z = @inbounds r.data[1, 1, k]
-@inline Base.setindex!(r::AF{Nothing, Nothing, Z}, d, k) where Z = @inbounds r.data[1, 1, k] = d
+@inline Base.getindex( r::ADF{X, Nothing, Nothing},    i) where X = @inbounds r.data[i, 1, 1]
+@inline Base.setindex!(r::ADF{X, Nothing, Nothing}, d, i) where X = @inbounds r.data[i, 1, 1] = d
+@inline Base.getindex( r::ADF{Nothing, Y, Nothing},    j) where Y = @inbounds r.data[1, j, 1]
+@inline Base.setindex!(r::ADF{Nothing, Y, Nothing}, d, j) where Y = @inbounds r.data[1, j, 1] = d
+@inline Base.getindex( r::ADF{Nothing, Nothing, Z},    k) where Z = @inbounds r.data[1, 1, k]
+@inline Base.setindex!(r::ADF{Nothing, Nothing, Z}, d, k) where Z = @inbounds r.data[1, 1, k] = d
 
 # Zero-dimensional fields
-@inline Base.getindex( r::AF{Nothing, Nothing, Nothing},    i, j, k) = @inbounds r.data[1, 1, 1]
-@inline Base.setindex!(r::AF{Nothing, Nothing, Nothing}, d, i, j, k) = @inbounds r.data[1, 1, 1] = d
+@inline Base.getindex( r::ADF{Nothing, Nothing, Nothing},    i, j, k) = @inbounds r.data[1, 1, 1]
+@inline Base.setindex!(r::ADF{Nothing, Nothing, Nothing}, d, i, j, k) = @inbounds r.data[1, 1, 1] = d
 
-@inline Base.getindex( r::AF{Nothing, Nothing, Nothing},  ) = @inbounds r.data[1, 1, 1]
-@inline Base.setindex!(r::AF{Nothing, Nothing, Nothing}, d) = @inbounds r.data[1, 1, 1] = d
-
+@inline Base.getindex( r::ADF{Nothing, Nothing, Nothing},  ) = @inbounds r.data[1, 1, 1]
+@inline Base.setindex!(r::ADF{Nothing, Nothing, Nothing}, d) = @inbounds r.data[1, 1, 1] = d
 

--- a/src/Fields/reduced_getindex_setindex.jl
+++ b/src/Fields/reduced_getindex_setindex.jl
@@ -1,0 +1,40 @@
+const AF = AbstractField
+
+# Two-dimensional fields
+@inline Base.getindex( r::AF{Nothing, Y, Z},    i, j, k) where {Y, Z} = @inbounds r.data[1, j, k]
+@inline Base.setindex!(r::AF{Nothing, Y, Z}, d, i, j, k) where {Y, Z} = @inbounds r.data[1, j, k] = d
+@inline Base.getindex( r::AF{X, Nothing, Z},    i, j, k) where {X, Z} = @inbounds r.data[i, 1, k]
+@inline Base.setindex!(r::AF{X, Nothing, Z}, d, i, j, k) where {X, Z} = @inbounds r.data[i, 1, k] = d
+@inline Base.getindex( r::AF{X, Y, Nothing},    i, j, k) where {X, Y} = @inbounds r.data[i, j, 1]
+@inline Base.setindex!(r::AF{X, Y, Nothing}, d, i, j, k) where {X, Y} = @inbounds r.data[i, j, 1] = d
+
+@inline Base.getindex( r::AF{Nothing, Y, Z},    j, k) where {Y, Z} = @inbounds r.data[1, j, k]
+@inline Base.setindex!(r::AF{Nothing, Y, Z}, d, j, k) where {Y, Z} = @inbounds r.data[1, j, k] = d
+@inline Base.getindex( r::AF{X, Nothing, Z},    i, k) where {X, Z} = @inbounds r.data[i, 1, k]
+@inline Base.setindex!(r::AF{X, Nothing, Z}, d, i, k) where {X, Z} = @inbounds r.data[i, 1, k] = d
+@inline Base.getindex( r::AF{X, Y, Nothing},    i, j) where {X, Y} = @inbounds r.data[i, j, 1]
+@inline Base.setindex!(r::AF{X, Y, Nothing}, d, i, j) where {X, Y} = @inbounds r.data[i, j, 1] = d
+
+# One-dimensional fields
+@inline Base.getindex( r::AF{X, Nothing, Nothing},    i, j, k) where X = @inbounds r.data[i, 1, 1]
+@inline Base.setindex!(r::AF{X, Nothing, Nothing}, d, i, j, k) where X = @inbounds r.data[i, 1, 1] = d
+@inline Base.getindex( r::AF{Nothing, Y, Nothing},    i, j, k) where Y = @inbounds r.data[1, j, 1]
+@inline Base.setindex!(r::AF{Nothing, Y, Nothing}, d, i, j, k) where Y = @inbounds r.data[1, j, 1] = d
+@inline Base.getindex( r::AF{Nothing, Nothing, Z},    i, j, k) where Z = @inbounds r.data[1, 1, k]
+@inline Base.setindex!(r::AF{Nothing, Nothing, Z}, d, i, j, k) where Z = @inbounds r.data[1, 1, k] = d
+
+@inline Base.getindex( r::AF{X, Nothing, Nothing},    i) where X = @inbounds r.data[i, 1, 1]
+@inline Base.setindex!(r::AF{X, Nothing, Nothing}, d, i) where X = @inbounds r.data[i, 1, 1] = d
+@inline Base.getindex( r::AF{Nothing, Y, Nothing},    j) where Y = @inbounds r.data[1, j, 1]
+@inline Base.setindex!(r::AF{Nothing, Y, Nothing}, d, j) where Y = @inbounds r.data[1, j, 1] = d
+@inline Base.getindex( r::AF{Nothing, Nothing, Z},    k) where Z = @inbounds r.data[1, 1, k]
+@inline Base.setindex!(r::AF{Nothing, Nothing, Z}, d, k) where Z = @inbounds r.data[1, 1, k] = d
+
+# Zero-dimensional fields
+@inline Base.getindex( r::AF{Nothing, Nothing, Nothing},    i, j, k) = @inbounds r.data[1, 1, 1]
+@inline Base.setindex!(r::AF{Nothing, Nothing, Nothing}, d, i, j, k) = @inbounds r.data[1, 1, 1] = d
+
+@inline Base.getindex( r::AF{Nothing, Nothing, Nothing},  ) = @inbounds r.data[1, 1, 1]
+@inline Base.setindex!(r::AF{Nothing, Nothing, Nothing}, d) = @inbounds r.data[1, 1, 1] = d
+
+


### PR DESCRIPTION
Previously, `getindex` for `Nothing` locations was specified to `AbstractReducedField`. This PR extends these functions to apply to `AbstractDataField`.

The effect of this is limited because `Field`s are still entirely "unwrapped" within kernels, meaning that we lose their location data.

If/when we are able to preserve location data for `Field` when adapting to the `GPU`, we may not need `ReducedField` or `AbstractReducedField` any longer -- we can instead use `Nothing` locations to indicate that a field is reduced along a particular direction.