### PR TITLE
Use literal square rather than exponentiation for WENO5

### DIFF
--- a/src/Advection/weno_fifth_order.jl
+++ b/src/Advection/weno_fifth_order.jl
@@ -46,32 +46,34 @@ struct WENO5 <: AbstractUpwindBiasedAdvectionScheme{2} end
 ##### Jiang & Shu (1996) WENO smoothness indicators. See also Equation 2.63 in Shu (1998).
 #####
 
-@inline left_biased_βx₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-1, j, k] - 2ψ[i,   j, k] + ψ[i+1, j, k])^2 + 1/4 * (3ψ[i-1, j, k] - 4ψ[i,   j, k] +  ψ[i+1, j, k])^2
-@inline left_biased_βx₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-2, j, k] - 2ψ[i-1, j, k] + ψ[i,   j, k])^2 + 1/4 * ( ψ[i-2, j, k]                 -  ψ[i,   j, k])^2
-@inline left_biased_βx₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-3, j, k] - 2ψ[i-2, j, k] + ψ[i-1, j, k])^2 + 1/4 * ( ψ[i-3, j, k] - 4ψ[i-2, j, k] + 3ψ[i-1, j, k])^2
+@inline pow2(x) = x * x
 
-@inline left_biased_βy₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-1, k] - 2ψ[i, j,   k] + ψ[i, j+1, k])^2 + 1/4 * (3ψ[i, j-1, k] - 4ψ[i,   j, k] +  ψ[i, j+1, k])^2
-@inline left_biased_βy₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-2, k] - 2ψ[i, j-1, k] + ψ[i, j,   k])^2 + 1/4 * ( ψ[i, j-2, k]                 -  ψ[i,   j, k])^2
-@inline left_biased_βy₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-3, k] - 2ψ[i, j-2, k] + ψ[i, j-1, k])^2 + 1/4 * ( ψ[i, j-3, k] - 4ψ[i, j-2, k] + 3ψ[i, j-1, k])^2
+@inline left_biased_βx₀(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i-1, j, k] - 2ψ[i,   j, k] + ψ[i+1, j, k]) + 1/4 * pow2(3ψ[i-1, j, k] - 4ψ[i,   j, k] +  ψ[i+1, j, k])
+@inline left_biased_βx₁(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i-2, j, k] - 2ψ[i-1, j, k] + ψ[i,   j, k]) + 1/4 * pow2( ψ[i-2, j, k]                 -  ψ[i,   j, k])
+@inline left_biased_βx₂(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i-3, j, k] - 2ψ[i-2, j, k] + ψ[i-1, j, k]) + 1/4 * pow2( ψ[i-3, j, k] - 4ψ[i-2, j, k] + 3ψ[i-1, j, k])
 
-@inline left_biased_βz₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-1] - 2ψ[i, j,   k] + ψ[i, j, k+1])^2 + 1/4 * (3ψ[i, j, k-1] - 4ψ[i, j,   k] +  ψ[i, j, k+1])^2
-@inline left_biased_βz₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-2] - 2ψ[i, j, k-1] + ψ[i, j,   k])^2 + 1/4 * ( ψ[i, j, k-2]                 -  ψ[i, j,   k])^2
-@inline left_biased_βz₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-3] - 2ψ[i, j, k-2] + ψ[i, j, k-1])^2 + 1/4 * ( ψ[i, j, k-3] - 4ψ[i, j, k-2] + 3ψ[i, j, k-1])^2
+@inline left_biased_βy₀(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j-1, k] - 2ψ[i, j,   k] + ψ[i, j+1, k]) + 1/4 * pow2(3ψ[i, j-1, k] - 4ψ[i,   j, k] +  ψ[i, j+1, k])
+@inline left_biased_βy₁(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j-2, k] - 2ψ[i, j-1, k] + ψ[i, j,   k]) + 1/4 * pow2( ψ[i, j-2, k]                 -  ψ[i,   j, k])
+@inline left_biased_βy₂(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j-3, k] - 2ψ[i, j-2, k] + ψ[i, j-1, k]) + 1/4 * pow2( ψ[i, j-3, k] - 4ψ[i, j-2, k] + 3ψ[i, j-1, k])
+
+@inline left_biased_βz₀(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j, k-1] - 2ψ[i, j,   k] + ψ[i, j, k+1]) + 1/4 * pow2(3ψ[i, j, k-1] - 4ψ[i, j,   k] +  ψ[i, j, k+1])
+@inline left_biased_βz₁(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j, k-2] - 2ψ[i, j, k-1] + ψ[i, j,   k]) + 1/4 * pow2( ψ[i, j, k-2]                 -  ψ[i, j,   k])
+@inline left_biased_βz₂(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j, k-3] - 2ψ[i, j, k-2] + ψ[i, j, k-1]) + 1/4 * pow2( ψ[i, j, k-3] - 4ψ[i, j, k-2] + 3ψ[i, j, k-1])
 
 # Right-biased smoothness indicators are a reflection or "symmetric modification" of the left-biased smoothness
 # indicators around grid point `i-1/2`.
 
