### PR TITLE
Reformulates TKEBasedVerticalDiffusivity

### DIFF
--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -96,9 +96,9 @@ GradientBoundaryCondition(val; kwargs...) = BoundaryCondition(Gradient, val; kwa
 @inline getbc(bc::BC{<:Open, Nothing}, i, j, grid, args...) = zero(eltype(grid))
 @inline getbc(bc::BC{<:Flux, Nothing}, i, j, grid, args...) = zero(eltype(grid))
 
-@inline getbc(bc::BC{C, <:Number},        args...)                         where C = bc.condition
-@inline getbc(bc::BC{C, <:AbstractArray}, i, j, grid, clock, model_fields) where C = @inbounds bc.condition[i, j]
-@inline getbc(bc::BC{C, <:Function},      i, j, grid, clock, model_fields) where C = bc.condition(i, j, grid, clock, model_fields)
+@inline getbc(bc::BC{C, <:Number},        args...)             where C = bc.condition
+@inline getbc(bc::BC{C, <:AbstractArray}, i, j, grid, args...) where C = @inbounds bc.condition[i, j]
+@inline getbc(bc::BC{C, <:Function},      i, j, grid, clock, model_fields, args...) where C = bc.condition(i, j, grid, clock, model_fields, args...)
 
 Adapt.adapt_structure(to, bc::BoundaryCondition) = BoundaryCondition(Adapt.adapt(to, bc.classification),
                                                                      Adapt.adapt(to, bc.condition))

--- a/src/BoundaryConditions/discrete_boundary_function.jl
+++ b/src/BoundaryConditions/discrete_boundary_function.jl
@@ -28,7 +28,7 @@ struct DiscreteBoundaryFunction{P, F}
 end
 
 const UnparameterizedDBF = DiscreteBoundaryFunction{<:Nothing}
-const UnparameterizedDBFBC = BoundaryCondition{<:Any, <:ParameterizedDBF}
+const UnparameterizedDBFBC = BoundaryCondition{<:Any, <:UnparameterizedDBF}
 const DBFBC = BoundaryCondition{<:Any, <:DiscreteBoundaryFunction}
 
 @inline getbc(bc::UnparameterizedDBFBC, i, j, grid, clock, model_fields, args...) =

--- a/src/BoundaryConditions/discrete_boundary_function.jl
+++ b/src/BoundaryConditions/discrete_boundary_function.jl
@@ -16,7 +16,7 @@ of `OffsetArray`s depending on the turbulence closure) of field data.
 When `parameters` is not `nothing`, the boundary condition `func` is called with
 the signature
 
-    `func(i, j, grid, clock, model_fields)`
+    `func(i, j, grid, clock, model_fields, parameters)`
 
 *Note* that the index `end` does *not* access the final physical grid point of
 a model field in any direction. The final grid point must be explictly specified, as
@@ -27,8 +27,9 @@ struct DiscreteBoundaryFunction{P, F}
     parameters :: P
 end
 
+const ParameterizedDBF = DiscreteBoundaryFunction{<:Nothing}
+const ParameterizedDBFBC = BoundaryCondition{<:Any, <:ParameterizedDBF}
 const DBFBC = BoundaryCondition{<:Any, <:DiscreteBoundaryFunction}
-const ParameterizedDBFBC = BoundaryCondition{<:Any, <:DiscreteBoundaryFunction{<:Nothing}}
 
 @inline getbc(bc::DBFBC, i, j, grid, clock, model_fields, args...) =
     bc.condition.func(i, j, grid, clock, model_fields)

--- a/src/BoundaryConditions/discrete_boundary_function.jl
+++ b/src/BoundaryConditions/discrete_boundary_function.jl
@@ -27,14 +27,14 @@ struct DiscreteBoundaryFunction{P, F}
     parameters :: P
 end
 
-const ParameterizedDBF = DiscreteBoundaryFunction{<:Nothing}
-const ParameterizedDBFBC = BoundaryCondition{<:Any, <:ParameterizedDBF}
+const UnparameterizedDBF = DiscreteBoundaryFunction{<:Nothing}
+const UnparameterizedDBFBC = BoundaryCondition{<:Any, <:ParameterizedDBF}
 const DBFBC = BoundaryCondition{<:Any, <:DiscreteBoundaryFunction}
 
