### PR TITLE
Unifying approaches for `min_Δxyz`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.58.3"
+version = "0.58.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Grids/regular_rectilinear_grid.jl
+++ b/src/Grids/regular_rectilinear_grid.jl
@@ -275,9 +275,33 @@ all_z_nodes(::Type{Face},   grid::RegularRectilinearGrid) = grid.zF
 # Get minima of grid
 #
 
-min_Δx(grid::RegularRectilinearGrid) = grid.Δx
-min_Δy(grid::RegularRectilinearGrid) = grid.Δy
-min_Δz(grid::RegularRectilinearGrid) = grid.Δz
+function min_Δx(grid::RegularRectilinearGrid)
+    topo = topology(grid)
+    if topo[1] == Flat
+        return Inf
+    else
+        return grid.Δx
+    end
+end
+
+function min_Δy(grid::RegularRectilinearGrid)
+    topo = topology(grid)
+    if topo[2] == Flat
+        return Inf
+    else
+        return grid.Δy
+    end
+end
+
+
+function min_Δz(grid::RegularRectilinearGrid)
+    topo = topology(grid)
+    if topo[3] == Flat
+        return Inf
+    else
+        return grid.Δz
+    end
+end
 
 # All grid metrics are constants / functions / ranges, so there's no architecture.
 architecture(::RegularRectilinearGrid) = nothing

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -323,6 +323,29 @@ all_z_nodes(::Type{Face}, grid::VerticallyStretchedRectilinearGrid) = grid.zᵃ�
 # Get minima of grid
 #
 
-min_Δx(grid::VerticallyStretchedRectilinearGrid) = grid.Δx
-min_Δy(grid::VerticallyStretchedRectilinearGrid) = grid.Δy
-min_Δz(grid::VerticallyStretchedRectilinearGrid) = minimum(view(grid.Δzᵃᵃᶜ, 1:grid.Nz))
+function min_Δx(grid::VerticallyStretchedRectilinearGrid)
+    topo = topology(grid)
+    if topo[1] == Flat
+        return Inf
+    else
+        return grid.Δx
+    end
+end
+
+function min_Δy(grid::VerticallyStretchedRectilinearGrid)
+    topo = topology(grid)
+    if topo[2] == Flat
+        return Inf
+    else
+        return grid.Δy
+    end
+end
+
+function min_Δz(grid::VerticallyStretchedRectilinearGrid)
+    topo = topology(grid)
+    if topo[3] == Flat
+        return Inf
+    else
+        return minimum(view(grid.Δzᵃᵃᶜ, 1:grid.Nz))
+    end
+end

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -2,7 +2,7 @@
 ##### Timescale for diffusion across one cell
 #####
 
-using Oceananigans.Grids: topology
+using Oceananigans.Grids: topology, min_Δx, min_Δy, min_Δz
 
 function min_Δxyz(grid)
     topo = topology(grid)
@@ -11,8 +11,19 @@ function min_Δxyz(grid)
     Δy = minimum_grid_spacing(grid.Δy, topo[2])
     Δz = minimum_grid_spacing(grid.Δz, topo[3])
 
-    return min(Δx, Δy, Δy)
+    return min(Δx, Δy, Δz)
 end
+
+function min_Δxyz(grid::VerticallyStretchedRectilinearGrid)
+    topo = topology(grid)
+
+    Δx = min_Δx(grid)
+    Δy = min_Δy(grid)
+    Δz = min_Δz(grid)
+
+    return min(Δx, Δy, Δz)
+end
+
 
 cell_diffusion_timescale(model) = cell_diffusion_timescale(model.closure, model.diffusivities, model.grid)
 cell_diffusion_timescale(::Nothing, diffusivities, grid) = Inf

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -5,22 +5,9 @@
 using Oceananigans.Grids: topology, min_Δx, min_Δy, min_Δz
 
 function min_Δxyz(grid)
-    topo = topology(grid)
-
-    Δx = minimum_grid_spacing(grid.Δx, topo[1])
-    Δy = minimum_grid_spacing(grid.Δy, topo[2])
-    Δz = minimum_grid_spacing(grid.Δz, topo[3])
-
-    return min(Δx, Δy, Δz)
-end
-
-function min_Δxyz(grid::VerticallyStretchedRectilinearGrid)
-    topo = topology(grid)
-
     Δx = min_Δx(grid)
     Δy = min_Δy(grid)
     Δz = min_Δz(grid)
-
     return min(Δx, Δy, Δz)
 end
 
@@ -35,9 +22,6 @@ maximum_numeric_diffusivity(κ::NamedTuple{()}) = 0 # tracers=nothing means empt
 # As the name suggests, we give up in the case of a function diffusivity
 maximum_numeric_diffusivity(κ::Function) = 0
 
-minimum_grid_spacing(Δx, TX)           = minimum(Δx)
-minimum_grid_spacing(Δx, ::Type{Flat}) = Inf
-
 function cell_diffusion_timescale(closure::IsotropicDiffusivity, diffusivities, grid)
     Δ = min_Δxyz(grid)
     max_κ = maximum_numeric_diffusivity(closure.κ)
