### PR TITLE
Try 2: ShallowWaterModel with ImmersedBoundaryGrid

### DIFF
--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -8,6 +8,8 @@ using Oceananigans.Fields
 using Oceananigans.Utils
 using Oceananigans.TurbulenceClosures: AbstractTurbulenceClosure, time_discretization
 
+import Oceananigans.Grids: with_halo
+
 import Oceananigans.TurbulenceClosures:
     viscous_flux_ux,
     viscous_flux_uy,
@@ -56,6 +58,8 @@ const IBG = ImmersedBoundaryGrid
 @inline get_ibg_property(ibg::IBG, ::Val{:grid}) = getfield(ibg, :grid)
 
 Adapt.adapt_structure(to, ibg::IBG) = ImmersedBoundaryGrid(adapt(to, ibg.grid), adapt(to, ibg.immersed_boundary))
+
+with_halo(halo, ibg::ImmersedBoundaryGrid) = ImmersedBoundaryGrid(with_halo(halo, ibg.grid), ibg.immersed_boundary)
 
 include("immersed_grid_metrics.jl")
 include("grid_fitted_immersed_boundary.jl")

--- a/src/Models/ShallowWaterModels/shallow_water_advection_operators.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_advection_operators.jl
@@ -1,5 +1,5 @@
 using Oceananigans.Grids: AbstractGrid
-using Oceananigans.Operators: Ax_ψᵃᵃᶜ, Ay_ψᵃᵃᶜ
+using Oceananigans.Operators: Ax_uᶠᶜᶜ, Ay_vᶜᶠᶜ
 
 #####
 ##### Momentum flux operators
@@ -22,11 +22,11 @@ using Oceananigans.Operators: Ax_ψᵃᵃᶜ, Ay_ψᵃᵃᶜ
 #####
 
 @inline div_hUu(i, j, k, grid, advection, solution) =
-    1 / Vᵃᵃᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, momentum_flux_huu, advection, solution) +
+    1 / Vᶠᶜᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, momentum_flux_huu, advection, solution) +
                                δyᵃᶜᵃ(i, j, k, grid, momentum_flux_huv, advection, solution))
 
 @inline div_hUv(i, j, k, grid, advection, solution) =
-    1 / Vᵃᵃᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, momentum_flux_hvu, advection, solution) +
+    1 / Vᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, momentum_flux_hvu, advection, solution) +
                                δyᵃᶠᵃ(i, j, k, grid, momentum_flux_hvv, advection, solution))
 
 # Support for no advection
@@ -38,7 +38,7 @@ using Oceananigans.Operators: Ax_ψᵃᵃᶜ, Ay_ψᵃᵃᶜ
 #####
 
 """
-    div_uhvh(i, j, k, grid, solution)
+    div_Uh(i, j, k, grid, solution)
 
 Calculates the divergence of the mass flux into a cell,
 
@@ -47,8 +47,8 @@ Calculates the divergence of the mass flux into a cell,
 which will end up at the location `ccc`.
 """
 @inline function div_Uh(i, j, k, grid, solution)
-    1/Vᵃᵃᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_ψᵃᵃᶜ, solution.uh) + 
-                             δyᵃᶜᵃ(i, j, k, grid, Ay_ψᵃᵃᶜ, solution.vh))
+    1/Vᶜᶜᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_uᶠᶜᶜ, solution.uh) + 
+                             δyᵃᶜᵃ(i, j, k, grid, Ay_vᶜᶠᶜ, solution.vh))
 end
 
 #####
@@ -72,7 +72,7 @@ a velocity field U = (u, v), ∇·(Uc),
 which will end up at the location `ccc`.
 """
 @inline function div_Uc(i, j, k, grid, advection, solution, c)
-    1/Vᵃᵃᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, transport_tracer_flux_x, advection, solution.uh, solution.h, c) +        
+    1/Vᶜᶜᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, transport_tracer_flux_x, advection, solution.uh, solution.h, c) +        
                              δyᵃᶜᵃ(i, j, k, grid, transport_tracer_flux_y, advection, solution.vh, solution.h, c))
 end
 
@@ -93,7 +93,7 @@ the horizontal divergence of the velocity field U = (u, v), c ∇·(U),
 which will end up at the location `ccc`.
 """
 @inline function c_div_U(i, j, k, grid, solution, c)
-    @inbounds c[i, j, k] * 1/Vᵃᵃᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, u, solution) + δyᵃᶜᵃ(i, j, k, grid, v, solution))
+    @inbounds c[i, j, k] * 1/Vᶜᶜᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, u, solution) + δyᵃᶜᵃ(i, j, k, grid, v, solution))
 end
 
 # Support for no advection

--- a/src/Models/ShallowWaterModels/solution_and_tracer_tendencies.jl
+++ b/src/Models/ShallowWaterModels/solution_and_tracer_tendencies.jl
@@ -25,7 +25,7 @@ Compute the tendency for the x-directional transport, uh
     g = gravitational_acceleration
 
     return ( - div_hUu(i, j, k, grid, advection, solution)
-             - ∂xᶠᵃᵃ(i, j, k, grid, gh2, solution.h, gravitational_acceleration)
+             - ∂xᶠᶜᵃ(i, j, k, grid, gh2, solution.h, gravitational_acceleration)
              - x_f_cross_U(i, j, k, grid, coriolis, solution)
              + forcings.uh(i, j, k, grid, clock, merge(solution, tracers)))
 end
