### PR TITLE
Correct min_Δz for VerticallyStretchedGrids

### DIFF
--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -206,7 +206,7 @@ function generate_stretched_vertical_grid(FT, z_topo, Nz, Hz, z_faces)
     z¹, zᴺ⁺¹ = interior_zF[1], interior_zF[Nz+1]
 
     zF₋ = [z¹   - sum(ΔzF₋[k:Hz]) for k = 1:Hz] # locations of faces in lower halo
-    zF₊ = [zᴺ⁺¹ + ΔzF₊[k]         for k = 1:Hz] # locations of faces in width of top halo region
+    zF₊ = reverse([zᴺ⁺¹ + sum(ΔzF₊[k:Hz]) for k = 1:Hz]) # locations of faces in width of top halo region
 
     zF = vcat(zF₋, interior_zF, zF₊)
 

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -342,6 +342,6 @@ function min_Δz(grid::VerticallyStretchedRectilinearGrid)
     if topo[3] == Flat
         return Inf
     else
-        return minimum(view(parent(grid.Δzᵃᵃᶜ), 1:grid.Nz))
+        return minimum(parent(grid.Δzᵃᵃᶜ))
     end
 end

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -346,6 +346,6 @@ function min_Δz(grid::VerticallyStretchedRectilinearGrid)
     if topo[3] == Flat
         return Inf
     else
-        return minimum(view(grid.Δzᵃᵃᶜ, 1:grid.Nz))
+        return minimum(view(parent(grid.Δzᵃᵃᶜ), 1:grid.Nz))
     end
 end

--- a/test/test_simulations.jl
+++ b/test/test_simulations.jl
@@ -10,7 +10,6 @@ function run_time_step_wizard_tests(arch)
     CFL = 0.45
     u₀ = 7
     Δt = 2.5
-
     model.velocities.u[1, 1, 1] = u₀
 
     wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0)
@@ -34,6 +33,23 @@ function run_time_step_wizard_tests(arch)
     wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0, max_Δt=3.99)
     update_Δt!(wizard, model)
     @test wizard.Δt ≈ 3.99
+
+
+    grid_stretched = VerticallyStretchedRectilinearGrid(size=(1,1,1), x=(0,1), y=(0,1), z_faces=z->z, 
+                                                        halo=(1,1,1), architecture=arch)
+    model = IncompressibleModel(architecture=arch, grid=grid_stretched)
+
+    Δx = grid_stretched.Δx
+    CFL = 0.45
+    u₀ = 7
+    Δt = 2.5
+    model.velocities.u[1, 1, 1] = u₀
+
+    CUDA.allowscalar(false)
+    wizard = TimeStepWizard(cfl=CFL, Δt=Δt, max_change=Inf, min_change=0)
+    update_Δt!(wizard, model)
+    @test wizard.Δt ≈ CFL * Δx / u₀
+    CUDA.allowscalar(true)
 
     return nothing
 end


### PR DESCRIPTION
Using `min_Δz(grid::VerticallyStretchedRectilinearGrid)` on GPU fails. The reason is that

```julia
julia> minimum(view(grid.Δzᵃᵃᶜ, 1:grid.Nz))
ERROR: scalar getindex is disallowed
```
fails on the GPU. The line should be `minimum(view(parent(grid.Δzᵃᵃᶜ), 1:grid.Nz))`.

This error had been there all along but I guess no one caught it. This commit should fix it, but should we also include a test that would catch it?