-@inline getbc(bc::DBFBC, i, j, grid, clock, model_fields, args...) =
+@inline getbc(bc::UnparameterizedDBFBC, i, j, grid, clock, model_fields, args...) =
     bc.condition.func(i, j, grid, clock, model_fields)
 
-@inline getbc(bc::ParameterizedDBFBC, i, j, grid, clock, model_fields, args...) =
+@inline getbc(bc::DBFBC, i, j, grid, clock, model_fields, args...) =
     bc.condition.func(i, j, grid, clock, model_fields, bc.condition.parameters)
 
 # Don't re-convert DiscreteBoundaryFunctions passed to BoundaryCondition constructor

--- a/src/CubedSpheres/CubedSpheres.jl
+++ b/src/CubedSpheres/CubedSpheres.jl
@@ -64,11 +64,11 @@ end
 
 import Oceananigans.Models.HydrostaticFreeSurfaceModels: apply_flux_bcs!
 
-function apply_flux_bcs!(Gcⁿ::AbstractCubedSphereField, events, c::AbstractCubedSphereField, arch, barrier, clock, model_fields)
+function apply_flux_bcs!(Gcⁿ::AbstractCubedSphereField, events, c::AbstractCubedSphereField, arch, barrier, args...)
 
     for (face_index, Gcⁿ_face) in enumerate(faces(Gcⁿ))
         apply_flux_bcs!(Gcⁿ_face, events, get_face(c, face_index), arch, barrier,
-                        clock, get_face(model_fields, face_index))
+                        Tuple(get_face(a, face_index) for a in args)...)
     end
 
     return nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
@@ -1,6 +1,7 @@
 import Oceananigans.TimeSteppers: calculate_tendencies!
 import Oceananigans: tracer_tendency_kernel_function
 
+using Oceananigans.Architectures: device_event
 using Oceananigans: fields, prognostic_fields
 using Oceananigans.Utils: work_layout
 using Oceananigans.TurbulenceClosures: TKEBasedVerticalDiffusivity
@@ -25,7 +26,9 @@ function calculate_tendencies!(model::HydrostaticFreeSurfaceModel)
                                                            model.free_surface,
                                                            model.tracers,
                                                            model.clock,
-                                                           fields(model))
+                                                           fields(model),
+                                                           model.closure,
+                                                           model.buoyancy)
 
     return nothing
 end
@@ -163,10 +166,10 @@ end
 ##### Boundary condributions to hydrostatic free surface model
 #####
 
-function apply_flux_bcs!(Gcⁿ, events, c, arch, barrier, clock, model_fields)
-    x_bcs_event = apply_x_bcs!(Gcⁿ, c, arch, barrier, clock, model_fields)
-    y_bcs_event = apply_y_bcs!(Gcⁿ, c, arch, barrier, clock, model_fields)
-    z_bcs_event = apply_z_bcs!(Gcⁿ, c, arch, barrier, clock, model_fields)
+function apply_flux_bcs!(Gcⁿ, events, c, arch, barrier, args...)
+    x_bcs_event = apply_x_bcs!(Gcⁿ, c, arch, barrier, args...)
+    y_bcs_event = apply_y_bcs!(Gcⁿ, c, arch, barrier, args...)
+    z_bcs_event = apply_z_bcs!(Gcⁿ, c, arch, barrier, args...)
 
     push!(events, x_bcs_event, y_bcs_event, z_bcs_event)
 
@@ -174,23 +177,23 @@ function apply_flux_bcs!(Gcⁿ, events, c, arch, barrier, clock, model_fields)
 end
 
 """ Apply boundary conditions by adding flux divergences to the right-hand-side. """
-function calculate_hydrostatic_boundary_tendency_contributions!(Gⁿ, arch, velocities, free_surface, tracers, clock, model_fields)
+function calculate_hydrostatic_boundary_tendency_contributions!(Gⁿ, arch, velocities, free_surface, tracers, args...)
 
-    barrier = Event(device(arch))
+    barrier = device_event(arch)
 
     events = []
 
     # Velocity fields
     for i in (:u, :v)
-        apply_flux_bcs!(Gⁿ[i], events, velocities[i], arch, barrier, clock, model_fields)
+        apply_flux_bcs!(Gⁿ[i], events, velocities[i], arch, barrier, args...)
     end
 
     # Free surface
