### PR TITLE
Use constant near-surface grid spacing in ocean wind mixing and convection example + fixes some docstrings

### DIFF
--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -30,7 +30,7 @@ using Oceananigans.Units: minute, minutes, hour
 
 # ## A vertically-stretched grid
 #
-# We use 32³ grid points with 2 m grid spacing in the horizontal and
+# We use 32³ grid points with 2 meter grid spacing in the horizontal and
 # varying spacing in the vertical, with higher resolution closer to the
 # surface. We use a two-parameter generating function to specify the
 # vertical cell interfaces:
@@ -38,7 +38,7 @@ using Oceananigans.Units: minute, minutes, hour
 Nz = 24 # vertical resolution
 Lz = 32 # domain depth
 refinement = 1.2 # controls spacing near surface (higher means finer spaced)
-stretching = 8 # controls rate of stretching at bottom 
+stretching = 8   # controls rate of stretching at bottom 
 
 ## Normalized height ranging from 0 to 1
 h(k) = (k - 1) / Nz
@@ -71,19 +71,19 @@ plot(grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz],
 
 buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=2e-4, β=8e-4))
 
-# where $α$ and $β$ are the thermal expansion and haline contraction
+# where ``α`` and ``β`` are the thermal expansion and haline contraction
 # coefficients for temperature and salinity.
 #
 # ## Boundary conditions
 #
 # We calculate the surface temperature flux associated with surface heating of
-# 200 W m⁻², reference density `ρ`, and heat capacity `cᴾ`,
+# 200 W m⁻², reference density `ρₒ`, and heat capacity `cᴾ`,
 
-Qʰ = 200  # W m⁻², surface _heat_ flux
+Qʰ = 200  # W m⁻², surface heat flux
 ρₒ = 1026 # kg m⁻³, average density at the surface of the world ocean
 cᴾ = 3991 # J K⁻¹ kg⁻¹, typical heat capacity for seawater
 
-Qᵀ = Qʰ / (ρₒ * cᴾ) # K m s⁻¹, surface _temperature_ flux
+Qᵀ = Qʰ / (ρₒ * cᴾ) # K m s⁻¹, surface temperature flux
 
 # Finally, we impose a temperature gradient `dTdz` both initially and at the
 # bottom of the domain, culminating in the boundary conditions on temperature,
@@ -156,7 +156,7 @@ model = IncompressibleModel(architecture = CPU(),
 #   `AnisotropicMinimumDissipation`, use `closure = ConstantSmagorinsky()` in the model constructor.
 #
 # * To change the `architecture` to `GPU`, replace `architecture = CPU()` with
-#   `architecture = GPU()``
+#   `architecture = GPU()`.
 
 # ## Initial conditions
 #

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -37,8 +37,8 @@ using Oceananigans.Units: minute, minutes, hour
 
 Nz = 24 # vertical resolution
 Lz = 32 # domain depth
-refinement = 1.5 # controls spacing near surface (higher means finer spaced)
-stretching = 10 # controls rate of stretching at bottom 
+refinement = 1.2 # controls spacing near surface (higher means finer spaced)
+stretching = 8 # controls rate of stretching at bottom 
 
 ## Normalized height ranging from 0 to 1
 h(k) = (k - 1) / Nz

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -28,30 +28,42 @@ using JLD2
 using Oceananigans
 using Oceananigans.Units: minute, minutes, hour
 
-# ## The grid
+# ## A vertically-stretched grid
 #
 # We use 32³ grid points with 2 m grid spacing in the horizontal and
 # varying spacing in the vertical, with higher resolution closer to the
-# surface,
+# surface. We use a two-parameter generating function to specify the
+# vertical cell interfaces:
 
-σ = 1.1 # stretching factor
-Nz = 24
-Lz = 32
+Nz = 24 # vertical resolution
+Lz = 32 # domain depth
+refinement = 1.5 # controls spacing near surface (higher means finer spaced)
+stretching = 10 # controls rate of stretching at bottom 
 
-hyperbolically_spaced_faces(k) = - Lz * (1 - tanh(σ * (k - 1) / Nz) / tanh(σ))
+## Normalized height ranging from 0 to 1
+h(k) = (k - 1) / Nz
+
+## Linear near-surface generator
+ζ₀(k) = 1 + (h(k) - 1) / refinement
+
+## Bottom-intensified stretching function 
+Σ(k) = (1 - exp(-stretching * h(k))) / (1 - exp(-stretching))
+
+## Generating function
+z_faces(k) = Lz * (ζ₀(k) * Σ(k) - 1)
 
 grid = VerticallyStretchedRectilinearGrid(size = (32, 32, Nz), 
                                           x = (0, 64),
                                           y = (0, 64),
-                                          z_faces = hyperbolically_spaced_faces)
+                                          z_faces = z_faces)
 
 # We plot vertical spacing versus depth to inspect the prescribed grid stretching:
 
 plot(grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz],