@@ -48,7 +48,7 @@ Compute the tendency for the y-directional transport, vh.
      g = gravitational_acceleration
 
     return ( - div_hUv(i, j, k, grid, advection, solution)
-             - ∂yᵃᶠᵃ(i, j, k, grid, gh2, solution.h, gravitational_acceleration)
+             - ∂yᶜᶠᵃ(i, j, k, grid, gh2, solution.h, gravitational_acceleration)
              - y_f_cross_U(i, j, k, grid, coriolis, solution)
              + forcings.vh(i, j, k, grid, clock, merge(solution, tracers)))
 end
@@ -85,7 +85,7 @@ end
 
     return ( -  div_Uc(i, j, k, grid, advection, solution, c) 
              + c_div_U(i, j, k, grid, solution, c)         
-             - ∇_dot_qᶜ(i, j, k, grid, closure, c, val_tracer_index, clock, diffusivities, tracers, nothing, nothing)
+             - ∇_dot_qᶜ(i, j, k, grid, closure, c, val_tracer_index, clock, diffusivities, tracers, nothing)
              + forcing(i, j, k, grid, clock, merge(solution, tracers)) 
             )
 end

--- a/src/Models/ShallowWaterModels/update_shallow_water_state.jl
+++ b/src/Models/ShallowWaterModels/update_shallow_water_state.jl
@@ -1,4 +1,5 @@
 using Oceananigans.BoundaryConditions: fill_halo_regions!
+using Oceananigans.ImmersedBoundaries: mask_immersed_field!
 
 import Oceananigans.TimeSteppers: update_state!
 
@@ -8,6 +9,11 @@ import Oceananigans.TimeSteppers: update_state!
 Fill halo regions for `model.solution` and `model.tracers`.
 """
 function update_state!(model::ShallowWaterModel)
+
+    # Mask immersed fields
+    masking_events = Tuple(mask_immersed_field!(field) for field in merge(model.solution, model.tracers))
+
+    wait(device(model.architecture), MultiEvent(masking_events))
 
     # Fill halos for velocities and tracers
     fill_halo_regions!(merge(model.solution, model.tracers),

--- a/test/test_shallow_water_models.jl
+++ b/test/test_shallow_water_models.jl
@@ -1,6 +1,7 @@
 using Oceananigans
 using Oceananigans.Models
 using Oceananigans.Grids
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary
 
 function time_stepping_shallow_water_model_works(arch, topo, coriolis, advection; timestepper=:RungeKutta3)
     grid = RegularRectilinearGrid(size=(1, 1), extent=(2π, 2π), topology=topo)

--- a/test/test_shallow_water_models.jl
+++ b/test/test_shallow_water_models.jl
@@ -184,10 +184,10 @@ end
         end
     end
 
-    @testset "ShallowWaterModels with ImmersedBoundaries" begin
+    @testset "ShallowWaterModels with ImmersedBoundaryGrid" begin
         for arch in archs
-            @testset "ShallowWaterModels with ImmersedBoundaries [$arch]" begin
-                @info "Testing ShallowWaterModels with ImmersedBoundaries [$arch]"
+            @testset "ShallowWaterModels with ImmersedBoundaryGrid [$arch]" begin
+                @info "Testing ShallowWaterModels with ImmersedBoundaryGrid [$arch]"
 
                 grid = RegularRectilinearGrid(size=(8, 8), x=(-10, 10), y=(0, 5), topology=(Periodic, Bounded, Flat))
                 

--- a/test/test_shallow_water_models.jl
+++ b/test/test_shallow_water_models.jl
@@ -183,4 +183,26 @@ end
             shallow_water_model_tracers_and_forcings_work(arch)
         end
     end
+
+    @testset "ShallowWaterModels with ImmersedBoundaries" begin
+        for arch in archs
+            @testset "ShallowWaterModels with ImmersedBoundaries [$arch]" begin
+                @info "Testing ShallowWaterModels with ImmersedBoundaries [$arch]"
+
+                grid = RegularRectilinearGrid(size=(8, 8), x=(-10, 10), y=(0, 5), topology=(Periodic, Bounded, Flat))
+                
+                # Gaussian bump of width "1"
+                bump(x, y, z) = y < exp(-x^2)
+                
+                grid_with_bump = ImmersedBoundaryGrid(grid, GridFittedBoundary(bump))
+                model = ShallowWaterModel(grid=grid_with_bump, gravitational_acceleration=1)
+                
+                set!(model, h=1)
+                simulation = Simulation(model, Δt=1.0, stop_iteration=1)
+                run!(simulation)
+
+                @test model.clock.iteration == 1
+            end
+        end
+    end
 end


### PR DESCRIPTION
This PR updates the grid metrics used by `ShallowWaterModel` and adds a masking step to `update_state!` so that `ShallowWaterModel`s can be run on `ImmersedBoundaryGrid`.

Co-authored by @francispoulin .

Supercedes #1663 