### PR TITLE
Make validation/barotropic/barotropic.jl run without errors

### DIFF
--- a/validation/barotropic_gyre/barotropic_gyre.jl
+++ b/validation/barotropic_gyre/barotropic_gyre.jl
@@ -2,6 +2,7 @@
 
 using Oceananigans
 using Oceananigans.Grids
+using Oceananigans.BoundaryConditions
 
 using Oceananigans.Coriolis:
     HydrostaticSphericalCoriolis,
@@ -31,8 +32,8 @@ grid = RegularLatitudeLongitudeGrid(size = (Nx, Ny, 1),
                                     latitude = (15, 75),
                                     z = (-4000, 0))
 
-#free_surface = ImplicitFreeSurface(gravitational_acceleration=0.1)
-free_surface = ExplicitFreeSurface(gravitational_acceleration=0.1)
+free_surface = ImplicitFreeSurface(gravitational_acceleration=0.1)
+# free_surface = ExplicitFreeSurface(gravitational_acceleration=0.1)
 
 coriolis = HydrostaticSphericalCoriolis(scheme = VectorInvariantEnstrophyConserving())
 


### PR DESCRIPTION
validation/barotropic/barotropic.jl currently errors when you try and run it

 1. The Flux() type is not imported
 2. The explicit stepper and timestep aren't in sync and code NaNs. The timestep is set for implicit free surface. 

These two tweaks make it run and produce something "reasonable". 
It could be good to have it set so it runs as cloned?
