### PR TITLE
Changed units in docstring for linear eq of state

### DIFF
--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -100,13 +100,13 @@ can be accomplished by passing `tracers = (:T, :S)` to a model constructor.
 ### Linear equation of state
 
 To use non-default thermal expansion and haline contraction coefficients, say
-``\alpha = 2 \times 10^{-3} \; \text{K}^{-1}`` and ``\beta = 5 \times 10^{-4} \text{ppt}^{-1}`` corresponding to some other
+``\alpha = 2 \times 10^{-3} \; \text{K}^{-1}`` and ``\beta = 5 \times 10^{-4} \text{psu}^{-1}`` corresponding to some other
 fluid, then use
 
 ```jldoctest
-julia> buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=1.67e-4, β=7.80e-4))
+julia> buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=2e-3, β=5e-4))
 SeawaterBuoyancy{Float64}: g = 9.80665
-└── equation of state: LinearEquationOfState{Float64}: α = 1.67e-04, β = 7.80e-04
+└── equation of state: LinearEquationOfState{Float64}: α = 2.00e-03, β = 5.00e-04
 ```
 
 ### Idealized nonlinear equations of state

--- a/src/BuoyancyModels/linear_equation_of_state.jl
+++ b/src/BuoyancyModels/linear_equation_of_state.jl
@@ -13,7 +13,7 @@ end
 
 Returns parameters for a linear equation of state for seawater with
 thermal expansion coefficient `α` [K⁻¹] and haline contraction coefficient
-`β` [ppt⁻¹]. The buoyancy perturbation associated with a linear equation of state is
+`β` [psu⁻¹]. The buoyancy perturbation associated with a linear equation of state is
 
 ```math
     b = g (α T - β S)


### PR DESCRIPTION
Changed units for haline contraction coefficients to match what's listed in table 1.2 of Vallis (from ppt to psu).