### PR TITLE
Better momentum/tracer advection docstrings and function names

### DIFF
--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -2,7 +2,6 @@ module Advection
 
 export 
     div_𝐯u, div_𝐯v, div_𝐯w, div_Uc,
-    U_grad_u, U_grad_v, U_grad_w, U_grad_c,
 
     momentum_flux_uu,
     momentum_flux_uv,

--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -1,7 +1,7 @@
 module Advection
 
 export 
-    div_Uu, div_Uv, div_Uw, div_Uc,
+    div_𝐯u, div_𝐯v, div_𝐯w, div_Uc,
     U_grad_u, U_grad_v, U_grad_w, U_grad_c,
 
     momentum_flux_uu,

--- a/src/Advection/momentum_advection_operators.jl
+++ b/src/Advection/momentum_advection_operators.jl
@@ -47,11 +47,11 @@ const ZeroU = NamedTuple{(:u, :v, :w), Tuple{ZeroField, ZeroField, ZeroField}}
 """
     div_Uu(i, j, k, grid, advection, U, u)
 
-Calculate the advection of momentum in the x-direction using the conservative form, ∇·(Uu)
+Calculate the advection of momentum in the ``x``-direction using the conservative form, ``𝛁⋅(𝐯 u)``,
 
     1/Vᵘ * [δxᶠᵃᵃ(ℑxᶜᵃᵃ(Ax * u) * ℑxᶜᵃᵃ(u)) + δy_fca(ℑxᶠᵃᵃ(Ay * v) * ℑyᵃᶠᵃ(u)) + δz_fac(ℑxᶠᵃᵃ(Az * w) * ℑzᵃᵃᶠ(u))]
 
-which will end up at the location `fcc`.
+which ends up at the location `fcc`.
 """
 @inline function div_Uu(i, j, k, grid, advection, U, u)
     return 1/Vᶠᶜᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uu, advection, U[1], u) +
@@ -62,11 +62,11 @@ end
 """
     div_Uv(i, j, k, grid, advection, U, v)
 
-Calculate the advection of momentum in the y-direction using the conservative form, ∇·(Uv)
+Calculate the advection of momentum in the ``y``-direction using the conservative form, ``𝛁⋅(𝐯 v)``,
 
     1/Vʸ * [δx_cfa(ℑyᵃᶠᵃ(Ax * u) * ℑxᶠᵃᵃ(v)) + δyᵃᶠᵃ(ℑyᵃᶜᵃ(Ay * v) * ℑyᵃᶜᵃ(v)) + δz_afc(ℑxᶠᵃᵃ(Az * w) * ℑzᵃᵃᶠ(w))]
 
-which will end up at the location `cfc`.
+which ends up at the location `cfc`.
 """
 @inline function div_Uv(i, j, k, grid, advection, U, v)
     return 1/Vᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uv, advection, U[1], v) +
@@ -77,11 +77,11 @@ end
 """
     div_Uw(i, j, k, grid, advection, U, w)
 
-Calculate the advection of momentum in the z-direction using the conservative form, ∇·(Uw)
+Calculate the advection of momentum in the ``z``-direction using the conservative form, ``𝛁⋅(𝐯 w)``,
 
     1/Vʷ * [δx_caf(ℑzᵃᵃᶠ(Ax * u) * ℑxᶠᵃᵃ(w)) + δy_acf(ℑzᵃᵃᶠ(Ay * v) * ℑyᵃᶠᵃ(w)) + δzᵃᵃᶠ(ℑzᵃᵃᶜ(Az * w) * ℑzᵃᵃᶜ(w))]
 
-which will end up at the location `ccf`.
+which ends up at the location `ccf`.
 """
 @inline function div_Uw(i, j, k, grid, advection, U, w)
     return 1/Vᶜᶜᶠ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uw, advection, U[1], w) +

--- a/src/Advection/momentum_advection_operators.jl
+++ b/src/Advection/momentum_advection_operators.jl
@@ -24,28 +24,28 @@ using Oceananigans.Fields: ZeroField
 const ZeroU = NamedTuple{(:u, :v, :w), Tuple{ZeroField, ZeroField, ZeroField}}
 
 # Compiler hints
