### PR TITLE
Increase tolerance on `FieldTimeSeries` reduction tests

### DIFF
--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -178,7 +178,7 @@ end
                 val1 = fun(f)
                 val2 = fun([fun(f[n]) for n in 1:Nt])
 
-                @test val1 ≈ val2 atol=ε
+                @test val1 ≈ val2 atol=4ε
             end
         end
     end


### PR DESCRIPTION
This tests also fails intermittently due to being slightly above the tight tolerance: https://buildkite.com/clima/oceananigans/builds/2660#fdbc1bf9-350b-4051-9977-5ec4683ca080/22-534