### PR TITLE
Allow non-zero diffusive and viscous fluxes with ImmersedBoundaryGrid

### DIFF
--- a/src/Advection/centered_advective_fluxes.jl
+++ b/src/Advection/centered_advective_fluxes.jl
@@ -1,5 +1,3 @@
-using Oceananigans.Grids: AbstractPrimaryGrid
-
 #####
 ##### Momentum and advective tracer flux operators for centered advection schemes
 #####

--- a/src/Advection/momentum_advection_operators.jl
+++ b/src/Advection/momentum_advection_operators.jl
@@ -5,21 +5,21 @@ using Oceananigans.Fields: ZeroField
 #####
 
 # Alternate names for advective fluxes
-@inline _advective_momentum_flux_Uu(i, j, k, grid::APG, args...) = advective_momentum_flux_Uu(i, j, k, grid, args...)
-@inline _advective_momentum_flux_Vu(i, j, k, grid::APG, args...) = advective_momentum_flux_Vu(i, j, k, grid, args...)
-@inline _advective_momentum_flux_Wu(i, j, k, grid::APG, args...) = advective_momentum_flux_Wu(i, j, k, grid, args...)
+@inline _advective_momentum_flux_Uu(args...) = advective_momentum_flux_Uu(args...)
+@inline _advective_momentum_flux_Vu(args...) = advective_momentum_flux_Vu(args...)
+@inline _advective_momentum_flux_Wu(args...) = advective_momentum_flux_Wu(args...)
 
-@inline _advective_momentum_flux_Uv(i, j, k, grid::APG, args...) = advective_momentum_flux_Uv(i, j, k, grid, args...)
-@inline _advective_momentum_flux_Vv(i, j, k, grid::APG, args...) = advective_momentum_flux_Vv(i, j, k, grid, args...)
-@inline _advective_momentum_flux_Wv(i, j, k, grid::APG, args...) = advective_momentum_flux_Wv(i, j, k, grid, args...)
+@inline _advective_momentum_flux_Uv(args...) = advective_momentum_flux_Uv(args...)
+@inline _advective_momentum_flux_Vv(args...) = advective_momentum_flux_Vv(args...)
+@inline _advective_momentum_flux_Wv(args...) = advective_momentum_flux_Wv(args...)
 
-@inline _advective_momentum_flux_Uw(i, j, k, grid::APG, args...) = advective_momentum_flux_Uw(i, j, k, grid, args...)
-@inline _advective_momentum_flux_Vw(i, j, k, grid::APG, args...) = advective_momentum_flux_Vw(i, j, k, grid, args...)
-@inline _advective_momentum_flux_Ww(i, j, k, grid::APG, args...) = advective_momentum_flux_Ww(i, j, k, grid, args...)
+@inline _advective_momentum_flux_Uw(args...) = advective_momentum_flux_Uw(args...)
+@inline _advective_momentum_flux_Vw(args...) = advective_momentum_flux_Vw(args...)
+@inline _advective_momentum_flux_Ww(args...) = advective_momentum_flux_Ww(args...)
 
-@inline _advective_tracer_flux_x(i, j, k, grid::APG, args...) = _advective_tracer_flux_x(i, j, k, grid, args...)
-@inline _advective_tracer_flux_y(i, j, k, grid::APG, args...) = _advective_tracer_flux_y(i, j, k, grid, args...)
-@inline _advective_tracer_flux_z(i, j, k, grid::APG, args...) = _advective_tracer_flux_z(i, j, k, grid, args...)
+@inline _advective_tracer_flux_x(args...) = _advective_tracer_flux_x(args...)
+@inline _advective_tracer_flux_y(args...) = _advective_tracer_flux_y(args...)
+@inline _advective_tracer_flux_z(args...) = _advective_tracer_flux_z(args...)
 
 const ZeroU = NamedTuple{(:u, :v, :w), Tuple{ZeroField, ZeroField, ZeroField}}
 

--- a/src/Advection/topologically_conditional_interpolation.jl
+++ b/src/Advection/topologically_conditional_interpolation.jl
@@ -10,9 +10,9 @@
 #####        close to the boundary, or a second-order interpolation if i is close to a boundary.
 #####
 
-using Oceananigans.Grids: AbstractPrimaryGrid, Bounded
+using Oceananigans.Grids: AbstractUnderlyingGrid, Bounded
 
-const APG = AbstractPrimaryGrid
+const AUG = AbstractUnderlyingGrid
 
 # Left-biased buffers are smaller by one grid point on the right side; vice versa for right-biased buffers
                                                                               # outside left | outside right buffer
@@ -33,28 +33,28 @@ for bias in (:symmetric, :left_biased, :right_biased)
             alt_interp = Symbol(:_, interp)
 
             # Simple translation for Periodic directions (fallback)
-            @eval $alt_interp(i, j, k, grid::APG, scheme, ψ) = $interp(i, j, k, grid, scheme, ψ)
+            @eval $alt_interp(i, j, k, grid::AUG, scheme, ψ) = $interp(i, j, k, grid, scheme, ψ)
 
             outside_buffer = Symbol(:outside_, bias, :_buffer)
 
             # Conditional high-order interpolation in Bounded directions
             if ξ == :x
                 @eval begin
-                    @inline $alt_interp(i, j, k, grid::APG{FT, <:Bounded}, scheme, ψ) where FT =
+                    @inline $alt_interp(i, j, k, grid::AUG{FT, <:Bounded}, scheme, ψ) where FT =
                         ifelse($outside_buffer(i, grid.Nx, scheme),
                                $interp(i, j, k, grid, scheme, ψ),
                                $second_order_interp(i, j, k, grid, ψ))
                 end
             elseif ξ == :y
                 @eval begin
-                    @inline $alt_interp(i, j, k, grid::APG{FT, TX, <:Bounded}, scheme, ψ) where {FT, TX} =
+                    @inline $alt_interp(i, j, k, grid::AUG{FT, TX, <:Bounded}, scheme, ψ) where {FT, TX} =
                         ifelse($outside_buffer(j, grid.Ny, scheme),
                                $interp(i, j, k, grid, scheme, ψ),
                                $second_order_interp(i, j, k, grid, ψ))
                 end
             elseif ξ == :z
                 @eval begin
