### PR TITLE
Add `show` method for `ZeroField`

### DIFF
--- a/src/Fields/show_fields.jl
+++ b/src/Fields/show_fields.jl
@@ -51,6 +51,8 @@ Base.show(io::IO, field::KernelComputedField) =
           "├── kernel: $(short_show(field.kernel))\n",
           "└── status: $(show_status(field.status))")
 
+Base.show(io::IO, field::ZeroField) = print(io, "ZeroField")
+
 short_show(array::OffsetArray{T, D, A}) where {T, D, A} = string("OffsetArray{$T, $D, $A}")
 
 Base.show(io::IO, ::MIME"text/plain", f::AbstractField) = show(io, f)


### PR DESCRIPTION
Right now `show` errors since `ZeroField.grid` is not a struct property.