### PR TITLE
Move simulation tips from using KernelComputedFields to KernelFunctionOperation

### DIFF
--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -128,8 +128,7 @@ look like this:
 
 ```julia
 using Oceananigans.Operators
-using Oceananigans.Grids: Center, Face
-using Oceananigans.Fields: KernelFunctionOperation
+using Oceananigans.AbstractOperations: KernelFunctionOperation
 
 @inline fψ_plus_gφ²(i, j, k, grid, f, ψ, g, φ) = @inbounds (f(i, j, k, grid, ψ) + g(i, j, k, grid, φ))^2
 function isotropic_viscous_dissipation_rate_ccc(i, j, k, grid, u, v, w, ν)
@@ -143,7 +142,7 @@ function isotropic_viscous_dissipation_rate_ccc(i, j, k, grid, u, v, w, ν)
 
     ϵ[i, j, k] = ν[i, j, k] * 2 * (Σˣˣ² + Σʸʸ² + Σᶻᶻ² + 2 * (Σˣʸ² + Σˣᶻ² + Σʸᶻ²))
 end
-ε = ComputedField(KernelFunctionOperation(Center, Center, Center, isotropic_viscous_dissipation_rate_ccc, grid;
+ε = ComputedField(KernelFunctionOperation{Center, Center, Center}(isotropic_viscous_dissipation_rate_ccc, grid;
                          computed_dependencies=(u, v, w, ν)))
 ```
 

--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -96,6 +96,9 @@ For example, in the example below, calculating `u²` works in both CPUs and GPUs
 `ε` will not compile on GPUs when we call the command `compute!`:
 
 ```julia
+using Oceananigans
+grid = RegularRectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
+model = IncompressibleModel(grid=grid, closure=IsotropicDiffusivity(ν=1e-6))
 u, v, w = model.velocities
 ν = model.closure.ν
 u² = ComputedField(u^2)
@@ -140,7 +143,7 @@ function isotropic_viscous_dissipation_rate_ccc(i, j, k, grid, u, v, w, ν)
     Σˣᶻ² = ℑxzᶜᵃᶜ(i, j, k, grid, fψ_plus_gφ², ∂zᵃᵃᶠ, u, ∂xᶠᵃᵃ, w) / 4
     Σʸᶻ² = ℑyzᵃᶜᶜ(i, j, k, grid, fψ_plus_gφ², ∂zᵃᵃᶠ, v, ∂yᵃᶠᵃ, w) / 4
 
-    ϵ[i, j, k] = ν[i, j, k] * 2 * (Σˣˣ² + Σʸʸ² + Σᶻᶻ² + 2 * (Σˣʸ² + Σˣᶻ² + Σʸᶻ²))
+    return ν[i, j, k] * 2 * (Σˣˣ² + Σʸʸ² + Σᶻᶻ² + 2 * (Σˣʸ² + Σˣᶻ² + Σʸᶻ²))
 end
 ε = ComputedField(KernelFunctionOperation{Center, Center, Center}(isotropic_viscous_dissipation_rate_ccc, grid;
                          computed_dependencies=(u, v, w, ν)))


### PR DESCRIPTION
First attempt at this. Still wasn't able to make sure the code in the example works.

In fact, so far it has failed:


```julia
julia> using Oceananigans.Operators

julia> using Oceananigans.Grids

julia> function isotropic_viscous_dissipation_rate_ccc(i, j, k, grid, u, v, w, ν)
           Σˣˣ² = ∂xᶜᵃᵃ(i, j, k, grid, u)^2
           Σʸʸ² = ∂yᵃᶜᵃ(i, j, k, grid, v)^2
           Σᶻᶻ² = ∂zᵃᵃᶜ(i, j, k, grid, w)^2

           Σˣʸ² = ℑxyᶜᶜᵃ(i, j, k, grid, fψ_plus_gφ², ∂yᵃᶠᵃ, u, ∂xᶠᵃᵃ, v) / 4
           Σˣᶻ² = ℑxzᶜᵃᶜ(i, j, k, grid, fψ_plus_gφ², ∂zᵃᵃᶠ, u, ∂xᶠᵃᵃ, w) / 4
           Σʸᶻ² = ℑyzᵃᶜᶜ(i, j, k, grid, fψ_plus_gφ², ∂zᵃᵃᶠ, v, ∂yᵃᶠᵃ, w) / 4

           ϵ[i, j, k] = ν[i, j, k] * 2 * (Σˣˣ² + Σʸʸ² + Σᶻᶻ² + 2 * (Σˣʸ² + Σˣᶻ² + Σʸᶻ²))
       end
isotropic_viscous_dissipation_rate_ccc (generic function with 1 method)

julia> ε = KernelFunctionOperation(Center, Center, Center, isotropic_viscous_dissipation_rate_ccc, grid;
                                computed_dependencies=(u, v, w, ν))
ERROR: MethodError: no method matching KernelFunctionOperation(::Type{Center}, ::Type{Center}, ::Type{Center}, ::typeof(isotropic_viscous_dissipation_rate_ccc), ::RegularRectilinearGrid{Float64, Periodic, Periodic, Bounded, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}}; computed_dependencies=(Field located at (Face, Center, Center)
├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (1, 1, 1)
├── grid: RegularRectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
└── boundary conditions: x=(west=Periodic, east=Periodic), y=(south=Periodic, north=Periodic), z=(bottom=ZeroFlux, top=ZeroFlux), Field located at (Center, Face, Center)
├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (1, 1, 1)
├── grid: RegularRectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
└── boundary conditions: x=(west=Periodic, east=Periodic), y=(south=Periodic, north=Periodic), z=(bottom=ZeroFlux, top=ZeroFlux), Field located at (Center, Center, Face)
├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (1, 1, 2)
├── grid: RegularRectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
└── boundary conditions: x=(west=Periodic, east=Periodic), y=(south=Periodic, north=Periodic), z=(bottom=NormalFlow, top=NormalFlow), 1))
Stacktrace:
 [1] top-level scope
   @ REPL[39]:1
```