-                    @inline $alt_interp(i, j, k, grid::APG{FT, TX, TY, <:Bounded}, scheme, ψ) where {FT, TX, TY} =
+                    @inline $alt_interp(i, j, k, grid::AUG{FT, TX, TY, <:Bounded}, scheme, ψ) where {FT, TX, TY} =
                         ifelse($outside_buffer(k, grid.Nz, scheme),
                                $interp(i, j, k, grid, scheme, ψ),
                                $second_order_interp(i, j, k, grid, ψ))

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -1,5 +1,3 @@
-using Oceananigans.Grids: AbstractPrimaryGrid
-
 #####
 ##### Momentum and tracer advective flux operators for upwind-biased advection schemes
 #####

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -2,7 +2,7 @@ module Grids
 
 export Center, Face
 export AbstractTopology, Periodic, Bounded, Flat, Connected, topology
-export AbstractGrid, AbstractPrimaryGrid, halo_size
+export AbstractGrid, AbstractUnderlyingGrid, halo_size
 export AbstractRectilinearGrid, RegularRectilinearGrid, VerticallyStretchedRectilinearGrid
 export AbstractCurvilinearGrid, AbstractHorizontallyCurvilinearGrid
 export RegularLatitudeLongitudeGrid, ConformalCubedSphereFaceGrid, ConformalCubedSphereGrid