-@inline div_Uu(i, j, k, grid, advection, ::ZeroU, u) = zero(eltype(grid))
-@inline div_Uv(i, j, k, grid, advection, ::ZeroU, v) = zero(eltype(grid))
-@inline div_Uw(i, j, k, grid, advection, ::ZeroU, w) = zero(eltype(grid))
+@inline div_𝐯u(i, j, k, grid, advection, ::ZeroU, u) = zero(eltype(grid))
+@inline div_𝐯v(i, j, k, grid, advection, ::ZeroU, v) = zero(eltype(grid))
+@inline div_𝐯w(i, j, k, grid, advection, ::ZeroU, w) = zero(eltype(grid))
 
-@inline div_Uu(i, j, k, grid, advection, U, ::ZeroField) = zero(eltype(grid))
-@inline div_Uv(i, j, k, grid, advection, U, ::ZeroField) = zero(eltype(grid))
-@inline div_Uw(i, j, k, grid, advection, U, ::ZeroField) = zero(eltype(grid))
+@inline div_𝐯u(i, j, k, grid, advection, U, ::ZeroField) = zero(eltype(grid))
+@inline div_𝐯v(i, j, k, grid, advection, U, ::ZeroField) = zero(eltype(grid))
+@inline div_𝐯w(i, j, k, grid, advection, U, ::ZeroField) = zero(eltype(grid))
 
-@inline div_Uu(i, j, k, grid, ::Nothing, U, u) = zero(eltype(grid))
-@inline div_Uv(i, j, k, grid, ::Nothing, U, v) = zero(eltype(grid))
-@inline div_Uw(i, j, k, grid, ::Nothing, U, w) = zero(eltype(grid))
+@inline div_𝐯u(i, j, k, grid, ::Nothing, U, u) = zero(eltype(grid))
+@inline div_𝐯v(i, j, k, grid, ::Nothing, U, v) = zero(eltype(grid))
+@inline div_𝐯w(i, j, k, grid, ::Nothing, U, w) = zero(eltype(grid))
 
-@inline div_Uu(i, j, k, grid, ::Nothing, ::ZeroU, u) = zero(eltype(grid))
-@inline div_Uv(i, j, k, grid, ::Nothing, ::ZeroU, v) = zero(eltype(grid))
-@inline div_Uw(i, j, k, grid, ::Nothing, ::ZeroU, w) = zero(eltype(grid))
+@inline div_𝐯u(i, j, k, grid, ::Nothing, ::ZeroU, u) = zero(eltype(grid))
+@inline div_𝐯v(i, j, k, grid, ::Nothing, ::ZeroU, v) = zero(eltype(grid))
+@inline div_𝐯w(i, j, k, grid, ::Nothing, ::ZeroU, w) = zero(eltype(grid))
 
-@inline div_Uu(i, j, k, grid, ::Nothing, U, ::ZeroField) = zero(eltype(grid))
-@inline div_Uv(i, j, k, grid, ::Nothing, U, ::ZeroField) = zero(eltype(grid))
-@inline div_Uw(i, j, k, grid, ::Nothing, U, ::ZeroField) = zero(eltype(grid))
+@inline div_𝐯u(i, j, k, grid, ::Nothing, U, ::ZeroField) = zero(eltype(grid))
+@inline div_𝐯v(i, j, k, grid, ::Nothing, U, ::ZeroField) = zero(eltype(grid))
+@inline div_𝐯w(i, j, k, grid, ::Nothing, U, ::ZeroField) = zero(eltype(grid))
 
 """
-    div_Uu(i, j, k, grid, advection, U, u)
+    div_𝐯u(i, j, k, grid, advection, U, u)
 
 Calculate the advection of momentum in the ``x``-direction using the conservative form, ``𝛁⋅(𝐯 u)``,
 
@@ -53,14 +53,14 @@ Calculate the advection of momentum in the ``x``-direction using the conservativ
 
 which ends up at the location `fcc`.
 """
