### PR TITLE
Fixes sign error in flux divergence of `AnisotropicBiharmonicDiffusivity`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.58.1"
+version = "0.58.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_biharmonic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_biharmonic_diffusivity.jl
@@ -62,21 +62,21 @@ end
 calculate_diffusivities!(K, arch, grid, closure::AnisotropicBiharmonicDiffusivity, args...) = nothing
 
 @inline ∂ⱼ_τ₁ⱼ(i, j, k, grid, closure::AnisotropicBiharmonicDiffusivity, clock, U, args...) = (
-    - closure.νx * ∂⁴xᶠᵃᵃ(i, j, k, grid, U.u)
-    - closure.νy * ∂⁴yᵃᶜᵃ(i, j, k, grid, U.u)
-    - closure.νz * ∂⁴zᵃᵃᶜ(i, j, k, grid, U.u)
+      closure.νx * ∂⁴xᶠᵃᵃ(i, j, k, grid, U.u)
+    + closure.νy * ∂⁴yᵃᶜᵃ(i, j, k, grid, U.u)
+    + closure.νz * ∂⁴zᵃᵃᶜ(i, j, k, grid, U.u)
     )
 
 @inline ∂ⱼ_τ₂ⱼ(i, j, k, grid, closure::AnisotropicBiharmonicDiffusivity, clock, U, args...) = (
-    - closure.νx * ∂⁴xᶜᵃᵃ(i, j, k, grid, U.v)
-    - closure.νy * ∂⁴yᵃᶠᵃ(i, j, k, grid, U.v)
-    - closure.νz * ∂⁴zᵃᵃᶜ(i, j, k, grid, U.v)
+      closure.νx * ∂⁴xᶜᵃᵃ(i, j, k, grid, U.v)
+    + closure.νy * ∂⁴yᵃᶠᵃ(i, j, k, grid, U.v)
+    + closure.νz * ∂⁴zᵃᵃᶜ(i, j, k, grid, U.v)
     )
 
 @inline ∂ⱼ_τ₃ⱼ(i, j, k, grid, closure::AnisotropicBiharmonicDiffusivity, clock, U, args...) = (
-    - closure.νx * ∂⁴xᶜᵃᵃ(i, j, k, grid, U.w)
-    - closure.νy * ∂⁴yᵃᶜᵃ(i, j, k, grid, U.w)
-    - closure.νz * ∂⁴zᵃᵃᶠ(i, j, k, grid, U.w)
+      closure.νx * ∂⁴xᶜᵃᵃ(i, j, k, grid, U.w)
+    + closure.νy * ∂⁴yᵃᶜᵃ(i, j, k, grid, U.w)
+    + closure.νz * ∂⁴zᵃᵃᶠ(i, j, k, grid, U.w)
     )
 
 @inline function ∇_dot_qᶜ(i, j, k, grid, closure::AnisotropicBiharmonicDiffusivity,
@@ -86,8 +86,8 @@ calculate_diffusivities!(K, arch, grid, closure::AnisotropicBiharmonicDiffusivit
     @inbounds κy = closure.κy[tracer_index]
     @inbounds κz = closure.κz[tracer_index]
 
-    return (- κx * ∂⁴xᶜᵃᵃ(i, j, k, grid, c)
-            - κy * ∂⁴yᵃᶜᵃ(i, j, k, grid, c)
-            - κz * ∂⁴zᵃᵃᶜ(i, j, k, grid, c)
+    return (  κx * ∂⁴xᶜᵃᵃ(i, j, k, grid, c)
+            + κy * ∂⁴yᵃᶜᵃ(i, j, k, grid, c)
+            + κz * ∂⁴zᵃᵃᶜ(i, j, k, grid, c)
            )
 end


### PR DESCRIPTION
Resolves #1702 noticed by @mukund-gupta .

In a [previous PR](https://github.com/CliMA/Oceananigans.jl/commit/3afd5b59fce91f9ab4aa6d0d19cd64fef7aea4cf#) we changed the notation of the closure term to indicate that it's the divergence of a flux, rather than specifically the divergence of a _viscous_ or _diffusive_ flux. This notational change required us to change the term's sign. Specifically, we used the redefinition

```
∂ⱼ_2ν_Σ₁ⱼ = - ∂ⱼ_τ₁ⱼ
```

for the diffusive flux of x-momentum.

However, we did not change the sign of the flux divergence for `AnisotropicBiharmonicDiffusivity`; we only changed the _name_ of the term. This PR corrects the sign error.

There are a few closures that don't have regression tests and this highlights the danger of that.