@@ -46,11 +30,9 @@ function cell_diffusion_timescale(closure::IsotropicDiffusivity, diffusivities, 
 end
 
 function cell_diffusion_timescale(closure::AnisotropicDiffusivity, diffusivities, grid)
-    topo = topology(grid)
-
-    Δx = minimum_grid_spacing(grid.Δx, topo[1])
-    Δy = minimum_grid_spacing(grid.Δy, topo[2])
-    Δz = minimum_grid_spacing(grid.Δz, topo[3])
+    Δx = min_Δx(grid)
+    Δy = min_Δy(grid)
+    Δz = min_Δz(grid)
 
     max_νx = maximum_numeric_diffusivity(closure.νx)
     max_νy = maximum_numeric_diffusivity(closure.νy)
@@ -69,11 +51,9 @@ function cell_diffusion_timescale(closure::AnisotropicDiffusivity, diffusivities
 end
 
 function cell_diffusion_timescale(closure::AnisotropicBiharmonicDiffusivity, diffusivities, grid)
-    topo = topology(grid)
-
-    Δx = minimum_grid_spacing(grid.Δx, topo[1])
-    Δy = minimum_grid_spacing(grid.Δy, topo[2])
-    Δz = minimum_grid_spacing(grid.Δz, topo[3])
+    Δx = min_Δx(grid)
+    Δy = min_Δy(grid)
+    Δz = min_Δz(grid)
 
     max_νx = maximum_numeric_diffusivity(closure.νx)
     max_νy = maximum_numeric_diffusivity(closure.νy)
@@ -92,11 +72,9 @@ function cell_diffusion_timescale(closure::AnisotropicBiharmonicDiffusivity, dif
 end
 
 function cell_diffusion_timescale(closure::HorizontallyCurvilinearAnisotropicDiffusivity, diffusivities, grid)
-    topo = topology(grid)
-
-    Δx = minimum_grid_spacing(grid.Δx, topo[1])
-    Δy = minimum_grid_spacing(grid.Δy, topo[2])
-    Δz = minimum_grid_spacing(grid.Δz, topo[3])
+    Δx = min_Δx(grid)
+    Δy = min_Δy(grid)
+    Δz = min_Δz(grid)
 
     max_νh = maximum_numeric_diffusivity(closure.νh)
     max_νz = maximum_numeric_diffusivity(closure.νz)
@@ -113,11 +91,9 @@ function cell_diffusion_timescale(closure::HorizontallyCurvilinearAnisotropicDif
 end
 
 function cell_diffusion_timescale(closure::HorizontallyCurvilinearAnisotropicBiharmonicDiffusivity, diffusivities, grid)
-    topo = topology(grid)
-
-    Δx = minimum_grid_spacing(grid.Δx, topo[1])
-    Δy = minimum_grid_spacing(grid.Δy, topo[2])
-    Δz = minimum_grid_spacing(grid.Δz, topo[3])
+    Δx = min_Δx(grid)
+    Δy = min_Δy(grid)
+    Δz = min_Δz(grid)
 
     max_νh = maximum_numeric_diffusivity(closure.νh)
     max_νz = maximum_numeric_diffusivity(closure.νz)

--- a/src/Utils/cell_advection_timescale.jl
+++ b/src/Utils/cell_advection_timescale.jl
@@ -1,35 +1,15 @@
-using Oceananigans.Grids: topology
-
-minimum_grid_spacing(Δx, TX          ) = CUDA.@allowscalar minimum(Δx)
-minimum_grid_spacing(Δx, ::Type{Flat}) = Inf
+using Oceananigans.Grids: topology, min_Δx, min_Δy, min_Δz
 
 "Returns the time-scale for advection on a regular grid across a single grid cell."
-function cell_advection_timescale(u, v, w, grid::RegularRectilinearGrid)
+function cell_advection_timescale(u, v, w, grid)
 
     umax = maximum(abs, u)
     vmax = maximum(abs, v)
     wmax = maximum(abs, w)
 
-    topo = topology(grid)
-
-    Δx = minimum_grid_spacing(grid.Δx, topo[1])
-    Δy = minimum_grid_spacing(grid.Δy, topo[2])
-    Δz = minimum_grid_spacing(grid.Δz, topo[3])
-
-    return min(Δx/umax, Δy/vmax, Δz/wmax)
-end
-
-function cell_advection_timescale(u, v, w, grid::VerticallyStretchedRectilinearGrid)
-
-    umax = maximum(abs, u)
-    vmax = maximum(abs, v)
-    wmax = maximum(abs, w)
-
-    topo = topology(grid)
-
-    Δx = minimum_grid_spacing(grid.Δx,    topo[1])
-    Δy = minimum_grid_spacing(grid.Δy,    topo[2])
-    Δz = minimum_grid_spacing(grid.Δzᵃᵃᶠ, topo[3])
+    Δx = min_Δx(grid)
+    Δy = min_Δy(grid)
+    Δz = min_Δz(grid)
 
     return min(Δx/umax, Δy/vmax, Δz/wmax)
 end


### PR DESCRIPTION
Closes https://github.com/CliMA/Oceananigans.jl/issues/1749

Apparently there are currently two ways to get minimum spacing from a grid, and they work a bit differently from each other, which is causing some problems with `VerticallyStretchedGrids`.

Option 1. This way works with `VerticallyStretchedGrids` and `RegularGrids`, whre each type of grid defines these separately.

```julia
    Δx = min_Δx(grid)
    Δy = min_Δy(grid)
    Δz = min_Δz(grid) 
```

Option 2: I suspect this was added recently (idk when or which commit) and it appears to be an ad-hoc way of dealing with flat dimensions.

```julia 
    Δx = minimum_grid_spacing(grid.Δx, topo[1])
    Δy = minimum_grid_spacing(grid.Δy, topo[2])
    Δz = minimum_grid_spacing(grid.Δz, topo[3])
```

I'm including both ways in my first commit (which solves an issue for `VerticallyStretchedGrids`) but I'm thinking of unifying this and use only `min_Δx`, which is imo more succinct and can also take Flat topologies into account.