### PR TITLE
Removes manual grid manipulation in VerticallyStretchedRectilinearGrid constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.58.4"
+version = "0.58.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -157,10 +157,6 @@ function VerticallyStretchedRectilinearGrid(FT = Float64;
     Δzᵃᵃᶠ = OffsetArray(Δzᵃᵃᶠ, -Hz)
     Δzᵃᵃᶜ = OffsetArray(Δzᵃᵃᶜ, -Hz)
 
-    # Needed for pressure solver solution to be divergence-free.
-    # Will figure out why later...
-    Δzᵃᵃᶠ[Nz] = Δzᵃᵃᶠ[Nz-1]
-
     # Seems needed to avoid out-of-bounds error in viscous dissipation
     # operators wanting to access Δzᵃᵃᶠ[Nz+2].
     Δzᵃᵃᶠ = OffsetArray(cat(Δzᵃᵃᶠ[0], Δzᵃᵃᶠ..., Δzᵃᵃᶠ[Nz], dims=1), -Hz-1)


### PR DESCRIPTION
These lines should not be there and at the least lower the accuracy of calculations on stretched grids.

We need tests that the metrics and grid geometry are correct for stretched grids (eg all the cell spacings added up gives the total domain size; cell centers are located halfway between cell interfaces, etc). 

Not sure why these lines are there but it may have been necessary due to a serious bug with the vertically stretched Poisson solver that was fixed in https://github.com/CliMA/Oceananigans.jl/pull/1541. I'm not sure.

