### PR TITLE
Fix name conflict in `Utils`

### DIFF
--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -11,6 +11,8 @@ export with_tracers
 export versioninfo_with_gpu, oceananigans_versioninfo
 export instantiate
 
+import CUDA  # To avoid name conflicts
+
 import Oceananigans: short_show
 
 #####

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -2,7 +2,6 @@
 ##### Utilities for launching kernels
 #####
 
-using CUDA
 using KernelAbstractions
 using Oceananigans.Architectures
 using Oceananigans.Grids

--- a/src/Utils/versioninfo.jl
+++ b/src/Utils/versioninfo.jl
@@ -1,6 +1,5 @@
 using Pkg
 using InteractiveUtils
-using CUDA
 using Oceananigans.Architectures
 
 function versioninfo_with_gpu()


### PR DESCRIPTION
This PR fixes

```
julia> using Oceananigans
[ Info: Precompiling Oceananigans [9e8cae18-63c1-5223-a75c-80ca9d6e9a09]
WARNING: using CUDA.instantiate in module Utils conflicts with an existing identifier.
```