### PR TITLE
New features for high-order advection in the presence of immersed boundaries

### DIFF
--- a/src/Advection/centered_advective_fluxes.jl
+++ b/src/Advection/centered_advective_fluxes.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Grids: AbstractPrimaryGrid
+
 #####
 ##### Momentum and advective tracer flux operators for centered advection schemes
 #####
@@ -5,6 +7,7 @@
 #####
 
 const Centered = AbstractCenteredAdvectionScheme
+const APG = AbstractPrimaryGrid
 
 #####
 ##### Advective momentum flux operators
@@ -12,22 +15,22 @@ const Centered = AbstractCenteredAdvectionScheme
 ##### Note the convention "advective_momentum_flux_Ua" corresponds to the advection _of_ a _by_ U.
 #####
 
-@inline advective_momentum_flux_Uu(i, j, k, grid, scheme::Centered, U, u) = Axᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
-@inline advective_momentum_flux_Vu(i, j, k, grid, scheme::Centered, V, u) = Ayᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
-@inline advective_momentum_flux_Wu(i, j, k, grid, scheme::Centered, W, u) = Azᶠᶜᵃ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
+@inline advective_momentum_flux_Uu(i, j, k, grid::APG, scheme::Centered, U, u) = Axᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
+@inline advective_momentum_flux_Vu(i, j, k, grid::APG, scheme::Centered, V, u) = Ayᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
+@inline advective_momentum_flux_Wu(i, j, k, grid::APG, scheme::Centered, W, u) = Azᶠᶜᵃ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
 
-@inline advective_momentum_flux_Uv(i, j, k, grid, scheme::Centered, U, v) = Axᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
-@inline advective_momentum_flux_Vv(i, j, k, grid, scheme::Centered, V, v) = Ayᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
-@inline advective_momentum_flux_Wv(i, j, k, grid, scheme::Centered, W, v) = Azᶜᶠᵃ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
+@inline advective_momentum_flux_Uv(i, j, k, grid::APG, scheme::Centered, U, v) = Axᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
+@inline advective_momentum_flux_Vv(i, j, k, grid::APG, scheme::Centered, V, v) = Ayᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
+@inline advective_momentum_flux_Wv(i, j, k, grid::APG, scheme::Centered, W, v) = Azᶜᶠᵃ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
 
-@inline advective_momentum_flux_Uw(i, j, k, grid, scheme::Centered, U, w) = Axᶠᶜᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
-@inline advective_momentum_flux_Vw(i, j, k, grid, scheme::Centered, V, w) = Ayᶜᶠᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
-@inline advective_momentum_flux_Ww(i, j, k, grid, scheme::Centered, W, w) = Azᶜᶜᵃ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
+@inline advective_momentum_flux_Uw(i, j, k, grid::APG, scheme::Centered, U, w) = Axᶠᶜᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
+@inline advective_momentum_flux_Vw(i, j, k, grid::APG, scheme::Centered, V, w) = Ayᶜᶠᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
+@inline advective_momentum_flux_Ww(i, j, k, grid::APG, scheme::Centered, W, w) = Azᶜᶜᵃ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
 
 #####
 ##### Advective tracer flux operators
 #####
     
