### PR TITLE
Validate field boundary conditions

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -15,6 +15,7 @@ using Oceananigans.Grids
 using Oceananigans.BoundaryConditions
 
 include("abstract_field.jl")
+include("validate_field_boundary_conditions.jl")
 include("reduced_getindex_setindex.jl")
 include("field.jl")
 include("zero_field.jl")

--- a/src/Fields/reduced_field.jl
+++ b/src/Fields/reduced_field.jl
@@ -1,5 +1,6 @@
 using Adapt
 
+using Oceananigans.BoundaryConditions: CoordinateBoundaryConditions
 import Oceananigans.BoundaryConditions: fill_halo_regions!
 
 #####
@@ -9,10 +10,6 @@ import Oceananigans.BoundaryConditions: fill_halo_regions!
 abstract type AbstractReducedField{X, Y, Z, A, G, T, N} <: AbstractDataField{X, Y, Z, A, G, T, 3} end
 
 const ARF = AbstractReducedField
-
-fill_halo_regions!(field::AbstractReducedField, arch, args...) =
-    fill_halo_regions!(field.data, field.boundary_conditions, arch, field.grid, args...; reduced_dimensions=field.dims)
-
 const DimsType = NTuple{N, Int} where N
 
 function validate_reduced_dims(dims)
@@ -100,6 +97,9 @@ function ReducedField(Xr, Yr, Zr, arch, grid; dims, data=nothing,
         boundary_conditions = FieldBoundaryConditions(grid, (X, Y, Z))
     end
 
+    # Can't apply boundary conditions in reduced directions
+    boundary_conditions = reduced_boundary_conditions(boundary_conditions; dims=dims)
+
     return ReducedField{X, Y, Z}(data, arch, grid, dims, boundary_conditions)
 end
 
@@ -114,6 +114,7 @@ Base.similar(r::AbstractReducedField{X, Y, Z, Arch}) where {X, Y, Z, Arch} =
 #####
 
 reduced_location(loc; dims) = Tuple(i ∈ dims ? Nothing : loc[i] for i in 1:3)
+reduced_boundary_conditions(bcs; dims) = Tuple(i ∈ dims ? CoordinateBoundaryConditions(nothing, nothing) : bcs[i] for i in 1:3)
 
 Adapt.adapt_structure(to, reduced_field::ReducedField{X, Y, Z}) where {X, Y, Z} =
     ReducedField{X, Y, Z}(adapt(to, reduced_field.data), nothing, adapt(to, reduced_field.grid), reduced_field.dims, nothing)

--- a/src/Fields/validate_field_boundary_conditions.jl
+++ b/src/Fields/validate_field_boundary_conditions.jl
@@ -1,0 +1,37 @@
+validate_boundary_condition(topo, bc, loc, side) = error("$side boundary condition $bc cannot be applied " *
+                                                          "to a field located at $loc in a $topo dimension.")
+
+# Whitelist...
+CenterBoundedBCs = Union{BoundaryCondition{<:Value},
+                         BoundaryCondition{<:Gradient},
+                         BoundaryCondition{<:Flux}}
+
+validate_boundary_condition(::Bounded, ::CenterBoundedBCs, ::Center, side) = nothing # fallback
+validate_boundary_condition(::Bounded, ::Union{nothing, BoundaryCondition{<:NormalFlow}}, ::Face, side) = nothing # fallback
+validate_boundary_condition(::Periodic, ::BoundaryCondition{<:Periodic}, loc, side) = nothing
+
+# Validate boundary conditions
+validate_field_boundary_conditions(::Nothing, grid, LX, LY, LZ) = nothing
+
+function validate_field_boundary_conditions(bcs, grid, LX, LY, LZ)
+    west_bc   = bcs.west
+    east_bc   = bcs.east
+    south_bc  = bcs.south
+    north_bc  = bcs.north
+    bottom_bc = bcs.bottom
+    top_bc    = bcs.top
+
+    TX, TY, TZ = topology(grid)
+
+    validate_boundary_condition(TX, west_bc, LX, :west)
+    validate_boundary_condition(TX, east_bc, LX, :east)
+
+    validate_boundary_condition(TY, south_bc, LY, :south)
+    validate_boundary_condition(TY, north_bc, LY, :north)
+
+    validate_boundary_condition(TZ, top_bc, LZ, :top)
+    validate_boundary_condition(TZ, bottom_bc, LZ, :bottom)
+
+    return nothing
+end
+

--- a/src/Fields/validate_field_boundary_conditions.jl
+++ b/src/Fields/validate_field_boundary_conditions.jl
@@ -1,3 +1,5 @@
+import Oceananigans.BoundaryConditions
+
 validate_boundary_condition(::Periodic, bc, loc, side) = throw(ArgumentError("$side boundary condition $bc is non-periodic. " *
                                                                              "Boundary conditions cannot be specified in Periodic directions!"))
 
@@ -20,7 +22,7 @@ CenterBoundedBCs = Union{BoundaryCondition{<:Value},
 validate_boundary_condition(::Flat, ::Nothing, loc, side) = nothing
 validate_boundary_condition(::Bounded, ::CenterBoundedBCs, ::Center, side) = nothing
 validate_boundary_condition(::Bounded, ::Union{Nothing, BoundaryCondition{<:NormalFlow}}, ::Face, side) = nothing
-validate_boundary_condition(::Periodic, ::BoundaryCondition{<:Periodic}, loc, side) = nothing
+validate_boundary_condition(::Periodic, ::BoundaryCondition{<:BoundaryConditions.Periodic}, loc, side) = nothing
 
 # Validate boundary conditions
 validate_field_boundary_conditions(::Nothing, grid, LX, LY, LZ) = nothing

--- a/src/Fields/validate_field_boundary_conditions.jl
+++ b/src/Fields/validate_field_boundary_conditions.jl
@@ -1,13 +1,25 @@
-validate_boundary_condition(topo, bc, loc, side) = error("$side boundary condition $bc cannot be applied " *
-                                                          "to a field located at $loc in a $topo dimension.")
+validate_boundary_condition(::Periodic, bc, loc, side) = throw(ArgumentError("$side boundary condition $bc is non-periodic. " *
+                                                                             "Boundary conditions cannot be specified in Periodic directions!")
+
+validate_boundary_condition(::Flat, bc, loc, side) = throw(ArgumentError("$side boundary condition $bc is not nothing. " *
+                                                                         "Boundary conditions cannot be specified in Flat directions!"))
+
+validate_boundary_condition(::Bounded, bc, ::Center, side) = throw(ArgumentError("$side boundary condition $bc is invalid. " *
+                                                                                 "Field at cell Center in Bounded directions must have either \n" *
+                                                                                 "FluxBoundaryCondition, ValueBoundaryCondition, or GradientBoundaryCondition")
+
+validate_boundary_condition(::Bounded, bc, ::Face, side) = throw(ArgumentError("$side boundary condition $bc is invalid. " *
+                                                                               "Field at cell Face in Bounded directions must have either \n" *
+                                                                               "NormalFlowBoundaryCondition or nothing.")
 
 # Whitelist...
 CenterBoundedBCs = Union{BoundaryCondition{<:Value},
                          BoundaryCondition{<:Gradient},
                          BoundaryCondition{<:Flux}}
 
-validate_boundary_condition(::Bounded, ::CenterBoundedBCs, ::Center, side) = nothing # fallback
-validate_boundary_condition(::Bounded, ::Union{nothing, BoundaryCondition{<:NormalFlow}}, ::Face, side) = nothing # fallback
+validate_boundary_condition(::Flat, ::Nothing, loc, side) = nothing
+validate_boundary_condition(::Bounded, ::CenterBoundedBCs, ::Center, side) = nothing
+validate_boundary_condition(::Bounded, ::Union{Nothing, BoundaryCondition{<:NormalFlow}}, ::Face, side) = nothing
 validate_boundary_condition(::Periodic, ::BoundaryCondition{<:Periodic}, loc, side) = nothing
 
 # Validate boundary conditions

--- a/src/Fields/validate_field_boundary_conditions.jl
+++ b/src/Fields/validate_field_boundary_conditions.jl
@@ -1,16 +1,16 @@
 validate_boundary_condition(::Periodic, bc, loc, side) = throw(ArgumentError("$side boundary condition $bc is non-periodic. " *
-                                                                             "Boundary conditions cannot be specified in Periodic directions!")
+                                                                             "Boundary conditions cannot be specified in Periodic directions!"))
 
 validate_boundary_condition(::Flat, bc, loc, side) = throw(ArgumentError("$side boundary condition $bc is not nothing. " *
                                                                          "Boundary conditions cannot be specified in Flat directions!"))
 
 validate_boundary_condition(::Bounded, bc, ::Center, side) = throw(ArgumentError("$side boundary condition $bc is invalid. " *
                                                                                  "Field at cell Center in Bounded directions must have either \n" *
-                                                                                 "FluxBoundaryCondition, ValueBoundaryCondition, or GradientBoundaryCondition")
+                                                                                 "FluxBoundaryCondition, ValueBoundaryCondition, or GradientBoundaryCondition"))
 
 validate_boundary_condition(::Bounded, bc, ::Face, side) = throw(ArgumentError("$side boundary condition $bc is invalid. " *
                                                                                "Field at cell Face in Bounded directions must have either \n" *
-                                                                               "NormalFlowBoundaryCondition or nothing.")
+                                                                               "NormalFlowBoundaryCondition or nothing."))
 
 # Whitelist...
 CenterBoundedBCs = Union{BoundaryCondition{<:Value},


### PR DESCRIPTION
This long overdue PR implementations a validation step in the lowest-level outer constructor for `Field`.

This resolves a number of issues but I need to find them.

Couple todo's:
- [ ] tests
- [x] expand error message to help users choose valid boundary conditions