### PR TITLE
Increase tolerance in implicit free surface solver tests

### DIFF
--- a/test/test_implicit_free_surface_solver.jl
+++ b/test/test_implicit_free_surface_solver.jl
@@ -40,8 +40,8 @@ function run_implicit_free_surface_solver_tests(arch, grid)
     implicit_free_surface_linear_operation!(left_hand_side, η, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, g, Δt)
 
     # Compare
-    extrema_tolerance = 1e-10
-    std_tolerance = 1e-10
+    extrema_tolerance = 5e-10
+    std_tolerance = 5e-10
 
     CUDA.@allowscalar begin
         @test minimum(abs, interior(left_hand_side) .- interior(right_hand_side)) < extrema_tolerance


### PR DESCRIPTION
It seems to fail every so often, e.g. https://buildkite.com/clima/oceananigans/builds/2664#0bb7666d-6e02-4fad-9ff7-060ef7ec3c27/31-2086