### PR TITLE
Exponentiate with Int32 not Int64

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.58.5"
+version = "0.58.6"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Advection/weno_fifth_order.jl
+++ b/src/Advection/weno_fifth_order.jl
@@ -46,7 +46,9 @@ struct WENO5 <: AbstractUpwindBiasedAdvectionScheme end
 ##### Jiang & Shu (1996) WENO smoothness indicators. See also Equation 2.63 in Shu (1998).
 #####
 
-const two_32 = Int32(2) # hut, hut...
+# We use 32-bit integer to represent the exponent "2" for fast exponentiation.
+# See https://github.com/CliMA/Oceananigans.jl/pull/1770 for more information.
+const two_32 = Int32(2) 
 
 @inline left_biased_βx₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-1, j, k] - 2ψ[i,   j, k] + ψ[i+1, j, k])^two_32 + 1/4 * (3ψ[i-1, j, k] - 4ψ[i,   j, k] +  ψ[i+1, j, k])^two_32
 @inline left_biased_βx₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-2, j, k] - 2ψ[i-1, j, k] + ψ[i,   j, k])^two_32 + 1/4 * ( ψ[i-2, j, k]                 -  ψ[i,   j, k])^two_32
@@ -88,8 +90,10 @@ const C3₂ = 1/10
 #####
 
 # Note: these constants may need to be changed for smooth solutions and/or fine grid.
-const ε = 1e-6
+# Note note: we use 32-bit integer to represent the exponent "2" for fast exponentiation.
+# see https://github.com/CliMA/Oceananigans.jl/pull/1770 for more information.
 const ƞ = Int32(2) # WENO exponent
+const ε = 1e-6
 
 @inline left_biased_αx₀(i, j, k, ψ) = C3₀ / (left_biased_βx₀(i, j, k, ψ) + ε)^ƞ
 @inline left_biased_αx₁(i, j, k, ψ) = C3₁ / (left_biased_βx₁(i, j, k, ψ) + ε)^ƞ

--- a/src/Advection/weno_fifth_order.jl
+++ b/src/Advection/weno_fifth_order.jl
@@ -46,32 +46,34 @@ struct WENO5 <: AbstractUpwindBiasedAdvectionScheme end
 ##### Jiang & Shu (1996) WENO smoothness indicators. See also Equation 2.63 in Shu (1998).
 #####
 
-@inline left_biased_βx₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-1, j, k] - 2ψ[i,   j, k] + ψ[i+1, j, k])^2 + 1/4 * (3ψ[i-1, j, k] - 4ψ[i,   j, k] +  ψ[i+1, j, k])^2
-@inline left_biased_βx₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-2, j, k] - 2ψ[i-1, j, k] + ψ[i,   j, k])^2 + 1/4 * ( ψ[i-2, j, k]                 -  ψ[i,   j, k])^2
-@inline left_biased_βx₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-3, j, k] - 2ψ[i-2, j, k] + ψ[i-1, j, k])^2 + 1/4 * ( ψ[i-3, j, k] - 4ψ[i-2, j, k] + 3ψ[i-1, j, k])^2
+const two_32 = Int32(2) # hut, hut...
 
-@inline left_biased_βy₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-1, k] - 2ψ[i, j,   k] + ψ[i, j+1, k])^2 + 1/4 * (3ψ[i, j-1, k] - 4ψ[i,   j, k] +  ψ[i, j+1, k])^2
-@inline left_biased_βy₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-2, k] - 2ψ[i, j-1, k] + ψ[i, j,   k])^2 + 1/4 * ( ψ[i, j-2, k]                 -  ψ[i,   j, k])^2
-@inline left_biased_βy₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-3, k] - 2ψ[i, j-2, k] + ψ[i, j-1, k])^2 + 1/4 * ( ψ[i, j-3, k] - 4ψ[i, j-2, k] + 3ψ[i, j-1, k])^2
+@inline left_biased_βx₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-1, j, k] - 2ψ[i,   j, k] + ψ[i+1, j, k])^two_32 + 1/4 * (3ψ[i-1, j, k] - 4ψ[i,   j, k] +  ψ[i+1, j, k])^two_32
+@inline left_biased_βx₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-2, j, k] - 2ψ[i-1, j, k] + ψ[i,   j, k])^two_32 + 1/4 * ( ψ[i-2, j, k]                 -  ψ[i,   j, k])^two_32
+@inline left_biased_βx₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-3, j, k] - 2ψ[i-2, j, k] + ψ[i-1, j, k])^two_32 + 1/4 * ( ψ[i-3, j, k] - 4ψ[i-2, j, k] + 3ψ[i-1, j, k])^two_32
 
