### PR TITLE
Simplifies models' constructors

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -51,7 +51,6 @@ end
     HydrostaticFreeSurfaceModel(;
                    grid,
            architecture = CPU(),
-                  clock = Clock{eltype(grid)}(0, 0, 1),
      momentum_advection = CenteredSecondOrder(),
        tracer_advection = CenteredSecondOrder(),
                buoyancy = SeawaterBuoyancy(eltype(grid)),
@@ -86,7 +85,6 @@ Keyword arguments
 """
 function HydrostaticFreeSurfaceModel(; grid,
                 architecture::AbstractArchitecture = CPU(),
-                                             clock = Clock{eltype(grid)}(0, 0, 1),
                                 momentum_advection = CenteredSecondOrder(),
                                   tracer_advection = CenteredSecondOrder(),
                                           buoyancy = SeawaterBuoyancy(eltype(grid)),
@@ -151,7 +149,10 @@ function HydrostaticFreeSurfaceModel(; grid,
                               implicit_solver = implicit_solver,
                               Gⁿ = HydrostaticFreeSurfaceTendencyFields(velocities, free_surface, architecture, grid, tracernames(tracers)),
                               G⁻ = HydrostaticFreeSurfaceTendencyFields(velocities, free_surface, architecture, grid, tracernames(tracers)))
-
+    
+    # Create clock
+    clock = Clock{eltype(grid)}(0, 0, 1)
+                              
     # Regularize forcing for model tracer and velocity fields.
     model_fields = hydrostatic_prognostic_fields(velocities, free_surface, tracers)
     forcing = model_forcing(model_fields; forcing...)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -126,6 +126,9 @@ function HydrostaticFreeSurfaceModel(; grid,
 
     model_field_names = (:u, :v, :w, :η, tracernames(tracers)...)
     boundary_conditions = regularize_field_boundary_conditions(boundary_conditions, grid, model_field_names)
+    
+    # Create clock
+    clock = Clock{eltype(grid)}(0, 0, 1)
 
     # TKEBasedVerticalDiffusivity enforces boundary conditions on TKE:
     boundary_conditions = add_closure_specific_boundary_conditions(closure, boundary_conditions, grid, tracernames(tracers), buoyancy)
@@ -149,9 +152,6 @@ function HydrostaticFreeSurfaceModel(; grid,
                               implicit_solver = implicit_solver,
                               Gⁿ = HydrostaticFreeSurfaceTendencyFields(velocities, free_surface, architecture, grid, tracernames(tracers)),
                               G⁻ = HydrostaticFreeSurfaceTendencyFields(velocities, free_surface, architecture, grid, tracernames(tracers)))
-    
-    # Create clock
-    clock = Clock{eltype(grid)}(0, 0, 1)
                               
     # Regularize forcing for model tracer and velocity fields.
     model_fields = hydrostatic_prognostic_fields(velocities, free_surface, tracers)

--- a/src/Models/IncompressibleModels/incompressible_model.jl
+++ b/src/Models/IncompressibleModels/incompressible_model.jl
@@ -47,7 +47,6 @@ end
                    grid,
            architecture = CPU(),
              float_type = Float64,
-                  clock = Clock{float_type}(0, 0, 1),
               advection = CenteredSecondOrder(),
                buoyancy = Buoyancy(SeawaterBuoyancy(float_type)),
                coriolis = nothing,
@@ -88,7 +87,6 @@ Keyword arguments
 function IncompressibleModel(;    grid,
     architecture::AbstractArchitecture = CPU(),
                             float_type = Float64,
-                                 clock = Clock{float_type}(0, 0, 1),
                              advection = CenteredSecondOrder(),
                               buoyancy = Buoyancy(model=SeawaterBuoyancy(float_type)),
                               coriolis = nothing,
@@ -154,6 +152,9 @@ function IncompressibleModel(;    grid,
     implicit_solver = implicit_diffusion_solver(time_discretization(closure), architecture, grid)
     timestepper = TimeStepper(timestepper, architecture, grid, tracernames(tracers), implicit_solver=implicit_solver)
 
+    # Create clock
+    clock = Clock{float_type}(0, 0, 1)
+    
     # Regularize forcing for model tracer and velocity fields.
     model_fields = merge(velocities, tracers)
     forcing = model_forcing(model_fields; forcing...)

--- a/src/Models/IncompressibleModels/incompressible_model.jl
+++ b/src/Models/IncompressibleModels/incompressible_model.jl
@@ -146,15 +146,15 @@ function IncompressibleModel(;    grid,
         pressure_solver = PressureSolver(architecture, grid)
     end
 
+    # Create clock
+    clock = Clock{float_type}(0, 0, 1)
+    
     background_fields = BackgroundFields(background_fields, tracernames(tracers), grid, clock)
 
     # Instantiate timestepper if not already instantiated
     implicit_solver = implicit_diffusion_solver(time_discretization(closure), architecture, grid)
     timestepper = TimeStepper(timestepper, architecture, grid, tracernames(tracers), implicit_solver=implicit_solver)
 
-    # Create clock
-    clock = Clock{float_type}(0, 0, 1)
-    
     # Regularize forcing for model tracer and velocity fields.
     model_fields = merge(velocities, tracers)
     forcing = model_forcing(model_fields; forcing...)

--- a/src/Models/ShallowWaterModels/shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_model.jl
@@ -61,7 +61,6 @@ end
                                grid,
                                gravitational_acceleration,
       architecture::AbstractArchitecture = CPU(),
-                                   clock = Clock{eltype(grid)}(0, 0, 1),
                                advection = UpwindBiasedFifthOrder(),
                                 coriolis = nothing,
                      forcing::NamedTuple = NamedTuple(),
@@ -80,7 +79,6 @@ Keyword arguments
     - `grid`: (required) The resolution and discrete geometry on which `model` is solved.
     - `gravitational_acceleration`: (required) The gravitational accelaration constant.
     - `architecture`: `CPU()` or `GPU()`. The computer architecture used to time-step `model`.
-    - `clock`: The `clock` for the model
     - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
     - `coriolis`: Parameters for the background rotation rate of the model.
     - `forcing`: `NamedTuple` of user-defined forcing functions that contribute to solution tendencies.
@@ -96,7 +94,6 @@ function ShallowWaterModel(;
                            grid,
                            gravitational_acceleration,
   architecture::AbstractArchitecture = CPU(),
-                               clock = Clock{eltype(grid)}(0, 0, 1),
                            advection = UpwindBiasedFifthOrder(),
                             coriolis = nothing,
                  forcing::NamedTuple = NamedTuple(),
@@ -127,11 +124,14 @@ function ShallowWaterModel(;
                               Gⁿ = ShallowWaterTendencyFields(architecture, grid, tracernames(tracers)),
                               G⁻ = ShallowWaterTendencyFields(architecture, grid, tracernames(tracers)))
 
+    # Create clock
+    clock = Clock{eltype(grid)}(0, 0, 1)
+    
     # Regularize forcing and closure for model tracer and velocity fields.
     model_fields = merge(solution, tracers)
     forcing = model_forcing(model_fields; forcing...)
     closure = with_tracers(tracernames(tracers), closure)
-
+    
     return ShallowWaterModel(grid,
                              architecture,
                              clock,


### PR DESCRIPTION
This PR removes `clock` from a `kwarg` in models' constructors and rather creates `clock` inside the constructor.

Closes #1710.