-@inline advective_tracer_flux_x(i, j, k, grid, scheme::Centered, U, c) = @inbounds Ax_uᶠᶜᶜ(i, j, k, grid, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
-@inline advective_tracer_flux_y(i, j, k, grid, scheme::Centered, V, c) = @inbounds Ay_vᶜᶠᶜ(i, j, k, grid, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
-@inline advective_tracer_flux_z(i, j, k, grid, scheme::Centered, W, c) = @inbounds Az_wᶜᶜᵃ(i, j, k, grid, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_x(i, j, k, grid::APG, scheme::Centered, U, c) = @inbounds Ax_uᶠᶜᶜ(i, j, k, grid, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_y(i, j, k, grid::APG, scheme::Centered, V, c) = @inbounds Ay_vᶜᶠᶜ(i, j, k, grid, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_z(i, j, k, grid::APG, scheme::Centered, W, c) = @inbounds Az_wᶜᶜᵃ(i, j, k, grid, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)

--- a/src/Advection/centered_advective_fluxes.jl
+++ b/src/Advection/centered_advective_fluxes.jl
@@ -7,22 +7,22 @@
 const Centered = AbstractCenteredAdvectionScheme
 
 #####
-##### Momentum flux operators
+##### Advective momentum flux operators
 #####
-##### Note the convention "momentum_flux_Ua" corresponds to the advection _of_ a _by_ U.
+##### Note the convention "advective_momentum_flux_Ua" corresponds to the advection _of_ a _by_ U.
 #####
 
-@inline momentum_flux_uu(i, j, k, grid, scheme::Centered, U, u) = Axᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
-@inline momentum_flux_uv(i, j, k, grid, scheme::Centered, V, u) = Ayᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
-@inline momentum_flux_uw(i, j, k, grid, scheme::Centered, W, u) = Azᶠᶜᵃ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
+@inline advective_momentum_flux_Uu(i, j, k, grid, scheme::Centered, U, u) = Axᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
+@inline advective_momentum_flux_Vu(i, j, k, grid, scheme::Centered, V, u) = Ayᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
+@inline advective_momentum_flux_Wu(i, j, k, grid, scheme::Centered, W, u) = Azᶠᶜᵃ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
 
-@inline momentum_flux_vu(i, j, k, grid, scheme::Centered, U, v) = Axᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
-@inline momentum_flux_vv(i, j, k, grid, scheme::Centered, V, v) = Ayᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
-@inline momentum_flux_vw(i, j, k, grid, scheme::Centered, W, v) = Azᶜᶠᵃ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
+@inline advective_momentum_flux_Uv(i, j, k, grid, scheme::Centered, U, v) = Axᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
+@inline advective_momentum_flux_Vv(i, j, k, grid, scheme::Centered, V, v) = Ayᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
+@inline advective_momentum_flux_Wv(i, j, k, grid, scheme::Centered, W, v) = Azᶜᶠᵃ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
 
-@inline momentum_flux_wu(i, j, k, grid, scheme::Centered, U, w) = Axᶠᶜᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
-@inline momentum_flux_wv(i, j, k, grid, scheme::Centered, V, w) = Ayᶜᶠᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
-@inline momentum_flux_ww(i, j, k, grid, scheme::Centered, W, w) = Azᶜᶜᵃ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
+@inline advective_momentum_flux_Uw(i, j, k, grid, scheme::Centered, U, w) = Axᶠᶜᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
+@inline advective_momentum_flux_Vw(i, j, k, grid, scheme::Centered, V, w) = Ayᶜᶠᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
+@inline advective_momentum_flux_Ww(i, j, k, grid, scheme::Centered, W, w) = Azᶜᶜᵃ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
 
 #####
 ##### Advective tracer flux operators

--- a/src/Advection/centered_advective_fluxes.jl
+++ b/src/Advection/centered_advective_fluxes.jl
@@ -7,7 +7,6 @@ using Oceananigans.Grids: AbstractPrimaryGrid
 #####
 
 const Centered = AbstractCenteredAdvectionScheme
-const APG = AbstractPrimaryGrid
 
 #####
 ##### Advective momentum flux operators
@@ -15,22 +14,22 @@ const APG = AbstractPrimaryGrid
 ##### Note the convention "advective_momentum_flux_Ua" corresponds to the advection _of_ a _by_ U.
 #####
 
-@inline advective_momentum_flux_Uu(i, j, k, grid::APG, scheme::Centered, U, u) = Axᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
-@inline advective_momentum_flux_Vu(i, j, k, grid::APG, scheme::Centered, V, u) = Ayᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
-@inline advective_momentum_flux_Wu(i, j, k, grid::APG, scheme::Centered, W, u) = Azᶠᶜᵃ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
+@inline advective_momentum_flux_Uu(i, j, k, grid, scheme::Centered, U, u) = Axᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
+@inline advective_momentum_flux_Vu(i, j, k, grid, scheme::Centered, V, u) = Ayᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
+@inline advective_momentum_flux_Wu(i, j, k, grid, scheme::Centered, W, u) = Azᶠᶜᵃ(i, j, k, grid) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
 
-@inline advective_momentum_flux_Uv(i, j, k, grid::APG, scheme::Centered, U, v) = Axᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
-@inline advective_momentum_flux_Vv(i, j, k, grid::APG, scheme::Centered, V, v) = Ayᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
-@inline advective_momentum_flux_Wv(i, j, k, grid::APG, scheme::Centered, W, v) = Azᶜᶠᵃ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
+@inline advective_momentum_flux_Uv(i, j, k, grid, scheme::Centered, U, v) = Axᶠᶠᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
+@inline advective_momentum_flux_Vv(i, j, k, grid, scheme::Centered, V, v) = Ayᶜᶜᶜ(i, j, k, grid) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
+@inline advective_momentum_flux_Wv(i, j, k, grid, scheme::Centered, W, v) = Azᶜᶠᵃ(i, j, k, grid) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
 
-@inline advective_momentum_flux_Uw(i, j, k, grid::APG, scheme::Centered, U, w) = Axᶠᶜᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
-@inline advective_momentum_flux_Vw(i, j, k, grid::APG, scheme::Centered, V, w) = Ayᶜᶠᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
-@inline advective_momentum_flux_Ww(i, j, k, grid::APG, scheme::Centered, W, w) = Azᶜᶜᵃ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
+@inline advective_momentum_flux_Uw(i, j, k, grid, scheme::Centered, U, w) = Axᶠᶜᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
+@inline advective_momentum_flux_Vw(i, j, k, grid, scheme::Centered, V, w) = Ayᶜᶠᶠ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
+@inline advective_momentum_flux_Ww(i, j, k, grid, scheme::Centered, W, w) = Azᶜᶜᵃ(i, j, k, grid) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W) * _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
 
 #####
 ##### Advective tracer flux operators
 #####
     
-@inline advective_tracer_flux_x(i, j, k, grid::APG, scheme::Centered, U, c) = @inbounds Ax_uᶠᶜᶜ(i, j, k, grid, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
-@inline advective_tracer_flux_y(i, j, k, grid::APG, scheme::Centered, V, c) = @inbounds Ay_vᶜᶠᶜ(i, j, k, grid, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
-@inline advective_tracer_flux_z(i, j, k, grid::APG, scheme::Centered, W, c) = @inbounds Az_wᶜᶜᵃ(i, j, k, grid, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_x(i, j, k, grid, scheme::Centered, U, c) = @inbounds Ax_uᶠᶜᶜ(i, j, k, grid, U) * _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_y(i, j, k, grid, scheme::Centered, V, c) = @inbounds Ay_vᶜᶠᶜ(i, j, k, grid, V) * _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
+@inline advective_tracer_flux_z(i, j, k, grid, scheme::Centered, W, c) = @inbounds Az_wᶜᶜᵃ(i, j, k, grid, W) * _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)

--- a/src/Advection/centered_second_order.jl
+++ b/src/Advection/centered_second_order.jl
@@ -8,17 +8,17 @@ boundary_buffer(::CenteredSecondOrder) = 0
 
 const C2 = CenteredSecondOrder
 
-@inline momentum_flux_uu(i, j, k, grid, ::C2, U, u) = ℑxᶜᵃᵃ(i, j, k, grid, Ax_uᶠᶜᶜ, U) * ℑxᶜᵃᵃ(i, j, k, grid, u)
-@inline momentum_flux_uv(i, j, k, grid, ::C2, V, u) = ℑxᶠᵃᵃ(i, j, k, grid, Ay_vᶜᶠᶜ, V) * ℑyᵃᶠᵃ(i, j, k, grid, u)
-@inline momentum_flux_uw(i, j, k, grid, ::C2, W, u) = ℑxᶠᵃᵃ(i, j, k, grid, Az_wᶜᶜᵃ, W) * ℑzᵃᵃᶠ(i, j, k, grid, u)
+@inline advective_momentum_flux_Uu(i, j, k, grid, ::C2, U, u) = ℑxᶜᵃᵃ(i, j, k, grid, Ax_uᶠᶜᶜ, U) * ℑxᶜᵃᵃ(i, j, k, grid, u)
+@inline advective_momentum_flux_Vu(i, j, k, grid, ::C2, V, u) = ℑxᶠᵃᵃ(i, j, k, grid, Ay_vᶜᶠᶜ, V) * ℑyᵃᶠᵃ(i, j, k, grid, u)
+@inline advective_momentum_flux_Wu(i, j, k, grid, ::C2, W, u) = ℑxᶠᵃᵃ(i, j, k, grid, Az_wᶜᶜᵃ, W) * ℑzᵃᵃᶠ(i, j, k, grid, u)
 
-@inline momentum_flux_vu(i, j, k, grid, ::C2, U, v) = ℑyᵃᶠᵃ(i, j, k, grid, Ax_uᶠᶜᶜ, U) * ℑxᶠᵃᵃ(i, j, k, grid, v)
-@inline momentum_flux_vv(i, j, k, grid, ::C2, V, v) = ℑyᵃᶜᵃ(i, j, k, grid, Ay_vᶜᶠᶜ, V) * ℑyᵃᶜᵃ(i, j, k, grid, v)
-@inline momentum_flux_vw(i, j, k, grid, ::C2, W, v) = ℑyᵃᶠᵃ(i, j, k, grid, Az_wᶜᶜᵃ, W) * ℑzᵃᵃᶠ(i, j, k, grid, v)
+@inline advective_momentum_flux_Uv(i, j, k, grid, ::C2, U, v) = ℑyᵃᶠᵃ(i, j, k, grid, Ax_uᶠᶜᶜ, U) * ℑxᶠᵃᵃ(i, j, k, grid, v)
+@inline advective_momentum_flux_Vv(i, j, k, grid, ::C2, V, v) = ℑyᵃᶜᵃ(i, j, k, grid, Ay_vᶜᶠᶜ, V) * ℑyᵃᶜᵃ(i, j, k, grid, v)
+@inline advective_momentum_flux_Wv(i, j, k, grid, ::C2, W, v) = ℑyᵃᶠᵃ(i, j, k, grid, Az_wᶜᶜᵃ, W) * ℑzᵃᵃᶠ(i, j, k, grid, v)
 
-@inline momentum_flux_wu(i, j, k, grid, ::C2, U, w) = ℑzᵃᵃᶠ(i, j, k, grid, Ax_uᶠᶜᶜ, U) * ℑxᶠᵃᵃ(i, j, k, grid, w)
-@inline momentum_flux_wv(i, j, k, grid, ::C2, V, w) = ℑzᵃᵃᶠ(i, j, k, grid, Ay_vᶜᶠᶜ, V) * ℑyᵃᶠᵃ(i, j, k, grid, w)
-@inline momentum_flux_ww(i, j, k, grid, ::C2, W, w) = ℑzᵃᵃᶜ(i, j, k, grid, Az_wᶜᶜᵃ, W) * ℑzᵃᵃᶜ(i, j, k, grid, w)
+@inline advective_momentum_flux_Uw(i, j, k, grid, ::C2, U, w) = ℑzᵃᵃᶠ(i, j, k, grid, Ax_uᶠᶜᶜ, U) * ℑxᶠᵃᵃ(i, j, k, grid, w)
+@inline advective_momentum_flux_Vw(i, j, k, grid, ::C2, V, w) = ℑzᵃᵃᶠ(i, j, k, grid, Ay_vᶜᶠᶜ, V) * ℑyᵃᶠᵃ(i, j, k, grid, w)
+@inline advective_momentum_flux_Ww(i, j, k, grid, ::C2, W, w) = ℑzᵃᵃᶜ(i, j, k, grid, Az_wᶜᶜᵃ, W) * ℑzᵃᵃᶜ(i, j, k, grid, w)
 
 # Calculate the flux of a tracer quantity c through the faces of a cell.
 # In this case, the fluxes are given by u*Ax*c̄ˣ, v*Ay*c̄ʸ, and w*Az*c̄ᶻ.

--- a/src/Advection/momentum_advection_operators.jl
+++ b/src/Advection/momentum_advection_operators.jl
@@ -12,9 +12,9 @@ Calculate the advection of momentum in the x-direction using the conservative fo
 which will end up at the location `fcc`.
 """
 @inline function div_Uu(i, j, k, grid, advection, U, u)
-    return 1/Vᶠᶜᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, momentum_flux_uu, advection, U.u, u) +
-                                    δyᵃᶜᵃ(i, j, k, grid, momentum_flux_uv, advection, U.v, u) +
-                                    δzᵃᵃᶜ(i, j, k, grid, momentum_flux_uw, advection, U.w, u))
+    return 1/Vᶠᶜᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, advective_momentum_flux_Uu, advection, U[1], u) +
+                                    δyᵃᶜᵃ(i, j, k, grid, advective_momentum_flux_Vu, advection, U[2], u) +
+                                    δzᵃᵃᶜ(i, j, k, grid, advective_momentum_flux_Wu, advection, U[3], u))
 end
 
 """
@@ -27,9 +27,9 @@ Calculate the advection of momentum in the y-direction using the conservative fo
 which will end up at the location `cfc`.
 """
 @inline function div_Uv(i, j, k, grid, advection, U, v)
-    return 1/Vᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, momentum_flux_vu, advection, U.u, v) +
-                                    δyᵃᶠᵃ(i, j, k, grid, momentum_flux_vv, advection, U.v, v)    +
-                                    δzᵃᵃᶜ(i, j, k, grid, momentum_flux_vw, advection, U.w, v))
+    return 1/Vᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, advective_momentum_flux_Uv, advection, U[1], v) +
+                                    δyᵃᶠᵃ(i, j, k, grid, advective_momentum_flux_Vv, advection, U[2], v)    +
+                                    δzᵃᵃᶜ(i, j, k, grid, advective_momentum_flux_Wv, advection, U[3], v))
 end
 
 """
@@ -42,9 +42,9 @@ Calculate the advection of momentum in the z-direction using the conservative fo
 which will end up at the location `ccf`.
 """
 @inline function div_Uw(i, j, k, grid, advection, U, w)
-    return 1/Vᶜᶜᶠ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, momentum_flux_wu, advection, U.u, w) +
-                                    δyᵃᶜᵃ(i, j, k, grid, momentum_flux_wv, advection, U.v, w) +
-                                    δzᵃᵃᶠ(i, j, k, grid, momentum_flux_ww, advection, U.w, w))
+    return 1/Vᶜᶜᶠ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, advective_momentum_flux_Uw, advection, U[1], w) +
+                                    δyᵃᶜᵃ(i, j, k, grid, advective_momentum_flux_Vw, advection, U[2], w) +
+                                    δzᵃᵃᶠ(i, j, k, grid, advective_momentum_flux_Ww, advection, U[3], w))
 end
 
 @inline div_Uu(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, u) where FT = zero(FT)

--- a/src/Advection/momentum_advection_operators.jl
+++ b/src/Advection/momentum_advection_operators.jl
@@ -2,6 +2,23 @@
 ##### Momentum advection operators
 #####
 
+# Alternate names for advective fluxes
+@inline _advective_momentum_flux_Uu(i, j, k, grid::APG, args...) = advective_momentum_flux_Uu(i, j, k, grid, args...)
+@inline _advective_momentum_flux_Vu(i, j, k, grid::APG, args...) = advective_momentum_flux_Vu(i, j, k, grid, args...)
+@inline _advective_momentum_flux_Wu(i, j, k, grid::APG, args...) = advective_momentum_flux_Wu(i, j, k, grid, args...)
+
+@inline _advective_momentum_flux_Uv(i, j, k, grid::APG, args...) = advective_momentum_flux_Uv(i, j, k, grid, args...)
+@inline _advective_momentum_flux_Vv(i, j, k, grid::APG, args...) = advective_momentum_flux_Vv(i, j, k, grid, args...)
+@inline _advective_momentum_flux_Wv(i, j, k, grid::APG, args...) = advective_momentum_flux_Wv(i, j, k, grid, args...)
+
+@inline _advective_momentum_flux_Uw(i, j, k, grid::APG, args...) = advective_momentum_flux_Uw(i, j, k, grid, args...)
+@inline _advective_momentum_flux_Vw(i, j, k, grid::APG, args...) = advective_momentum_flux_Vw(i, j, k, grid, args...)
+@inline _advective_momentum_flux_Ww(i, j, k, grid::APG, args...) = advective_momentum_flux_Ww(i, j, k, grid, args...)
+
+@inline _advective_tracer_flux_x(i, j, k, grid::APG, args...) = _advective_tracer_flux_x(i, j, k, grid, args...)
+@inline _advective_tracer_flux_y(i, j, k, grid::APG, args...) = _advective_tracer_flux_y(i, j, k, grid, args...)
+@inline _advective_tracer_flux_z(i, j, k, grid::APG, args...) = _advective_tracer_flux_z(i, j, k, grid, args...)
+
 """
     div_Uu(i, j, k, grid, advection, U, u)
 
@@ -12,9 +29,9 @@ Calculate the advection of momentum in the x-direction using the conservative fo
 which will end up at the location `fcc`.
 """
 @inline function div_Uu(i, j, k, grid, advection, U, u)
-    return 1/Vᶠᶜᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, advective_momentum_flux_Uu, advection, U[1], u) +
-                                    δyᵃᶜᵃ(i, j, k, grid, advective_momentum_flux_Vu, advection, U[2], u) +
-                                    δzᵃᵃᶜ(i, j, k, grid, advective_momentum_flux_Wu, advection, U[3], u))
+    return 1/Vᶠᶜᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uu, advection, U[1], u) +
+                                    δyᵃᶜᵃ(i, j, k, grid, _advective_momentum_flux_Vu, advection, U[2], u) +
+                                    δzᵃᵃᶜ(i, j, k, grid, _advective_momentum_flux_Wu, advection, U[3], u))
 end
 
 """
@@ -27,9 +44,9 @@ Calculate the advection of momentum in the y-direction using the conservative fo
 which will end up at the location `cfc`.
 """
 @inline function div_Uv(i, j, k, grid, advection, U, v)
-    return 1/Vᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, advective_momentum_flux_Uv, advection, U[1], v) +
-                                    δyᵃᶠᵃ(i, j, k, grid, advective_momentum_flux_Vv, advection, U[2], v)    +
-                                    δzᵃᵃᶜ(i, j, k, grid, advective_momentum_flux_Wv, advection, U[3], v))
+    return 1/Vᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uv, advection, U[1], v) +
+                                    δyᵃᶠᵃ(i, j, k, grid, _advective_momentum_flux_Vv, advection, U[2], v)    +
+                                    δzᵃᵃᶜ(i, j, k, grid, _advective_momentum_flux_Wv, advection, U[3], v))
 end
 
 """
@@ -42,9 +59,9 @@ Calculate the advection of momentum in the z-direction using the conservative fo
 which will end up at the location `ccf`.
 """
 @inline function div_Uw(i, j, k, grid, advection, U, w)
-    return 1/Vᶜᶜᶠ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, advective_momentum_flux_Uw, advection, U[1], w) +
-                                    δyᵃᶜᵃ(i, j, k, grid, advective_momentum_flux_Vw, advection, U[2], w) +
-                                    δzᵃᵃᶠ(i, j, k, grid, advective_momentum_flux_Ww, advection, U[3], w))
+    return 1/Vᶜᶜᶠ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uw, advection, U[1], w) +
+                                    δyᵃᶜᵃ(i, j, k, grid, _advective_momentum_flux_Vw, advection, U[2], w) +
+                                    δzᵃᵃᶠ(i, j, k, grid, _advective_momentum_flux_Ww, advection, U[3], w))
 end
 
 @inline div_Uu(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, u) where FT = zero(FT)

--- a/src/Advection/topologically_conditional_interpolation.jl
+++ b/src/Advection/topologically_conditional_interpolation.jl
@@ -35,7 +35,7 @@ for bias in (:symmetric, :left_biased, :right_biased)
             # Simple translation for Periodic directions (fallback)
             @eval $alt_interp(i, j, k, grid::APG, scheme, ψ) = $interp(i, j, k, grid, scheme, ψ)
 
-            outside_buffer = Symbol(:outside, bias, :_buffer)
+            outside_buffer = Symbol(:outside_, bias, :_buffer)
 
             # Conditional high-order interpolation in Bounded directions
             if ξ == :x

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -18,7 +18,7 @@ const APG = AbstractPrimaryGrid
 ##### Note the convention "advective_momentum_flux_AB" corresponds to the advection _of_ B _by_ A.
 #####
 
-@inline function advective_momentum_flux_uu(i, j, k, grid::APG, scheme::Upwind, U, u)
+@inline function advective_momentum_flux_Uu(i, j, k, grid::APG, scheme::Upwind, U, u)
 
     ũ  =    _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U)
     uᴸ =  _left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -8,7 +8,6 @@ using Oceananigans.Grids: AbstractPrimaryGrid
 #####
 
 const Upwind = AbstractUpwindBiasedAdvectionScheme
-const APG = AbstractPrimaryGrid
 
 @inline upwind_biased_product(ũ, ψᴸ, ψᴿ) = ((ũ + abs(ũ)) * ψᴸ + (ũ - abs(ũ)) * ψᴿ) / 2
 
@@ -18,7 +17,7 @@ const APG = AbstractPrimaryGrid
 ##### Note the convention "advective_momentum_flux_AB" corresponds to the advection _of_ B _by_ A.
 #####
 
-@inline function advective_momentum_flux_Uu(i, j, k, grid::APG, scheme::Upwind, U, u)
+@inline function advective_momentum_flux_Uu(i, j, k, grid, scheme::Upwind, U, u)
 
     ũ  =    _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U)
     uᴸ =  _left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
@@ -27,7 +26,7 @@ const APG = AbstractPrimaryGrid
     return Axᶜᶜᶜ(i, j, k, grid) * upwind_biased_product(ũ, uᴸ, uᴿ)
 end
 
-@inline function advective_momentum_flux_Vu(i, j, k, grid::APG, scheme::Upwind, V, u)
+@inline function advective_momentum_flux_Vu(i, j, k, grid, scheme::Upwind, V, u)
 
     ṽ  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V)
     uᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
@@ -36,7 +35,7 @@ end
     return Ayᶠᶠᶜ(i, j, k, grid) * upwind_biased_product(ṽ, uᴸ, uᴿ)
 end
 
-@inline function advective_momentum_flux_Wu(i, j, k, grid::APG, scheme::Upwind, W, u)
+@inline function advective_momentum_flux_Wu(i, j, k, grid, scheme::Upwind, W, u)
 
     w̃  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W)
     uᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
@@ -45,7 +44,7 @@ end
     return Azᶠᶜᵃ(i, j, k, grid) * upwind_biased_product(w̃, uᴸ, uᴿ)
 end
 
-@inline function advective_momentum_flux_Uv(i, j, k, grid::APG, scheme::Upwind, U, v)
+@inline function advective_momentum_flux_Uv(i, j, k, grid, scheme::Upwind, U, v)
 
     ũ  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U)
     vᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
@@ -54,7 +53,7 @@ end
     return Axᶠᶠᶜ(i, j, k, grid) * upwind_biased_product(ũ, vᴸ, vᴿ)
 end
 
-@inline function advective_momentum_flux_Vv(i, j, k, grid::APG, scheme::Upwind, V, v)
+@inline function advective_momentum_flux_Vv(i, j, k, grid, scheme::Upwind, V, v)
 
     ṽ  =    _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V)
     vᴸ =  _left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
@@ -63,7 +62,7 @@ end
     return Ayᶜᶜᶜ(i, j, k, grid) * upwind_biased_product(ṽ, vᴸ, vᴿ)
 end
 
-@inline function advective_momentum_flux_Wv(i, j, k, grid::APG, scheme::Upwind, W, v)
+@inline function advective_momentum_flux_Wv(i, j, k, grid, scheme::Upwind, W, v)
 
     w̃  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W)
     vᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
@@ -72,7 +71,7 @@ end
     return Azᶜᶠᵃ(i, j, k, grid) * upwind_biased_product(w̃, vᴸ, vᴿ)
 end
 
-@inline function advective_momentum_flux_Uw(i, j, k, grid::APG, scheme::Upwind, U, w)
+@inline function advective_momentum_flux_Uw(i, j, k, grid, scheme::Upwind, U, w)
 
     ũ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U)
     wᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
@@ -81,7 +80,7 @@ end
     return Axᶠᶜᶠ(i, j, k, grid) * upwind_biased_product(ũ, wᴸ, wᴿ)
 end
 
-@inline function advective_momentum_flux_Vw(i, j, k, grid::APG, scheme::Upwind, V, w)
+@inline function advective_momentum_flux_Vw(i, j, k, grid, scheme::Upwind, V, w)
 
     ṽ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V)
     wᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
@@ -90,7 +89,7 @@ end
     return Ayᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ṽ, wᴸ, wᴿ)
 end
 
-@inline function advective_momentum_flux_Ww(i, j, k, grid::APG, scheme::Upwind, W, w)
+@inline function advective_momentum_flux_Ww(i, j, k, grid, scheme::Upwind, W, w)
 
     w̃  =    _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W)
     wᴸ =  _left_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
@@ -103,7 +102,7 @@ end
 ##### Tracer advection operators
 #####
     
-@inline function advective_tracer_flux_x(i, j, k, grid::APG, scheme::Upwind, U, c) 
+@inline function advective_tracer_flux_x(i, j, k, grid, scheme::Upwind, U, c) 
 
     @inbounds ũ = U[i, j, k]
     cᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
@@ -112,7 +111,7 @@ end
     return Axᶠᶜᶜ(i, j, k, grid) * upwind_biased_product(ũ, cᴸ, cᴿ)
 end
 
-@inline function advective_tracer_flux_y(i, j, k, grid::APG, scheme::Upwind, V, c)
+@inline function advective_tracer_flux_y(i, j, k, grid, scheme::Upwind, V, c)
 
     @inbounds ṽ = V[i, j, k]
     cᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
@@ -121,7 +120,7 @@ end
     return Ayᶜᶠᶜ(i, j, k, grid) * upwind_biased_product(ṽ, cᴸ, cᴿ)
 end
 
-@inline function advective_tracer_flux_z(i, j, k, grid::APG, scheme::Upwind, W, c)
+@inline function advective_tracer_flux_z(i, j, k, grid, scheme::Upwind, W, c)
 
     @inbounds w̃ = W[i, j, k]
     cᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -12,10 +12,10 @@ const Upwind = AbstractUpwindBiasedAdvectionScheme
 #####
 ##### Momentum advection operators
 #####
-##### Note the convention "momentum_flux_AB" corresponds to the advection _of_ B _by_ A.
+##### Note the convention "advective_momentum_flux_AB" corresponds to the advection _of_ B _by_ A.
 #####
 
-@inline function momentum_flux_uu(i, j, k, grid, scheme::Upwind, U, u)
+@inline function advective_momentum_flux_uu(i, j, k, grid, scheme::Upwind, U, u)
 
     ũ  =    _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U)
     uᴸ =  _left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
@@ -24,7 +24,7 @@ const Upwind = AbstractUpwindBiasedAdvectionScheme
     return Axᶜᶜᶜ(i, j, k, grid) * upwind_biased_product(ũ, uᴸ, uᴿ)
 end
 
-@inline function momentum_flux_uv(i, j, k, grid, scheme::Upwind, V, u)
+@inline function advective_momentum_flux_Vu(i, j, k, grid, scheme::Upwind, V, u)
 
     ṽ  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V)
     uᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
@@ -33,7 +33,7 @@ end
     return Ayᶠᶠᶜ(i, j, k, grid) * upwind_biased_product(ṽ, uᴸ, uᴿ)
 end
 
-@inline function momentum_flux_uw(i, j, k, grid, scheme::Upwind, W, u)
+@inline function advective_momentum_flux_Wu(i, j, k, grid, scheme::Upwind, W, u)
 
     w̃  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W)
     uᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
@@ -42,7 +42,7 @@ end
     return Azᶠᶜᵃ(i, j, k, grid) * upwind_biased_product(w̃, uᴸ, uᴿ)
 end
 
-@inline function momentum_flux_vu(i, j, k, grid, scheme::Upwind, U, v)
+@inline function advective_momentum_flux_Uv(i, j, k, grid, scheme::Upwind, U, v)
 
     ũ  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U)
     vᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
@@ -51,7 +51,7 @@ end
     return Axᶠᶠᶜ(i, j, k, grid) * upwind_biased_product(ũ, vᴸ, vᴿ)
 end
 
-@inline function momentum_flux_vv(i, j, k, grid, scheme::Upwind, V, v)
+@inline function advective_momentum_flux_Vv(i, j, k, grid, scheme::Upwind, V, v)
 
     ṽ  =    _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V)
     vᴸ =  _left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
@@ -60,7 +60,7 @@ end
     return Ayᶜᶜᶜ(i, j, k, grid) * upwind_biased_product(ṽ, vᴸ, vᴿ)
 end
 
-@inline function momentum_flux_vw(i, j, k, grid, scheme::Upwind, W, v)
+@inline function advective_momentum_flux_Wv(i, j, k, grid, scheme::Upwind, W, v)
 
     w̃  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W)
     vᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
@@ -69,7 +69,7 @@ end
     return Azᶜᶠᵃ(i, j, k, grid) * upwind_biased_product(w̃, vᴸ, vᴿ)
 end
 
-@inline function momentum_flux_wu(i, j, k, grid, scheme::Upwind, U, w)
+@inline function advective_momentum_flux_Uw(i, j, k, grid, scheme::Upwind, U, w)
 
     ũ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U)
     wᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
@@ -78,7 +78,7 @@ end
     return Axᶠᶜᶠ(i, j, k, grid) * upwind_biased_product(ũ, wᴸ, wᴿ)
 end
 
-@inline function momentum_flux_wv(i, j, k, grid, scheme::Upwind, V, w)
+@inline function advective_momentum_flux_Vw(i, j, k, grid, scheme::Upwind, V, w)
 
     ṽ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V)
     wᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
@@ -87,7 +87,7 @@ end
     return Ayᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ṽ, wᴸ, wᴿ)
 end
 
-@inline function momentum_flux_ww(i, j, k, grid, scheme::Upwind, W, w)
+@inline function advective_momentum_flux_Ww(i, j, k, grid, scheme::Upwind, W, w)
 
     w̃  =    _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W)
     wᴸ =  _left_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Grids: AbstractPrimaryGrid
+
 #####
 ##### Momentum and tracer advective flux operators for upwind-biased advection schemes
 #####
@@ -6,6 +8,7 @@
 #####
 
 const Upwind = AbstractUpwindBiasedAdvectionScheme
+const APG = AbstractPrimaryGrid
 
 @inline upwind_biased_product(ũ, ψᴸ, ψᴿ) = ((ũ + abs(ũ)) * ψᴸ + (ũ - abs(ũ)) * ψᴿ) / 2
 
@@ -15,7 +18,7 @@ const Upwind = AbstractUpwindBiasedAdvectionScheme
 ##### Note the convention "advective_momentum_flux_AB" corresponds to the advection _of_ B _by_ A.
 #####
 
-@inline function advective_momentum_flux_uu(i, j, k, grid, scheme::Upwind, U, u)
+@inline function advective_momentum_flux_uu(i, j, k, grid::APG, scheme::Upwind, U, u)
 
     ũ  =    _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U)
     uᴸ =  _left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
@@ -24,7 +27,7 @@ const Upwind = AbstractUpwindBiasedAdvectionScheme
     return Axᶜᶜᶜ(i, j, k, grid) * upwind_biased_product(ũ, uᴸ, uᴿ)
 end
 
-@inline function advective_momentum_flux_Vu(i, j, k, grid, scheme::Upwind, V, u)
+@inline function advective_momentum_flux_Vu(i, j, k, grid::APG, scheme::Upwind, V, u)
 
     ṽ  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V)
     uᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
@@ -33,7 +36,7 @@ end
     return Ayᶠᶠᶜ(i, j, k, grid) * upwind_biased_product(ṽ, uᴸ, uᴿ)
 end
 
-@inline function advective_momentum_flux_Wu(i, j, k, grid, scheme::Upwind, W, u)
+@inline function advective_momentum_flux_Wu(i, j, k, grid::APG, scheme::Upwind, W, u)
 
     w̃  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W)
     uᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
@@ -42,7 +45,7 @@ end
     return Azᶠᶜᵃ(i, j, k, grid) * upwind_biased_product(w̃, uᴸ, uᴿ)
 end
 
-@inline function advective_momentum_flux_Uv(i, j, k, grid, scheme::Upwind, U, v)
+@inline function advective_momentum_flux_Uv(i, j, k, grid::APG, scheme::Upwind, U, v)
 
     ũ  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U)
     vᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
@@ -51,7 +54,7 @@ end
     return Axᶠᶠᶜ(i, j, k, grid) * upwind_biased_product(ũ, vᴸ, vᴿ)
 end
 
-@inline function advective_momentum_flux_Vv(i, j, k, grid, scheme::Upwind, V, v)
+@inline function advective_momentum_flux_Vv(i, j, k, grid::APG, scheme::Upwind, V, v)
 
     ṽ  =    _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V)
     vᴸ =  _left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
@@ -60,7 +63,7 @@ end
     return Ayᶜᶜᶜ(i, j, k, grid) * upwind_biased_product(ṽ, vᴸ, vᴿ)
 end
 
-@inline function advective_momentum_flux_Wv(i, j, k, grid, scheme::Upwind, W, v)
+@inline function advective_momentum_flux_Wv(i, j, k, grid::APG, scheme::Upwind, W, v)
 
     w̃  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W)
     vᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
@@ -69,7 +72,7 @@ end
     return Azᶜᶠᵃ(i, j, k, grid) * upwind_biased_product(w̃, vᴸ, vᴿ)
 end
 
-@inline function advective_momentum_flux_Uw(i, j, k, grid, scheme::Upwind, U, w)
+@inline function advective_momentum_flux_Uw(i, j, k, grid::APG, scheme::Upwind, U, w)
 
     ũ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U)
     wᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
@@ -78,7 +81,7 @@ end
     return Axᶠᶜᶠ(i, j, k, grid) * upwind_biased_product(ũ, wᴸ, wᴿ)
 end
 
-@inline function advective_momentum_flux_Vw(i, j, k, grid, scheme::Upwind, V, w)
+@inline function advective_momentum_flux_Vw(i, j, k, grid::APG, scheme::Upwind, V, w)
 
     ṽ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V)
     wᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
@@ -87,7 +90,7 @@ end
     return Ayᵃᵃᶠ(i, j, k, grid) * upwind_biased_product(ṽ, wᴸ, wᴿ)
 end
 
-@inline function advective_momentum_flux_Ww(i, j, k, grid, scheme::Upwind, W, w)
+@inline function advective_momentum_flux_Ww(i, j, k, grid::APG, scheme::Upwind, W, w)
 
     w̃  =    _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W)
     wᴸ =  _left_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
@@ -100,7 +103,7 @@ end
 ##### Tracer advection operators
 #####
     
-@inline function advective_tracer_flux_x(i, j, k, grid, scheme::Upwind, U, c) 
+@inline function advective_tracer_flux_x(i, j, k, grid::APG, scheme::Upwind, U, c) 
 
     @inbounds ũ = U[i, j, k]
     cᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
@@ -109,7 +112,7 @@ end
     return Axᶠᶜᶜ(i, j, k, grid) * upwind_biased_product(ũ, cᴸ, cᴿ)
 end
 
-@inline function advective_tracer_flux_y(i, j, k, grid, scheme::Upwind, V, c)
+@inline function advective_tracer_flux_y(i, j, k, grid::APG, scheme::Upwind, V, c)
 
     @inbounds ṽ = V[i, j, k]
     cᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
@@ -118,7 +121,7 @@ end
     return Ayᶜᶠᶜ(i, j, k, grid) * upwind_biased_product(ṽ, cᴸ, cᴿ)
 end
 
-@inline function advective_tracer_flux_z(i, j, k, grid, scheme::Upwind, W, c)
+@inline function advective_tracer_flux_z(i, j, k, grid::APG, scheme::Upwind, W, c)
 
     @inbounds w̃ = W[i, j, k]
     cᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -11,6 +11,18 @@ using Oceananigans.TurbulenceClosures: AbstractTurbulenceClosure, time_discretiz
 import Oceananigans.Grids: with_halo
 
 import Oceananigans.TurbulenceClosures:
+    _advective_momentum_flux_Uu,
+    _advective_momentum_flux_Uv,
+    _advective_momentum_flux_Uw,
+    _advective_momentum_flux_Vu,
+    _advective_momentum_flux_Vv,
+    _advective_momentum_flux_Vw,
+    _advective_momentum_flux_Wu,
+    _advective_momentum_flux_Wv,
+    _advective_momentum_flux_Ww,
+    _advective_tracer_flux_x,
+    _advective_tracer_flux_y,
+    _advective_tracer_flux_z,
     viscous_flux_ux,
     viscous_flux_uy,
     viscous_flux_uz,

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -8,9 +8,23 @@ using Oceananigans.Fields
 using Oceananigans.Utils
 using Oceananigans.TurbulenceClosures: AbstractTurbulenceClosure, time_discretization
 
+using Oceananigans.Advection:
+    advective_momentum_flux_Uu,
+    advective_momentum_flux_Uv,
+    advective_momentum_flux_Uw,
+    advective_momentum_flux_Vu,
+    advective_momentum_flux_Vv,
+    advective_momentum_flux_Vw,
+    advective_momentum_flux_Wu,
+    advective_momentum_flux_Wv,
+    advective_momentum_flux_Ww,
+    advective_tracer_flux_x,
+    advective_tracer_flux_y,
+    advective_tracer_flux_z
+
 import Oceananigans.Grids: with_halo
 
-import Oceananigans.TurbulenceClosures:
+import Oceananigans.Advection:
     _advective_momentum_flux_Uu,
     _advective_momentum_flux_Uv,
     _advective_momentum_flux_Uw,
@@ -22,7 +36,9 @@ import Oceananigans.TurbulenceClosures:
     _advective_momentum_flux_Ww,
     _advective_tracer_flux_x,
     _advective_tracer_flux_y,
-    _advective_tracer_flux_z,
+    _advective_tracer_flux_z
+
+import Oceananigans.TurbulenceClosures:
     viscous_flux_ux,
     viscous_flux_uy,
     viscous_flux_uz,

--- a/src/ImmersedBoundaries/grid_fitted_immersed_boundary.jl
+++ b/src/ImmersedBoundaries/grid_fitted_immersed_boundary.jl
@@ -32,6 +32,10 @@ const f = Face()
 
 @inline solid_node(::Face, ::Face, ::Face, i, j, k, ibg) = solid_node(c, f, f, i, j, k, ibg) || solid_node(c, f, f, i-1, j, k, ibg)
 
+#####
+##### Advective fluxes
+#####
+
 # ccc, ffc, fcf
 @inline viscous_flux_ux(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(c, c, c, i, j, k, ibg), zero(FT), viscous_flux_ux(i, j, k, ibg.grid, disc, clo, args...))
 @inline viscous_flux_uy(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(f, f, c, i, j, k, ibg), zero(FT), viscous_flux_uy(i, j, k, ibg.grid, disc, clo, args...))
@@ -52,3 +56,6 @@ const f = Face()
 @inline diffusive_flux_y(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(c, f, c, i, j, k, ibg), zero(FT), diffusive_flux_y(i, j, k, ibg.grid, disc, clo, args...))
 @inline diffusive_flux_z(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(c, c, f, i, j, k, ibg), zero(FT), diffusive_flux_z(i, j, k, ibg.grid, disc, clo, args...))
 
+#####
+##### Advective fluxes
+#####

--- a/src/ImmersedBoundaries/grid_fitted_immersed_boundary.jl
+++ b/src/ImmersedBoundaries/grid_fitted_immersed_boundary.jl
@@ -32,55 +32,55 @@ const f = Face()
 
 @inline solid_node(::Face, ::Face, ::Face, i, j, k, ibg) = solid_node(c, f, f, i, j, k, ibg) || solid_node(c, f, f, i-1, j, k, ibg)
 
-@inline conditional_flux_ccc(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(c, c, c, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
-@inline conditional_flux_ffc(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(f, f, c, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
-@inline conditional_flux_fcf(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(f, c, f, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
-@inline conditional_flux_cff(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(c, f, f, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
+@inline conditional_flux_ccc(i, j, k, ibg::IBG{FT}, grid, flux, args...) where FT = ifelse(solid_node(c, c, c, i, j, k, ibg), zero(FT), flux(i, j, k, grid, args...))
+@inline conditional_flux_ffc(i, j, k, ibg::IBG{FT}, grid, flux, args...) where FT = ifelse(solid_node(f, f, c, i, j, k, ibg), zero(FT), flux(i, j, k, grid, args...))
+@inline conditional_flux_fcf(i, j, k, ibg::IBG{FT}, grid, flux, args...) where FT = ifelse(solid_node(f, c, f, i, j, k, ibg), zero(FT), flux(i, j, k, grid, args...))
+@inline conditional_flux_cff(i, j, k, ibg::IBG{FT}, grid, flux, args...) where FT = ifelse(solid_node(c, f, f, i, j, k, ibg), zero(FT), flux(i, j, k, grid, args...))
 
-@inline conditional_flux_fcc(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(f, c, c, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
-@inline conditional_flux_cfc(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(c, f, c, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
-@inline conditional_flux_ccf(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(c, c, f, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
+@inline conditional_flux_fcc(i, j, k, ibg::IBG{FT}, grid, flux, args...) where FT = ifelse(solid_node(f, c, c, i, j, k, ibg), zero(FT), flux(i, j, k, grid, args...))
+@inline conditional_flux_cfc(i, j, k, ibg::IBG{FT}, grid, flux, args...) where FT = ifelse(solid_node(c, f, c, i, j, k, ibg), zero(FT), flux(i, j, k, grid, args...))
+@inline conditional_flux_ccf(i, j, k, ibg::IBG{FT}, grid, flux, args...) where FT = ifelse(solid_node(c, c, f, i, j, k, ibg), zero(FT), flux(i, j, k, grid, args...))
 
 #####
 ##### Advective fluxes
 #####
 
 # ccc, ffc, fcf
- @inline viscous_flux_ux(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccc(i, j, k, ibg, viscous_flux_ux, disc, clo, args...)
- @inline viscous_flux_uy(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ffc(i, j, k, ibg, viscous_flux_uy, disc, clo, args...)
- @inline viscous_flux_uz(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_fcf(i, j, k, ibg, viscous_flux_uz, disc, clo, args...)
+ @inline viscous_flux_ux(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccc(i, j, k, ibg, ibg.grid, viscous_flux_ux, disc, clo, args...)
+ @inline viscous_flux_uy(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ffc(i, j, k, ibg, ibg.grid, viscous_flux_uy, disc, clo, args...)
+ @inline viscous_flux_uz(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_fcf(i, j, k, ibg, ibg.grid, viscous_flux_uz, disc, clo, args...)
  
  # ffc, ccc, cff
- @inline viscous_flux_vx(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ffc(i, j, k, ibg, viscous_flux_vx, disc, clo, args...)
- @inline viscous_flux_vy(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccc(i, j, k, ibg, viscous_flux_vy, disc, clo, args...)
- @inline viscous_flux_vz(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_cff(i, j, k, ibg, viscous_flux_vz, disc, clo, args...)
+ @inline viscous_flux_vx(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ffc(i, j, k, ibg, ibg.grid, viscous_flux_vx, disc, clo, args...)
+ @inline viscous_flux_vy(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccc(i, j, k, ibg, ibg.grid, viscous_flux_vy, disc, clo, args...)
+ @inline viscous_flux_vz(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_cff(i, j, k, ibg, ibg.grid, viscous_flux_vz, disc, clo, args...)
  
  # fcf, cff, ccc
- @inline viscous_flux_wx(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_fcf(i, j, k, ibg, viscous_flux_wx, disc, clo, args...)
- @inline viscous_flux_wy(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_cff(i, j, k, ibg, viscous_flux_wy, disc, clo, args...)
- @inline viscous_flux_wz(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccc(i, j, k, ibg, viscous_flux_wz, disc, clo, args...)
+ @inline viscous_flux_wx(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_fcf(i, j, k, ibg, ibg.grid, viscous_flux_wx, disc, clo, args...)
+ @inline viscous_flux_wy(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_cff(i, j, k, ibg, ibg.grid, viscous_flux_wy, disc, clo, args...)
+ @inline viscous_flux_wz(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccc(i, j, k, ibg, ibg.grid, viscous_flux_wz, disc, clo, args...)
 
 # fcc, cfc, ccf
-@inline diffusive_flux_x(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_fcc(i, j, k, ibg, diffusive_flux_x, disc, clo, args...)
-@inline diffusive_flux_y(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_cfc(i, j, k, ibg, diffusive_flux_y, disc, clo, args...)
-@inline diffusive_flux_z(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccf(i, j, k, ibg, diffusive_flux_z, disc, clo, args...)
+@inline diffusive_flux_x(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_fcc(i, j, k, ibg, ibg.grid, diffusive_flux_x, disc, clo, args...)
+@inline diffusive_flux_y(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_cfc(i, j, k, ibg, ibg.grid, diffusive_flux_y, disc, clo, args...)
+@inline diffusive_flux_z(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccf(i, j, k, ibg, ibg.grid, diffusive_flux_z, disc, clo, args...)
 
 #####
 ##### Advective fluxes
 #####
 
-@inline advective_momentum_flux_Uu(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, advective_momentum_flux_Uu, args...)
-@inline advective_momentum_flux_Vu(i, j, k, grid::IBG, args...) = conditional_flux_ffc(i, j, k, ibg, advective_momentum_flux_Vu, args...)
-@inline advective_momentum_flux_Wu(i, j, k, grid::IBG, args...) = conditional_flux_fcf(i, j, k, ibg, advective_momentum_flux_Wu, args...)
+@inline _advective_momentum_flux_Uu(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, ibg, advective_momentum_flux_Uu, args...)
+@inline _advective_momentum_flux_Vu(i, j, k, grid::IBG, args...) = conditional_flux_ffc(i, j, k, ibg, ibg, advective_momentum_flux_Vu, args...)
+@inline _advective_momentum_flux_Wu(i, j, k, grid::IBG, args...) = conditional_flux_fcf(i, j, k, ibg, ibg, advective_momentum_flux_Wu, args...)
+
+@inline _advective_momentum_flux_Uv(i, j, k, grid::IBG, args...) = conditional_flux_ffc(i, j, k, ibg, ibg, advective_momentum_flux_Uv, args...)
+@inline _advective_momentum_flux_Vv(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, ibg, advective_momentum_flux_Vv, args...)
+@inline _advective_momentum_flux_Wv(i, j, k, grid::IBG, args...) = conditional_flux_cff(i, j, k, ibg, ibg, advective_momentum_flux_Wv, args...)
+
+@inline _advective_momentum_flux_Uw(i, j, k, grid::IBG, args...) = conditional_flux_fcf(i, j, k, ibg, ibg, advective_momentum_flux_Uw, args...)
+@inline _advective_momentum_flux_Vw(i, j, k, grid::IBG, args...) = conditional_flux_cff(i, j, k, ibg, ibg, advective_momentum_flux_Vw, args...)
+@inline _advective_momentum_flux_Ww(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, ibg, advective_momentum_flux_Ww, args...)
                                                                                                                                            
-@inline advective_momentum_flux_Uv(i, j, k, grid::IBG, args...) = conditional_flux_ffc(i, j, k, ibg, advective_momentum_flux_Uv, args...)
-@inline advective_momentum_flux_Vv(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, advective_momentum_flux_Vv, args...)
-@inline advective_momentum_flux_Wv(i, j, k, grid::IBG, args...) = conditional_flux_cff(i, j, k, ibg, advective_momentum_flux_Wv, args...)
-                                                                                                                                           
-@inline advective_momentum_flux_Uw(i, j, k, grid::IBG, args...) = conditional_flux_fcf(i, j, k, ibg, advective_momentum_flux_Uw, args...)
-@inline advective_momentum_flux_Vw(i, j, k, grid::IBG, args...) = conditional_flux_cff(i, j, k, ibg, advective_momentum_flux_Vw, args...)
-@inline advective_momentum_flux_Ww(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, advective_momentum_flux_Ww, args...)
-                                                                                                                                           
-@inline advective_tracer_flux_x(i, j, k, grid::IBG, args...) = conditional_flux_fcc(i, j, k, ibg, advective_tracer_flux_x, args...)
-@inline advective_tracer_flux_y(i, j, k, grid::IBG, args...) = conditional_flux_cfc(i, j, k, ibg, advective_tracer_flux_y, args...)
-@inline advective_tracer_flux_z(i, j, k, grid::IBG, args...) = conditional_flux_ccf(i, j, k, ibg, advective_tracer_flux_z, args...)
+@inline _advective_tracer_flux_x(i, j, k, grid::IBG, args...) = conditional_flux_fcc(i, j, k, ibg, ibg, advective_tracer_flux_x, args...)
+@inline _advective_tracer_flux_y(i, j, k, grid::IBG, args...) = conditional_flux_cfc(i, j, k, ibg, ibg, advective_tracer_flux_y, args...)
+@inline _advective_tracer_flux_z(i, j, k, grid::IBG, args...) = conditional_flux_ccf(i, j, k, ibg, ibg, advective_tracer_flux_z, args...)

--- a/src/ImmersedBoundaries/grid_fitted_immersed_boundary.jl
+++ b/src/ImmersedBoundaries/grid_fitted_immersed_boundary.jl
@@ -69,18 +69,18 @@ const f = Face()
 ##### Advective fluxes
 #####
 
-@inline _advective_momentum_flux_Uu(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, ibg, advective_momentum_flux_Uu, args...)
-@inline _advective_momentum_flux_Vu(i, j, k, grid::IBG, args...) = conditional_flux_ffc(i, j, k, ibg, ibg, advective_momentum_flux_Vu, args...)
-@inline _advective_momentum_flux_Wu(i, j, k, grid::IBG, args...) = conditional_flux_fcf(i, j, k, ibg, ibg, advective_momentum_flux_Wu, args...)
+@inline _advective_momentum_flux_Uu(i, j, k, ibg::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, ibg, advective_momentum_flux_Uu, args...)
+@inline _advective_momentum_flux_Vu(i, j, k, ibg::IBG, args...) = conditional_flux_ffc(i, j, k, ibg, ibg, advective_momentum_flux_Vu, args...)
+@inline _advective_momentum_flux_Wu(i, j, k, ibg::IBG, args...) = conditional_flux_fcf(i, j, k, ibg, ibg, advective_momentum_flux_Wu, args...)
 
-@inline _advective_momentum_flux_Uv(i, j, k, grid::IBG, args...) = conditional_flux_ffc(i, j, k, ibg, ibg, advective_momentum_flux_Uv, args...)
-@inline _advective_momentum_flux_Vv(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, ibg, advective_momentum_flux_Vv, args...)
-@inline _advective_momentum_flux_Wv(i, j, k, grid::IBG, args...) = conditional_flux_cff(i, j, k, ibg, ibg, advective_momentum_flux_Wv, args...)
+@inline _advective_momentum_flux_Uv(i, j, k, ibg::IBG, args...) = conditional_flux_ffc(i, j, k, ibg, ibg, advective_momentum_flux_Uv, args...)
+@inline _advective_momentum_flux_Vv(i, j, k, ibg::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, ibg, advective_momentum_flux_Vv, args...)
+@inline _advective_momentum_flux_Wv(i, j, k, ibg::IBG, args...) = conditional_flux_cff(i, j, k, ibg, ibg, advective_momentum_flux_Wv, args...)
 
-@inline _advective_momentum_flux_Uw(i, j, k, grid::IBG, args...) = conditional_flux_fcf(i, j, k, ibg, ibg, advective_momentum_flux_Uw, args...)
-@inline _advective_momentum_flux_Vw(i, j, k, grid::IBG, args...) = conditional_flux_cff(i, j, k, ibg, ibg, advective_momentum_flux_Vw, args...)
-@inline _advective_momentum_flux_Ww(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, ibg, advective_momentum_flux_Ww, args...)
+@inline _advective_momentum_flux_Uw(i, j, k, ibg::IBG, args...) = conditional_flux_fcf(i, j, k, ibg, ibg, advective_momentum_flux_Uw, args...)
+@inline _advective_momentum_flux_Vw(i, j, k, ibg::IBG, args...) = conditional_flux_cff(i, j, k, ibg, ibg, advective_momentum_flux_Vw, args...)
+@inline _advective_momentum_flux_Ww(i, j, k, ibg::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, ibg, advective_momentum_flux_Ww, args...)
                                                                                                                                            
-@inline _advective_tracer_flux_x(i, j, k, grid::IBG, args...) = conditional_flux_fcc(i, j, k, ibg, ibg, advective_tracer_flux_x, args...)
-@inline _advective_tracer_flux_y(i, j, k, grid::IBG, args...) = conditional_flux_cfc(i, j, k, ibg, ibg, advective_tracer_flux_y, args...)
-@inline _advective_tracer_flux_z(i, j, k, grid::IBG, args...) = conditional_flux_ccf(i, j, k, ibg, ibg, advective_tracer_flux_z, args...)
+@inline _advective_tracer_flux_x(i, j, k, ibg::IBG, args...) = conditional_flux_fcc(i, j, k, ibg, ibg, advective_tracer_flux_x, args...)
+@inline _advective_tracer_flux_y(i, j, k, ibg::IBG, args...) = conditional_flux_cfc(i, j, k, ibg, ibg, advective_tracer_flux_y, args...)
+@inline _advective_tracer_flux_z(i, j, k, ibg::IBG, args...) = conditional_flux_ccf(i, j, k, ibg, ibg, advective_tracer_flux_z, args...)

--- a/src/ImmersedBoundaries/grid_fitted_immersed_boundary.jl
+++ b/src/ImmersedBoundaries/grid_fitted_immersed_boundary.jl
@@ -32,30 +32,55 @@ const f = Face()
 
 @inline solid_node(::Face, ::Face, ::Face, i, j, k, ibg) = solid_node(c, f, f, i, j, k, ibg) || solid_node(c, f, f, i-1, j, k, ibg)
 
+@inline conditional_flux_ccc(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(c, c, c, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
+@inline conditional_flux_ffc(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(f, f, c, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
+@inline conditional_flux_fcf(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(f, c, f, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
+@inline conditional_flux_cff(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(c, f, f, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
+
+@inline conditional_flux_fcc(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(f, c, c, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
+@inline conditional_flux_cfc(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(c, f, c, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
+@inline conditional_flux_ccf(i, j, k, ibg::IBG{FT}, flux, args...) where FT = ifelse(solid_node(c, c, f, i, j, k, ibg), zero(FT), flux(i, j, k, ibg.grid, args...))
+
 #####
 ##### Advective fluxes
 #####
 
 # ccc, ffc, fcf
-@inline viscous_flux_ux(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(c, c, c, i, j, k, ibg), zero(FT), viscous_flux_ux(i, j, k, ibg.grid, disc, clo, args...))
-@inline viscous_flux_uy(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(f, f, c, i, j, k, ibg), zero(FT), viscous_flux_uy(i, j, k, ibg.grid, disc, clo, args...))
-@inline viscous_flux_uz(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(f, c, f, i, j, k, ibg), zero(FT), viscous_flux_uz(i, j, k, ibg.grid, disc, clo, args...))
-
-# ffc, ccc, cff
-@inline viscous_flux_vx(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(f, f, c, i, j, k, ibg), zero(FT), viscous_flux_vx(i, j, k, ibg.grid, disc, clo, args...))
-@inline viscous_flux_vy(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(c, c, c, i, j, k, ibg), zero(FT), viscous_flux_vy(i, j, k, ibg.grid, disc, clo, args...))
-@inline viscous_flux_vz(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(c, f, f, i, j, k, ibg), zero(FT), viscous_flux_vz(i, j, k, ibg.grid, disc, clo, args...))
-
-# fcf, cff, ccc
-@inline viscous_flux_wx(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(f, c, f, i, j, k, ibg), zero(FT), viscous_flux_wx(i, j, k, ibg.grid, disc, clo, args...))
-@inline viscous_flux_wy(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(c, f, f, i, j, k, ibg), zero(FT), viscous_flux_wy(i, j, k, ibg.grid, disc, clo, args...))
-@inline viscous_flux_wz(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(c, c, c, i, j, k, ibg), zero(FT), viscous_flux_wz(i, j, k, ibg.grid, disc, clo, args...))
+ @inline viscous_flux_ux(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccc(i, j, k, ibg, viscous_flux_ux, disc, clo, args...)
+ @inline viscous_flux_uy(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ffc(i, j, k, ibg, viscous_flux_uy, disc, clo, args...)
+ @inline viscous_flux_uz(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_fcf(i, j, k, ibg, viscous_flux_uz, disc, clo, args...)
+ 
+ # ffc, ccc, cff
+ @inline viscous_flux_vx(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ffc(i, j, k, ibg, viscous_flux_vx, disc, clo, args...)
+ @inline viscous_flux_vy(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccc(i, j, k, ibg, viscous_flux_vy, disc, clo, args...)
+ @inline viscous_flux_vz(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_cff(i, j, k, ibg, viscous_flux_vz, disc, clo, args...)
+ 
+ # fcf, cff, ccc
+ @inline viscous_flux_wx(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_fcf(i, j, k, ibg, viscous_flux_wx, disc, clo, args...)
+ @inline viscous_flux_wy(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_cff(i, j, k, ibg, viscous_flux_wy, disc, clo, args...)
+ @inline viscous_flux_wz(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccc(i, j, k, ibg, viscous_flux_wz, disc, clo, args...)
 
 # fcc, cfc, ccf
-@inline diffusive_flux_x(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(f, c, c, i, j, k, ibg), zero(FT), diffusive_flux_x(i, j, k, ibg.grid, disc, clo, args...))
-@inline diffusive_flux_y(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(c, f, c, i, j, k, ibg), zero(FT), diffusive_flux_y(i, j, k, ibg.grid, disc, clo, args...))
-@inline diffusive_flux_z(i, j, k, ibg::IBG{FT}, disc::ATD, clo::ATC, args...) where FT = ifelse(solid_node(c, c, f, i, j, k, ibg), zero(FT), diffusive_flux_z(i, j, k, ibg.grid, disc, clo, args...))
+@inline diffusive_flux_x(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_fcc(i, j, k, ibg, diffusive_flux_x, disc, clo, args...)
+@inline diffusive_flux_y(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_cfc(i, j, k, ibg, diffusive_flux_y, disc, clo, args...)
+@inline diffusive_flux_z(i, j, k, ibg::IBG, disc::ATD, clo::ATC, args...) = conditional_flux_ccf(i, j, k, ibg, diffusive_flux_z, disc, clo, args...)
 
 #####
 ##### Advective fluxes
 #####
+
+@inline advective_momentum_flux_Uu(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, advective_momentum_flux_Uu, args...)
+@inline advective_momentum_flux_Vu(i, j, k, grid::IBG, args...) = conditional_flux_ffc(i, j, k, ibg, advective_momentum_flux_Vu, args...)
+@inline advective_momentum_flux_Wu(i, j, k, grid::IBG, args...) = conditional_flux_fcf(i, j, k, ibg, advective_momentum_flux_Wu, args...)
+                                                                                                                                           
+@inline advective_momentum_flux_Uv(i, j, k, grid::IBG, args...) = conditional_flux_ffc(i, j, k, ibg, advective_momentum_flux_Uv, args...)
+@inline advective_momentum_flux_Vv(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, advective_momentum_flux_Vv, args...)
+@inline advective_momentum_flux_Wv(i, j, k, grid::IBG, args...) = conditional_flux_cff(i, j, k, ibg, advective_momentum_flux_Wv, args...)
+                                                                                                                                           
+@inline advective_momentum_flux_Uw(i, j, k, grid::IBG, args...) = conditional_flux_fcf(i, j, k, ibg, advective_momentum_flux_Uw, args...)
+@inline advective_momentum_flux_Vw(i, j, k, grid::IBG, args...) = conditional_flux_cff(i, j, k, ibg, advective_momentum_flux_Vw, args...)
+@inline advective_momentum_flux_Ww(i, j, k, grid::IBG, args...) = conditional_flux_ccc(i, j, k, ibg, advective_momentum_flux_Ww, args...)
+                                                                                                                                           
+@inline advective_tracer_flux_x(i, j, k, grid::IBG, args...) = conditional_flux_fcc(i, j, k, ibg, advective_tracer_flux_x, args...)
+@inline advective_tracer_flux_y(i, j, k, grid::IBG, args...) = conditional_flux_cfc(i, j, k, ibg, advective_tracer_flux_y, args...)
+@inline advective_tracer_flux_z(i, j, k, grid::IBG, args...) = conditional_flux_ccf(i, j, k, ibg, advective_tracer_flux_z, args...)

--- a/src/Models/ShallowWaterModels/shallow_water_advection_operators.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_advection_operators.jl
@@ -1,3 +1,9 @@
+using Oceananigans.Advection: 
+    _advective_momentum_flux_Uu,
+    _advective_momentum_flux_Uv,
+    _advective_momentum_flux_Vu,
+    _advective_momentum_flux_Vv
+
 using Oceananigans.Grids: AbstractGrid
 using Oceananigans.Operators: Ax_uᶠᶜᶜ, Ay_vᶜᶠᶜ
 
@@ -6,16 +12,16 @@ using Oceananigans.Operators: Ax_uᶠᶜᶜ, Ay_vᶜᶠᶜ
 #####
 
 @inline momentum_flux_huu(i, j, k, grid, advection, solution) =
-    @inbounds advective_momentum_flux_Uu(i, j, k, grid, advection, solution.uh, solution.uh) / solution.h[i, j, k]
+    @inbounds _advective_momentum_flux_Uu(i, j, k, grid, advection, solution.uh, solution.uh) / solution.h[i, j, k]
 
 @inline momentum_flux_hvu(i, j, k, grid, advection, solution) =
-    @inbounds advective_momentum_flux_Vu(i, j, k, grid, advection, solution.vh, solution.uh) / ℑxyᶠᶠᵃ(i, j, k, grid, solution.h)
+    @inbounds _advective_momentum_flux_Vu(i, j, k, grid, advection, solution.vh, solution.uh) / ℑxyᶠᶠᵃ(i, j, k, grid, solution.h)
 
 @inline momentum_flux_huv(i, j, k, grid, advection, solution) =
-    @inbounds advective_momentum_flux_Uv(i, j, k, grid, advection, solution.uh, solution.vh) / ℑxyᶠᶠᵃ(i, j, k, grid, solution.h)
+    @inbounds _advective_momentum_flux_Uv(i, j, k, grid, advection, solution.uh, solution.vh) / ℑxyᶠᶠᵃ(i, j, k, grid, solution.h)
 
 @inline momentum_flux_hvv(i, j, k, grid, advection, solution) =
-    @inbounds advective_momentum_flux_Vv(i, j, k, grid, advection, solution.vh, solution.vh) / solution.h[i, j, k]
+    @inbounds _advective_momentum_flux_Vv(i, j, k, grid, advection, solution.vh, solution.vh) / solution.h[i, j, k]
 
 #####
 ##### Momentum flux divergence operators

--- a/src/Models/ShallowWaterModels/shallow_water_advection_operators.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_advection_operators.jl
@@ -6,16 +6,16 @@ using Oceananigans.Operators: Ax_uᶠᶜᶜ, Ay_vᶜᶠᶜ
 #####
 
 @inline momentum_flux_huu(i, j, k, grid, advection, solution) =
-    @inbounds momentum_flux_uu(i, j, k, grid, advection, solution.uh, solution.uh) / solution.h[i, j, k]
-
-@inline momentum_flux_huv(i, j, k, grid, advection, solution) =
-    @inbounds momentum_flux_uv(i, j, k, grid, advection, solution.vh, solution.uh) / ℑxyᶠᶠᵃ(i, j, k, grid, solution.h)
+    @inbounds advective_momentum_flux_Uu(i, j, k, grid, advection, solution.uh, solution.uh) / solution.h[i, j, k]
 
 @inline momentum_flux_hvu(i, j, k, grid, advection, solution) =
-    @inbounds momentum_flux_vu(i, j, k, grid, advection, solution.uh, solution.vh) / ℑxyᶠᶠᵃ(i, j, k, grid, solution.h)
+    @inbounds advective_momentum_flux_Vu(i, j, k, grid, advection, solution.vh, solution.uh) / ℑxyᶠᶠᵃ(i, j, k, grid, solution.h)
+
+@inline momentum_flux_huv(i, j, k, grid, advection, solution) =
+    @inbounds advective_momentum_flux_Uv(i, j, k, grid, advection, solution.uh, solution.vh) / ℑxyᶠᶠᵃ(i, j, k, grid, solution.h)
 
 @inline momentum_flux_hvv(i, j, k, grid, advection, solution) =
-    @inbounds momentum_flux_vv(i, j, k, grid, advection, solution.vh, solution.vh) / solution.h[i, j, k]
+    @inbounds advective_momentum_flux_Vv(i, j, k, grid, advection, solution.vh, solution.vh) / solution.h[i, j, k]
 
 #####
 ##### Momentum flux divergence operators
@@ -23,10 +23,10 @@ using Oceananigans.Operators: Ax_uᶠᶜᶜ, Ay_vᶜᶠᶜ
 
 @inline div_hUu(i, j, k, grid, advection, solution) =
     1 / Vᶠᶜᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, momentum_flux_huu, advection, solution) +
-                               δyᵃᶜᵃ(i, j, k, grid, momentum_flux_huv, advection, solution))
+                               δyᵃᶜᵃ(i, j, k, grid, momentum_flux_hvu, advection, solution))
 
 @inline div_hUv(i, j, k, grid, advection, solution) =
-    1 / Vᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, momentum_flux_hvu, advection, solution) +
+    1 / Vᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, momentum_flux_huv, advection, solution) +
                                δyᵃᶠᵃ(i, j, k, grid, momentum_flux_hvv, advection, solution))
 
 # Support for no advection
@@ -85,7 +85,7 @@ end
 """
     c_div_U(i, j, k, grid, advection, U)
 
-Calculates the produce of the tracer concentration c with 
+Calculates the product of the tracer concentration c with 
 the horizontal divergence of the velocity field U = (u, v), c ∇·(U),
 
     1/V * [δxᶜᵃᵃ(Ax * uh / h) + δyᵃᶜᵃ(Ay * vh / h]


### PR DESCRIPTION
High-order advection schemes invoke wide stencils that can produce unintended non-zero fluxes across solid immersed boundaries. This PR elides advective fluxes across immersed boundaries for `GridFittedImmersedBoundary` to address that.

In addition, we should probably introduce boundary-conditional interpolation so that we limit to second-order advection close to immersed boundaries. I'll drop that into this PR too and add a test for high-order advection with immersed boundaries.