-@inline function div_Uu(i, j, k, grid, advection, U, u)
+@inline function div_𝐯u(i, j, k, grid, advection, U, u)
     return 1/Vᶠᶜᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uu, advection, U[1], u) +
                                     δyᵃᶜᵃ(i, j, k, grid, _advective_momentum_flux_Vu, advection, U[2], u) +
                                     δzᵃᵃᶜ(i, j, k, grid, _advective_momentum_flux_Wu, advection, U[3], u))
 end
 
 """
-    div_Uv(i, j, k, grid, advection, U, v)
+    div_𝐯v(i, j, k, grid, advection, U, v)
 
 Calculate the advection of momentum in the ``y``-direction using the conservative form, ``𝛁⋅(𝐯 v)``,
 
@@ -68,14 +68,14 @@ Calculate the advection of momentum in the ``y``-direction using the conservativ
 
 which ends up at the location `cfc`.
 """
-@inline function div_Uv(i, j, k, grid, advection, U, v)
+@inline function div_𝐯v(i, j, k, grid, advection, U, v)
     return 1/Vᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uv, advection, U[1], v) +
                                     δyᵃᶠᵃ(i, j, k, grid, _advective_momentum_flux_Vv, advection, U[2], v)    +
                                     δzᵃᵃᶜ(i, j, k, grid, _advective_momentum_flux_Wv, advection, U[3], v))
 end
 
 """
-    div_Uw(i, j, k, grid, advection, U, w)
+    div_𝐯w(i, j, k, grid, advection, U, w)
 
 Calculate the advection of momentum in the ``z``-direction using the conservative form, ``𝛁⋅(𝐯 w)``,
 
@@ -83,7 +83,7 @@ Calculate the advection of momentum in the ``z``-direction using the conservativ
 
 which ends up at the location `ccf`.
 """
-@inline function div_Uw(i, j, k, grid, advection, U, w)
+@inline function div_𝐯w(i, j, k, grid, advection, U, w)
     return 1/Vᶜᶜᶠ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uw, advection, U[1], w) +
                                     δyᵃᶜᵃ(i, j, k, grid, _advective_momentum_flux_Vw, advection, U[2], w) +
                                     δzᵃᵃᶠ(i, j, k, grid, _advective_momentum_flux_Ww, advection, U[3], w))

--- a/src/Advection/tracer_advection_operators.jl
+++ b/src/Advection/tracer_advection_operators.jl
@@ -17,12 +17,12 @@ const ZeroU = NamedTuple{(:u, :v, :w), Tuple{ZeroField, ZeroField, ZeroField}}
 """
     div_uc(i, j, k, grid, advection, U, c)
 
-Calculates the divergence of the flux of a tracer quantity c being advected by
-a velocity field U = (u, v, w), ∇·(Uc),
+Calculates the divergence of the flux of a tracer quantity ``c`` being advected by
+a velocity field, ``𝛁⋅(𝐯 c)``,
 
     1/V * [δxᶜᵃᵃ(Ax * u * ℑxᶠᵃᵃ(c)) + δyᵃᶜᵃ(Ay * v * ℑyᵃᶠᵃ(c)) + δzᵃᵃᶜ(Az * w * ℑzᵃᵃᶠ(c))]
 
-which will end up at the location `ccc`.
+which ends up at the location `ccc`.
 """
 @inline function div_Uc(i, j, k, grid, advection, U, c)
     1/Vᶜᶜᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, advective_tracer_flux_x, advection, U.u, c) +

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_advection.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_advection.jl
@@ -1,7 +1,7 @@
 using Oceananigans.Operators
 
 using Oceananigans.Operators: Δx_vᶜᶠᵃ, Δy_uᶠᶜᵃ, Δxᶠᶜᵃ, Δyᶜᶠᵃ, Az_wᶜᶜᵃ
-using Oceananigans.Advection: div_Uu, div_Uv
+using Oceananigans.Advection: div_𝐯u, div_𝐯v
 
 ######
 ###### Horizontally-vector-invariant formulation of momentum advection
@@ -29,8 +29,8 @@ using Oceananigans.Advection: div_Uu, div_Uv
 ###### Conservative formulation of momentum advection
 ######
 
