### PR TITLE
Using Flat for shallow water benchmark

### DIFF
--- a/benchmark/benchmark_shallow_water_model.jl
+++ b/benchmark/benchmark_shallow_water_model.jl
@@ -7,7 +7,7 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_shallow_water_model(Arch, FT, N)
-    grid = RegularRectilinearGrid(FT, size=(N, N, 1), extent=(1, 1, 1))
+    grid = RegularRectilinearGrid(FT, size=(N, N), extent=(1, 1), topology=(Periodic, Periodic, Flat), halo=(3, 3, 0))
     model = ShallowWaterModel(architecture=Arch(), grid=grid, gravitational_acceleration=1.0)
     set!(model, h=1)
 


### PR DESCRIPTION
Using `Flat` should be more efficient in terms of memory.