@@ -81,26 +81,26 @@ Abstract supertype for grids with elements of type `FT` and topology `{TX, TY, T
 abstract type AbstractGrid{FT, TX, TY, TZ} end
 
 """
-    AbstractPrimaryGrid{FT, TX, TY, TZ}
+    AbstractUnderlyingGrid{FT, TX, TY, TZ}
 
 Abstract supertype for "primary" grids (as opposed to grids with immersed boundaries)
 with elements of type `FT` and topology `{TX, TY, TZ}`.
 """
-abstract type AbstractPrimaryGrid{FT, TX, TY, TZ} <: AbstractGrid{FT, TX, TY, TZ} end
+abstract type AbstractUnderlyingGrid{FT, TX, TY, TZ} <: AbstractGrid{FT, TX, TY, TZ} end
 
 """
     AbstractRectilinearGrid{FT, TX, TY, TZ}
 
 Abstract supertype for rectilinear grids with elements of type `FT` and topology `{TX, TY, TZ}`.
 """
-abstract type AbstractRectilinearGrid{FT, TX, TY, TZ} <: AbstractPrimaryGrid{FT, TX, TY, TZ} end
+abstract type AbstractRectilinearGrid{FT, TX, TY, TZ} <: AbstractUnderlyingGrid{FT, TX, TY, TZ} end
 
 """
     AbstractCurvilinearGrid{FT, TX, TY, TZ}
 
 Abstract supertype for curvilinear grids with elements of type `FT` and topology `{TX, TY, TZ}`.
 """
-abstract type AbstractCurvilinearGrid{FT, TX, TY, TZ} <: AbstractPrimaryGrid{FT, TX, TY, TZ} end
+abstract type AbstractCurvilinearGrid{FT, TX, TY, TZ} <: AbstractUnderlyingGrid{FT, TX, TY, TZ} end
 
 """
     AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ}

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -123,8 +123,8 @@ PressureSolver(arch, ibg::ImmersedBoundaryGrid) = PressureSolver(arch, ibg.grid)
 @inline znode(LX, LY, LZ, i, j, k, ibg::ImmersedBoundaryGrid) = znode(LX, LY, LZ, i, j, k, ibg.grid)
 
 all_x_nodes(loc, ibg::ImmersedBoundaryGrid) = all_x_nodes(loc, ibg.grid)
-all_y_nodes(loc, ibg::ImmersedBoundaryGrid) = all_x_nodes(loc, ibg.grid)
-all_z_nodes(loc, ibg::ImmersedBoundaryGrid) = all_x_nodes(loc, ibg.grid)
+all_y_nodes(loc, ibg::ImmersedBoundaryGrid) = all_y_nodes(loc, ibg.grid)
+all_z_nodes(loc, ibg::ImmersedBoundaryGrid) = all_z_nodes(loc, ibg.grid)
 
 include("immersed_grid_metrics.jl")
 include("grid_fitted_immersed_boundary.jl")

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -85,7 +85,7 @@ struct ImmersedBoundaryGrid{FT, TX, TY, TZ, G, I} <: AbstractGrid{FT, TX, TY, TZ
     grid :: G
     immersed_boundary :: I
 
-    function ImmersedBoundaryGrid(grid::G, ib::I) where {G <: AbstractPrimaryGrid, I}
+    function ImmersedBoundaryGrid(grid::G, ib::I) where {G <: AbstractUnderlyingGrid, I}
         @warn "ImmersedBoundaryGrid is unvalidated and may produce incorrect results. " *
               "Don't hesitate to help validate ImmersedBoundaryGrid by reporting any bugs " *
               "or unexpected behavior to https://github.com/CliMA/Oceananigans.jl/issues"

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -40,7 +40,7 @@ import Oceananigans.Utils: cell_advection_timescale
 import Oceananigans.Solvers: PressureSolver
 import Oceananigans.Grids: with_halo
 import Oceananigans.Coriolis: φᶠᶠᵃ
-import Oceananigans.Grids: with_halo, xnode, ynode, znode
+import Oceananigans.Grids: with_halo, xnode, ynode, znode, all_x_nodes, all_y_nodes, all_z_nodes
 
 import Oceananigans.Advection:
     _advective_momentum_flux_Uu,
@@ -121,6 +121,10 @@ PressureSolver(arch, ibg::ImmersedBoundaryGrid) = PressureSolver(arch, ibg.grid)
 @inline xnode(LX, LY, LZ, i, j, k, ibg::ImmersedBoundaryGrid) = xnode(LX, LY, LZ, i, j, k, ibg.grid)
 @inline ynode(LX, LY, LZ, i, j, k, ibg::ImmersedBoundaryGrid) = ynode(LX, LY, LZ, i, j, k, ibg.grid)
 @inline znode(LX, LY, LZ, i, j, k, ibg::ImmersedBoundaryGrid) = znode(LX, LY, LZ, i, j, k, ibg.grid)
+
+all_x_nodes(loc, ibg::ImmersedBoundaryGrid) = all_x_nodes(loc, ibg.grid)
+all_y_nodes(loc, ibg::ImmersedBoundaryGrid) = all_x_nodes(loc, ibg.grid)
+all_z_nodes(loc, ibg::ImmersedBoundaryGrid) = all_x_nodes(loc, ibg.grid)
 
 include("immersed_grid_metrics.jl")
 include("grid_fitted_immersed_boundary.jl")

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -85,7 +85,7 @@ struct ImmersedBoundaryGrid{FT, TX, TY, TZ, G, I} <: AbstractGrid{FT, TX, TY, TZ
     grid :: G
     immersed_boundary :: I
 
-    function ImmersedBoundaryGrid{TX, TY, TZ}(grid::G, ib::I) where {TX, TY, TZ, G <: AbstractPrimaryGrid, I}
+    function ImmersedBoundaryGrid{TX, TY, TZ}(grid::G, ib::I) where {TX, TY, TZ, G <: AbstractUnderlyingGrid, I}
         FT = eltype(grid)
         return new{FT, TX, TY, TZ, G, I}(grid, ib)
     end

--- a/src/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/TurbulenceClosures/TurbulenceClosures.jl
@@ -51,22 +51,6 @@ abstract type AbstractTurbulenceClosure{TimeDiscretization} end
 # Fallbacks
 add_closure_specific_boundary_conditions(closure, boundary_conditions, args...) = boundary_conditions
 
-viscous_flux_ux(i, j, k, grid, args...) = zero(eltype(grid))
-viscous_flux_uy(i, j, k, grid, args...) = zero(eltype(grid))
-viscous_flux_uz(i, j, k, grid, args...) = zero(eltype(grid))
-
-viscous_flux_vx(i, j, k, grid, args...) = zero(eltype(grid))
-viscous_flux_vy(i, j, k, grid, args...) = zero(eltype(grid))
-viscous_flux_vz(i, j, k, grid, args...) = zero(eltype(grid))
-
-viscous_flux_wx(i, j, k, grid, args...) = zero(eltype(grid))
-viscous_flux_wy(i, j, k, grid, args...) = zero(eltype(grid))
-viscous_flux_wz(i, j, k, grid, args...) = zero(eltype(grid))
-
-diffusive_flux_x(i, j, k, grid, args...) = zero(eltype(grid))
-diffusive_flux_y(i, j, k, grid, args...) = zero(eltype(grid))
-diffusive_flux_z(i, j, k, grid, args...) = zero(eltype(grid))
-
 #####
 ##### Include module code
 #####

--- a/src/TurbulenceClosures/abstract_isotropic_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_isotropic_diffusivity_closure.jl
@@ -77,8 +77,8 @@ const VerticallyBoundedGrid{FT} = AbstractGrid{FT, <:Any, <:Any, <:Bounded}
 @inline ivd_viscous_flux_vz(i, j, k, grid, closure, clock, U, args...) = - ν_σᶜᶠᶠ(i, j, k, grid, clock, viscosity(closure, args...), ∂yᶜᶠᵃ, U.v)
 
 # General functions (eg for vertically periodic)
-@inline viscous_flux_uz(i, j, k, grid   ::VITD, closure::AID, args...) = ivd_viscous_flux_uz(i, j, k, grid, closure, args...)
-@inline viscous_flux_vz(i, j, k, grid   ::VITD, closure::AID, args...) = ivd_viscous_flux_vz(i, j, k, grid, closure, args...)
+@inline viscous_flux_uz(i, j, k, grid,  ::VITD, closure::AID, args...) = ivd_viscous_flux_uz(i, j, k, grid, closure, args...)
+@inline viscous_flux_vz(i, j, k, grid,  ::VITD, closure::AID, args...) = ivd_viscous_flux_vz(i, j, k, grid, closure, args...)
 @inline viscous_flux_wz(i, j, k, grid,  ::VITD, closure::AID, args...) = zero(eltype(grid))
 @inline diffusive_flux_z(i, j, k, grid, ::VITD, closure::AID, clock, args...) = zero(eltype(grid))
                   

--- a/src/TurbulenceClosures/abstract_isotropic_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_isotropic_diffusivity_closure.jl
@@ -42,34 +42,33 @@ at index `i, j, k` and location `ᶜᶜᶜ`.
 #####
 
 const AID = AbstractIsotropicDiffusivity
-const APG = AbstractPrimaryGrid # as opposed to a grid containing an immersed boundary
 
-@inline viscous_flux_ux(i, j, k, grid::APG, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶜᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₁₁, U.u, U.v, U.w)
-@inline viscous_flux_uy(i, j, k, grid::APG, closure::AID, clock, U, args...) = - 2 * ν_σᶠᶠᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₁₂, U.u, U.v, U.w)
-@inline viscous_flux_uz(i, j, k, grid::APG, closure::AID, clock, U, args...) = - 2 * ν_σᶠᶜᶠ(i, j, k, grid, clock, viscosity(closure, args...), Σ₁₃, U.u, U.v, U.w)
+@inline viscous_flux_ux(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶜᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₁₁, U.u, U.v, U.w)
+@inline viscous_flux_uy(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶠᶠᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₁₂, U.u, U.v, U.w)
+@inline viscous_flux_uz(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶠᶜᶠ(i, j, k, grid, clock, viscosity(closure, args...), Σ₁₃, U.u, U.v, U.w)
 
-@inline viscous_flux_vx(i, j, k, grid::APG, closure::AID, clock, U, args...) = - 2 * ν_σᶠᶠᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₂₁, U.u, U.v, U.w)
-@inline viscous_flux_vy(i, j, k, grid::APG, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶜᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₂₂, U.u, U.v, U.w)
-@inline viscous_flux_vz(i, j, k, grid::APG, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶠᶠ(i, j, k, grid, clock, viscosity(closure, args...), Σ₂₃, U.u, U.v, U.w)
+@inline viscous_flux_vx(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶠᶠᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₂₁, U.u, U.v, U.w)
+@inline viscous_flux_vy(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶜᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₂₂, U.u, U.v, U.w)
+@inline viscous_flux_vz(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶠᶠ(i, j, k, grid, clock, viscosity(closure, args...), Σ₂₃, U.u, U.v, U.w)
 
-@inline viscous_flux_wx(i, j, k, grid::APG, closure::AID, clock, U, args...) = - 2 * ν_σᶠᶜᶠ(i, j, k, grid, clock, viscosity(closure, args...), Σ₃₁, U.u, U.v, U.w)
-@inline viscous_flux_wy(i, j, k, grid::APG, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶠᶠ(i, j, k, grid, clock, viscosity(closure, args...), Σ₃₂, U.u, U.v, U.w)
-@inline viscous_flux_wz(i, j, k, grid::APG, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶜᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₃₃, U.u, U.v, U.w)
+@inline viscous_flux_wx(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶠᶜᶠ(i, j, k, grid, clock, viscosity(closure, args...), Σ₃₁, U.u, U.v, U.w)
+@inline viscous_flux_wy(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶠᶠ(i, j, k, grid, clock, viscosity(closure, args...), Σ₃₂, U.u, U.v, U.w)
+@inline viscous_flux_wz(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶜᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₃₃, U.u, U.v, U.w)
 
 #####
 ##### Diffusive fluxes
 #####
 
-@inline diffusive_flux_x(i, j, k, grid::APG, closure::AID, c, c_idx, clock, args...) = diffusive_flux_x(i, j, k, grid, clock, diffusivity(closure, c_idx, args...), c)
-@inline diffusive_flux_y(i, j, k, grid::APG, closure::AID, c, c_idx, clock, args...) = diffusive_flux_y(i, j, k, grid, clock, diffusivity(closure, c_idx, args...), c)
-@inline diffusive_flux_z(i, j, k, grid::APG, closure::AID, c, c_idx, clock, args...) = diffusive_flux_z(i, j, k, grid, clock, diffusivity(closure, c_idx, args...), c)
+@inline diffusive_flux_x(i, j, k, grid, closure::AID, c, c_idx, clock, args...) = diffusive_flux_x(i, j, k, grid, clock, diffusivity(closure, c_idx, args...), c)
+@inline diffusive_flux_y(i, j, k, grid, closure::AID, c, c_idx, clock, args...) = diffusive_flux_y(i, j, k, grid, clock, diffusivity(closure, c_idx, args...), c)
+@inline diffusive_flux_z(i, j, k, grid, closure::AID, c, c_idx, clock, args...) = diffusive_flux_z(i, j, k, grid, clock, diffusivity(closure, c_idx, args...), c)
 
 #####
 ##### Support for VerticallyImplicitTimeDiscretization
 #####
 
 const VITD = VerticallyImplicitTimeDiscretization
-const VerticallyBoundedGrid{FT} = APG{FT, <:Any, <:Any, <:Bounded}
+const VerticallyBoundedGrid{FT} = AbstractGrid{FT, <:Any, <:Any, <:Bounded}
 
 @inline z_viscosity(closure::AID, args...) = viscosity(closure, args...)
 @inline z_diffusivity(closure::AID, c_idx, args...) = diffusivity(closure, c_idx, args...)
@@ -78,10 +77,10 @@ const VerticallyBoundedGrid{FT} = APG{FT, <:Any, <:Any, <:Bounded}
 @inline ivd_viscous_flux_vz(i, j, k, grid, closure, clock, U, args...) = - ν_σᶜᶠᶠ(i, j, k, grid, clock, viscosity(closure, args...), ∂yᶜᶠᵃ, U.v)
 
 # General functions (eg for vertically periodic)
-@inline viscous_flux_uz(i, j, k, grid::APG,     ::VITD, closure::AID, args...) = ivd_viscous_flux_uz(i, j, k, grid, closure, args...)
-@inline viscous_flux_vz(i, j, k, grid::APG,     ::VITD, closure::AID, args...) = ivd_viscous_flux_vz(i, j, k, grid, closure, args...)
-@inline viscous_flux_wz(i, j, k, grid::APG{FT}, ::VITD, closure::AID, args...) where FT = zero(FT)
-@inline diffusive_flux_z(i, j, k, grid::APG{FT}, ::VITD, closure::AID, clock, args...) where FT = zero(FT)
+@inline viscous_flux_uz(i, j, k, grid   ::VITD, closure::AID, args...) = ivd_viscous_flux_uz(i, j, k, grid, closure, args...)
+@inline viscous_flux_vz(i, j, k, grid   ::VITD, closure::AID, args...) = ivd_viscous_flux_vz(i, j, k, grid, closure, args...)
+@inline viscous_flux_wz(i, j, k, grid,  ::VITD, closure::AID, args...) = zero(eltype(grid))
+@inline diffusive_flux_z(i, j, k, grid, ::VITD, closure::AID, clock, args...) = zero(eltype(grid))
                   
 # Vertically bounded grids
 #

--- a/src/TurbulenceClosures/implicit_explicit_time_discretization.jl
+++ b/src/TurbulenceClosures/implicit_explicit_time_discretization.jl
@@ -34,21 +34,20 @@ struct VerticallyImplicitTimeDiscretization <: AbstractTimeDiscretization end
 ##### ExplicitTimeDiscretization: move along, nothing to worry about here (use fallbacks).
 #####
 
-const APG = AbstractPrimaryGrid
 const ATD = AbstractTimeDiscretization
 
-@inline diffusive_flux_x(i, j, k, grid::APG, ::ATD, args...) = diffusive_flux_x(i, j, k, grid, args...)
-@inline diffusive_flux_y(i, j, k, grid::APG, ::ATD, args...) = diffusive_flux_y(i, j, k, grid, args...)
-@inline diffusive_flux_z(i, j, k, grid::APG, ::ATD, args...) = diffusive_flux_z(i, j, k, grid, args...) 
+@inline diffusive_flux_x(i, j, k, grid, ::ATD, args...) = diffusive_flux_x(i, j, k, grid, args...)
+@inline diffusive_flux_y(i, j, k, grid, ::ATD, args...) = diffusive_flux_y(i, j, k, grid, args...)
+@inline diffusive_flux_z(i, j, k, grid, ::ATD, args...) = diffusive_flux_z(i, j, k, grid, args...) 
 
-@inline viscous_flux_ux(i, j, k, grid::APG, ::ATD, args...) = viscous_flux_ux(i, j, k, grid, args...)
-@inline viscous_flux_uy(i, j, k, grid::APG, ::ATD, args...) = viscous_flux_uy(i, j, k, grid, args...)
-@inline viscous_flux_uz(i, j, k, grid::APG, ::ATD, args...) = viscous_flux_uz(i, j, k, grid, args...)
+@inline viscous_flux_ux(i, j, k, grid, ::ATD, args...) = viscous_flux_ux(i, j, k, grid, args...)
+@inline viscous_flux_uy(i, j, k, grid, ::ATD, args...) = viscous_flux_uy(i, j, k, grid, args...)
+@inline viscous_flux_uz(i, j, k, grid, ::ATD, args...) = viscous_flux_uz(i, j, k, grid, args...)
 
-@inline viscous_flux_vx(i, j, k, grid::APG, ::ATD, args...) = viscous_flux_vx(i, j, k, grid, args...)
-@inline viscous_flux_vy(i, j, k, grid::APG, ::ATD, args...) = viscous_flux_vy(i, j, k, grid, args...)
-@inline viscous_flux_vz(i, j, k, grid::APG, ::ATD, args...) = viscous_flux_vz(i, j, k, grid, args...)
+@inline viscous_flux_vx(i, j, k, grid, ::ATD, args...) = viscous_flux_vx(i, j, k, grid, args...)
+@inline viscous_flux_vy(i, j, k, grid, ::ATD, args...) = viscous_flux_vy(i, j, k, grid, args...)
+@inline viscous_flux_vz(i, j, k, grid, ::ATD, args...) = viscous_flux_vz(i, j, k, grid, args...)
 
-@inline viscous_flux_wx(i, j, k, grid::APG, ::ATD, args...) = viscous_flux_wx(i, j, k, grid, args...)
-@inline viscous_flux_wy(i, j, k, grid::APG, ::ATD, args...) = viscous_flux_wy(i, j, k, grid, args...)
-@inline viscous_flux_wz(i, j, k, grid::APG, ::ATD, args...) = viscous_flux_wz(i, j, k, grid, args...)
+@inline viscous_flux_wx(i, j, k, grid, ::ATD, args...) = viscous_flux_wx(i, j, k, grid, args...)
+@inline viscous_flux_wy(i, j, k, grid, ::ATD, args...) = viscous_flux_wy(i, j, k, grid, args...)
+@inline viscous_flux_wz(i, j, k, grid, ::ATD, args...) = viscous_flux_wz(i, j, k, grid, args...)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_diffusivity.jl
@@ -67,34 +67,32 @@ calculate_diffusivities!(K, arch, grid, closure::AnisotropicDiffusivity, args...
 ##### Diffusive fluxes
 #####
 
-const APG = AbstractPrimaryGrid
-
-@inline function diffusive_flux_x(i, j, k, grid::APG, closure::AD, c, ::Val{tracer_index}, clock, args...) where tracer_index
+@inline function diffusive_flux_x(i, j, k, grid, closure::AD, c, ::Val{tracer_index}, clock, args...) where tracer_index
     @inbounds κx = closure.κx[tracer_index]
     return diffusive_flux_x(i, j, k, grid, clock, κx, c)
 end
 
-@inline function diffusive_flux_y(i, j, k, grid::APG, closure::AD, c, ::Val{tracer_index}, clock, args...) where tracer_index
+@inline function diffusive_flux_y(i, j, k, grid, closure::AD, c, ::Val{tracer_index}, clock, args...) where tracer_index
     @inbounds κy = closure.κy[tracer_index]
     return diffusive_flux_y(i, j, k, grid, clock, κy, c)
 end
 
-@inline function diffusive_flux_z(i, j, k, grid::APG, closure::AD, c, ::Val{tracer_index}, clock, args...) where tracer_index
+@inline function diffusive_flux_z(i, j, k, grid, closure::AD, c, ::Val{tracer_index}, clock, args...) where tracer_index
     @inbounds κz = closure.κz[tracer_index]
     return diffusive_flux_z(i, j, k, grid, clock, κz, c)
 end
 
-viscous_flux_ux(i, j, k, grid::APG, closure::AD, clock, U, args...) = viscous_flux_ux(i, j, k, grid, clock, closure.νx, U[1])
-viscous_flux_uy(i, j, k, grid::APG, closure::AD, clock, U, args...) = viscous_flux_uy(i, j, k, grid, clock, closure.νy, U[1])  
-viscous_flux_uz(i, j, k, grid::APG, closure::AD, clock, U, args...) = viscous_flux_uz(i, j, k, grid, clock, closure.νz, U[1])
+viscous_flux_ux(i, j, k, grid, closure::AD, clock, U, args...) = viscous_flux_ux(i, j, k, grid, clock, closure.νx, U[1])
+viscous_flux_uy(i, j, k, grid, closure::AD, clock, U, args...) = viscous_flux_uy(i, j, k, grid, clock, closure.νy, U[1])  
+viscous_flux_uz(i, j, k, grid, closure::AD, clock, U, args...) = viscous_flux_uz(i, j, k, grid, clock, closure.νz, U[1])
 
-viscous_flux_vx(i, j, k, grid::APG, closure::AD, clock, U, args...) = viscous_flux_vx(i, j, k, grid, clock, closure.νx, U[2])
-viscous_flux_vy(i, j, k, grid::APG, closure::AD, clock, U, args...) = viscous_flux_vy(i, j, k, grid, clock, closure.νy, U[2])  
-viscous_flux_vz(i, j, k, grid::APG, closure::AD, clock, U, args...) = viscous_flux_vz(i, j, k, grid, clock, closure.νz, U[2])
+viscous_flux_vx(i, j, k, grid, closure::AD, clock, U, args...) = viscous_flux_vx(i, j, k, grid, clock, closure.νx, U[2])
+viscous_flux_vy(i, j, k, grid, closure::AD, clock, U, args...) = viscous_flux_vy(i, j, k, grid, clock, closure.νy, U[2])  
+viscous_flux_vz(i, j, k, grid, closure::AD, clock, U, args...) = viscous_flux_vz(i, j, k, grid, clock, closure.νz, U[2])
 
-viscous_flux_wx(i, j, k, grid::APG, closure::AD, clock, U, args...) = viscous_flux_wx(i, j, k, grid, clock, closure.νx, U[3])
-viscous_flux_wy(i, j, k, grid::APG, closure::AD, clock, U, args...) = viscous_flux_wy(i, j, k, grid, clock, closure.νy, U[3])  
-viscous_flux_wz(i, j, k, grid::APG, closure::AD, clock, U, args...) = viscous_flux_wz(i, j, k, grid, clock, closure.νz, U[3])
+viscous_flux_wx(i, j, k, grid, closure::AD, clock, U, args...) = viscous_flux_wx(i, j, k, grid, clock, closure.νx, U[3])
+viscous_flux_wy(i, j, k, grid, closure::AD, clock, U, args...) = viscous_flux_wy(i, j, k, grid, clock, closure.νy, U[3])  
+viscous_flux_wz(i, j, k, grid, closure::AD, clock, U, args...) = viscous_flux_wz(i, j, k, grid, clock, closure.νz, U[3])
 
 #####
 ##### Support for vertically implicit time integration
@@ -107,9 +105,9 @@ z_diffusivity(closure::AD, ::Val{tracer_index}, args...) where tracer_index = @i
 
 const VerticallyBoundedGrid{FT} = AbstractPrimaryGrid{FT, <:Any, <:Any, <:Bounded}
 
-@inline diffusive_flux_z(i, j, k, grid::APG{FT}, ::VITD, closure::AD, args...) where FT = zero(FT)
-@inline viscous_flux_uz(i, j, k, grid::APG{FT}, ::VITD, closure::AD, args...) where FT = zero(FT)
-@inline viscous_flux_vz(i, j, k, grid::APG{FT}, ::VITD, closure::AD, args...) where FT = zero(FT)
+@inline diffusive_flux_z(i, j, k, grid, ::VITD, closure::AD, args...) = zero(eltype(grid))
+@inline viscous_flux_uz(i, j, k, grid, ::VITD, closure::AD, args...) = zero(eltype(grid))
+@inline viscous_flux_vz(i, j, k, grid, ::VITD, closure::AD, args...) = zero(eltype(grid))
 
 @inline function diffusive_flux_z(i, j, k, grid::VerticallyBoundedGrid{FT}, ::VITD, closure::AD, args...) where FT
     return ifelse(k == 1 || k == grid.Nz+1, 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_diffusivity.jl
@@ -103,7 +103,7 @@ const VITD = VerticallyImplicitTimeDiscretization
 z_viscosity(closure::AD, args...) = closure.νz
 z_diffusivity(closure::AD, ::Val{tracer_index}, args...) where tracer_index = @inbounds closure.κz[tracer_index]
 
-const VerticallyBoundedGrid{FT} = AbstractPrimaryGrid{FT, <:Any, <:Any, <:Bounded}
+const VerticallyBoundedGrid{FT} = AbstractGrid{FT, <:Any, <:Any, <:Bounded}
 
 @inline diffusive_flux_z(i, j, k, grid, ::VITD, closure::AD, args...) = zero(eltype(grid))
 @inline viscous_flux_uz(i, j, k, grid, ::VITD, closure::AD, args...) = zero(eltype(grid))

--- a/src/TurbulenceClosures/turbulence_closure_implementations/convective_adjustment_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/convective_adjustment_vertical_diffusivity.jl
@@ -187,12 +187,11 @@ end
 @inline κᶜᶜᶠ(i, j, k, grid, clock, c::ConvectiveAdjustmentCoeff{I}) where I = κᶜᶜᶠ(i, j, k, grid, clock, c.closure, c.stable_buoyancy_gradient, Val(I))
 
 const VITD = VerticallyImplicitTimeDiscretization
-const APG = AbstractPrimaryGrid
-const VerticallyBoundedGrid{FT} = AbstractPrimaryGrid{FT, <:Any, <:Any, <:Bounded}
+const VerticallyBoundedGrid{FT} = AbstractGrid{FT, <:Any, <:Any, <:Bounded}
 
-@inline diffusive_flux_z(i, j, k, grid::APG{FT}, ::VITD, closure::CAVD, args...) where FT = zero(FT)
-@inline viscous_flux_uz(i, j, k, grid::APG{FT}, ::VITD, closure::CAVD, args...) where FT = zero(FT)
-@inline viscous_flux_vz(i, j, k, grid::APG{FT}, ::VITD, closure::CAVD, args...) where FT = zero(FT)
+@inline diffusive_flux_z(i, j, k, grid, ::VITD, closure::CAVD, args...) = zero(eltype(grid))
+@inline viscous_flux_uz(i, j, k, grid, ::VITD, closure::CAVD, args...) = zero(eltype(grid))
+@inline viscous_flux_vz(i, j, k, grid, ::VITD, closure::CAVD, args...) = zero(eltype(grid))
 
 @inline function diffusive_flux_z(i, j, k, grid::VerticallyBoundedGrid{FT}, ::VITD, closure::CAVD, args...) where FT
     return ifelse(k == 1 || k == grid.Nz+1, 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/horizontally_curvilinear_anisotropic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/horizontally_curvilinear_anisotropic_diffusivity.jl
@@ -54,29 +54,27 @@ function with_tracers(tracers, closure::HorizontallyCurvilinearAnisotropicDiffus
     return HorizontallyCurvilinearAnisotropicDiffusivity{TD}(closure.νh, closure.νz, κh, κz)
 end
 
-const APG = AbstractPrimaryGrid
-
 calculate_diffusivities!(K, arch, grid, closure::HorizontallyCurvilinearAnisotropicDiffusivity, args...) = nothing
 
-viscous_flux_ux(i, j, k, grid::APG, closure::HCAD, clock, U, args...) = - ν_δᶜᶜᶜ(i, j, k, grid, clock, closure.νh, U.u, U.v)   
-viscous_flux_uy(i, j, k, grid::APG, closure::HCAD, clock, U, args...) = + ν_ζᶠᶠᶜ(i, j, k, grid, clock, closure.νh, U.u, U.v)   
-viscous_flux_uz(i, j, k, grid::APG, closure::HCAD, clock, U, args...) = - ν_uzᶠᶜᶠ(i, j, k, grid, clock, closure.νz, U.u)
+viscous_flux_ux(i, j, k, grid, closure::HCAD, clock, U, args...) = - ν_δᶜᶜᶜ(i, j, k, grid, clock, closure.νh, U.u, U.v)   
+viscous_flux_uy(i, j, k, grid, closure::HCAD, clock, U, args...) = + ν_ζᶠᶠᶜ(i, j, k, grid, clock, closure.νh, U.u, U.v)   
+viscous_flux_uz(i, j, k, grid, closure::HCAD, clock, U, args...) = - ν_uzᶠᶜᶠ(i, j, k, grid, clock, closure.νz, U.u)
                                                          
-viscous_flux_vx(i, j, k, grid::APG, closure::HCAD, clock, U, args...) = - ν_ζᶠᶠᶜ(i, j, k, grid, clock, closure.νh, U.u, U.v)
-viscous_flux_vy(i, j, k, grid::APG, closure::HCAD, clock, U, args...) = - ν_δᶜᶜᶜ(i, j, k, grid, clock, closure.νh, U.u, U.v)
-viscous_flux_vz(i, j, k, grid::APG, closure::HCAD, clock, U, args...) = - ν_vzᶜᶠᶠ(i, j, k, grid, clock, closure.νz, U.v)
+viscous_flux_vx(i, j, k, grid, closure::HCAD, clock, U, args...) = - ν_ζᶠᶠᶜ(i, j, k, grid, clock, closure.νh, U.u, U.v)
+viscous_flux_vy(i, j, k, grid, closure::HCAD, clock, U, args...) = - ν_δᶜᶜᶜ(i, j, k, grid, clock, closure.νh, U.u, U.v)
+viscous_flux_vz(i, j, k, grid, closure::HCAD, clock, U, args...) = - ν_vzᶜᶠᶠ(i, j, k, grid, clock, closure.νz, U.v)
 
-@inline function diffusive_flux_x(i, j, k, grid::APG, closure::HCAD, c, ::Val{tracer_index}, clock, args...) where tracer_index
+@inline function diffusive_flux_x(i, j, k, grid, closure::HCAD, c, ::Val{tracer_index}, clock, args...) where tracer_index
     @inbounds κh = closure.κh[tracer_index]
     return diffusive_flux_x(i, j, k, grid, clock, κh, c)
 end
 
-@inline function diffusive_flux_y(i, j, k, grid::APG, closure::HCAD, c, ::Val{tracer_index}, clock, args...) where tracer_index
+@inline function diffusive_flux_y(i, j, k, grid, closure::HCAD, c, ::Val{tracer_index}, clock, args...) where tracer_index
     @inbounds κh = closure.κh[tracer_index]
     return diffusive_flux_y(i, j, k, grid, clock, κh, c)
 end
 
-@inline function diffusive_flux_z(i, j, k, grid::APG, closure::HCAD, c, ::Val{tracer_index}, clock, args...) where tracer_index
+@inline function diffusive_flux_z(i, j, k, grid, closure::HCAD, c, ::Val{tracer_index}, clock, args...) where tracer_index
     @inbounds κz = closure.κz[tracer_index]
     return diffusive_flux_z(i, j, k, grid, clock, κz, c)
 end
@@ -90,11 +88,11 @@ const VITD = VerticallyImplicitTimeDiscretization
 z_viscosity(closure::HorizontallyCurvilinearAnisotropicDiffusivity, args...) = closure.νz
 z_diffusivity(closure::HorizontallyCurvilinearAnisotropicDiffusivity, ::Val{tracer_index}, args...) where tracer_index = @inbounds closure.κz[tracer_index]
 
-const VerticallyBoundedGrid{FT} = AbstractPrimaryGrid{FT, <:Any, <:Any, <:Bounded}
+const VerticallyBoundedGrid{FT} = AbstractGrid{FT, <:Any, <:Any, <:Bounded}
 
-@inline diffusive_flux_z(i, j, k, grid::APG{FT}, ::VITD, closure::HCAD, args...) where FT = zero(FT)
-@inline viscous_flux_uz(i, j, k, grid::APG{FT}, ::VITD, closure::HCAD, args...) where FT = zero(FT)
-@inline viscous_flux_vz(i, j, k, grid::APG{FT}, ::VITD, closure::HCAD, args...) where FT = zero(FT)
+@inline diffusive_flux_z(i, j, k, grid, ::VITD, closure::HCAD, args...) = zero(eltype(grid))
+@inline viscous_flux_uz(i, j, k, grid, ::VITD, closure::HCAD, args...) = zero(eltype(grid))
+@inline viscous_flux_vz(i, j, k, grid, ::VITD, closure::HCAD, args...) = zero(eltype(grid))
 
 @inline function diffusive_flux_z(i, j, k, grid::VerticallyBoundedGrid{FT}, ::VITD, closure::HCAD, args...) where FT
     return ifelse(k == 1 || k == grid.Nz+1, 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
@@ -550,7 +550,7 @@ const VITD = VerticallyImplicitTimeDiscretization
     end
 end
 
-const VerticallyBoundedGrid{FT} = AbstractPrimaryGrid{FT, <:Any, <:Any, <:Bounded}
+const VerticallyBoundedGrid{FT} = AbstractGrid{FT, <:Any, <:Any, <:Bounded}
 
 @inline diffusive_flux_z(i, j, k, grid::APG{FT}, ::VITD, closure::TKEVD, args...) where FT = zero(FT)
 @inline viscous_flux_uz(i, j, k, grid::APG{FT}, ::VITD, closure::TKEVD, args...) where FT = zero(FT)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
@@ -525,6 +525,12 @@ end
 @inline diffusive_flux_z(i, j, k, grid, closure, e, ::TKETracerIndex{N}, args...) where N = diffusive_flux_z(i, j, k, grid, closure, e, Val(N), args...)
 
 # Shortcuts --- TKEVD incurs no horizontal transport
+@inline viscous_flux_ux(i, j, k, grid, ::TKEVD, args...) = zero(eltype(grid))
+@inline viscous_flux_uy(i, j, k, grid, ::TKEVD, args...) = zero(eltype(grid))
+@inline viscous_flux_vx(i, j, k, grid, ::TKEVD, args...) = zero(eltype(grid))
+@inline viscous_flux_vy(i, j, k, grid, ::TKEVD, args...) = zero(eltype(grid))
+@inline viscous_flux_wx(i, j, k, grid, ::TKEVD, args...) = zero(eltype(grid))
+@inline viscous_flux_wy(i, j, k, grid, ::TKEVD, args...) = zero(eltype(grid))
 @inline diffusive_flux_x(i, j, k, grid, ::TKEVD, args...) = zero(eltype(grid))
 @inline diffusive_flux_y(i, j, k, grid, ::TKEVD, args...) = zero(eltype(grid))
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
@@ -552,9 +552,9 @@ end
 
 const VerticallyBoundedGrid{FT} = AbstractGrid{FT, <:Any, <:Any, <:Bounded}
 
-@inline diffusive_flux_z(i, j, k, grid::APG{FT}, ::VITD, closure::TKEVD, args...) where FT = zero(FT)
-@inline viscous_flux_uz(i, j, k, grid::APG{FT}, ::VITD, closure::TKEVD, args...) where FT = zero(FT)
-@inline viscous_flux_vz(i, j, k, grid::APG{FT}, ::VITD, closure::TKEVD, args...) where FT = zero(FT)
+@inline diffusive_flux_z(i, j, k, grid, ::VITD, closure::TKEVD, args...) = zero(eltype(grid))
+@inline viscous_flux_uz(i, j, k, grid, ::VITD, closure::TKEVD, args...) = zero(eltype(grid))
+@inline viscous_flux_vz(i, j, k, grid, ::VITD, closure::TKEVD, args...) = zero(eltype(grid))
 
 @inline function diffusive_flux_z(i, j, k, grid::VerticallyBoundedGrid{FT}, ::VITD, closure::TKEVD, args...) where FT
     return ifelse(k == 1 || k == grid.Nz+1, 

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -1,4 +1,5 @@
 using Oceananigans.TurbulenceClosures: ExplicitTimeDiscretization, VerticallyImplicitTimeDiscretization, z_viscosity
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary
 
 function relative_error(u_num, u, time)
     u_ans = Field(location(u_num), architecture(u_num), u_num.grid, nothing)
@@ -81,7 +82,7 @@ function test_diffusion_cosine(fieldname, timestepper, grid, time_discretization
     diffusing_cosine(κ, m, z, t) = exp(-κ * m^2 * t) * cos(m * z)
 
     # Step forward with small time-step relative to diff. time-scale
-    Δt = 1e-6 * Lz^2 / κ
+    Δt = 1e-6 * grid.Lz^2 / κ
     for n in 1:10
         ab2_or_rk3_time_step!(model, Δt, n)
     end

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -277,8 +277,8 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
 
             for Closure in Closures
                 @info "  Testing that time stepping works [$(typeof(arch)), $FT, $Closure]..."
-                if Closure === TwoDimensionalLeith && arch isa CPU
-                    # This test is extremely slow so we skip.
+                if Closure === TwoDimensionalLeith
+                    # TwoDimensionalLeith is slow on the CPU and doesn't compile right now on the GPU.
                     # See: https://github.com/CliMA/Oceananigans.jl/pull/1074
                     @test_skip time_stepping_works_with_closure(arch, FT, Closure)
                 else


### PR DESCRIPTION
Previously the functions viscous_flux_u* and diffusive_flux_* dispatched on AbstractPrimaryGrid. AbstractPrimaryGrid (now called AbstractUnderlyingGrid is an abstract type for distinguishing between ImmersedBoundaryGrid and the "primitive" / "primary" / "underlying" counterparts (I guess I'm still not sure what the best name is).

As a result, flux calculations with ImmersedBoundaryGrid were hitting fallback flux functions that returned 0.

This PR removes most instances dispatching on grid (except where necessary, where the dispatched type was changed from AbstractPrimaryGrid to AbstractGrid). It also nukes the fallbacks (which were the reason this issue escaped detection originally).

This PR also adds a minimal test that _vertical_ diffusive and viscous fluxes work. It does not test the horizontal fluxes, but the test will catch egregious bugs like the one this PR fixes.

The original motivation for dispatching on AbstractPrimaryGrid is not only wrong but also appears to be unnecessary, since the tests on this PR pass.

For some reason TwoDimensionalLeith was also having trouble compiling on the GPU, so we're skipping those tests for now.