-      marker = :circle,
-      ylabel = "Depth (m)",
-      xlabel = "Vertical spacing (m)",
-      legend = nothing)
+     marker = :circle,
+     ylabel = "Depth (m)",
+     xlabel = "Vertical spacing (m)",
+     legend = nothing)
 
 # ## Buoyancy that depends on temperature and salinity
 #

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -35,7 +35,7 @@ using Oceananigans.Units: minute, minutes, hour
 # surface. We use a two-parameter generating function to specify the
 # vertical cell interfaces:
 
-Nz = 24 # vertical resolution
+Nz = 24 # number of points in the vertical direction
 Lz = 32 # domain depth
 refinement = 1.2 # controls spacing near surface (higher means finer spaced)
 stretching = 8   # controls rate of stretching at bottom 

--- a/src/Grids/regular_rectilinear_grid.jl
+++ b/src/Grids/regular_rectilinear_grid.jl
@@ -70,7 +70,7 @@ indicating the left and right endpoints of each dimensions, e.g. `x=(-π, π)` o
 the `extent` argument, e.g. `extent=(Lx, Ly, Lz)` which specifies the extent of each dimension
 in which case 0 ≤ x ≤ Lx, 0 ≤ y ≤ Ly, and -Lz ≤ z ≤ 0.
 
-A grid topology may be specified via a tuple assigning one of `Periodic`, `Bounded, and `Flat`
+A grid topology may be specified via a tuple assigning one of `Periodic`, `Bounded`, and `Flat`
 to each dimension. By default, a horizontally periodic grid topology `(Periodic, Periodic, Bounded)`
 is assumed.
 

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -73,7 +73,7 @@ Keyword arguments
 The physical extent of the domain can be specified via `x` and `y` keyword arguments
 indicating the left and right endpoints of each dimensions, e.g. `x=(-π, π)`.
 
-A grid topology may be specified via a tuple assigning one of `Periodic`, `Bounded, and `Flat`
+A grid topology may be specified via a tuple assigning one of `Periodic`, `Bounded`, and `Flat`
 to each dimension. By default, a horizontally periodic grid topology `(Periodic, Periodic, Bounded)`
 is assumed.
 
@@ -108,6 +108,8 @@ Generate a horizontally-periodic grid with cell interfaces stretched
 hyperbolically near the top:
 
 ```jldoctest
+using Oceananigans
+
 σ = 1.1 # stretching factor
 Nz = 24 # vertical resolution
 Lz = 32 # depth (m)

--- a/src/Grids/vertically_stretched_rectilinear_grid.jl
+++ b/src/Grids/vertically_stretched_rectilinear_grid.jl
@@ -52,7 +52,7 @@ Keyword arguments
 
 - `topology`: A 3-tuple `(Tx, Ty, Tz)` specifying the topology of the domain.
               `Tz` must be `Bounded` for `VerticallyStretchedRectilinearGrid`.
-              `Tx` and `Ty` specify whether the `x`- and `y`-` directions are
+              `Tx` and `Ty` specify whether the `x`- and `y`- directions are
               `Periodic`, `Bounded`, or `Flat`. The topology `Flat` indicates that a model does
               not vary in that directions so that derivatives and interpolation are zero.
               The default is `topology=(Periodic, Periodic, Bounded)`.