-@inline right_biased_βx₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i,   j, k] - 2ψ[i+1, j, k] + ψ[i+2, j, k])^2 + 1/4 * ( ψ[i,   j, k] - 4ψ[i+1, j, k] + 3ψ[i+2, j, k])^2
-@inline right_biased_βx₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-1, j, k] - 2ψ[i,   j, k] + ψ[i+1, j, k])^2 + 1/4 * ( ψ[i-1, j, k]                 -  ψ[i+1, j, k])^2
-@inline right_biased_βx₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i-2, j, k] - 2ψ[i-1, j, k] + ψ[i,   j, k])^2 + 1/4 * (3ψ[i-2, j, k] - 4ψ[i-1, j, k] +  ψ[i,   j, k])^2
+@inline right_biased_βx₀(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i,   j, k] - 2ψ[i+1, j, k] + ψ[i+2, j, k]) + 1/4 * pow2( ψ[i,   j, k] - 4ψ[i+1, j, k] + 3ψ[i+2, j, k])
+@inline right_biased_βx₁(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i-1, j, k] - 2ψ[i,   j, k] + ψ[i+1, j, k]) + 1/4 * pow2( ψ[i-1, j, k]                 -  ψ[i+1, j, k])
+@inline right_biased_βx₂(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i-2, j, k] - 2ψ[i-1, j, k] + ψ[i,   j, k]) + 1/4 * pow2(3ψ[i-2, j, k] - 4ψ[i-1, j, k] +  ψ[i,   j, k])
 
-@inline right_biased_βy₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j,   k] - 2ψ[i, j+1, k] + ψ[i, j+2, k])^2 + 1/4 * ( ψ[i,   j, k] - 4ψ[i, j+1, k] + 3ψ[i, j+2, k])^2
-@inline right_biased_βy₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-1, k] - 2ψ[i, j,   k] + ψ[i, j+1, k])^2 + 1/4 * ( ψ[i, j-1, k]                 -  ψ[i, j+1, k])^2
-@inline right_biased_βy₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j-2, k] - 2ψ[i, j-1, k] + ψ[i, j,   k])^2 + 1/4 * (3ψ[i, j-2, k] - 4ψ[i, j-1, k] +  ψ[i,   j, k])^2
+@inline right_biased_βy₀(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j,   k] - 2ψ[i, j+1, k] + ψ[i, j+2, k]) + 1/4 * pow2( ψ[i,   j, k] - 4ψ[i, j+1, k] + 3ψ[i, j+2, k])
+@inline right_biased_βy₁(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j-1, k] - 2ψ[i, j,   k] + ψ[i, j+1, k]) + 1/4 * pow2( ψ[i, j-1, k]                 -  ψ[i, j+1, k])
+@inline right_biased_βy₂(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j-2, k] - 2ψ[i, j-1, k] + ψ[i, j,   k]) + 1/4 * pow2(3ψ[i, j-2, k] - 4ψ[i, j-1, k] +  ψ[i,   j, k])
 