-    apply_flux_bcs!(Gⁿ.η, events, displacement(free_surface), arch, barrier, clock, model_fields)
+    apply_flux_bcs!(Gⁿ.η, events, displacement(free_surface), arch, barrier, args...)
 
     # Tracer fields
     for i in propertynames(tracers)
-        apply_flux_bcs!(Gⁿ[i], events, tracers[i], arch, barrier, clock, model_fields)
+        apply_flux_bcs!(Gⁿ[i], events, tracers[i], arch, barrier, args...)
     end
 
     events = filter(e -> typeof(e) <: Event, events)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
@@ -1,7 +1,13 @@
+using Adapt
+
+import Oceananigans.BoundaryConditions: getbc
+
 using Oceananigans.Architectures: architecture, device_event
-using Oceananigans.BoundaryConditions: default_prognostic_field_boundary_condition, FieldBoundaryConditions
+using Oceananigans.BoundaryConditions: default_prognostic_field_boundary_condition
+using Oceananigans.BoundaryConditions: BoundaryCondition, FieldBoundaryConditions, DiscreteBoundaryFunction
 using Oceananigans.BuoyancyModels: ∂z_b, top_buoyancy_flux
 using Oceananigans.Operators: ℑzᵃᵃᶜ
+
 
 function hydrostatic_turbulent_kinetic_energy_tendency end
 
