### PR TITLE
Fixes typo in Docs/Physics/HydrostaticFreeSurfaceModel

### DIFF
--- a/docs/src/physics/hydrostatic_free_surface_model.md
+++ b/docs/src/physics/hydrostatic_free_surface_model.md
@@ -63,7 +63,7 @@ The terms that appear on the right-hand side of the momentum conservation equati
 The conservation law for tracers in Oceananigans.jl is
 ```math
     \begin{align}
-    \partial_t c = - \boldsymbol{u} \boldsymbol{\cdot} \boldsymbol{\nabla} c
+    \partial_t c = - \boldsymbol{v} \boldsymbol{\cdot} \boldsymbol{\nabla} c
                    - \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{q}_c
                    + F_c \, ,
     \label{eq:tracer}


### PR DESCRIPTION
The tracer advection in the `HydrostaticFreeSurfaceModel` is done by 3D velocity (u, v, w) and not by 2D (u, v, 0).

Closes #1728.