### PR TITLE
Make Immersed work with cubed sphere

### DIFF
--- a/src/CubedSpheres/CubedSpheres.jl
+++ b/src/CubedSpheres/CubedSpheres.jl
@@ -9,6 +9,7 @@ include("cubed_sphere_faces.jl")
 include("cubed_sphere_set!.jl")
 include("cubed_sphere_halo_filling.jl")
 include("cubed_sphere_kernel_launching.jl")
+include("immersed_conformal_cubed_sphere_grid.jl")
 
 #####
 ##### Validating cubed sphere stuff

--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -48,13 +48,11 @@ const CubedSphereField                     = Field{X, Y, Z, A, <:CubedSphereData
 const CubedSphereReducedField              = ReducedField{X, Y, Z, A, <:CubedSphereData} where {X, Y, Z, A}
 const CubedSphereAbstractField             = AbstractField{X, Y, Z, A, <:ConformalCubedSphereGrid} where {X, Y, Z, A}
 const CubedSphereAbstractDataField         = AbstractDataField{X, Y, Z, A, <:ConformalCubedSphereGrid} where {X, Y, Z, A}
-const ImmersedCubedSphereAbstractDataField = AbstractDataField{X, Y, Z, A, <:ConformalCubedSphereGrid} where {X, Y, Z, A}
 
-const AbstractCubedSphereField{X, Y, Z, A} = Union{            CubedSphereAbstractField{X, Y, Z, A},
-                                                           CubedSphereAbstractDataField{X, Y, Z, A},
-                                                   ImmersedCubedSphereAbstractDataField{X, Y, Z, A},
-                                                                       CubedSphereField{X, Y, Z, A},
-                                                  } where {X, Y, Z, A}
+const AbstractCubedSphereField{X, Y, Z, A} = Union{    CubedSphereAbstractField{X, Y, Z, A},
+                                                   CubedSphereAbstractDataField{X, Y, Z, A},
+                                                        CubedSphereReducedField{X, Y, Z, A},
+                                                               CubedSphereField{X, Y, Z, A}} where {X, Y, Z, A}
 
 #####
 ##### new data

--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -35,8 +35,8 @@ const ImmersedCubedSphereFaceField    = AbstractField{X, Y, Z, A, <:ImmersedConf
 const CubedSphereFaceField = Union{NonImmersedCubedSphereFaceField{X, Y, Z, A},
                                       ImmersedCubedSphereFaceField{X, Y, Z, A}} where {X, Y, Z, A}
 
-const NonImmersedCubedSphereAbstractReducedFaceField = {AbstractReducedField{X, Y, Z, A, D, <:ConformalCubedSphereFaceGrid} where {X, Y, Z, A, D}
-const ImmersedCubedSphereAbstractReducedFaceField = {AbstractReducedField{X, Y, Z, A, D, <:ImmersedConformalCubedSphereFaceGrid} where {X, Y, Z, A, D}
+const NonImmersedCubedSphereAbstractReducedFaceField = AbstractReducedField{X, Y, Z, A, D, <:ConformalCubedSphereFaceGrid} where {X, Y, Z, A, D}
+const ImmersedCubedSphereAbstractReducedFaceField = AbstractReducedField{X, Y, Z, A, D, <:ImmersedConformalCubedSphereFaceGrid} where {X, Y, Z, A, D}
 
 const CubedSphereAbstractReducedFaceField = Union{NonImmersedCubedSphereAbstractReducedFaceField{X, Y, Z, A},
                                                      ImmersedCubedSphereAbstractReducedFaceField{X, Y, Z, A}} where {X, Y, Z, A}
@@ -48,6 +48,7 @@ const CubedSphereField                     = Field{X, Y, Z, A, <:CubedSphereData
 const CubedSphereReducedField              = ReducedField{X, Y, Z, A, <:CubedSphereData} where {X, Y, Z, A}
 const CubedSphereAbstractField             = AbstractField{X, Y, Z, A, <:ConformalCubedSphereGrid} where {X, Y, Z, A}
 const CubedSphereAbstractDataField         = AbstractDataField{X, Y, Z, A, <:ConformalCubedSphereGrid} where {X, Y, Z, A}
+const ImmersedCubedSphereAbstractDataField = AbstractDataField{X, Y, Z, A, <:ConformalCubedSphereGrid} where {X, Y, Z, A}
 
 const AbstractCubedSphereField{X, Y, Z, A} = Union{            CubedSphereAbstractField{X, Y, Z, A},
                                                            CubedSphereAbstractDataField{X, Y, Z, A},

--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -109,7 +109,7 @@ end
 
 Base.size(data::CubedSphereData) = (size(data.faces[1])..., length(data.faces))
 
-@inline function get_face(field::AbstractCubedSphereField, face_index)
+@inline function get_face(field::CubedSphereField, face_index)
     X, Y, Z = location(field)
 
     # Should we define a new lower-level constructor for Field that doesn't call validate_field_data?
@@ -119,7 +119,7 @@ Base.size(data::CubedSphereData) = (size(data.faces[1])..., length(data.faces))
                           get_face(field.boundary_conditions, face_index))
 end
 
-@inline function get_face(reduced_field::CubedSphereAbstractReducedField, face_index)
+@inline function get_face(reduced_field::CubedSphereReducedField, face_index)
     X, Y, Z = location(reduced_field)
 
     return ReducedField{X, Y, Z}(get_face(reduced_field.data, face_index),

--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -54,9 +54,6 @@ const AbstractCubedSphereField{X, Y, Z, A} = Union{    CubedSphereAbstractField{
                                                         CubedSphereReducedField{X, Y, Z, A},
                                                                CubedSphereField{X, Y, Z, A}} where {X, Y, Z, A}
 
-# KernelComputedCubedSphereField
-const KernelComputedCubedSphereField = KernelComputedField{X, Y, Z, A, S, D, G, T, K, B, F, P} where {X, Y, Z, A, S, D<:CubedSphereFaces, G, T, K, B, F, P}
-
 #####
 ##### new data
 #####
@@ -131,7 +128,7 @@ end
                                  get_face(reduced_field.boundary_conditions, face_index))
 end
 
-@inline function get_face(kernel_field::KernelComputedCubedSphereField, face_index)
+@inline function get_face(kernel_field::CubedSphereAbstractDataField, face_index)
     X, Y, Z = location(kernel_field)
 
     return Field{X, Y, Z}(get_face(kernel_field.data, face_index),

--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -7,7 +7,7 @@ using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 import Base: getindex, size, show, minimum, maximum
 import Statistics: mean
 
-import Oceananigans.Fields: AbstractField, AbstractDataField, AbstractReducedField, Field, ReducedField, minimum, maximum, mean, location, short_show
+import Oceananigans.Fields: AbstractField, AbstractDataField, AbstractReducedField, Field, ReducedField, minimum, maximum, mean, location, short_show, KernelComputedField
 import Oceananigans.Grids: new_data
 import Oceananigans.BoundaryConditions: FieldBoundaryConditions
 
@@ -53,6 +53,9 @@ const AbstractCubedSphereField{X, Y, Z, A} = Union{    CubedSphereAbstractField{
                                                    CubedSphereAbstractDataField{X, Y, Z, A},
                                                         CubedSphereReducedField{X, Y, Z, A},
                                                                CubedSphereField{X, Y, Z, A}} where {X, Y, Z, A}
+
+# KernelComputedCubedSphereField
+const KernelComputedCubedSphereField = KernelComputedField{X, Y, Z, A, S, D, G, T, K, B, F, P} where {X, Y, Z, A, S, D<:CubedSphereFaces, G, T, K, B, F, P}
 
 #####
 ##### new data
@@ -126,6 +129,15 @@ end
                                  get_face(reduced_field.grid, face_index),
                                  reduced_field.dims,
                                  get_face(reduced_field.boundary_conditions, face_index))
+end
+
+@inline function get_face(kernel_field::KernelComputedCubedSphereField, face_index)
+    X, Y, Z = location(kernel_field)
+
+    return Field{X, Y, Z}(get_face(kernel_field.data, face_index),
+                                 kernel_field.architecture,
+                                 get_face(kernel_field.grid, face_index),
+                                 get_face(kernel_field.boundary_conditions, face_index))
 end
 
 faces(field::AbstractCubedSphereField) = Tuple(get_face(field, face_index) for face_index in 1:length(field.data.faces))

--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -25,16 +25,21 @@ const CubedSphereData = CubedSphereFaces{<:OffsetArray}
 
 # Some dispatch foo to make a type union for CubedSphereFaceField...
 #
-# Grids:
+# Conformal cubed sphere grid wrapped in ImmersedBoundaryGrid:
 const ImmersedConformalCubedSphereFaceGrid = ImmersedBoundaryGrid{FT, TX, TY, TZ, <:ConformalCubedSphereFaceGrid} where {FT, TX, TY, TZ}
-const ImmersedConformalCubedSphereGrid = ImmersedBoundaryGrid{FT, TX, TY, TZ, <:ConformalCubedSphereGrid} where {FT, TX, TY, TZ}
 
-# Face Fields:
-const ImmersedCubedSphereFaceField    = AbstractField{X, Y, Z, A, <:ImmersedConformalCubedSphereFaceGrid} where {X, Y, Z, A}
+# CubedSphereFaceField:
 const NonImmersedCubedSphereFaceField = AbstractField{X, Y, Z, A, <:ConformalCubedSphereFaceGrid} where {X, Y, Z, A}
+const ImmersedCubedSphereFaceField    = AbstractField{X, Y, Z, A, <:ImmersedConformalCubedSphereFaceGrid} where {X, Y, Z, A}
 
 const CubedSphereFaceField = Union{NonImmersedCubedSphereFaceField{X, Y, Z, A},
                                       ImmersedCubedSphereFaceField{X, Y, Z, A}} where {X, Y, Z, A}
+
+const NonImmersedCubedSphereAbstractReducedFaceField = {AbstractReducedField{X, Y, Z, A, D, <:ConformalCubedSphereFaceGrid} where {X, Y, Z, A, D}
+const ImmersedCubedSphereAbstractReducedFaceField = {AbstractReducedField{X, Y, Z, A, D, <:ImmersedConformalCubedSphereFaceGrid} where {X, Y, Z, A, D}
+
+const CubedSphereAbstractReducedFaceField = Union{NonImmersedCubedSphereAbstractReducedFaceField{X, Y, Z, A},
+                                                     ImmersedCubedSphereAbstractReducedFaceField{X, Y, Z, A}} where {X, Y, Z, A}
 
 # CubedSphereField
 
@@ -43,15 +48,10 @@ const CubedSphereField                     = Field{X, Y, Z, A, <:CubedSphereData
 const CubedSphereReducedField              = ReducedField{X, Y, Z, A, <:CubedSphereData} where {X, Y, Z, A}
 const CubedSphereAbstractField             = AbstractField{X, Y, Z, A, <:ConformalCubedSphereGrid} where {X, Y, Z, A}
 const CubedSphereAbstractDataField         = AbstractDataField{X, Y, Z, A, <:ConformalCubedSphereGrid} where {X, Y, Z, A}
-const ImmersedCubedSphereAbstractDataField = AbstractDataField{X, Y, Z, A, <:ImmersedConformalCubedSphereGrid} where {X, Y, Z, A}
-
-# Why is this here?
-const CubedSphereAbstractReducedField = AbstractReducedField{X, Y, Z, A, D, <:ConformalCubedSphereFaceGrid} where {X, Y, Z, A, D}
 
 const AbstractCubedSphereField{X, Y, Z, A} = Union{            CubedSphereAbstractField{X, Y, Z, A},
                                                            CubedSphereAbstractDataField{X, Y, Z, A},
                                                    ImmersedCubedSphereAbstractDataField{X, Y, Z, A},
-                                                        CubedSphereAbstractReducedField{X, Y, Z, A},
                                                                        CubedSphereField{X, Y, Z, A},
                                                   } where {X, Y, Z, A}
 
@@ -59,12 +59,12 @@ const AbstractCubedSphereField{X, Y, Z, A} = Union{            CubedSphereAbstra
 ##### new data
 #####
 
-function new_data(FT, arch::AbstractCPUArchitecture, grid::Union{ConformalCubedSphereGrid, ImmersedConformalCubedSphereGrid}, (X, Y, Z))
+function new_data(FT, arch::AbstractCPUArchitecture, grid::ConformalCubedSphereGrid, (X, Y, Z))
     faces = Tuple(new_data(FT, arch, face_grid, (X, Y, Z)) for face_grid in grid.faces)
     return CubedSphereFaces{typeof(faces[1]), typeof(faces)}(faces)
 end
 
-function new_data(FT, arch::AbstractGPUArchitecture, grid::Union{ConformalCubedSphereGrid, ImmersedConformalCubedSphereGrid}, (X, Y, Z))
+function new_data(FT, arch::AbstractGPUArchitecture, grid::ConformalCubedSphereGrid, (X, Y, Z))
     faces = Tuple(new_data(FT, arch, face_grid, (X, Y, Z)) for face_grid in grid.faces)
     return CubedSphereFaces{typeof(faces[1]), typeof(faces)}(faces)
 end

--- a/src/CubedSpheres/immersed_conformal_cubed_sphere_grid.jl
+++ b/src/CubedSpheres/immersed_conformal_cubed_sphere_grid.jl
@@ -10,16 +10,8 @@ function ImmersedBoundaryGrid(grid::ConformalCubedSphereGrid, immersed_boundary)
     return cubed_sphere_immersed_grid 
 end
 
-import Oceananigans.Grids: new_data
-
-function new_data(FT, arch, ibg::ImmersedBoundaryGrid{F,TX,TY,TZ,G}, loc ) where {F,TX,TY,TZ,G<:ConformalCubedSphereGrid}
-         println("Hello from IBG cube sphere new_data")
-         return new_data(FT, arch, ibg.grid, loc )
-end
-
 import Oceananigans.Operators: Γᶠᶠᵃ
 
-@inline function Γᶠᶠᵃ(i, j, k, ibg::ImmersedBoundaryGrid{F, TX, TY, TZ, G}, u, v) where {F,TX,TY,TZ,G<:ConformalCubedSphereGrid}
-    println("Hello from immersed cube specific Γᶠᶠᵃ")
+@inline function Γᶠᶠᵃ(i, j, k, ibg::ImmersedBoundaryGrid{F, TX, TY, TZ, G, I}, u, v) where {F,TX,TY,TZ,G<:ConformalCubedSphereFaceGrid,I}
     Γᶠᶠᵃ(i, j, k, ibg.grid, u, v)
 end

--- a/src/CubedSpheres/immersed_conformal_cubed_sphere_grid.jl
+++ b/src/CubedSpheres/immersed_conformal_cubed_sphere_grid.jl
@@ -10,3 +10,9 @@ function ImmersedBoundaryGrid(grid::ConformalCubedSphereGrid, immersed_boundary)
     return cubed_sphere_immersed_grid 
 end
 
+import Oceananigans.Grids: new_data
+
+function new_data(FT, arch, ibg::ImmersedBoundaryGrid{F,TX,TY,TZ,G}, loc ) where {F,TX,TY,TZ,G<:ConformalCubedSphereGrid}
+         println("Hello from IBG cube sphere new_data")
+         return new_data(FT, arch, ibg.grid, loc )
+end

--- a/src/CubedSpheres/immersed_conformal_cubed_sphere_grid.jl
+++ b/src/CubedSpheres/immersed_conformal_cubed_sphere_grid.jl
@@ -16,3 +16,10 @@ function new_data(FT, arch, ibg::ImmersedBoundaryGrid{F,TX,TY,TZ,G}, loc ) where
          println("Hello from IBG cube sphere new_data")
          return new_data(FT, arch, ibg.grid, loc )
 end
+
+import Oceananigans.Operators: Γᶠᶠᵃ
+
+@inline function Γᶠᶠᵃ(i, j, k, ibg::ImmersedBoundaryGrid{F, TX, TY, TZ, G}, u, v) where {F,TX,TY,TZ,G<:ConformalCubedSphereGrid}
+    println("Hello from immersed cube specific Γᶠᶠᵃ")
+    Γᶠᶠᵃ(i, j, k, ibg.grid, u, v)
+end

--- a/src/CubedSpheres/immersed_conformal_cubed_sphere_grid.jl
+++ b/src/CubedSpheres/immersed_conformal_cubed_sphere_grid.jl
@@ -1,0 +1,12 @@
+import Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
+
+function ImmersedBoundaryGrid(grid::ConformalCubedSphereGrid, immersed_boundary)
+    faces = Tuple(ImmersedBoundaryGrid(get_face(grid, i), immersed_boundary) for i = 1:6)
+    FT = eltype(grid)
+    face_connectivity = grid.face_connectivity
+
+    cubed_sphere_immersed_grid = ConformalCubedSphereGrid{FT, typeof(faces), typeof(face_connectivity)}(faces, face_connectivity)
+     
+    return cubed_sphere_immersed_grid 
+end
+

--- a/src/Models/HydrostaticFreeSurfaceModels/update_hydrostatic_free_surface_model_state.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/update_hydrostatic_free_surface_model_state.jl
@@ -19,8 +19,11 @@ function update_state!(model::HydrostaticFreeSurfaceModel)
 
     wait(device(model.architecture), MultiEvent(masking_events))
 
-    # Fill halos for velocities and tracers
+    # Fill halos for velocities and tracers. On the CubedSphere, the halo filling for velocity fields is wrong.
     fill_halo_regions!(prognostic_fields(model), model.architecture, model.clock, fields(model))
+
+    # This _refills_ the halos for horizontal velocity fields when grid::ConformalCubedSphereGrid
+    # For every other type of grid, fill_horizontal_velocity_halos! does nothing.
     fill_horizontal_velocity_halos!(model.velocities.u, model.velocities.v, model.architecture)
 
     compute_w_from_continuity!(model)

--- a/validation/immersed_boundaries/animate_on_map_projection.jl
+++ b/validation/immersed_boundaries/animate_on_map_projection.jl
@@ -1,0 +1,109 @@
+using Printf
+using Glob
+using JLD2
+using PyCall
+
+using Oceananigans.Utils: prettytime
+
+np = pyimport("numpy")
+ma = pyimport("numpy.ma")
+plt = pyimport("matplotlib.pyplot")
+mticker = pyimport("matplotlib.ticker")
+ccrs = pyimport("cartopy.crs")
+cmocean = pyimport("cmocean")
+
+function plot_cubed_sphere_tracer_field!(fig, ax, var, grid; add_colorbar, transform, cmap, vmin, vmax)
+
+    Nf = grid["faces"] |> keys |> length
+    Nx = grid["faces/1/Nx"]
+    Ny = grid["faces/1/Ny"]
+    Hx = grid["faces/1/Hx"]
+    Hy = grid["faces/1/Hy"]
+
+    for face in 1:Nf
+        λᶠᶠᵃ = grid["faces/$face/λᶠᶠᵃ"][1+Hx:Nx+2Hx, 1+Hy:Ny+2Hy]
+        φᶠᶠᵃ = grid["faces/$face/φᶠᶠᵃ"][1+Hx:Nx+2Hx, 1+Hy:Ny+2Hy]
+
+        var_face = var[face][:, :, 1]
+
+        # Remove very specific problematic grid cells near λ = 180° on face 6 that mess up the plot.
+        # May be related to https://github.com/SciTools/cartopy/issues/1151
+        # Not needed for Orthographic or NearsidePerspective projection so let's use those.
+        # if face == 6
+        #     for i in 1:Nx+1, j in 1:Ny+1
+        #         if isapprox(λᶠᶠᵃ[i, j], -180, atol=15)
+        #             var_face[min(i, Nx), min(j, Ny)] = NaN
+        #         end
+        #     end
+        # end
+
+        var_face_masked = ma.masked_where(np.isnan(var_face), var_face)
+
+        im = ax.pcolormesh(λᶠᶠᵃ, φᶠᶠᵃ, var_face_masked; transform, cmap, vmin, vmax)
+
+        # Add colorbar below all the subplots.
+        if add_colorbar && face == Nf
+            ax_cbar = fig.add_axes([0.25, 0.1, 0.5, 0.02])
+            fig.colorbar(im, cax=ax_cbar, orientation="horizontal")
+        end
+
+        ax.set_global()
+    end
+
+    return ax
+end
+
+function animate_rossby_haurwitz(; projections=[ccrs.Robinson()])
+
+    ## Extract data
+
+    file = jldopen("cubed_sphere_rossby_haurwitz.jld2")
+
+    iterations = parse.(Int, keys(file["timeseries/t"]))
+
+    ## Makie movie of tracer field h
+
+    for (n, i) in enumerate(iterations)
+        @info "Plotting iteration $i/$(iterations[end]) (frame $n/$(length(iterations)))..."
+
+        u = file["timeseries/u/$i"]
+        v = file["timeseries/v/$i"]
+        η = file["timeseries/η/$i"]
+
+        t = prettytime(file["timeseries/t/$i"])
+        plot_title = "Rossby-Haurwitz wave (mode 4): η(λ, φ) at t = $t"
+
+        fig = plt.figure(figsize=(16, 9))
+        n_subplots = length(projections)
+        subplot_kwargs = (transform=ccrs.PlateCarree(), cmap=cmocean.cm.balance, vmin=8000-80, vmax=8000+80)
+
+        for (n, projection) in enumerate(projections)
+            ax = fig.add_subplot(1, n_subplots, n, projection=projection)
+            plot_cubed_sphere_tracer_field!(fig, ax, η, file["grid"]; add_colorbar = (n == n_subplots), subplot_kwargs...)
+            n_subplots == 1 && ax.set_title(plot_title)
+
+            gl = ax.gridlines(color="gray", alpha=0.5, linestyle="--")
+            gl.xlocator = mticker.FixedLocator(-180:30:180)
+            gl.ylocator = mticker.FixedLocator(-80:20:80)
+        end
+
+        n_subplots > 1 && fig.suptitle(plot_title, y=0.85)
+
+        filename = @sprintf("cubed_sphere_rossby_haurwitz_%04d.png", n)
+        plt.savefig(filename, dpi=200, bbox_inches="tight")
+        plt.close(fig)
+    end
+
+    close(file)
+
+    filename_pattern = "cubed_sphere_rossby_haurwitz_%04d.png"
+    output_filename  = "cubed_sphere_rossby_haurwitz.mp4"
+
+    # Need extra crop video filter in case we end up with odd number of pixels in width or height.
+    # See: https://stackoverflow.com/a/29582287
+    run(`ffmpeg -y -i $filename_pattern -c:v libx264 -vf "fps=30, crop=trunc(iw/2)*2:trunc(ih/2)*2" -pix_fmt yuv420p $output_filename`)
+
+    [rm(f) for f in glob("cubed_sphere_rossby_haurwitz_*.png")]
+
+    return nothing
+end

--- a/validation/immersed_boundaries/animate_on_map_projection.jl
+++ b/validation/immersed_boundaries/animate_on_map_projection.jl
@@ -15,14 +15,14 @@ cmocean = pyimport("cmocean")
 function plot_cubed_sphere_tracer_field!(fig, ax, var, grid; add_colorbar, transform, cmap, vmin, vmax)
 
     Nf = grid["faces"] |> keys |> length
-    Nx = grid["faces/1/Nx"]
-    Ny = grid["faces/1/Ny"]
-    Hx = grid["faces/1/Hx"]
-    Hy = grid["faces/1/Hy"]
+    Nx = grid["faces/1/grid/Nx"]
+    Ny = grid["faces/1/grid/Ny"]
+    Hx = grid["faces/1/grid/Hx"]
+    Hy = grid["faces/1/grid/Hy"]
 
     for face in 1:Nf
-        λᶠᶠᵃ = grid["faces/$face/λᶠᶠᵃ"][1+Hx:Nx+2Hx, 1+Hy:Ny+2Hy]
-        φᶠᶠᵃ = grid["faces/$face/φᶠᶠᵃ"][1+Hx:Nx+2Hx, 1+Hy:Ny+2Hy]
+        λᶠᶠᵃ = grid["faces/$face/grid/λᶠᶠᵃ"][1+Hx:Nx+Hx+1, 1+Hy:Ny+Hy+1]
+        φᶠᶠᵃ = grid["faces/$face/grid/φᶠᶠᵃ"][1+Hx:Nx+Hx+1, 1+Hy:Ny+Hy+1]
 
         var_face = var[face][:, :, 1]
 

--- a/validation/immersed_boundaries/animate_three_spheres.jl
+++ b/validation/immersed_boundaries/animate_three_spheres.jl
@@ -1,0 +1,104 @@
+using Printf
+using Glob
+using JLD2
+using PyCall
+
+using Oceananigans.Utils: prettytime
+
+np = pyimport("numpy")
+ma = pyimport("numpy.ma")
+plt = pyimport("matplotlib.pyplot")
+mticker = pyimport("matplotlib.ticker")
+ccrs = pyimport("cartopy.crs")
+cmocean = pyimport("cmocean")
+
+function plot_cubed_sphere_tracer_field!(fig, ax, var, grid; add_colorbar, transform, cmap, vmin, vmax)
+
+    Nf = grid["faces"] |> keys |> length
+    Nx = grid["faces/1/Nx"]
+    Ny = grid["faces/1/Ny"]
+    Hx = grid["faces/1/Hx"]
+    Hy = grid["faces/1/Hy"]
+
+    for face in 1:Nf
+        λᶠᶠᵃ = grid["faces/$face/λᶠᶠᵃ"][1+Hx:Nx+2Hx, 1+Hy:Ny+2Hy]
+        φᶠᶠᵃ = grid["faces/$face/φᶠᶠᵃ"][1+Hx:Nx+2Hx, 1+Hy:Ny+2Hy]
+
+        var_face = var[face][:, :, 1]
+
+        var_face_masked = ma.masked_where(np.isnan(var_face), var_face)
+
+        im = ax.pcolormesh(λᶠᶠᵃ, φᶠᶠᵃ, var_face_masked; transform, cmap, vmin, vmax)
+
+        # Add colorbar below all the subplots.
+        if add_colorbar && face == Nf
+            ax_cbar = fig.add_axes([0.25, 0.1, 0.5, 0.02])
+            fig.colorbar(im, cax=ax_cbar, orientation="horizontal")
+        end
+
+        ax.set_global()
+    end
+
+    return ax
+end
+
+function animate_rossby_haurwitz_three_spheres(; projection=ccrs.NearsidePerspective(central_longitude=0, central_latitude=0))
+
+    ## Extract data
+
+    file = jldopen("cubed_sphere_rossby_haurwitz.jld2")
+
+    iterations = parse.(Int, keys(file["timeseries/t"]))
+
+    ## Makie movie of u, v, η
+
+    for (n, i) in enumerate(iterations)
+        @info "Plotting iteration $i/$(iterations[end]) (frame $n/$(length(iterations)))..."
+
+        u = file["timeseries/u/$i"]
+        v = file["timeseries/v/$i"]
+        η = file["timeseries/η/$i"]
+
+        t = prettytime(file["timeseries/t/$i"])
+        plot_title = "Rossby-Haurwitz wave (mode 4) at t = $t"
+
+        fig = plt.figure(figsize=(16, 9))
+
+        ax = fig.add_subplot(1, 3, 1, projection=projection)
+        plot_cubed_sphere_tracer_field!(fig, ax, u, file["grid"], transform=ccrs.PlateCarree(), cmap=cmocean.cm.balance, vmin=-80, vmax=80, add_colorbar=false)
+        gl = ax.gridlines(color="gray", alpha=0.5, linestyle="--")
+        gl.xlocator = mticker.FixedLocator(-180:30:180)
+        gl.ylocator = mticker.FixedLocator(-80:20:80)
+
+        ax = fig.add_subplot(1, 3, 2, projection=projection)
+        plot_cubed_sphere_tracer_field!(fig, ax, v, file["grid"], transform=ccrs.PlateCarree(), cmap=cmocean.cm.balance, vmin=-80, vmax=80, add_colorbar=false)
+        gl = ax.gridlines(color="gray", alpha=0.5, linestyle="--")
+        gl.xlocator = mticker.FixedLocator(-180:30:180)
+        gl.ylocator = mticker.FixedLocator(-80:20:80)
+
+        ax = fig.add_subplot(1, 3, 3, projection=projection)
+        plot_cubed_sphere_tracer_field!(fig, ax, η, file["grid"], transform=ccrs.PlateCarree(), cmap=cmocean.cm.balance, vmin=8000, vmax=8250, add_colorbar=false)
+        gl = ax.gridlines(color="gray", alpha=0.5, linestyle="--")
+        gl.xlocator = mticker.FixedLocator(-180:30:180)
+        gl.ylocator = mticker.FixedLocator(-80:20:80)
+
+        fig.suptitle(plot_title, y=0.75)
+
+        filename = @sprintf("cubed_sphere_rossby_haurwitz_%04d.png", n)
+        plt.savefig(filename, dpi=200, bbox_inches="tight")
+        plt.close(fig)
+    end
+
+    close(file)
+
+    filename_pattern = "cubed_sphere_rossby_haurwitz_%04d.png"
+    output_filename  = "cubed_sphere_rossby_haurwitz_three_spheres.mp4"
+
+    # Need extra crop video filter in case we end up with odd number of pixels in width or height.
+    # See: https://stackoverflow.com/a/29582287
+    run(`ffmpeg -y -i $filename_pattern -c:v libx264 -vf "fps=10, crop=trunc(iw/2)*2:trunc(ih/2)*2" -pix_fmt yuv420p $output_filename`)
+
+    [rm(f) for f in glob("cubed_sphere_rossby_haurwitz_*.png")]
+
+    return nothing
+end

--- a/validation/immersed_boundaries/cubed_sphere_rossby_haurwitz.jl
+++ b/validation/immersed_boundaries/cubed_sphere_rossby_haurwitz.jl
@@ -1,0 +1,229 @@
+using Statistics
+using Logging
+using Printf
+using DataDeps
+using JLD2
+
+using Oceananigans
+using Oceananigans.Units
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary
+
+using Oceananigans.Diagnostics: accurate_cell_advection_timescale
+
+Logging.global_logger(OceananigansLogger())
+
+#####
+##### Progress monitor
+#####
+
+mutable struct Progress
+    interval_start_time :: Float64
+end
+
+function (p::Progress)(sim)
+    wall_time = (time_ns() - p.interval_start_time) * 1e-9
+    progress = 100 * (sim.model.clock.time / sim.stop_time)
+
+    @info @sprintf("[%06.2f%%] Time: %s, iteration: %d, max(|u⃗|): (%.2e, %.2e) m/s, extrema(η): (min=%.2e, max=%.2e), CFL: %.2e, Δ(wall time): %s",
+                   progress,
+                   prettytime(sim.model.clock.time),
+                   sim.model.clock.iteration,
+                   maximum(abs, sim.model.velocities.u),
+                   maximum(abs, sim.model.velocities.v),
+                   minimum(sim.model.free_surface.η),
+                   maximum(sim.model.free_surface.η),
+                   sim.parameters.cfl(sim.model),
+                   prettytime(wall_time))
+
+    p.interval_start_time = time_ns()
+
+    return nothing
+end
+
+#####
+##### Script starts here
+#####
+
+ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"
+
+Logging.global_logger(OceananigansLogger())
+
+dd32 = DataDep("cubed_sphere_32_grid",
+    "Conformal cubed sphere grid with 32×32 grid points on each face",
+    "https://github.com/CliMA/OceananigansArtifacts.jl/raw/main/cubed_sphere_grids/cubed_sphere_32_grid.jld2",
+    "b1dafe4f9142c59a2166458a2def743cd45b20a4ed3a1ae84ad3a530e1eff538" # sha256sum
+)
+
+dd96 = DataDep("cubed_sphere_96_grid",
+    "Conformal cubed sphere grid with 96×96 grid points on each face",
+    "https://github.com/CliMA/OceananigansArtifacts.jl/raw/main/cubed_sphere_grids/cs96/cubed_sphere_96_grid.jld2"
+)
+
+DataDeps.register(dd32)
+DataDeps.register(dd96)
+
+function diagnose_velocities_from_streamfunction(ψ, grid)
+    ψᶠᶠᶜ = Field(Face, Face,   Center, CPU(), grid)
+    uᶠᶜᶜ = Field(Face, Center, Center, CPU(), grid)
+    vᶜᶠᶜ = Field(Center, Face, Center, CPU(), grid)
+
+    for (f, grid_face) in enumerate(grid.faces)
+        Nx, Ny, Nz = size(grid_face)
+
+        ψᶠᶠᶜ_face = ψᶠᶠᶜ.data.faces[f]
+        uᶠᶜᶜ_face = uᶠᶜᶜ.data.faces[f]
+        vᶜᶠᶜ_face = vᶜᶠᶜ.data.faces[f]
+
+        for i in 1:Nx+1, j in 1:Ny+1
+            ψᶠᶠᶜ_face[i, j, 1] = ψ(grid_face.λᶠᶠᵃ[i, j], grid_face.φᶠᶠᵃ[i, j])
+        end
+
+        for i in 1:Nx+1, j in 1:Ny
+            uᶠᶜᶜ_face[i, j, 1] = (ψᶠᶠᶜ_face[i, j, 1] - ψᶠᶠᶜ_face[i, j+1, 1]) / grid.faces[f].Δyᶠᶜᵃ[i, j]
+        end
+
+        for i in 1:Nx, j in 1:Ny+1
+            vᶜᶠᶜ_face[i, j, 1] = (ψᶠᶠᶜ_face[i+1, j, 1] - ψᶠᶠᶜ_face[i, j, 1]) / grid.faces[f].Δxᶜᶠᵃ[i, j]
+        end
+    end
+
+    return uᶠᶜᶜ, vᶜᶠᶜ, ψᶠᶠᶜ
+end
+
+function cubed_sphere_rossby_haurwitz(grid_filepath; check_fields=false)
+
+    ## Grid setup
+
+    H = 8kilometers
+    underlying_grid = ConformalCubedSphereGrid(grid_filepath, Nz=1, z=(-H, 0))
+
+    #solid(x, y, z) = false
+    #grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBoundary(solid))
+    grid = underlying_grid
+
+    ## Model setup
+
+    model = HydrostaticFreeSurfaceModel(
+              architecture = CPU(),
+                      grid = grid,
+        momentum_advection = VectorInvariant(),
+              free_surface = ExplicitFreeSurface(gravitational_acceleration=100),
+                  coriolis = HydrostaticSphericalCoriolis(scheme = VectorInvariantEnstrophyConserving()),
+                   closure = nothing,
+                   tracers = nothing,
+                  buoyancy = nothing
+    )
+
+    ## Rossby-Haurwitz initial condition from Williamson et al. (§3.6, 1992)
+    ## # here: θ ∈ [-π/2, π/2] is latitude, ϕ ∈ [0, 2π) is longitude
+
+    R = grid.faces[1].radius
+    K = 7.848e-6
+    ω = 0
+    n = 4
+
+    g = model.free_surface.gravitational_acceleration
+    Ω = model.coriolis.rotation_rate
+
+    A(θ) = ω/2 * (2 * Ω + ω) * cos(θ)^2 + 1/4 * K^2 * cos(θ)^(2*n) * ((n+1) * cos(θ)^2 + (2 * n^2 - n - 2) - 2 * n^2 * sec(θ)^2 )
+    B(θ) = 2 * K * (Ω + ω) * ((n+1) * (n+2))^(-1) * cos(θ)^(n) * ( n^2 + 2*n + 2 - (n+1)^2 * cos(θ)^2) # why not  (n+1)^2 sin(θ)^2 + 1
+    C(θ)  = 1/4 * K^2 * cos(θ)^(2 * n) * ( (n+1) * cos(θ)^2 - (n+2))
+
+    ψ(θ, ϕ) = -R^2 * ω * sin(θ)^2 + R^2 * K * cos(θ)^n * sin(θ) * cos(n*ϕ)
+
+    u(θ, ϕ) =  R * ω * cos(θ) + R * K * cos(θ)^(n-1) * (n * sin(θ)^2 - cos(θ)^2) * cos(n*ϕ)
+    v(θ, ϕ) = -n * K * R * cos(θ)^(n-1) * sin(θ) * sin(n*ϕ)
+
+    h(θ, ϕ) = H + R^2/g * (A(θ) + B(θ) * cos(n * ϕ) + C(θ) * cos(2n * ϕ))
+
+    # Total initial conditions
+    # Previously: θ ∈ [-π/2, π/2] is latitude, ϕ ∈ [0, 2π) is longitude
+    # Oceananigans: ϕ ∈ [-90, 90], λ ∈ [-180, 180],
+
+    rescale¹(λ) = (λ + 180)/ 360 * 2π # λ to θ
+    rescale²(ϕ) = ϕ / 180 * π # θ to ϕ
+
+    # arguments were u(θ, ϕ), λ |-> ϕ, θ |-> ϕ
+    uᵢ(λ, ϕ, z) = u(rescale²(ϕ), rescale¹(λ))
+    vᵢ(λ, ϕ, z) = v(rescale²(ϕ), rescale¹(λ))
+    ηᵢ(λ, ϕ)    = h(rescale²(ϕ), rescale¹(λ))
+
+    # set!(model, u=uᵢ, v=vᵢ, η = ηᵢ)
+
+    ψ₀(λ, φ) = ψ(rescale²(φ), rescale¹(λ))
+
+    u₀, v₀, _ = diagnose_velocities_from_streamfunction(ψ₀, grid)
+
+    Oceananigans.set!(model, u=u₀, v=v₀, η=ηᵢ)
+
+    ## Simulation setup
+
+    # Compute amount of time needed for a 45° rotation.
+    angular_velocity = (n * (3+n) * ω - 2Ω) / ((1+n) * (2+n))
+    stop_time = deg2rad(360) / abs(angular_velocity)
+    @info "Stop time = $(prettytime(stop_time))"
+
+    Δt = 20seconds
+
+    gravity_wave_speed = sqrt(g * H)
+    min_spacing = filter(!iszero, grid.faces[1].Δyᶠᶠᵃ) |> minimum
+    wave_propagation_time_scale = min_spacing / gravity_wave_speed
+    gravity_wave_cfl = Δt / wave_propagation_time_scale
+    @info "Gravity wave CFL = $gravity_wave_cfl"
+
+    if !isnothing(model.closure)
+        ν = model.closure.νh
+        diffusive_cfl = ν * Δt / min_spacing^2
+        @info "Diffusive CFL = $diffusive_cfl"
+    end
+
+    cfl = CFL(Δt, accurate_cell_advection_timescale)
+
+    simulation = Simulation(model,
+                        Δt = Δt,
+                 stop_time = stop_time,
+        iteration_interval = 20,
+                  progress = Progress(time_ns()),
+                parameters = (; cfl)
+    )
+
+    if check_fields
+        fields_to_check = (
+            u = model.velocities.u,
+            v = model.velocities.v,
+            η = model.free_surface.η
+        )
+
+        simulation.diagnostics[:state_checker] =
+            StateChecker(model, fields=fields_to_check, schedule=IterationInterval(20))
+    end
+
+    output_fields = merge(model.velocities, (η=model.free_surface.η,))
+
+    simulation.output_writers[:fields] =
+    JLD2OutputWriter(model, output_fields,
+        schedule = TimeInterval(1hour),
+          prefix = "cubed_sphere_rossby_haurwitz",
+           force = true)
+
+    run!(simulation)
+
+    return simulation
+end
+
+
+include("animate_on_map_projection.jl")
+
+function run_cubed_sphere_rossby_haurwitz_validation(grid_filepath=datadep"cubed_sphere_32_grid/cubed_sphere_32_grid.jld2")
+
+    simulation = cubed_sphere_rossby_haurwitz(grid_filepath)
+
+    projections = [
+        ccrs.NearsidePerspective(central_longitude=0, central_latitude=30),
+        ccrs.NearsidePerspective(central_longitude=180, central_latitude=-30)
+    ]
+
+    animate_rossby_haurwitz(projections=projections)
+
+    return simulation
+end

--- a/validation/immersed_boundaries/immersed_cubed_sphere_rossby_haurwitz.jl
+++ b/validation/immersed_boundaries/immersed_cubed_sphere_rossby_haurwitz.jl
@@ -148,12 +148,32 @@ function cubed_sphere_rossby_haurwitz(grid_filepath; check_fields=false)
     vᵢ(λ, ϕ, z) = v(rescale²(ϕ), rescale¹(λ))
     ηᵢ(λ, ϕ)    = h(rescale²(ϕ), rescale¹(λ))
 
-    # set!(model, u=uᵢ, v=vᵢ, η = ηᵢ)
+    #=
+    #TODO: get this to work.
+    ψ₀(λ, φ, z) = ψ(rescale²(φ), rescale¹(λ))
+
+    u, v, w = model.velocities
+    ψ = Field(Face, Face, Center, model.architecture, grid)
+    u .= - ∂y(ψ)
+    v .= + ∂x(ψ)
+
+    # Note: this does _not_ fill halos!
+    for i = 1:6
+        face_ψ = Field(Face, Face, Center, model.architecture, get_face(grid, i))
+        set!(face_ψ, ψ₀)
+
+        face_u = get_face(model.velocities.u, i)
+        face_v = get_face(model.velocities.v, i)
+
+        face_u .= - ∂y(face_ψ)
+        face_v .= + ∂x(face_ψ)
+    end
+    =#
 
     ψ₀(λ, φ) = ψ(rescale²(φ), rescale¹(λ))
-
     u₀, v₀, _ = diagnose_velocities_from_streamfunction(ψ₀, grid)
 
+    # _Now_ we fill halos:
     Oceananigans.set!(model, u=u₀, v=v₀, η=ηᵢ)
 
     ## Simulation setup

--- a/validation/immersed_boundaries/immersed_cubed_sphere_rossby_haurwitz.jl
+++ b/validation/immersed_boundaries/immersed_cubed_sphere_rossby_haurwitz.jl
@@ -90,7 +90,7 @@ function diagnose_velocities_from_streamfunction(ψ, grid)
     return uᶠᶜᶜ, vᶜᶠᶜ, ψᶠᶠᶜ
 end
 
-function cubed_sphere_rossby_haurwitz(grid_filepath; check_fields=false, nsteps=nothing, immersed=false)
+function cubed_sphere_rossby_haurwitz(grid_filepath; check_fields=false, nsteps=nothing, immersed=false, momvi=false)
 
     ## Grid setup
 
@@ -107,10 +107,16 @@ function cubed_sphere_rossby_haurwitz(grid_filepath; check_fields=false, nsteps=
 
     ## Model setup
 
+    if momvi
+        momentum_advection = VectorInvariant()
+    else
+        momentum_advection = nothing
+    end
+
     model = HydrostaticFreeSurfaceModel(
               architecture = CPU(),
                       grid = grid,
-        momentum_advection = VectorInvariant(),
+        momentum_advection = momentum_advection,
               free_surface = ExplicitFreeSurface(gravitational_acceleration=100),
                   coriolis = HydrostaticSphericalCoriolis(scheme = VectorInvariantEnstrophyConserving()),
                    closure = nothing,
@@ -260,5 +266,5 @@ function run_cubed_sphere_rossby_haurwitz_validation(grid_filepath=datadep"cubed
 end
 
 grid_filepath=datadep"cubed_sphere_32_grid/cubed_sphere_32_grid.jld2"
-simulation_1 = cubed_sphere_rossby_haurwitz(grid_filepath,check_fields=true,nsteps=1,immersed=true)
-simulation_2 = cubed_sphere_rossby_haurwitz(grid_filepath,check_fields=true,nsteps=1,immersed=false)
+s1 = cubed_sphere_rossby_haurwitz(grid_filepath,check_fields=true,nsteps=1,immersed=true,momvi=false)
+s2 = cubed_sphere_rossby_haurwitz(grid_filepath,check_fields=true,nsteps=1,immersed=false,momvi=false)

--- a/validation/immersed_boundaries/immersed_cubed_sphere_rossby_haurwitz.jl
+++ b/validation/immersed_boundaries/immersed_cubed_sphere_rossby_haurwitz.jl
@@ -191,13 +191,11 @@ function cubed_sphere_rossby_haurwitz(grid_filepath; check_fields=false, nsteps=
     # Compute amount of time needed for a 45° rotation.
     angular_velocity = (n * (3+n) * ω - 2Ω) / ((1+n) * (2+n))
     stop_time = deg2rad(360) / abs(angular_velocity)
-    @info "Stop time = $(prettytime(stop_time))"
-
     Δt = 20seconds
-    stop_time = 23900*Δt
     if nsteps != nothing
         stop_time=nsteps*Δt
     end
+    @info "Stop time = $(prettytime(stop_time))"
 
     gravity_wave_speed = sqrt(g * H)
     min_spacing = filter(!iszero, grid.faces[1].Δyᶠᶠᵃ) |> minimum
@@ -266,5 +264,6 @@ function run_cubed_sphere_rossby_haurwitz_validation(grid_filepath=datadep"cubed
 end
 
 grid_filepath=datadep"cubed_sphere_32_grid/cubed_sphere_32_grid.jld2"
-s1 = cubed_sphere_rossby_haurwitz(grid_filepath,check_fields=true,nsteps=1,immersed=true,momvi=false)
-s2 = cubed_sphere_rossby_haurwitz(grid_filepath,check_fields=true,nsteps=1,immersed=false,momvi=false)
+s1 = cubed_sphere_rossby_haurwitz(grid_filepath,check_fields=true,nsteps=1,immersed=true,momvi=true)
+s2 = cubed_sphere_rossby_haurwitz(grid_filepath,check_fields=true,nsteps=1,immersed=false,momvi=true)
+display([ s1.model.timestepper.Gⁿ.v.data[1][:,1,1]  s2.model.timestepper.Gⁿ.v.data[1][:,1,1] ] )


### PR DESCRIPTION
This PR adds a set of changes so that needed dispatch paths for CubedSphereGrid are followed when CubedSphereFaceGrid tuple is wrapped in an ImmersedBoundary type. 

With these changes the https://github.com/CliMA/Oceananigans.jl/blob/cnh-glw/immersed-cubed-sphere/validation/immersed_boundaries/immersed_cubed_sphere_rossby_haurwitz.jl code works identically for non-immersed and immersed cube sphere. 