### PR TITLE
Update instructions for building docs

### DIFF
--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -106,7 +106,7 @@ You can preview how the Documentation will look like after merging by building t
 locally. From the main directory of your local repository call
 
 ```
-julia --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
+julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
 julia --project=docs/ docs/make.jl
 ```
  


### PR DESCRIPTION
This PR updates the instructions for building docs locally. We should avoid `Pkg.develop()` since we are offering a `docs/Manifest.toml`.