-@inline right_biased_βz₀(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j,   k] - 2ψ[i, j, k+1] + ψ[i, j, k+2])^2 + 1/4 * ( ψ[i, j,   k] - 4ψ[i, j, k+1] + 3ψ[i, j, k+2])^2
-@inline right_biased_βz₁(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-1] - 2ψ[i, j,   k] + ψ[i, j, k+1])^2 + 1/4 * ( ψ[i, j, k-1]                 -  ψ[i, j, k+1])^2
-@inline right_biased_βz₂(i, j, k, ψ) = @inbounds 13/12 * (ψ[i, j, k-2] - 2ψ[i, j, k-1] + ψ[i, j,   k])^2 + 1/4 * (3ψ[i, j, k-2] - 4ψ[i, j, k-1] +  ψ[i, j,   k])^2
+@inline right_biased_βz₀(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j,   k] - 2ψ[i, j, k+1] + ψ[i, j, k+2]) + 1/4 * pow2( ψ[i, j,   k] - 4ψ[i, j, k+1] + 3ψ[i, j, k+2])
+@inline right_biased_βz₁(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j, k-1] - 2ψ[i, j,   k] + ψ[i, j, k+1]) + 1/4 * pow2( ψ[i, j, k-1]                 -  ψ[i, j, k+1])
+@inline right_biased_βz₂(i, j, k, ψ) = @inbounds 13/12 * pow2(ψ[i, j, k-2] - 2ψ[i, j, k-1] + ψ[i, j,   k]) + 1/4 * pow2(3ψ[i, j, k-2] - 4ψ[i, j, k-1] +  ψ[i, j,   k])
 
 #####
 ##### WENO-5 optimal weights
@@ -85,33 +87,33 @@ const C3₂ = 1/10
 ##### WENO-5 raw weights
 #####
 
-# Note: these constants may need to be changed for smooth solutions and/or fine grid.
+# Note: we assume a WENO exponent of "2" by using pow2 below.
+# This exponent and the constant ϵ may need to be changed for smooth solutions and/or fine grid.
 const ε = 1e-6
-const ƞ = 2  # WENO exponent
 
-@inline left_biased_αx₀(i, j, k, ψ) = C3₀ / (left_biased_βx₀(i, j, k, ψ) + ε)^ƞ
-@inline left_biased_αx₁(i, j, k, ψ) = C3₁ / (left_biased_βx₁(i, j, k, ψ) + ε)^ƞ
-@inline left_biased_αx₂(i, j, k, ψ) = C3₂ / (left_biased_βx₂(i, j, k, ψ) + ε)^ƞ
+@inline left_biased_αx₀(i, j, k, ψ) = C3₀ / pow2(left_biased_βx₀(i, j, k, ψ) + ε)
+@inline left_biased_αx₁(i, j, k, ψ) = C3₁ / pow2(left_biased_βx₁(i, j, k, ψ) + ε)
+@inline left_biased_αx₂(i, j, k, ψ) = C3₂ / pow2(left_biased_βx₂(i, j, k, ψ) + ε)
 
-@inline left_biased_αy₀(i, j, k, ψ) = C3₀ / (left_biased_βy₀(i, j, k, ψ) + ε)^ƞ
-@inline left_biased_αy₁(i, j, k, ψ) = C3₁ / (left_biased_βy₁(i, j, k, ψ) + ε)^ƞ
-@inline left_biased_αy₂(i, j, k, ψ) = C3₂ / (left_biased_βy₂(i, j, k, ψ) + ε)^ƞ
+@inline left_biased_αy₀(i, j, k, ψ) = C3₀ / pow2(left_biased_βy₀(i, j, k, ψ) + ε)
+@inline left_biased_αy₁(i, j, k, ψ) = C3₁ / pow2(left_biased_βy₁(i, j, k, ψ) + ε)
+@inline left_biased_αy₂(i, j, k, ψ) = C3₂ / pow2(left_biased_βy₂(i, j, k, ψ) + ε)
 