-@inline left_biased_βz₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-1] - 2ψ[i, j,   k] + ψ[i, j, k+1])^2 + 1/4 * (3ψ[i, j, k-1] - 4ψ[i, j,   k] +  ψ[i, j, k+1])^2
-@inline left_biased_βz₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-2] - 2ψ[i, j, k-1] + ψ[i, j,   k])^2 + 1/4 * ( ψ[i, j, k-2]                 -  ψ[i, j,   k])^2
-@inline left_biased_βz₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-3] - 2ψ[i, j, k-2] + ψ[i, j, k-1])^2 + 1/4 * ( ψ[i, j, k-3] - 4ψ[i, j, k-2] + 3ψ[i, j, k-1])^2
+@inline left_biased_βy₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-1, k] - 2ψ[i, j,   k] + ψ[i, j+1, k])^two_32 + 1/4 * (3ψ[i, j-1, k] - 4ψ[i,   j, k] +  ψ[i, j+1, k])^two_32
+@inline left_biased_βy₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-2, k] - 2ψ[i, j-1, k] + ψ[i, j,   k])^two_32 + 1/4 * ( ψ[i, j-2, k]                 -  ψ[i,   j, k])^two_32
+@inline left_biased_βy₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-3, k] - 2ψ[i, j-2, k] + ψ[i, j-1, k])^two_32 + 1/4 * ( ψ[i, j-3, k] - 4ψ[i, j-2, k] + 3ψ[i, j-1, k])^two_32
+
+@inline left_biased_βz₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-1] - 2ψ[i, j,   k] + ψ[i, j, k+1])^two_32 + 1/4 * (3ψ[i, j, k-1] - 4ψ[i, j,   k] +  ψ[i, j, k+1])^two_32
+@inline left_biased_βz₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-2] - 2ψ[i, j, k-1] + ψ[i, j,   k])^two_32 + 1/4 * ( ψ[i, j, k-2]                 -  ψ[i, j,   k])^two_32
+@inline left_biased_βz₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-3] - 2ψ[i, j, k-2] + ψ[i, j, k-1])^two_32 + 1/4 * ( ψ[i, j, k-3] - 4ψ[i, j, k-2] + 3ψ[i, j, k-1])^two_32
 
 # Right-biased smoothness indicators are a reflection or "symmetric modification" of the left-biased smoothness
 # indicators around grid point `i-1/2`.
 
-@inline right_biased_βx₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i,   j, k] - 2ψ[i+1, j, k] + ψ[i+2, j, k])^2 + 1/4 * ( ψ[i,   j, k] - 4ψ[i+1, j, k] + 3ψ[i+2, j, k])^2
-@inline right_biased_βx₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-1, j, k] - 2ψ[i,   j, k] + ψ[i+1, j, k])^2 + 1/4 * ( ψ[i-1, j, k]                 -  ψ[i+1, j, k])^2
-@inline right_biased_βx₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-2, j, k] - 2ψ[i-1, j, k] + ψ[i,   j, k])^2 + 1/4 * (3ψ[i-2, j, k] - 4ψ[i-1, j, k] +  ψ[i,   j, k])^2
+@inline right_biased_βx₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i,   j, k] - 2ψ[i+1, j, k] + ψ[i+2, j, k])^two_32 + 1/4 * ( ψ[i,   j, k] - 4ψ[i+1, j, k] + 3ψ[i+2, j, k])^two_32
+@inline right_biased_βx₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-1, j, k] - 2ψ[i,   j, k] + ψ[i+1, j, k])^two_32 + 1/4 * ( ψ[i-1, j, k]                 -  ψ[i+1, j, k])^two_32
+@inline right_biased_βx₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-2, j, k] - 2ψ[i-1, j, k] + ψ[i,   j, k])^two_32 + 1/4 * (3ψ[i-2, j, k] - 4ψ[i-1, j, k] +  ψ[i,   j, k])^two_32
 
