### PR TITLE
No need for explicit dependence on ArrayInterface.jl anymore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.58.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CUDAKernels = "72cfdca4-0801-4ab0-bf6a-d52aa10adc57"
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"


### PR DESCRIPTION
Don't think we need it anymore and it's blocking the v0.58.0 tag: https://github.com/JuliaRegistries/General/pull/37071