-@inline left_biased_αz₀(i, j, k, ψ) = C3₀ / (left_biased_βz₀(i, j, k, ψ) + ε)^ƞ
-@inline left_biased_αz₁(i, j, k, ψ) = C3₁ / (left_biased_βz₁(i, j, k, ψ) + ε)^ƞ
-@inline left_biased_αz₂(i, j, k, ψ) = C3₂ / (left_biased_βz₂(i, j, k, ψ) + ε)^ƞ
+@inline left_biased_αz₀(i, j, k, ψ) = C3₀ / pow2(left_biased_βz₀(i, j, k, ψ) + ε)
+@inline left_biased_αz₁(i, j, k, ψ) = C3₁ / pow2(left_biased_βz₁(i, j, k, ψ) + ε)
+@inline left_biased_αz₂(i, j, k, ψ) = C3₂ / pow2(left_biased_βz₂(i, j, k, ψ) + ε)
 
-@inline right_biased_αx₀(i, j, k, ψ) = C3₂ / (right_biased_βx₀(i, j, k, ψ) + ε)^ƞ
-@inline right_biased_αx₁(i, j, k, ψ) = C3₁ / (right_biased_βx₁(i, j, k, ψ) + ε)^ƞ
-@inline right_biased_αx₂(i, j, k, ψ) = C3₀ / (right_biased_βx₂(i, j, k, ψ) + ε)^ƞ
+@inline right_biased_αx₀(i, j, k, ψ) = C3₂ / pow2(right_biased_βx₀(i, j, k, ψ) + ε)
+@inline right_biased_αx₁(i, j, k, ψ) = C3₁ / pow2(right_biased_βx₁(i, j, k, ψ) + ε)
+@inline right_biased_αx₂(i, j, k, ψ) = C3₀ / pow2(right_biased_βx₂(i, j, k, ψ) + ε)
 
-@inline right_biased_αy₀(i, j, k, ψ) = C3₂ / (right_biased_βy₀(i, j, k, ψ) + ε)^ƞ
-@inline right_biased_αy₁(i, j, k, ψ) = C3₁ / (right_biased_βy₁(i, j, k, ψ) + ε)^ƞ
-@inline right_biased_αy₂(i, j, k, ψ) = C3₀ / (right_biased_βy₂(i, j, k, ψ) + ε)^ƞ
+@inline right_biased_αy₀(i, j, k, ψ) = C3₂ / pow2(right_biased_βy₀(i, j, k, ψ) + ε)
+@inline right_biased_αy₁(i, j, k, ψ) = C3₁ / pow2(right_biased_βy₁(i, j, k, ψ) + ε)
+@inline right_biased_αy₂(i, j, k, ψ) = C3₀ / pow2(right_biased_βy₂(i, j, k, ψ) + ε)
 
-@inline right_biased_αz₀(i, j, k, ψ) = C3₂ / (right_biased_βz₀(i, j, k, ψ) + ε)^ƞ
-@inline right_biased_αz₁(i, j, k, ψ) = C3₁ / (right_biased_βz₁(i, j, k, ψ) + ε)^ƞ
-@inline right_biased_αz₂(i, j, k, ψ) = C3₀ / (right_biased_βz₂(i, j, k, ψ) + ε)^ƞ
+@inline right_biased_αz₀(i, j, k, ψ) = C3₂ / pow2(right_biased_βz₀(i, j, k, ψ) + ε)
+@inline right_biased_αz₁(i, j, k, ψ) = C3₁ / pow2(right_biased_βz₁(i, j, k, ψ) + ε)
+@inline right_biased_αz₂(i, j, k, ψ) = C3₀ / pow2(right_biased_βz₂(i, j, k, ψ) + ε)
 
 #####
 ##### WENO-5 normalized weights


### PR DESCRIPTION
This is an alternative attempt from #1770 to resolve #1764. 