### PR TITLE
Nuke float_type arg for IncompressibleModel

### DIFF
--- a/benchmark/benchmark_abstract_operations.jl
+++ b/benchmark/benchmark_abstract_operations.jl
@@ -26,7 +26,7 @@ for Arch in Archs
     N = Arch == CPU ? (32, 32, 32) : (256, 256, 256)
 
     grid = RegularRectilinearGrid(FT, size=N, extent=(1, 1, 1))
-    model = IncompressibleModel(architecture=Arch(), float_type=FT, grid=grid,
+    model = IncompressibleModel(architecture=Arch(), grid=grid,
                                 buoyancy=nothing, tracers=(:α, :β, :γ, :δ, :ζ))
 
     ε(x, y, z) = randn()

--- a/benchmark/benchmark_incompressible_model.jl
+++ b/benchmark/benchmark_incompressible_model.jl
@@ -10,7 +10,7 @@ pyplot()
 
 function benchmark_incompressible_model(Arch, FT, N)
     grid = RegularRectilinearGrid(FT, size=(N, N, N), extent=(1, 1, 1))
-    model = IncompressibleModel(architecture=Arch(), float_type=FT, grid=grid)
+    model = IncompressibleModel(architecture=Arch(), grid=grid)
 
     time_step!(model, 1) # warmup
 

--- a/benchmark/benchmark_vertically_stretched_incompressible_model.jl
+++ b/benchmark/benchmark_vertically_stretched_incompressible_model.jl
@@ -9,7 +9,7 @@ using Benchmarks
 
 function benchmark_vertically_stretched_incompressible_model(Arch, FT, N)
     grid = VerticallyStretchedRectilinearGrid(architecture=Arch(), size=(N, N, N), x=(0, 1), y=(0, 1), z_faces=collect(0:N))
-    model = IncompressibleModel(architecture=Arch(), float_type=FT, grid=grid)
+    model = IncompressibleModel(architecture=Arch(), grid=grid)
 
     time_step!(model, 1) # warmup
 

--- a/benchmark/benchmarkable_incompressible_model.jl
+++ b/benchmark/benchmarkable_incompressible_model.jl
@@ -19,7 +19,7 @@ for Arch in Architectures, FT in Float_types, N in Ns
     @info "Setting up benchmark: ($Arch, $FT, $N)..."
 
     grid = RegularRectilinearGrid(FT, size=(N, N, N), extent=(1, 1, 1))
-    model = IncompressibleModel(architecture=Arch(), float_type=FT, grid=grid)
+    model = IncompressibleModel(architecture=Arch(), grid=grid)
 
     time_step!(model, 1) # warmup
 

--- a/src/Models/IncompressibleModels/incompressible_model.jl
+++ b/src/Models/IncompressibleModels/incompressible_model.jl
@@ -46,10 +46,9 @@ end
     IncompressibleModel(;
                    grid,
            architecture = CPU(),
-             float_type = Float64,
-                  clock = Clock{float_type}(0, 0, 1),
+                  clock = Clock{eltype(grid)}(0, 0, 1),
               advection = CenteredSecondOrder(),
-               buoyancy = Buoyancy(SeawaterBuoyancy(float_type)),
+               buoyancy = Buoyancy(SeawaterBuoyancy(eltype(grid))),
                coriolis = nothing,
            stokes_drift = nothing,
                 forcing = NamedTuple(),
@@ -73,7 +72,6 @@ Keyword arguments
 
     - `grid`: (required) The resolution and discrete geometry on which `model` is solved.
     - `architecture`: `CPU()` or `GPU()`. The computer architecture used to time-step `model`.
-    - `float_type`: `Float32` or `Float64`. The floating point type used for `model` data.
     - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
     - `buoyancy`: The buoyancy model. See `Oceananigans.BuoyancyModels`.
     - `closure`: The turbulence closure for `model`. See `Oceananigans.TurbulenceClosures`.
@@ -87,10 +85,9 @@ Keyword arguments
 """
 function IncompressibleModel(;    grid,
     architecture::AbstractArchitecture = CPU(),
-                            float_type = Float64,
-                                 clock = Clock{float_type}(0, 0, 1),
+                                 clock = Clock{eltype(grid)}(0, 0, 1),
                              advection = CenteredSecondOrder(),
-                              buoyancy = Buoyancy(model=SeawaterBuoyancy(float_type)),
+                              buoyancy = Buoyancy(model=SeawaterBuoyancy(eltype(grid))),
                               coriolis = nothing,
                           stokes_drift = nothing,
                    forcing::NamedTuple = NamedTuple(),

--- a/src/Models/IncompressibleModels/non_dimensional_model.jl
+++ b/src/Models/IncompressibleModels/non_dimensional_model.jl
@@ -2,10 +2,10 @@ using Oceananigans.TurbulenceClosures: IsotropicDiffusivity
 using Oceananigans.BuoyancyModels
 
 """
-    NonDimensionalIncompressibleModel(; N, L, Re, Pr=0.7, Ro=Inf, float_type=Float64, kwargs...)
+    NonDimensionalIncompressibleModel(; grid, Re, Pr=0.7, Ro=Inf, kwargs...)
 
-Construct a "Non-dimensional" `Model` with resolution `N`, domain extent `L`,
-precision `float_type`, and the four non-dimensional numbers:
+Construct a "Non-dimensional" `Model` on `grid` with the four non-dimensional numbers:
+
 
     * `Re = U λ / ν` (Reynolds number)
     * `Pr = U λ / κ` (Prandtl number)
@@ -21,12 +21,16 @@ Note that `N`, `L`, and `Re` are required.
 
 Additional `kwargs` are passed to the regular `IncompressibleModel` constructor.
 """
-function NonDimensionalIncompressibleModel(; grid, float_type=Float64, Re, Pr=0.7, Ro=Inf,
-    buoyancy = BuoyancyTracer(),
-    coriolis = FPlane(float_type, f=1/Ro),
-     closure = IsotropicDiffusivity(float_type, ν=1/Re, κ=1/(Pr*Re)),
-    kwargs...)
+function NonDimensionalIncompressibleModel(; grid, Re, Pr=0.7, Ro=Inf,
+                                           buoyancy = BuoyancyTracer(),
+                                           coriolis = FPlane(eltype(grid), f=1/Ro),
+                                           closure = IsotropicDiffusivity(eltype(grid), ν=1/Re, κ=1/(Pr*Re)),
+                                           kwargs...)
 
-    return IncompressibleModel(; float_type=float_type, grid=grid, closure=closure,
-                               coriolis=coriolis, tracers=(:b,), buoyancy=buoyancy, kwargs...)
+    return IncompressibleModel(grid=grid,
+                               closure=closure,
+                               coriolis=coriolis,
+                               tracers=:b,
+                               buoyancy=buoyancy,
+                               kwargs...)
 end

--- a/src/Models/IncompressibleModels/non_dimensional_model.jl
+++ b/src/Models/IncompressibleModels/non_dimensional_model.jl
@@ -27,7 +27,7 @@ function NonDimensionalIncompressibleModel(; grid, Re, Pr=0.7, Ro=Inf,
                                            closure = IsotropicDiffusivity(eltype(grid), ν=1/Re, κ=1/(Pr*Re)),
                                            kwargs...)
 
-    return IncompressibleModel(grid=grid,
+    return IncompressibleModel(; grid=grid,
                                closure=closure,
                                coriolis=coriolis,
                                tracers=:b,

--- a/test/test_boundary_conditions_integration.jl
+++ b/test/test_boundary_conditions_integration.jl
@@ -7,7 +7,7 @@ function test_boundary_condition(arch, FT, topo, side, field_name, boundary_cond
     field_boundary_conditions = TracerBoundaryConditions(grid; boundary_condition_kwarg...)
     bcs = NamedTuple{(field_name,)}((field_boundary_conditions,))
 
-    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT,
+    model = IncompressibleModel(grid=grid, architecture=arch,
                                 boundary_conditions=bcs)
 
     success = try
@@ -82,7 +82,7 @@ function fluxes_with_diffusivity_boundary_conditions_are_correct(arch, FT)
     model_bcs = (b=buoyancy_bcs, κₑ=(b=κₑ_bcs,))
 
     model = IncompressibleModel(
-        grid=grid, architecture=arch, float_type=FT, tracers=:b, buoyancy=BuoyancyTracer(),
+        grid=grid, architecture=arch, tracers=:b, buoyancy=BuoyancyTracer(),
         closure=AnisotropicMinimumDissipation(), boundary_conditions=model_bcs
     )
 
@@ -178,7 +178,6 @@ test_boundary_conditions(C, FT, ArrayType) = (integer_bc(C, FT, ArrayType),
 
         model = IncompressibleModel(architecture = arch,
                                     grid = grid,
-                                    float_type = FT,
                                     boundary_conditions = boundary_conditions)
 
         @test location(model.velocities.u.boundary_conditions.bottom.condition) == (Face, Center, Nothing)

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -19,8 +19,7 @@ TestModel_VerticallyStrectedRectGrid(arch, FT, ν=1.0, Δx=0.5) =
     IncompressibleModel(
           grid = VerticallyStretchedRectilinearGrid(FT, architecture = arch, size=(3, 3, 3), x=(0, 3Δx), y=(0, 3Δx), z_faces=0:Δx:3Δx,),
        closure = IsotropicDiffusivity(FT, ν=ν, κ=ν),
-  architecture = arch,
-    float_type = FT
+  architecture = arch
 )
 
 
@@ -28,8 +27,7 @@ TestModel_RegularRectGrid(arch, FT, ν=1.0, Δx=0.5) =
     IncompressibleModel(
           grid = RegularRectilinearGrid(FT, topology=(Periodic, Periodic, Periodic), size=(3, 3, 3), extent=(3Δx, 3Δx, 3Δx)),
        closure = IsotropicDiffusivity(FT, ν=ν, κ=ν),
-  architecture = arch,
-    float_type = FT
+  architecture = arch
 )
 
 function diagnostic_windowed_spatial_average(arch, FT)

--- a/test/test_incompressible_models.jl
+++ b/test/test_incompressible_models.jl
@@ -22,7 +22,7 @@
 		        arch isa GPU && topo == (Bounded, Bounded, Bounded) && continue
 
                 grid = RegularRectilinearGrid(FT, topology=topo, size=(16, 16, 2), extent=(1, 2, 3))
-                model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT)
+                model = IncompressibleModel(grid=grid, architecture=arch)
 
                 @test model isa IncompressibleModel
             end
@@ -85,7 +85,7 @@
         @info "  Testing non-dimensional model construction..."
         for arch in archs, FT in float_types
             grid = RegularRectilinearGrid(FT, size=(16, 16, 2), extent=(3, 2, 1))
-            model = NonDimensionalIncompressibleModel(architecture=arch, float_type=FT, grid=grid, Re=1, Pr=1, Ro=Inf)
+            model = NonDimensionalIncompressibleModel(architecture=arch, grid=grid, Re=1, Pr=1, Ro=Inf)
 
             # Just testing that a NonDimensionalIncompressibleModel was constructed with no errors/crashes.
             @test model isa IncompressibleModel
@@ -99,7 +99,7 @@
             L = (2π, 3π, 5π)
 
             grid = RegularRectilinearGrid(FT, size=N, extent=L)
-            model = IncompressibleModel(architecture=arch, float_type=eltype(grid), grid=grid)
+            model = IncompressibleModel(architecture=arch, grid=grid)
 
             u, v, w = model.velocities
             T, S = model.tracers

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -15,7 +15,7 @@ end
 function time_stepping_works_with_coriolis(arch, FT, Coriolis)
     grid = RegularRectilinearGrid(FT, size=(1, 1, 1), extent=(1, 2, 3))
     c = Coriolis(FT, latitude=45)
-    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, coriolis=c)
+    model = IncompressibleModel(grid=grid, architecture=arch, coriolis=c)
 
     time_step!(model, 1, euler=true)
 
@@ -31,7 +31,7 @@ function time_stepping_works_with_closure(arch, FT, Closure; buoyancy=Buoyancy(m
     # Use halos of size 2 to accomadate time stepping with AnisotropicBiharmonicDiffusivity.
     grid = RegularRectilinearGrid(FT; size=(1, 1, 1), halo=(2, 2, 2), extent=(1, 2, 3))
 
-    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT,
+    model = IncompressibleModel(grid=grid, architecture=arch,
                                 closure=Closure(FT), tracers=tracers, buoyancy=buoyancy)
 
     time_step!(model, 1, euler=true)
@@ -49,7 +49,7 @@ end
 
 function time_stepping_works_with_nothing_closure(arch, FT)
     grid = RegularRectilinearGrid(FT; size=(1, 1, 1), extent=(1, 2, 3))
-    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, closure=nothing)
+    model = IncompressibleModel(grid=grid, architecture=arch, closure=nothing)
     time_step!(model, 1, euler=true)
     return true  # Test that no errors/crashes happen when time stepping.
 end
@@ -60,7 +60,7 @@ function time_stepping_works_with_nonlinear_eos(arch, FT, EOS)
     eos = EOS()
     b = SeawaterBuoyancy(equation_of_state=eos)
 
-    model = IncompressibleModel(architecture=arch, float_type=FT, grid=grid, buoyancy=b)
+    model = IncompressibleModel(architecture=arch, grid=grid, buoyancy=b)
     time_step!(model, 1, euler=true)
 
     return true  # Test that no errors/crashes happen when time stepping.
@@ -72,7 +72,7 @@ function run_first_AB2_time_step_tests(arch, FT)
     # Weird grid size to catch https://github.com/CliMA/Oceananigans.jl/issues/780
     grid = RegularRectilinearGrid(FT, size=(13, 17, 19), extent=(1, 2, 3))
 
-    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, forcing=(T=add_ones,))
+    model = IncompressibleModel(grid=grid, architecture=arch, forcing=(T=add_ones,))
     time_step!(model, 1, euler=true)
 
     # Test that GT = 1, T = 1 after 1 time step and that AB2 actually reduced to forward Euler.
@@ -145,7 +145,7 @@ function tracer_conserved_in_channel(arch, FT, Nt)
 
     topology = (Periodic, Bounded, Bounded)
     grid = RegularRectilinearGrid(size=(Nx, Ny, Nz), extent=(Lx, Ly, Lz))
-    model = IncompressibleModel(architecture = arch, float_type = FT, grid = grid,
+    model = IncompressibleModel(architecture = arch, grid = grid,
                                 closure = AnisotropicDiffusivity(νh=νh, νz=νz, κh=κh, κz=κz))
 
     Ty = 1e-4  # Meridional temperature gradient [K/m].

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -146,10 +146,8 @@ end
 function time_step_with_tupled_closure(FT, arch)
     closure_tuple = (AnisotropicMinimumDissipation(FT), AnisotropicDiffusivity(FT))
 
-    model = IncompressibleModel(
-        architecture=arch, float_type=FT, closure=closure_tuple,
-        grid=RegularRectilinearGrid(FT, size=(1, 1, 1), extent=(1, 2, 3))
-    )
+    model = IncompressibleModel(architecture=arch, closure=closure_tuple,
+                                grid=RegularRectilinearGrid(FT, size=(1, 1, 1), extent=(1, 2, 3)))
 
     time_step!(model, 1, euler=true)
     return true


### PR DESCRIPTION
The floating point type can and should be determined from `eltype(grid)`, since `grid` is a required argument for constructing `IncompressibleModel`. An independent `float_type` argument is not only redundant but creates the possibility that models can have inconsistent float types. Eliminating this argument and using `eltype(grid)` as the source of knowledge re: floating point types solves this problem.