@@ -100,11 +106,7 @@ function TKEBasedVerticalDiffusivity(FT=Float64;
           "is unvalidated and whose default parameters are not calibrated for \n" * 
           "realistic ocean conditions or for use in a three-dimensional \n" *
           "simulation. Use with caution and report bugs and problems with physics \n" *
-          "to https://github.com/CliMA/Oceananigans.jl/issues. \n\n" *
-
-          "Note: `TKEBasedVerticalDiffusivity` will generally produce \n" *
-          "incorrect results if its parameters are altered _after_ \n" *
-          "model instantiation."
+          "to https://github.com/CliMA/Oceananigans.jl/issues."
 
     dissipation_parameter = convert(FT, dissipation_parameter)
     mixing_length_parameter = convert(FT, mixing_length_parameter)
@@ -134,9 +136,13 @@ where ``B`` is buoyancy and ``∂z`` denotes a vertical derviative.
 The Richardson-number dependent diffusivities are multiplied by the stability
 function
 
-    ``σ(Ri) = σ⁻ + (σ⁺ - σ⁻) * step(Ri, Riᶜ, Riʷ)``
+    1. ``σ(Ri) = σ⁻ * (1 + rσ * step(Ri, Riᶜ, Riʷ))``
+    3. ``σ(Ri) = σ⁻ + (σ⁺ - σ⁻) * step(Ri, Riᶜ, Riʷ)``
 
-where ``σ⁰``, ``σᵟ``, ``Riᶜ``, and ``Riʷ`` are free parameters,
+σ⁻ = σ₀
+rσ = (σ⁺ - σ⁻) / σ₀
+
+where ``σ₀``, ``Δσ``, ``Riᶜ``, and ``Riʷ`` are free parameters,
 and ``step`` is a smooth step function defined by
 
     ``step(x, c, w) = (1 + \tanh((x - c) / w)) / 2``.
@@ -151,11 +157,11 @@ annealing and noisy Ensemble Kalman Inversion methods.
 """
 Base.@kwdef struct RiDependentDiffusivityScaling{FT}
     Cᴷu⁻  :: FT = 0.15
-    Cᴷu⁺  :: FT = 0.73
+    Cᴷuʳ  :: FT = 3.87
     Cᴷc⁻  :: FT = 0.40
-    Cᴷc⁺  :: FT = 1.77
+    Cᴷcʳ  :: FT = 0.77
     Cᴷe⁻  :: FT = 0.13
-    Cᴷe⁺  :: FT = 1.22
+    Cᴷeʳ  :: FT = 1.11
     CᴷRiʷ :: FT = 0.72
     CᴷRiᶜ :: FT = 0.76
 end
@@ -189,7 +195,25 @@ Base.@kwdef struct TKESurfaceFlux{FT}
     CᵂwΔ :: FT = 1.31
 end
 
-@inline function top_tke_flux(i, j, grid, surface_model::TKESurfaceFlux, closure,
+for S in (:RiDependentDiffusivityScaling, :TKESurfaceFlux)
+    @eval @inline convert_eltype(::Type{FT}, s::$S) where FT = $S{FT}(; Dict(p => getproperty(s, p) for p in propertynames(s))...)
+    @eval @inline convert_eltype(::Type{FT}, s::$S{FT}) where FT = s
+end
+
+#####
+##### TKE top boundary condition
+#####
+
+""" Compute the flux of TKE through the surface / top boundary. """
+@inline function top_tke_flux(i, j, grid, clock, fields, parameters, closure, buoyancy)
+    top_tracer_bcs = parameters.top_tracer_boundary_conditions
+    top_velocity_bcs = parameters.top_velocity_boundary_conditions
+
+    return _top_tke_flux(i, j, grid, closure.surface_model, closure,
+                         buoyancy, fields, top_tracer_bcs, top_velocity_bcs, clock)
+end
+
+@inline function _top_tke_flux(i, j, grid, surface_model::TKESurfaceFlux, closure,
                               buoyancy, fields, top_tracer_bcs, top_velocity_bcs, clock)
 
     wΔ³ = top_convective_turbulent_velocity³(i, j, grid, clock, fields, buoyancy, top_tracer_bcs)
@@ -202,17 +226,7 @@ end
     return - Cᴰ * (Cᵂu★ * u★^3 + CᵂwΔ * wΔ³)
 end
 
-
-for S in (:RiDependentDiffusivityScaling, :TKESurfaceFlux)
-    @eval @inline convert_eltype(::Type{FT}, s::$S) where FT = $S{FT}(; Dict(p => getproperty(s, p) for p in propertynames(s))...)
-    @eval @inline convert_eltype(::Type{FT}, s::$S{FT}) where FT = s
-end
-
-#####
-##### TKE top boundary condition
-#####
-
-""" Computes the friction velocity based on fluxes of u and v. """
+""" Computes the friction velocity u★ based on fluxes of u and v. """
 @inline function friction_velocity(i, j, grid, clock, fields, velocity_bcs)
     FT = eltype(grid)
     Qᵘ = getbc(velocity_bcs.u, i, j, grid, clock, fields) 
@@ -220,6 +234,7 @@ end
     return sqrt(sqrt(Qᵘ^2 + Qᵛ^2))
 end
 
+""" Computes the convective velocity w★. """
 @inline function top_convective_turbulent_velocity³(i, j, grid, clock, fields, buoyancy, tracer_bcs)
     FT = eltype(grid)
     Qᵇ = top_buoyancy_flux(i, j, grid, buoyancy, tracer_bcs, clock, fields)
@@ -227,15 +242,21 @@ end
     return max(zero(FT), Qᵇ) * Δz   
 end
 
-@inline function top_tke_flux(i, j, grid, clock, fields, parameters)
-    buoyancy = parameters.buoyancy
-    top_tracer_bcs = parameters.top_tracer_boundary_conditions
-    top_velocity_bcs = parameters.top_velocity_boundary_conditions
-    closure = parameters.closure # problematic because model.closure can be changed.
-
-    return top_tke_flux(i, j, grid, closure.surface_model, closure,
-                        buoyancy, fields, top_tracer_bcs, top_velocity_bcs, clock)
+struct TKETopBoundaryConditionParameters{C, U}
+    top_tracer_boundary_conditions :: C
+    top_velocity_boundary_conditions :: U
 end
+
+@inline Adapt.adapt_structure(to, p::TKETopBoundaryConditionParameters) =
+    TKETopBoundaryConditionParameters(adapt(to, p.top_tracer_boundary_conditions),
+                                      adapt(to, p.top_velocity_boundary_conditions))
+
+using Oceananigans.BoundaryConditions: Flux
+const TKEBoundaryFunction = DiscreteBoundaryFunction{<:TKETopBoundaryConditionParameters}
+const TKEBoundaryCondition = BoundaryCondition{<:Flux, <:TKEBoundaryFunction}
+
+@inline getbc(bc::TKEBoundaryCondition, i, j, grid, clock, model_fields, closure, buoyancy) =
+    bc.condition.func(i, j, grid, clock, model_fields, bc.condition.parameters, closure, buoyancy)
 
 #####
 ##### Utilities for model constructors
@@ -270,10 +291,7 @@ function add_closure_specific_boundary_conditions(closure::TKEVD,
     top_tracer_bcs = top_tracer_boundary_conditions(grid, tracer_names, user_bcs)
     top_velocity_bcs = top_velocity_boundary_conditions(grid, user_bcs)
 
-    parameters = (buoyancy = buoyancy,
-                  top_tracer_boundary_conditions = top_tracer_bcs,
-                  top_velocity_boundary_conditions = top_velocity_bcs,
-                  closure = closure)
+    parameters = TKETopBoundaryConditionParameters(top_tracer_bcs, top_velocity_bcs)
 
     top_tke_bc = FluxBoundaryCondition(top_tke_flux, discrete_form=true, parameters=parameters)
 
@@ -284,12 +302,12 @@ function add_closure_specific_boundary_conditions(closure::TKEVD,
         e_bcs = user_bcs[:e]
         
         tke_bcs = FieldBoundaryConditions(grid, (Center, Center, Center),
-                                                   top = top_tke_bc,
-                                                   bottom = e_bcs.bottom,
-                                                   north = e_bcs.north,
-                                                   south = e_bcs.south,
-                                                   east = e_bcs.east,
-                                                   west = e_bcs.west)
+                                          top = top_tke_bc,
+                                          bottom = e_bcs.bottom,
+                                          north = e_bcs.north,
+                                          south = e_bcs.south,
+                                          east = e_bcs.east,
+                                          west = e_bcs.west)
     else
         tke_bcs = FieldBoundaryConditions(grid, (Center, Center, Center), top=top_tke_bc)
     end
@@ -397,13 +415,15 @@ end
 
 @inline step(x, c, w) = (1 + tanh((x - c) / w)) / 2
 
-@inline scale(Ri, σ⁻, σ⁺, c, w) = σ⁻ + (σ⁺ - σ⁻) * step(Ri, c, w)
+@inline scale(Ri, σ⁻, rσ, c, w) = σ⁻ * (1 + rσ * step(Ri, c, w))
+
+#@inline scale(Ri, σ⁻, rσ, c, w) = σ⁻ + (σ⁺ - σ⁻) * step(Ri, c, w)
 
 @inline function momentum_diffusivity_scale(i, j, k, grid, closure, velocities, tracers, buoyancy)
     Ri = Riᶜᶜᶜ(i, j, k, grid, velocities, tracers, buoyancy)
     return scale(Ri,
                  closure.diffusivity_scaling.Cᴷu⁻,
-                 closure.diffusivity_scaling.Cᴷu⁺,
+                 closure.diffusivity_scaling.Cᴷuʳ,
                  closure.diffusivity_scaling.CᴷRiᶜ,
                  closure.diffusivity_scaling.CᴷRiʷ)
 end
@@ -412,7 +432,7 @@ end
     Ri = Riᶜᶜᶜ(i, j, k, grid, velocities, tracers, buoyancy)
     return scale(Ri,
                  closure.diffusivity_scaling.Cᴷc⁻,
-                 closure.diffusivity_scaling.Cᴷc⁺,
+                 closure.diffusivity_scaling.Cᴷcʳ,
                  closure.diffusivity_scaling.CᴷRiᶜ,
                  closure.diffusivity_scaling.CᴷRiʷ)
 end
@@ -421,7 +441,7 @@ end
     Ri = Riᶜᶜᶜ(i, j, k, grid, velocities, tracers, buoyancy)
     return scale(Ri,
                  closure.diffusivity_scaling.Cᴷe⁻,
-                 closure.diffusivity_scaling.Cᴷe⁺,
+                 closure.diffusivity_scaling.Cᴷeʳ,
                  closure.diffusivity_scaling.CᴷRiᶜ,
                  closure.diffusivity_scaling.CᴷRiʷ)
 end


### PR DESCRIPTION
This PR reformulates TKEBasedVerticalDiffusivity simply through a redefinition of parameters.

It also makes a more important change to the code that passes `model.closure` and `model.buoyancy` to the kernels that evaluate boundary fluxes. This is necessary to make `TKEBasedVerticalDiffusivity` models robust against changes to parameters after model construction. The changes are made in a way that have no affect on the API or other models.

Resolves #1695 .

cc @adelinehillier