-@inline right_biased_βy₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j,   k] - 2ψ[i, j+1, k] + ψ[i, j+2, k])^2 + 1/4 * ( ψ[i,   j, k] - 4ψ[i, j+1, k] + 3ψ[i, j+2, k])^2
-@inline right_biased_βy₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-1, k] - 2ψ[i, j,   k] + ψ[i, j+1, k])^2 + 1/4 * ( ψ[i, j-1, k]                 -  ψ[i, j+1, k])^2
-@inline right_biased_βy₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-2, k] - 2ψ[i, j-1, k] + ψ[i, j,   k])^2 + 1/4 * (3ψ[i, j-2, k] - 4ψ[i, j-1, k] +  ψ[i,   j, k])^2
+@inline right_biased_βy₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j,   k] - 2ψ[i, j+1, k] + ψ[i, j+2, k])^two_32 + 1/4 * ( ψ[i,   j, k] - 4ψ[i, j+1, k] + 3ψ[i, j+2, k])^two_32
+@inline right_biased_βy₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-1, k] - 2ψ[i, j,   k] + ψ[i, j+1, k])^two_32 + 1/4 * ( ψ[i, j-1, k]                 -  ψ[i, j+1, k])^two_32
+@inline right_biased_βy₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-2, k] - 2ψ[i, j-1, k] + ψ[i, j,   k])^two_32 + 1/4 * (3ψ[i, j-2, k] - 4ψ[i, j-1, k] +  ψ[i,   j, k])^two_32
 
-@inline right_biased_βz₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j,   k] - 2ψ[i, j, k+1] + ψ[i, j, k+2])^2 + 1/4 * ( ψ[i, j,   k] - 4ψ[i, j, k+1] + 3ψ[i, j, k+2])^2
-@inline right_biased_βz₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-1] - 2ψ[i, j,   k] + ψ[i, j, k+1])^2 + 1/4 * ( ψ[i, j, k-1]                 -  ψ[i, j, k+1])^2
-@inline right_biased_βz₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-2] - 2ψ[i, j, k-1] + ψ[i, j,   k])^2 + 1/4 * (3ψ[i, j, k-2] - 4ψ[i, j, k-1] +  ψ[i, j,   k])^2
+@inline right_biased_βz₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j,   k] - 2ψ[i, j, k+1] + ψ[i, j, k+2])^two_32 + 1/4 * ( ψ[i, j,   k] - 4ψ[i, j, k+1] + 3ψ[i, j, k+2])^two_32
+@inline right_biased_βz₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-1] - 2ψ[i, j,   k] + ψ[i, j, k+1])^two_32 + 1/4 * ( ψ[i, j, k-1]                 -  ψ[i, j, k+1])^two_32
+@inline right_biased_βz₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-2] - 2ψ[i, j, k-1] + ψ[i, j,   k])^two_32 + 1/4 * (3ψ[i, j, k-2] - 4ψ[i, j, k-1] +  ψ[i, j,   k])^two_32
 
 #####
 ##### WENO-5 optimal weights
@@ -87,7 +89,7 @@ const C3₂ = 1/10
 
 # Note: these constants may need to be changed for smooth solutions and/or fine grid.
 const ε = 1e-6
-const ƞ = 2  # WENO exponent
+const ƞ = Int32(2) # WENO exponent
 
 @inline left_biased_αx₀(i, j, k, ψ) = C3₀ / (left_biased_βx₀(i, j, k, ψ) + ε)^ƞ
 @inline left_biased_αx₁(i, j, k, ψ) = C3₁ / (left_biased_βx₁(i, j, k, ψ) + ε)^ƞ


### PR DESCRIPTION
"2... 32... hut, hut... !"

No idea if this resolves #1764 but perhaps.

Why? Because CUDA replaces `Int64` with `Float64` when exponentiating:

https://github.com/JuliaGPU/CUDA.jl/blob/5d6127dbbef495c94d3dd8de98162188062e11b1/src/device/intrinsics/math.jl#L218-L224

(If I'm understanding that code correctly.)

For `Int32` it calls CUDA function that's specific to integer exponents.

Hmm!