### PR TITLE
Reduce ContinuousBoundaryFunction location + features for auxiliary fields

### DIFF
--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -96,9 +96,9 @@ GradientBoundaryCondition(val; kwargs...) = BoundaryCondition(Gradient, val; kwa
 @inline getbc(bc::BC{<:Open, Nothing}, i, j, grid, args...) = zero(eltype(grid))
 @inline getbc(bc::BC{<:Flux, Nothing}, i, j, grid, args...) = zero(eltype(grid))
 
-@inline getbc(bc::BC{C, <:Number},        args...)                         where C = bc.condition
-@inline getbc(bc::BC{C, <:AbstractArray}, i, j, grid, clock, model_fields) where C = @inbounds bc.condition[i, j]
-@inline getbc(bc::BC{C, <:Function},      i, j, grid, clock, model_fields) where C = bc.condition(i, j, grid, clock, model_fields)
+@inline getbc(bc::BC{C, <:Number},        args...)             where C = bc.condition
+@inline getbc(bc::BC{C, <:AbstractArray}, i, j, grid, args...) where C = @inbounds bc.condition[i, j]
+@inline getbc(bc::BC{C, <:Function},      i, j, grid, args...) where C = bc.condition(i, j, grid, args...)
 
 Adapt.adapt_structure(to, bc::BoundaryCondition) = BoundaryCondition(Adapt.adapt(to, bc.classification),
                                                                      Adapt.adapt(to, bc.condition))


### PR DESCRIPTION
This PR makes a few small changes needed to use ContinuousBoundaryFunction with auxiliary fields, which have no notion of "time" or other model fields. For this case; we want to be able to write something like

```julia
c_surface(x, y) = cos(pi * x)
c_bcs = FieldBoundaryConditions(grid, (Center, Center, Center), top = ValueBoundaryCondition(c_surface))
c = CenterField(grid, c_bcs)
fill_halo_regions!(c.architecture, c)
```

Prior to this PR this would fail (we only supported constant boundary conditions on auxiliary fields).

This PR also "reduces" the location at which the boundary condition is applied, so that `ReducedField`s might use something like

```julia
r_surface(x) = cos(pi * x)
r_bcs = FieldBoundaryConditions(grid, (Center, Nothing, Center), top = ValueBoundaryCondition(r_surface))
r = ReducedField(Center, Nothing, Center, grid, r_bcs)
fill_halo_regions!(r.architecture, r)
```

if we eventually set the location of fields in `Flat` dimensions to `Nothing` this will also have an impact on syntax used for building models.

This PR needs a test or two before merging.

cc @navidcy 