### PR TITLE
Cleanup of doctest files after building docs

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -245,6 +245,11 @@ git-tree-sha1 = "47ce50b742921377301e15005c96e979574e130b"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
 version = "2.68.1+0"
 
+[[Glob]]
+git-tree-sha1 = "4df9f7e06108728ebf00a0a11edee4b29a482bb2"
+uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
+version = "1.3.0"
+
 [[Grisu]]
 git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
 uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -170,7 +170,7 @@ deploydocs(
   push_preview = true
 )
 
-# Clean up temporary .jld2 and .nc files created by doctests
+@info "Cleaning up temporary .jld2 and .nc files created by doctests..."
 for file in vcat(glob("docs/*.jld2"), glob("docs/*.nc"))
     rm(file)
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ using Documenter
 using DocumenterCitations
 using Literate
 using Plots # to avoid capturing precompilation output by Literate
+using Glob
 
 using Oceananigans
 using Oceananigans.Operators
@@ -168,3 +169,8 @@ deploydocs(
       versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
   push_preview = true
 )
+
+# Clean up temporary .jld2 and .nc files created by doctests
+for file in vcat(glob("docs/*.jld2"), glob("docs/*.nc"))
+    rm(file)
+end

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -159,12 +159,15 @@ locally. From the main directory of your local repository call
 ```
 julia --project -e 'using Pkg; Pkg.instantiate()'
 julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
-julia --project=docs/ docs/make.jl
+JULIA_DEBUG=Documenter julia --project=docs/ docs/make.jl
 ```
- 
-and then open `docs/build/index.html` in your favorite browser. The building of the documentation
-performs some basic tests (`doctests`), which create some temporary `.nc` and `.jld2` files.
-Make sure you delete those files before rebuilding the documentation, e.g.,
+
+and then open `docs/build/index.html` in your favorite browser. Providing the environment variable 
+`JULIA_DEBUG=Documenter` will provide with more information in the documentation build process and
+thus help figuring out a potential bug.
+
+The building of the documentation performs some basic tests (`doctests`), which create some temporary
+`.nc` and `.jld2` files. Make sure you delete those files before rebuilding the documentation, e.g.,
 
 ```
 rm docs/*.jld2

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -166,14 +166,6 @@ and then open `docs/build/index.html` in your favorite browser. Providing the en
 `JULIA_DEBUG=Documenter` will provide with more information in the documentation build process and
 thus help figuring out a potential bug.
 
-The building of the documentation performs some basic tests (`doctests`), which create some temporary
-`.nc` and `.jld2` files. Make sure you delete those files before rebuilding the documentation, e.g.,
-
-```
-rm docs/*.jld2
-rm docs/*.nc
-```
-
 ## Credits
 
 This contributor's guide is heavily based on the excellent [MetPy contributor's guide](https://github.com/Unidata/MetPy/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
This PR removes temporary `.nc` and `.jld2` files that are created by Doctests when building the Docs.