### PR TITLE
Avoid data dep race condition in CI

### DIFF
--- a/test/data_dependencies.jl
+++ b/test/data_dependencies.jl
@@ -8,3 +8,7 @@ dd = DataDep("cubed_sphere_32_grid",
 )
 
 DataDeps.register(dd)
+
+# Trigger datadep download to avoid race condition in CI.
+# See: https://github.com/oxinabox/DataDeps.jl/issues/141
+datadep"cubed_sphere_32_grid"


### PR DESCRIPTION
Sometimes different Buildkite jobs try to download the same file as the same time leading to freezes like in https://buildkite.com/clima/oceananigans/builds/3066#157d0809-a11d-476b-b78d-fc5b1a241286

This PR tries to avoid race conditions by just downloading the file once during the initialization stage.

Doesn't always happen though so not sure when/how to merge.