-@inline U_dot_∇u(i, j, k, grid, advection::AbstractAdvectionScheme, U) = div_Uu(i, j, k, grid, advection, U, U.u)
-@inline U_dot_∇v(i, j, k, grid, advection::AbstractAdvectionScheme, U) = div_Uv(i, j, k, grid, advection, U, U.v)
+@inline U_dot_∇u(i, j, k, grid, advection::AbstractAdvectionScheme, U) = div_𝐯u(i, j, k, grid, advection, U, U.u)
+@inline U_dot_∇v(i, j, k, grid, advection::AbstractAdvectionScheme, U) = div_𝐯v(i, j, k, grid, advection, U, U.v)
 
 ######
 ###### No advection

--- a/src/Models/IncompressibleModels/velocity_and_tracer_tendencies.jl
+++ b/src/Models/IncompressibleModels/velocity_and_tracer_tendencies.jl
@@ -42,9 +42,9 @@ pressure anomaly.
                                      hydrostatic_pressure,
                                      clock)
 
-    return ( - div_Uu(i, j, k, grid, advection, velocities, velocities.u)
-             - div_Uu(i, j, k, grid, advection, background_fields.velocities, velocities.u)
-             - div_Uu(i, j, k, grid, advection, velocities, background_fields.velocities.u)
+    return ( - div_𝐯u(i, j, k, grid, advection, velocities, velocities.u)
+             - div_𝐯u(i, j, k, grid, advection, background_fields.velocities, velocities.u)
+             - div_𝐯u(i, j, k, grid, advection, velocities, background_fields.velocities.u)
              - x_f_cross_U(i, j, k, grid, coriolis, velocities)
              - ∂xᶠᶜᵃ(i, j, k, grid, hydrostatic_pressure)
              - ∂ⱼ_τ₁ⱼ(i, j, k, grid, closure, clock, velocities, diffusivities, tracers, buoyancy)
@@ -91,9 +91,9 @@ pressure anomaly.
                                      hydrostatic_pressure,
                                      clock)
 
-    return ( - div_Uv(i, j, k, grid, advection, velocities, velocities.v)
-             - div_Uv(i, j, k, grid, advection, background_fields.velocities, velocities.v)
-             - div_Uv(i, j, k, grid, advection, velocities, background_fields.velocities.v)
+    return ( - div_𝐯v(i, j, k, grid, advection, velocities, velocities.v)
+             - div_𝐯v(i, j, k, grid, advection, background_fields.velocities, velocities.v)
+             - div_𝐯v(i, j, k, grid, advection, velocities, background_fields.velocities.v)
              - y_f_cross_U(i, j, k, grid, coriolis, velocities)
              - ∂yᶜᶠᵃ(i, j, k, grid, hydrostatic_pressure)
              - ∂ⱼ_τ₂ⱼ(i, j, k, grid, closure, clock, velocities, diffusivities, tracers, buoyancy)
@@ -136,9 +136,9 @@ velocity components, tracer fields, and precalculated diffusivities where applic
                                      forcings,
                                      clock)
 
-    return ( - div_Uw(i, j, k, grid, advection, velocities, velocities.w)
-             - div_Uw(i, j, k, grid, advection, background_fields.velocities, velocities.w)
-             - div_Uw(i, j, k, grid, advection, velocities, background_fields.velocities.w)
+    return ( - div_𝐯w(i, j, k, grid, advection, velocities, velocities.w)
+             - div_𝐯w(i, j, k, grid, advection, background_fields.velocities, velocities.w)
+             - div_𝐯w(i, j, k, grid, advection, velocities, background_fields.velocities.w)
              - z_f_cross_U(i, j, k, grid, coriolis, velocities)
              - ∂ⱼ_τ₃ⱼ(i, j, k, grid, closure, clock, velocities, diffusivities, tracers, buoyancy)
              + z_curl_Uˢ_cross_U(i, j, k, grid, stokes_drift, velocities, clock.time)


### PR DESCRIPTION
Use latex rendering for divergence of momentum/tracers. Now the total flow U -> 𝐯, consistent with [notation convention](https://clima.github.io/OceananigansDocumentation/dev/physics/notation/).

I was also tempted to rename the functions, e.g., `div_Uv`  to `div_𝐯u` for consistency. Shall we?

Also, does a bit of a cleanup. (Closes #1841.)