@@ -100,6 +100,33 @@ Grid properties
 - `(xᶜᵃᵃ, yᵃᶜᵃ, zᵃᵃᶜ)`: (x, y, z) coordinates of cell centers.
 
 - `(xᶠᵃᵃ, yᵃᶠᵃ, zᵃᵃᶠ)`: (x, y, z) coordinates of cell faces.
+
+Example
+=======
+
+Generate a horizontally-periodic grid with cell interfaces stretched
+hyperbolically near the top:
+
+```jldoctest
+σ = 1.1 # stretching factor
+Nz = 24 # vertical resolution
+Lz = 32 # depth (m)
+
+hyperbolically_spaced_faces(k) = - Lz * (1 - tanh(σ * (k - 1) / Nz) / tanh(σ))
+
+grid = VerticallyStretchedRectilinearGrid(size = (32, 32, Nz),
+                                          x = (0, 64),
+                                          y = (0, 64),
+                                          z_faces = hyperbolically_spaced_faces)
+
+# output
+VerticallyStretchedRectilinearGrid{Float64, Periodic, Periodic, Bounded}
+                   domain: x ∈ [0.0, 64.0], y ∈ [0.0, 64.0], z ∈ [-32.0, -0.0]
+                 topology: (Periodic, Periodic, Bounded)
+  resolution (Nx, Ny, Nz): (32, 32, 24)
+   halo size (Hx, Hy, Hz): (1, 1, 1)
+grid spacing (Δx, Δy, Δz): (2.0, 2.0, [min=0.6826950100338962, max=1.8309085743885056])
+```
 """
 function VerticallyStretchedRectilinearGrid(FT = Float64;
                                             architecture = CPU(),


### PR DESCRIPTION
This PR updates `examples/ocean_wind_mixing_and_convection.jl` with a new grid generating function that produces a constant grid spacing near the surface. A visualization of the grid spacing is

![image](https://user-images.githubusercontent.com/15271942/124339919-d3ba0080-db6e-11eb-96f2-999856d9556d.png)

@tomchor proposed this idea in #1762, but we couldn't find a suitable generating function and so a grid that becomes ever more refined toward the surface was used instead. I think a grid with constant near-surface spacing and bottom-intensified stretching will be useful for boundary layer turbulence experiments, so I thought it was worthwhile to spend a bit more time to come up with something.

I thought the hyperbolic generating function was also useful, so I added it to the docstring for `VerticallyStretchedRectilinearGrid` as an example. This PR also fixes a typo in that docstring.

Some notes:

I developed a two-parameter stretching function:

```julia
## Linear near-surface generator
ζ₀(k) = 1 + (h(k) - 1) / refinement

## Bottom-intensified stretching function 
Σ(k) = (1 - exp(-stretching * h(k))) / (1 - exp(-stretching))

## Generating function
z_faces(k) = Lz * (ζ₀(k) * Σ(k) - 1)
```

with `refinement` and `stretching` parameters`. Finding a suitable grid requires playing with both these parameters: perhaps counter-intuitively, when the `refinement` is weaker, the `stretching` has to be stronger to obtain a grid that's nearly constantly spaced near the surface. I think a slightly more convenient parameterization would use a "transition" parameter (controlling the depth at which the grid transitions from constant spacing to stretched) rather than a stretching parameter (there would also be a small parameter involved to control "how close" the spacing would be to constant at the transition depth).

However I couldn't figure out how to implement such a parameterization without solving a transcendental equation. The idea I had was to set the slope of `Σ` to a small number at a specified fraction of the domain height `hᵢ` by solving

```julia
Σ′ = stretching * exp(-stretching * hᵢ) / (1 - exp(-stretching)) = ϵ
```

for `stretching`. In the above, `ϵ` is a small parameter controlling the smallness of `Σ′` at the normalized height. Both `ϵ` and `hᵢ` are parameters.

Aside from being not quite right, there's something a little off about this approach. I think `stretching` should somehow depend on `refinement`; eg when `refinement = 1` then no stretching is needed.