### PR TITLE
`ShallowWaterModel` API documentation + Add all models in Model setup/Overview

### DIFF
--- a/docs/oceananigans.bib
+++ b/docs/oceananigans.bib
@@ -725,7 +725,7 @@
 }
 
 @article{vanRoekel18,
-	title = {The {KPP} boundary layer scheme for the ocean: {Revisiting its formulation and benchmarking one-dimensional simulations relative to {LES}},
+	title = {The {KPP} boundary layer scheme for the ocean: {Revisiting} its formulation and benchmarking one-dimensional simulations relative to {LES}},
 	volume = {10},
 	doi = {10/gd8fjp},
     number = {11},

--- a/docs/src/model_setup/overview.md
+++ b/docs/src/model_setup/overview.md
@@ -22,9 +22,3 @@ IncompressibleModel
 ```@docs
 HydrostaticFreeSurfaceModel
 ```
-
-### `ShallowWaterModel`
-
-```@docs
-ShallowWaterModel
-```

--- a/docs/src/model_setup/overview.md
+++ b/docs/src/model_setup/overview.md
@@ -22,3 +22,9 @@ IncompressibleModel
 ```@docs
 HydrostaticFreeSurfaceModel
 ```
+
+### `ShallowWaterModel`
+
+```@docs
+ShallowWaterModel
+```

--- a/docs/src/model_setup/overview.md
+++ b/docs/src/model_setup/overview.md
@@ -1,14 +1,30 @@
 # Model setup
 
-This section describes all the options and features that can be used to set up a model. For more detailed information
-consult the API documentation.
+This section describes all the options and features that can be used to set up a model. For 
+more detailed information consult the API documentation.
 
-Each structure covered in this section can be constructed and passed to the `IncompressibleModel` constructor. For
-examples of model construction, see the examples. The validation experiments provide more advanced examples.
+Each structure covered in this section can be constructed and passed to the models' constructors. 
+For examples of model construction, see the examples. The validation experiments provide more 
+advanced examples.
 
-For reference, here are all the option or keyword arguments that can be passed to `IncompressibleModel`. See the
-different sections on the sidebar for more details and examples for each keyword argument.
+For reference, here are all the option or keyword arguments that can be passed to the models
+currently implemented in Oceananigans.jl. See the different sections on the sidebar for more 
+details and examples for each keyword argument.
+
+### `IncompressibleModel`
 
 ```@docs
 IncompressibleModel
+```
+
+### `HydrostaticFreeSurfaceModel`
+
+```@docs
+HydrostaticFreeSurfaceModel
+```
+
+### `ShallowWaterModel`
+
+```@docs
+ShallowWaterModel
 ```

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -20,7 +20,6 @@ include("HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl")
 include("ShallowWaterModels/ShallowWaterModels.jl")
 
 using .IncompressibleModels: IncompressibleModel, NonDimensionalIncompressibleModel
-using .ShallowWaterModels: ShallowWaterModel
 
 using .HydrostaticFreeSurfaceModels:
     HydrostaticFreeSurfaceModel, VectorInvariant,
@@ -28,5 +27,7 @@ using .HydrostaticFreeSurfaceModels:
     HydrostaticSphericalCoriolis,
     VectorInvariantEnstrophyConserving, VectorInvariantEnergyConserving,
     PrescribedVelocityFields
+
+using .ShallowWaterModels: ShallowWaterModel
 
 end

--- a/src/Models/ShallowWaterModels/shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_model.jl
@@ -56,6 +56,42 @@ struct ShallowWaterModel{G, A<:AbstractArchitecture, T, V, R, F, E, B, Q, C, K, 
 
 end
 
+"""
+    ShallowWaterModel(;
+                               grid,
+                               gravitational_acceleration,
+      architecture::AbstractArchitecture = CPU(),
+                                   clock = Clock{eltype(grid)}(0, 0, 1),
+                               advection = UpwindBiasedFifthOrder(),
+                                coriolis = nothing,
+                     forcing::NamedTuple = NamedTuple(),
+                                 closure = nothing,
+                              bathymetry = nothing,
+                                 tracers = (),
+                           diffusivities = nothing,
+         boundary_conditions::NamedTuple = NamedTuple(),
+                     timestepper::Symbol = :RungeKutta3)
+
+Construct a shallow water `Oceananigans.jl` model on `grid` with `gravitational_acceleration` constant.
+
+Keyword arguments
+=================
+
+    - `grid`: (required) The resolution and discrete geometry on which `model` is solved.
+    - `gravitational_acceleration`: (required) The gravitational accelaration constant.
+    - `architecture`: `CPU()` or `GPU()`. The computer architecture used to time-step `model`.
+    - `clock`: The `clock` for the model
+    - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
+    - `coriolis`: Parameters for the background rotation rate of the model.
+    - `forcing`: `NamedTuple` of user-defined forcing functions that contribute to solution tendencies.
+    - `bathymetry`: The bottom bathymetry.
+    - `tracers`: A tuple of symbols defining the names of the modeled tracers, or a `NamedTuple` of
+                 preallocated `CenterField`s.
+    - `diffusivities`: 
+    - `boundary_conditions`: `NamedTuple` containing field boundary conditions.
+    - `timestepper`: A symbol that specifies the time-stepping method. Either `:QuasiAdamsBashforth2`,
+                     `:RungeKutta3`.
+"""
 function ShallowWaterModel(;
                            grid,
                            gravitational_acceleration,
@@ -66,7 +102,6 @@ function ShallowWaterModel(;
                  forcing::NamedTuple = NamedTuple(),
                              closure = nothing,
                           bathymetry = nothing,
-                            solution = nothing,
                              tracers = (),
                        diffusivities = nothing,
      boundary_conditions::NamedTuple = NamedTuple(),

--- a/src/Models/ShallowWaterModels/shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_model.jl
@@ -38,7 +38,7 @@ function ShallowWaterSolutionFields(arch, grid, bcs)
     return (uh=uh, vh=vh, h=h)
 end
 
-struct ShallowWaterModel{G, A<:AbstractArchitecture, T, V, R, F, E, B, Q, C, K, TS} <: AbstractModel{TS}
+mutable struct ShallowWaterModel{G, A<:AbstractArchitecture, T, V, R, F, E, B, Q, C, K, TS} <: AbstractModel{TS}
 
                           grid :: G         # Grid of physical points on which `Model` is solved
                   architecture :: A         # Computer `Architecture` on which `Model` is run

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -57,7 +57,10 @@ export
     LagrangianParticles,
 
     # Models
-    IncompressibleModel, NonDimensionalIncompressibleModel, HydrostaticFreeSurfaceModel, fields,
+    IncompressibleModel, NonDimensionalIncompressibleModel,
+    HydrostaticFreeSurfaceModel,
+    ShallowWaterModel,
+    fields,
 
     # Hydrostatic free surface model stuff
     VectorInvariant, ExplicitFreeSurface, ImplicitFreeSurface,


### PR DESCRIPTION
This PR adds docstring to `ShallowWaterModel` and also includes all models in Model setup/Overview.

Closes #1708 and closes #1709.