### PR TITLE
Flat VerticallyStretchedRectilinearGrid plus new hydrostatic and flat internal wave tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.59.0"
+version = "0.59.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -47,19 +47,34 @@ The operators in this file fall into three categories:
 @inline Δzᵃᵃᶜ(i, j, k, grid::VerticallyStretchedRectilinearGrid) = @inbounds grid.Δzᵃᵃᶜ[k]
 
 #####
-##### "Spacings" in Flat directions. Here we dispatch to `one`. This abuse of notation
-##### makes volumes correct as we want to multiply by 1, and avoids issues with
-##### derivatives such as those involved in the pressure correction step.
+##### "Spacings" in Flat directions for rectilinear grids.
+##### Here we dispatch all spacings to `one`. This abuse of notation
+##### makes volumes and areas correct.
 #####
 
 using Oceananigans.Grids: Flat
 
-@inline Δx(   i, j, k, grid::RegularRectilinearGrid{FT, Flat})         where FT           = one(FT)
-@inline Δy(   i, j, k, grid::RegularRectilinearGrid{FT, TX, Flat})     where {FT, TX}     = one(FT)
-@inline ΔzC(  i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
-@inline ΔzF(  i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
-@inline Δzᵃᵃᶠ(i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
-@inline Δzᵃᵃᶜ(i, j, k, grid::RegularRectilinearGrid{FT, TX, TY, Flat}) where {FT, TX, TY} = one(FT)
+const XFlatRectilinearGrid = AbstractRectilinearGrid{<:Any, Flat}
+const YFlatRectilinearGrid = AbstractRectilinearGrid{<:Any, <:Any, Flat}
+const ZFlatRectilinearGrid = AbstractRectilinearGrid{<:Any, <:Any, <:Any, Flat}
+
+@inline Δx(   i, j, k, grid::XFlatRectilinearGrid) = one(eltype(grid))
+@inline Δy(   i, j, k, grid::YFlatRectilinearGrid) = one(eltype(grid))
+
+@inline Δxᶜᶜᵃ(i, j, k, grid::XFlatRectilinearGrid) = one(eltype(grid))
+@inline Δxᶜᶠᵃ(i, j, k, grid::XFlatRectilinearGrid) = one(eltype(grid))
+@inline Δxᶠᶠᵃ(i, j, k, grid::XFlatRectilinearGrid) = one(eltype(grid))
+@inline Δxᶠᶜᵃ(i, j, k, grid::XFlatRectilinearGrid) = one(eltype(grid))
+
+@inline Δyᶜᶜᵃ(i, j, k, grid::YFlatRectilinearGrid) = one(eltype(grid))
+@inline Δyᶠᶜᵃ(i, j, k, grid::YFlatRectilinearGrid) = one(eltype(grid))
+@inline Δyᶜᶠᵃ(i, j, k, grid::YFlatRectilinearGrid) = one(eltype(grid))
+@inline Δyᶠᶠᵃ(i, j, k, grid::YFlatRectilinearGrid) = one(eltype(grid))
+
+@inline ΔzC(  i, j, k, grid::ZFlatRectilinearGrid) = one(eltype(grid))
+@inline ΔzF(  i, j, k, grid::ZFlatRectilinearGrid) = one(eltype(grid))
+@inline Δzᵃᵃᶠ(i, j, k, grid::ZFlatRectilinearGrid) = one(eltype(grid))
+@inline Δzᵃᵃᶜ(i, j, k, grid::ZFlatRectilinearGrid) = one(eltype(grid))
 
 #####
 ##### Areas for horizontally-regular algorithms

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -51,30 +51,53 @@ The operators in this file fall into three categories:
 ##### Here we dispatch all spacings to `one`. This abuse of notation
 ##### makes volumes and areas correct.
 #####
+##### Note: Vertical metrics are specific to each rectilinear grid type; therefore
+##### we must dispatch on Flat vertical directions for each grid independently.
+#####
 
 using Oceananigans.Grids: Flat
 
-const XFlatRectilinearGrid = AbstractRectilinearGrid{<:Any, Flat}
-const YFlatRectilinearGrid = AbstractRectilinearGrid{<:Any, <:Any, Flat}
-const ZFlatRectilinearGrid = AbstractRectilinearGrid{<:Any, <:Any, <:Any, Flat}
+#####
+##### Horizontal metrics for AbstractRectilinearGrid
+#####
 
-@inline Δx(   i, j, k, grid::XFlatRectilinearGrid) = one(eltype(grid))
-@inline Δy(   i, j, k, grid::YFlatRectilinearGrid) = one(eltype(grid))
+const XFlatARG = AbstractRectilinearGrid{<:Any, <:Flat}
+const YFlatARG = AbstractRectilinearGrid{<:Any, <:Any, <:Flat}
 
-@inline Δxᶜᶜᵃ(i, j, k, grid::XFlatRectilinearGrid) = one(eltype(grid))
-@inline Δxᶜᶠᵃ(i, j, k, grid::XFlatRectilinearGrid) = one(eltype(grid))
-@inline Δxᶠᶠᵃ(i, j, k, grid::XFlatRectilinearGrid) = one(eltype(grid))
-@inline Δxᶠᶜᵃ(i, j, k, grid::XFlatRectilinearGrid) = one(eltype(grid))
+@inline Δx(i, j, k, grid::XFlatARG) = one(eltype(grid))
+@inline Δy(i, j, k, grid::YFlatARG) = one(eltype(grid))
 
-@inline Δyᶜᶜᵃ(i, j, k, grid::YFlatRectilinearGrid) = one(eltype(grid))
-@inline Δyᶠᶜᵃ(i, j, k, grid::YFlatRectilinearGrid) = one(eltype(grid))
-@inline Δyᶜᶠᵃ(i, j, k, grid::YFlatRectilinearGrid) = one(eltype(grid))
-@inline Δyᶠᶠᵃ(i, j, k, grid::YFlatRectilinearGrid) = one(eltype(grid))
+@inline Δxᶜᶜᵃ(i, j, k, grid::XFlatARG) = one(eltype(grid))
+@inline Δxᶜᶠᵃ(i, j, k, grid::XFlatARG) = one(eltype(grid))
+@inline Δxᶠᶠᵃ(i, j, k, grid::XFlatARG) = one(eltype(grid))
+@inline Δxᶠᶜᵃ(i, j, k, grid::XFlatARG) = one(eltype(grid))
 
-@inline ΔzC(  i, j, k, grid::ZFlatRectilinearGrid) = one(eltype(grid))
-@inline ΔzF(  i, j, k, grid::ZFlatRectilinearGrid) = one(eltype(grid))
-@inline Δzᵃᵃᶠ(i, j, k, grid::ZFlatRectilinearGrid) = one(eltype(grid))
-@inline Δzᵃᵃᶜ(i, j, k, grid::ZFlatRectilinearGrid) = one(eltype(grid))
+@inline Δyᶜᶜᵃ(i, j, k, grid::YFlatARG) = one(eltype(grid))
+@inline Δyᶠᶜᵃ(i, j, k, grid::YFlatARG) = one(eltype(grid))
+@inline Δyᶜᶠᵃ(i, j, k, grid::YFlatARG) = one(eltype(grid))
+@inline Δyᶠᶠᵃ(i, j, k, grid::YFlatARG) = one(eltype(grid))
+
+##### 
+##### Vertical metrics for RegularRectilinearGrid
+##### 
+
+const ZFlatRRG = RegularRectilinearGrid{<:Any, <:Any, <:Any, <:Flat}
+
+@inline ΔzC(  i, j, k, grid::ZFlatRRG) = one(eltype(grid))
+@inline ΔzF(  i, j, k, grid::ZFlatRRG) = one(eltype(grid))
+@inline Δzᵃᵃᶠ(i, j, k, grid::ZFlatRRG) = one(eltype(grid))
+@inline Δzᵃᵃᶜ(i, j, k, grid::ZFlatRRG) = one(eltype(grid))
+
+##### 
+##### Vertical metrics for VerticallyStretchedRectilinearGrid
+##### 
+
+const ZFlatVSRG = VerticallyStretchedRectilinearGrid{<:Any, <:Any, <:Any, <:Flat}
+
+@inline ΔzC(  i, j, k, grid::ZFlatVSRG) = one(eltype(grid))
+@inline ΔzF(  i, j, k, grid::ZFlatVSRG) = one(eltype(grid))
+@inline Δzᵃᵃᶠ(i, j, k, grid::ZFlatVSRG) = one(eltype(grid))
+@inline Δzᵃᵃᶜ(i, j, k, grid::ZFlatVSRG) = one(eltype(grid))
 
 #####
 ##### Areas for horizontally-regular algorithms

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -49,7 +49,7 @@ The operators in this file fall into three categories:
 #####
 ##### "Spacings" in Flat directions for rectilinear grids.
 ##### Here we dispatch all spacings to `one`. This abuse of notation
-##### makes volumes and areas correct.
+##### makes volumes and areas correct. E.g., with `z` Flat we have `v = dx * dy * 1`.
 #####
 ##### Note: Vertical metrics are specific to each rectilinear grid type; therefore
 ##### we must dispatch on Flat vertical directions for each grid independently.

--- a/src/Solvers/discrete_transforms.jl
+++ b/src/Solvers/discrete_transforms.jl
@@ -27,7 +27,7 @@ normalization_factor(arch, topo, direction, N) = 1
 `FFTW.REDFT01` needs to be normalized by 1/2N.
 See: http://www.fftw.org/fftw3_doc/1d-Real_002deven-DFTs-_0028DCTs_0029.html#g_t1d-Real_002deven-DFTs-_0028DCTs_0029
 """
-normalization_factor(::CPU, ::Bounded, ::Backward, N) = 1/(2N)
+normalization_factor(::CPU, ::Bounded, ::Backward, N) = 1 / 2N
 
 #####
 ##### Twiddle factors

--- a/src/Solvers/fft_based_poisson_solver.jl
+++ b/src/Solvers/fft_based_poisson_solver.jl
@@ -25,7 +25,7 @@ function FFTBasedPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
     transforms = plan_transforms(arch, grid, storage, planner_flag)
 
     # Need buffer for index permutations and transposes.
-    buffer_needed = arch isa GPU && Bounded in topo ? true : false
+    buffer_needed = arch isa GPU && Bounded in topo
     buffer = buffer_needed ? similar(storage) : nothing
 
     return FFTBasedPoissonSolver(arch, grid, eigenvalues, storage, buffer, transforms)

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -61,7 +61,7 @@ function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
                                          upper_diagonal = upper_diagonal)
 
     # Need buffer for index permutations and transposes.
-    buffer_needed = arch isa GPU && Bounded in (TX, TY) ? true : false
+    buffer_needed = arch isa GPU && Bounded in (TX, TY)
     buffer = buffer_needed ? similar(sol_storage) : nothing
 
     # Storage space for right hand side of Poisson equation

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -1,4 +1,5 @@
 using Oceananigans.Operators: Δzᵃᵃᶜ, Δzᵃᵃᶠ
+using Oceananigans.Architectures: device_event
 
 struct FourierTridiagonalPoissonSolver{A, G, B, R, S, β, T}
                   architecture :: A
@@ -10,7 +11,7 @@ struct FourierTridiagonalPoissonSolver{A, G, B, R, S, β, T}
                     transforms :: T
 end
 
-@kernel function compute_diagonals!(D, grid, λx, λy)
+@kernel function compute_main_diagonals!(D, grid, λx, λy)
     i, j = @index(Global, NTuple)
     Nz = grid.Nz
 
@@ -42,16 +43,13 @@ function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
     transforms = plan_transforms(arch, grid, sol_storage, planner_flag)
 
     # Lower and upper diagonals are the same
-    CUDA.allowscalar(true)
     lower_diagonal = CUDA.@allowscalar [1 / Δzᵃᵃᶠ(1, 1, k, grid) for k in 2:Nz]
     lower_diagonal = arch_array(arch, lower_diagonal)
     upper_diagonal = lower_diagonal
-    CUDA.allowscalar(false)
 
     # Compute diagonal coefficients for each grid point
     diagonal = arch_array(arch, zeros(Nx, Ny, Nz))
-    event = launch!(arch, grid, :xy, compute_diagonals!, diagonal, grid, λx, λy,
-                    dependencies=Event(device(arch)))
+    event = launch!(arch, grid, :xy, compute_main_diagonals!, diagonal, grid, λx, λy, dependencies=device_event(arch))
     wait(device(arch), event)
 
     # Set up batched tridiagonal solver

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -28,11 +28,6 @@ function FourierTridiagonalPoissonSolver(arch, grid, planner_flag=FFTW.PATIENT)
     TX, TY, TZ = topology(grid)
     TZ != Bounded && error("FourierTridiagonalPoissonSolver can only be used with a Bounded z topology.")
 
-    if grid isa VerticallyStretchedRectilinearGrid && any([T() isa Flat for T in (TX, TY)])
-        @warn "FourierTridiagonalPoissonSolver is probably wrong for topologies that contain " *
-              "Flat dimensions."
-    end
-
     Nx, Ny, Nz = size(grid)
 
     # Compute discrete Poisson eigenvalues

--- a/src/Solvers/plan_transforms.jl
+++ b/src/Solvers/plan_transforms.jl
@@ -46,9 +46,7 @@ plan_forward_transform(A::Union{Array, CuArray}, ::Flat, args...) = nothing
 
 batchable_GPU_topologies = ((Periodic, Periodic, Periodic),
                             (Periodic, Periodic, Bounded),
-                            (Bounded, Periodic, Periodic),
-                            (Periodic, Periodic, Flat),
-                            (Flat, Periodic, Periodic))
+                            (Bounded,  Periodic, Periodic))
 
 # In principle the order in which the transforms are applied does not matter of course,
 # but in practice we want to perform the `Bounded` forward transforms first because on
@@ -81,22 +79,23 @@ function plan_transforms(arch, grid::RegularRectilinearGrid, storage, planner_fl
     periodic_dims = findall(t -> t == Periodic, topo)
     bounded_dims = findall(t -> t == Bounded, topo)
 
-    if arch isa GPU && !(topo in batchable_GPU_topologies)
+    # Convert Flat to Bounded for inferring batchability and transform ordering
+    # Note that transforms are omitted in Flat directions.
+    unflattened_topo = (T() isa Flat ? Bounded : T for T in topo)
+
+    if arch isa GPU && !(unflattened_topo in batchable_GPU_topologies)
 
         rs_storage = reshape(storage, (Ny, Nx, Nz))
-        forward_plan_x = plan_forward_transform(storage   , topo[1](), [1], planner_flag)
+        forward_plan_x = plan_forward_transform(storage,    topo[1](), [1], planner_flag)
         forward_plan_y = plan_forward_transform(rs_storage, topo[2](), [1], planner_flag)
-        forward_plan_z = plan_forward_transform(storage   , topo[3](), [3], planner_flag)
+        forward_plan_z = plan_forward_transform(storage,    topo[3](), [3], planner_flag)
 
-        backward_plan_x = plan_backward_transform(storage   , topo[1](), [1], planner_flag)
+        backward_plan_x = plan_backward_transform(storage,    topo[1](), [1], planner_flag)
         backward_plan_y = plan_backward_transform(rs_storage, topo[2](), [1], planner_flag)
-        backward_plan_z = plan_backward_transform(storage   , topo[3](), [3], planner_flag)
+        backward_plan_z = plan_backward_transform(storage,    topo[3](), [3], planner_flag)
 
         forward_plans = (forward_plan_x, forward_plan_y, forward_plan_z)
         backward_plans = (backward_plan_x, backward_plan_y, backward_plan_z)
-
-        # Convert Flat to Bounded for ordering purposes (transforms are omitted in Flat directions anyways)
-        unflattened_topo = (T() isa Flat ? Bounded : T for T in topo)
 
         f_order = forward_orders(unflattened_topo...)
         b_order = backward_orders(unflattened_topo...)
@@ -117,9 +116,8 @@ function plan_transforms(arch, grid::RegularRectilinearGrid, storage, planner_fl
         # This is the case where batching transforms is possible. It's always possible on the CPU
         # since FFTW is awesome so it includes all topologies on the CPU.
         #
-        # On the GPU batching is possible when the topology is not one of non_batched_topologies
-        # (where an FFT is needed along dimension 2), so it includes (Periodic, Periodic, Periodic),
-        # (Periodic, Periodic, Bounded), and (Bounded, Periodic, Periodic).
+        # `batchable_GPU_topologies` occurs when there are two adjacent `Periodic` dimensions:
+        # (Periodic, Periodic, Periodic), (Periodic, Periodic, Bounded), and (Bounded, Periodic, Periodic).
 
         forward_periodic_plan = plan_forward_transform(storage, Periodic(), periodic_dims, planner_flag)
         forward_bounded_plan = plan_forward_transform(storage, Bounded(), bounded_dims, planner_flag)
@@ -152,84 +150,54 @@ function plan_transforms(arch, grid::VerticallyStretchedRectilinearGrid, storage
     periodic_dims = findall(t -> t == Periodic, (TX, TY))
     bounded_dims = findall(t -> t == Bounded, (TX, TY))
 
-    if arch isa GPU && !(topo in batchable_GPU_topologies)
-        if (TX, TY) == (Periodic, Bounded)
-            forward_plan_x = plan_forward_transform(storage, Periodic(), [1], planner_flag)
-            forward_plan_y = plan_forward_transform(reshape(storage, (Ny, Nx, Nz)), Bounded(), [1], planner_flag)
+    # Convert Flat to Bounded for ordering purposes (transforms are omitted in Flat directions anyways)
+    unflattened_topo = (T() isa Flat ? Bounded : T for T in topo)
 
-            backward_plan_x = plan_backward_transform(storage, Periodic(), [1], planner_flag)
-            backward_plan_y = plan_backward_transform(reshape(storage, (Ny, Nx, Nz)), Bounded(),  [1], planner_flag)
-
-            forward_transforms = (
-                DiscreteTransform(forward_plan_y, Forward(), arch, grid, [2]),
-                DiscreteTransform(forward_plan_x, Forward(), arch, grid, [1])
-            )
-
-            backward_transforms = (
-                DiscreteTransform(backward_plan_x, Backward(), arch, grid, [1]),
-                DiscreteTransform(backward_plan_y, Backward(), arch, grid, [2])
-            )
-
-        elseif (TX, TY) == (Bounded, Periodic)
-            forward_plan_x = plan_forward_transform(storage, Bounded(), [1], planner_flag)
-            forward_plan_y = plan_forward_transform(reshape(storage, (Ny, Nx, Nz)), Periodic(), [1], planner_flag)
-
-            backward_plan_x = plan_backward_transform(storage, Bounded(), [1], planner_flag)
-            backward_plan_y = plan_backward_transform(reshape(storage, (Ny, Nx, Nz)), Periodic(),  [1], planner_flag)
-
-            forward_transforms = (
-                DiscreteTransform(forward_plan_x, Forward(), arch, grid, [1]),
-                DiscreteTransform(forward_plan_y, Forward(), arch, grid, [2])
-            )
-
-            backward_transforms = (
-                DiscreteTransform(backward_plan_y, Backward(), arch, grid, [2]),
-                DiscreteTransform(backward_plan_x, Backward(), arch, grid, [1])
-            )
-
-        elseif (TX, TY) == (Bounded, Bounded)
-            forward_plan_x = plan_forward_transform(storage, Bounded(), [1], planner_flag)
-            forward_plan_y = plan_forward_transform(reshape(storage, (Ny, Nx, Nz)), Bounded(), [1], planner_flag)
-
-            backward_plan_x = plan_backward_transform(storage, Bounded(), [1], planner_flag)
-            backward_plan_y = plan_backward_transform(reshape(storage, (Ny, Nx, Nz)), Bounded(),  [1], planner_flag)
-
-            forward_transforms = (
-                DiscreteTransform(forward_plan_x, Forward(), arch, grid, [1]),
-                DiscreteTransform(forward_plan_y, Forward(), arch, grid, [2])
-            )
-
-            backward_transforms = (
-                DiscreteTransform(backward_plan_x, Backward(), arch, grid, [1]),
-                DiscreteTransform(backward_plan_y, Backward(), arch, grid, [2])
-            )
-        end
-    else
+    if arch isa CPU || topo == (Periodic, Periodic, Bounded)
         # This is the case where batching transforms is possible. It's always possible on the CPU
         # since FFTW is awesome so it includes all topologies on the CPU.
         #
-        # On the GPU batching is possible when the topology is not one of non_batched_topologies
-        # (where an FFT is needed along dimension 2), so it includes (Periodic, Periodic, Periodic),
-        # (Periodic, Periodic, Bounded), and (Bounded, Periodic, Periodic).
+        # On the GPU and for vertically Bounded grids, batching is possible when topo == (Periodic, Periodic, Bounded).
 
         forward_periodic_plan = plan_forward_transform(storage, Periodic(), periodic_dims, planner_flag)
         forward_bounded_plan = plan_forward_transform(storage, Bounded(), bounded_dims, planner_flag)
 
-        forward_transforms = (
-            DiscreteTransform(forward_bounded_plan, Forward(), arch, grid, bounded_dims),
-            DiscreteTransform(forward_periodic_plan, Forward(), arch, grid, periodic_dims)
-        )
+        forward_transforms = (DiscreteTransform(forward_bounded_plan, Forward(), arch, grid, bounded_dims),
+                              DiscreteTransform(forward_periodic_plan, Forward(), arch, grid, periodic_dims))
 
         backward_periodic_plan = plan_backward_transform(storage, Periodic(), periodic_dims, planner_flag)
         backward_bounded_plan = plan_backward_transform(storage, Bounded(), bounded_dims, planner_flag)
 
-        backward_transforms = (
-            DiscreteTransform(backward_periodic_plan, Backward(), arch, grid, periodic_dims),
-            DiscreteTransform(backward_bounded_plan, Backward(), arch, grid, bounded_dims)
-        )
+        backward_transforms = (DiscreteTransform(backward_periodic_plan, Backward(), arch, grid, periodic_dims),
+                               DiscreteTransform(backward_bounded_plan, Backward(), arch, grid, bounded_dims))
+
+    else # we are on the GPU and we cannot / should not batch
+        rs_storage = reshape(storage, (Ny, Nx, Nz))
+
+        forward_plan_x = plan_forward_transform(storage,    topo[1](), [1], planner_flag)
+        forward_plan_y = plan_forward_transform(rs_storage, topo[2](), [1], planner_flag)
+
+        backward_plan_x = plan_backward_transform(storage,    topo[1](), [1], planner_flag)
+        backward_plan_y = plan_backward_transform(rs_storage, topo[2](), [1], planner_flag)
+
+        forward_plans = (forward_plan_x, forward_plan_y)
+        backward_plans = (backward_plan_x, backward_plan_y)
+
+        f_order = forward_orders(unflattened_topo...)
+        b_order = backward_orders(unflattened_topo...)
+
+        # Extract third dimension
+        f_order = Tuple(f_order[i] for i in findall(d -> d != 3, f_order))
+        b_order = Tuple(b_order[i] for i in findall(d -> d != 3, b_order))
+
+        forward_transforms = (DiscreteTransform(forward_plans[f_order[1]], Forward(), arch, grid, [f_order[1]]),
+                              DiscreteTransform(forward_plans[f_order[2]], Forward(), arch, grid, [f_order[2]]))
+
+        backward_transforms = (DiscreteTransform(backward_plans[b_order[1]], Backward(), arch, grid, [b_order[1]]),
+                               DiscreteTransform(backward_plans[b_order[2]], Backward(), arch, grid, [b_order[2]]))
     end
 
-    transforms = (forward = forward_transforms, backward = backward_transforms)
+    transforms = (forward=forward_transforms, backward=backward_transforms)
 
     return transforms
 end

--- a/src/Solvers/plan_transforms.jl
+++ b/src/Solvers/plan_transforms.jl
@@ -81,7 +81,7 @@ function plan_transforms(arch, grid::RegularRectilinearGrid, storage, planner_fl
 
     # Convert Flat to Bounded for inferring batchability and transform ordering
     # Note that transforms are omitted in Flat directions.
-    unflattened_topo = (T() isa Flat ? Bounded : T for T in topo)
+    unflattened_topo = Tuple(T() isa Flat ? Bounded : T for T in topo)
 
     if arch isa GPU && !(unflattened_topo in batchable_GPU_topologies)
 
@@ -151,7 +151,7 @@ function plan_transforms(arch, grid::VerticallyStretchedRectilinearGrid, storage
     bounded_dims = findall(t -> t == Bounded, (TX, TY))
 
     # Convert Flat to Bounded for ordering purposes (transforms are omitted in Flat directions anyways)
-    unflattened_topo = (T() isa Flat ? Bounded : T for T in topo)
+    unflattened_topo = Tuple(T() isa Flat ? Bounded : T for T in topo)
 
     if arch isa CPU || topo == (Periodic, Periodic, Bounded)
         # This is the case where batching transforms is possible. It's always possible on the CPU

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -496,9 +496,9 @@ end
 
     @testset "Time stepping ShallowWaterModel" begin
         topo = (Periodic, Periodic, Flat)
-        full_grid = RegularRectilinearGrid(topology=topo, size=(8, 8), extent=(1, 2), halo=(3,3))
+        full_grid = RegularRectilinearGrid(topology=topo, size=(8, 8), extent=(1, 2), halo=(3, 3))
         arch = MultiCPU(grid=full_grid, ranks=(1, 4, 1))
-        model = DistributedShallowWaterModel(architecture=arch, grid=full_grid, gravitational_acceleration=1)
+        model = DistributedShallowWaterModel(architecture=arch, advection=nothing, grid=full_grid, gravitational_acceleration=1)
 
         set!(model, h=1)
         time_step!(model, 1)

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -427,7 +427,7 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                                                      size=(Nx, Nz), x=(0, Lx), z=(-Lz, 0))
 
         # Vertically stretched grid with regular spacing and no flat dimension
-        z_faces = collect(znodes(Face, regular_grid))
+        z_faces = collect(znodes(Face, y_periodic_regular_grid))
         y_periodic_regularly_spaced_vertically_stretched_grid = VerticallyStretchedRectilinearGrid(topology=(Periodic, Periodic, Bounded),
                                                                                                    size=(Nx, 1, Nz), x=(0, Lx), y=(0, Lx), z_faces=z_faces)
 

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -467,12 +467,6 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                 @info "  Testing internal wave [IncompressibleModel, $grid_name, $topo]..."
                 internal_wave_dynamics_test(model, solution, Δt)
             end
-
-            solution, kwargs, background_fields, Δt, σ = internal_wave_solution(L=Lx, background_stratification=true)
-
-            @info "  Testing internal wave with background stratification [IncompressibleModel, $grid_name, $topo]..."
-            model = IncompressibleModel(; grid=y_periodic_regular_grid, background_fields=background_fields, kwargs...)
-            internal_wave_dynamics_test(model, solution, Δt)
         end
     end
 
@@ -490,7 +484,18 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
         for timestepper in (:QuasiAdamsBashforth2,) #timesteppers
             @info "  Testing dynamics with background fields [$timestepper]..."
             @test_skip passive_tracer_advection_test(timestepper, background_velocity_field=true)
-            @test internal_wave_test(timestepper, background_stratification=true)
+                        
+            Nx = Nz = 128
+            Lx = Lz = 2π
+
+            # Regular grid with no flat dimension
+            y_periodic_regular_grid = RegularRectilinearGrid(topology=(Periodic, Periodic, Bounded),
+                                                             size=(Nx, 1, Nz), x=(0, Lx), y=(0, Lx), z=(-Lz, 0))
+                        
+            solution, kwargs, background_fields, Δt, σ = internal_wave_solution(L=Lx, background_stratification=true)
+
+            model = IncompressibleModel(; grid=y_periodic_regular_grid, background_fields=background_fields, kwargs...)
+            internal_wave_dynamics_test(model, solution, Δt)
         end
     end
 

--- a/test/test_internal_wave_dynamics.jl
+++ b/test/test_internal_wave_dynamics.jl
@@ -1,0 +1,74 @@
+function internal_wave_solution(; L, background_stratification=false)
+    # Internal wave parameters
+     ν = κ = 1e-9
+    z₀ = -L/3
+     δ = L/20
+    a₀ = 1e-3
+     m = 16
+     k = 1
+     f = 0.2
+     ℕ = 1.0
+     σ = sqrt( (ℕ^2*k^2 + f^2*m^2) / (k^2 + m^2) )
+
+    # Numerical parameters
+    Δt = 0.01 * 1/σ
+
+    cᵍ = m * σ / (k^2 + m^2) * (f^2/σ^2 - 1)
+     U = a₀ * k * σ   / (σ^2 - f^2)
+     V = a₀ * k * f   / (σ^2 - f^2)
+     W = a₀ * m * σ   / (σ^2 - ℕ^2)
+     B = a₀ * m * ℕ^2 / (σ^2 - ℕ^2)
+
+    a(x, y, z, t) = exp( -(z - cᵍ*t - z₀)^2 / (2*δ)^2 )
+
+    u(x, y, z, t) = a(x, y, z, t) * U * cos(k*x + m*z - σ*t)
+    v(x, y, z, t) = a(x, y, z, t) * V * sin(k*x + m*z - σ*t)
+    w(x, y, z, t) = a(x, y, z, t) * W * cos(k*x + m*z - σ*t)
+
+    # Buoyancy field depends on whether we use background fields or not
+    wavy_b(x, y, z, t) = a(x, y, z, t) * B * sin(k*x + m*z - σ*t)
+    background_b(x, y, z, t) = ℕ^2 * z
+
+    if background_stratification # Move stratification to a background field
+        background_fields = (; b=background_b)
+        b = wavy_b
+    else
+        background_fields = NamedTuple()
+        b(x, y, z, t) = wavy_b(x, y, z, t) + background_b(x, y, z, t)
+    end
+
+    u₀(x, y, z) = u(x, y, z, 0)
+    v₀(x, y, z) = v(x, y, z, 0)
+    w₀(x, y, z) = w(x, y, z, 0)
+    b₀(x, y, z) = b(x, y, z, 0)
+
+    solution = (; u, v, w, b)
+
+    # Form model keyword arguments
+    closure = IsotropicDiffusivity(ν=ν, κ=κ)
+    buoyancy = BuoyancyTracer()
+    tracers = :b
+    coriolis = FPlane(f=f)
+    model_kwargs = (; closure, buoyancy, tracers, coriolis)
+
+    return solution, model_kwargs, background_fields, Δt, σ
+end
+
+function internal_wave_dynamics_test(model, solution, Δt)
+    # Make initial conditions
+    u₀(x, y, z) = solution.u(x, y, z, 0)
+    v₀(x, y, z) = solution.v(x, y, z, 0)
+    w₀(x, y, z) = solution.w(x, y, z, 0)
+    b₀(x, y, z) = solution.b(x, y, z, 0)
+    
+    set!(model, u=u₀, v=v₀, w=w₀, b=b₀)
+
+    simulation = Simulation(model, stop_iteration=10, Δt=Δt)
+    try run!(simulation); catch; end # so the test continues to execute if there's a NaN
+
+    # Tolerance was found by trial and error...
+    @test relative_error(model.velocities.u, solution.u, model.clock.time) < 1e-4
+
+    return nothing
+end
+

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -280,11 +280,10 @@ two_dimensional_topologies = [
         (Periodic, Bounded,  Bounded),
         (Bounded,  Periodic, Bounded),
         (Bounded,  Bounded,  Bounded),
-    # Note: FourierTridiagonalPoissonSolver doesn't appear to work with Flat
-    #    (Flat,     Bounded,  Bounded),
-    #    (Flat,     Periodic, Bounded),
-    #    (Bounded,  Flat,     Bounded),
-    #    (Periodic, Flat,     Bounded)
+        (Flat,     Bounded,  Bounded),
+        (Flat,     Periodic, Bounded),
+        (Bounded,  Flat,     Bounded),
+        (Periodic, Flat,     Bounded)
     ]
 
     for arch in archs, topo in vs_topos

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -183,14 +183,12 @@ end
 PB = (Periodic, Bounded)
 topos = collect(Iterators.product(PB, PB, PB))[:]
 
-two_dimensional_topologies = [
-                              (Flat,     Bounded,  Bounded),
+two_dimensional_topologies = [(Flat,     Bounded,  Bounded),
                               (Bounded,  Flat,     Bounded),
                               (Bounded,  Bounded,  Flat),
                               (Flat,     Periodic, Bounded),
                               (Periodic, Flat,     Bounded),
-                              (Periodic, Bounded,  Flat),
-                             ]
+                              (Periodic, Bounded,  Flat)]
 
 @testset "Poisson solvers" begin
     @info "Testing Poisson solvers..."
@@ -200,12 +198,10 @@ two_dimensional_topologies = [
             @info "  Testing Poisson solver instantiation [$(typeof(arch))]..."
             for FT in float_types
 
-                grids_3d = [
-                            RegularRectilinearGrid(FT, size=(2, 2, 2), extent=(1, 1, 1)),
+                grids_3d = [RegularRectilinearGrid(FT, size=(2, 2, 2), extent=(1, 1, 1)),
                             RegularRectilinearGrid(FT, size=(1, 2, 2), extent=(1, 1, 1)),
                             RegularRectilinearGrid(FT, size=(2, 1, 2), extent=(1, 1, 1)),
-                            RegularRectilinearGrid(FT, size=(2, 2, 1), extent=(1, 1, 1))
-                           ]
+                            RegularRectilinearGrid(FT, size=(2, 2, 1), extent=(1, 1, 1))]
 
                 grids_2d = [RegularRectilinearGrid(FT, size=(2, 2), extent=(1, 1), topology=topo)
                             for topo in two_dimensional_topologies]
@@ -227,12 +223,10 @@ two_dimensional_topologies = [
             for topo in topos
                 for N in [7, 16]
 
-                    grids_3d = [
-                                RegularRectilinearGrid(topology=topo, size=(N, N, N), extent=(1, 1, 1)),
+                    grids_3d = [RegularRectilinearGrid(topology=topo, size=(N, N, N), extent=(1, 1, 1)),
                                 RegularRectilinearGrid(topology=topo, size=(1, N, N), extent=(1, 1, 1)),
                                 RegularRectilinearGrid(topology=topo, size=(N, 1, N), extent=(1, 1, 1)),
-                                RegularRectilinearGrid(topology=topo, size=(N, N, 1), extent=(1, 1, 1))
-                               ]
+                                RegularRectilinearGrid(topology=topo, size=(N, N, 1), extent=(1, 1, 1))]
 
                     grids_2d = [RegularRectilinearGrid(size=(N, N), extent=(1, 1), topology=topo)
                                 for topo in two_dimensional_topologies]
@@ -258,7 +252,7 @@ two_dimensional_topologies = [
 
             # Do a couple at Float32 (since its too expensive to repeat all tests...)
             Float32_grids = [RegularRectilinearGrid(Float32, topology=(Periodic, Bounded, Bounded), size=(16, 16, 16), extent=(1, 1, 1)),
-                     RegularRectilinearGrid(Float32, topology=(Bounded, Bounded, Periodic), size=(7, 11, 13), extent=(1, 1, 1))]
+                             RegularRectilinearGrid(Float32, topology=(Bounded, Bounded, Periodic), size=(7, 11, 13), extent=(1, 1, 1))]
 
             for grid in Float32_grids
                 @test divergence_free_poisson_solution(arch, grid)


### PR DESCRIPTION
This PR implements seven new internal wave dynamics tests that run for both `IncompressibleModel` and `HydrostaticFreeSurfaceModel`, on vertically-stretched grids, and on `Flat` topologies for both models and both regular and stretched grids.

The tests show that `VerticallyStretchedRectilinearGrid` does not work with `Flat` dimensions.

For `IncompressibleModel`, this usage produces a warning that "`FourierTridiagonalPoissonSolver` is probably not correct." Ironically, it's this warning thats _probably_ not correct: the issue with `Flat` and vertically-stretched grids appears to lie in the lack of flat grid metrics for any grid but `RegularRectilinearGrid` --- not the Poisson solver.

We can fix this problem in this PR. In that case it will resolve #1849.