### PR TITLE
Introducing Callback for Simulations

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -70,7 +70,7 @@ export
     Clock, TimeStepWizard, time_step!,
 
     # Simulations
-    Simulation, run!, Callback,
+    Simulation, run!, Callback, iteration,
     iteration_limit_exceeded, stop_time_exceeded, wall_time_limit_exceeded,
 
     # Diagnostics

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -70,7 +70,7 @@ export
     Clock, TimeStepWizard, time_step!,
 
     # Simulations
-    Simulation, run!,
+    Simulation, run!, Callback,
     iteration_limit_exceeded, stop_time_exceeded, wall_time_limit_exceeded,
 
     # Diagnostics

--- a/src/Simulations/Simulations.jl
+++ b/src/Simulations/Simulations.jl
@@ -1,6 +1,6 @@
 module Simulations
 
-export TimeStepWizard, Simulation, run!
+export TimeStepWizard, Simulation, run!, Callback
 
 import Base: show
 
@@ -13,6 +13,7 @@ using Oceananigans.OutputWriters
 using Oceananigans.TimeSteppers
 using Oceananigans.Utils
 
+include("callback.jl")
 include("time_step_wizard.jl")
 include("simulation.jl")
 include("run.jl")

--- a/src/Simulations/callback.jl
+++ b/src/Simulations/callback.jl
@@ -1,0 +1,31 @@
+struct Callback{F, S}
+    func :: F
+    schedule :: S
+end
+
+(callback::Callback)(sim) = callback.func(sim)
+
+"""
+    Callback(func; schedule=IterationInterval(1))
+
+Return `Callback` that executes `func(sim::Simulation)` on `schedule`.
+"""
+Callback(func; schedule=IterationInterval(1)) = Callback(func, schedule)
+
+#####
+##### Utilities for run!
+#####
+
+default_callback_name(n) = Symbol(:callback, n)
+
+function add_callbacks!(sim, callbacks)
+    n_existing_callbacks = length(sim.callbacks)
+
+    for (i, callback) in enumerate(callbacks)
+        name = default_callback_name(n_existing_callbacks + i)
+        sim.callbacks[name] = callback
+    end
+
+    return nothing
+end
+

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -122,10 +122,12 @@ Possible values for `pickup` are:
 Note that `pickup=true` and `pickup=iteration` will fail if `simulation.output_writers` contains
 more than one checkpointer.
 """
-function run!(sim; pickup=false)
+function run!(sim; pickup=false, callbacks=[])
 
     model = sim.model
     clock = model.clock
+
+    add_callbacks!(sim, callbacks)
 
     if we_want_to_pickup(pickup)
         checkpointers = filter(writer -> writer isa Checkpointer, collect(values(sim.output_writers)))
@@ -157,6 +159,7 @@ function run!(sim; pickup=false)
         if clock.iteration == 0
             [run_diagnostic!(diag, sim.model) for diag in values(sim.diagnostics)]
             [write_output!(writer, sim.model) for writer in values(sim.output_writers)]
+            [callback(sim) for callback in values(sim.callbacks)]
         end
 
         # Ensure that the simulation doesn't iterate past `stop_iteration`.
@@ -177,8 +180,9 @@ function run!(sim; pickup=false)
             ab2_or_rk3_time_step!(model, Δt, euler=euler)
 
             # Run diagnostics, then write output
-            [  diag.schedule(model) && run_diagnostic!(diag, sim.model) for diag in values(sim.diagnostics)]
-            [writer.schedule(model) && write_output!(writer, sim.model) for writer in values(sim.output_writers)]
+            [  diag.schedule(model)   && run_diagnostic!(diag, sim.model) for diag in values(sim.diagnostics)]
+            [writer.schedule(model)   && write_output!(writer, sim.model) for writer in values(sim.output_writers)]
+            [callback.schedule(model) && callback(sim)                    for callback in values(sim.callbacks)]
         end
 
         sim.progress(sim)
@@ -189,5 +193,5 @@ function run!(sim; pickup=false)
         sim.run_time += time_after - time_before
     end
 
-    return nothing
+    return sim
 end

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -193,5 +193,5 @@ function run!(sim; pickup=false, callbacks=[])
         sim.run_time += time_after - time_before
     end
 
-    return sim
+    return nothing
 end

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -2,7 +2,7 @@
 
 default_progress(simulation) = nothing
 
-mutable struct Simulation{M, Δ, C, I, T, W, R, D, O, P, F, Π}
+mutable struct Simulation{M, Δ, C, I, T, W, R, P, F, Π}
                  model :: M
                     Δt :: Δ
          stop_criteria :: C
@@ -10,8 +10,9 @@ mutable struct Simulation{M, Δ, C, I, T, W, R, D, O, P, F, Π}
              stop_time :: T
        wall_time_limit :: W
               run_time :: R
-           diagnostics :: D
-        output_writers :: O
+           diagnostics :: OrderedDict{Symbol, AbstractDiagnostic}
+        output_writers :: OrderedDict{Symbol, AbstractOutputWriter}
+             callbacks :: OrderedDict{Symbol, Callback}
               progress :: P
     iteration_interval :: F
             parameters :: Π
@@ -25,6 +26,7 @@ end
        wall_time_limit = Inf,
            diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
         output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
+              callback = OrderedDict{Symbol, Callback}(),
               progress = nothing,
     iteration_interval = 1,
             parameters = nothing)
@@ -55,6 +57,7 @@ function Simulation(model; Δt,
       wall_time_limit = Inf,
           diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
        output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
+            callbacks = OrderedDict{Symbol, Callback}(),
              progress = default_progress,
    iteration_interval = 1,
            parameters = nothing)
@@ -78,7 +81,7 @@ function Simulation(model; Δt,
    run_time = 0.0
 
    return Simulation(model, Δt, stop_criteria, stop_iteration, stop_time, wall_time_limit,
-                     run_time, diagnostics, output_writers, progress, iteration_interval,
+                     run_time, diagnostics, output_writers, callbacks, progress, iteration_interval,
                      parameters)
 end
 

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -20,47 +20,54 @@ end
 
 """
     Simulation(model; Δt,
-         stop_criteria = Function[iteration_limit_exceeded, stop_time_exceeded, wall_time_limit_exceeded],
-        stop_iteration = Inf,
-             stop_time = Inf,
-       wall_time_limit = Inf,
-           diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
-        output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
-              callback = OrderedDict{Symbol, Callback}(),
-              progress = nothing,
-    iteration_interval = 1,
-            parameters = nothing)
+               stop_criteria = Function[iteration_limit_exceeded, stop_time_exceeded, wall_time_limit_exceeded],
+               stop_iteration = Inf,
+               stop_time = Inf,
+               wall_time_limit = Inf,
+               diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
+               output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
+               callback = OrderedDict{Symbol, Callback}(),
+               progress = nothing,
+               iteration_interval = 1,
+               parameters = nothing)
 
 Construct an Oceananigans.jl `Simulation` for a `model` with time step `Δt`.
 
 Keyword arguments
 =================
-- `Δt`: Required keyword argument specifying the simulation time step. Can be a `Number`
-  for constant time steps or a `TimeStepWizard` for adaptive time-stepping.
-- `stop_criteria`: A list of functions or callable objects (each taking a single argument,
-  the `simulation`). If any of the functions return `true` when the stop criteria is
-  evaluated the simulation will stop.
-- `stop_iteration`: Stop the simulation after this many iterations.
-- `stop_time`: Stop the simulation once this much model clock time has passed.
-- `wall_time_limit`: Stop the simulation if it's been running for longer than this many
-   seconds of wall clock time.
-- `progress`: A function with a single argument, the `simulation`. Will be called every
-  `iteration_interval` iterations. Useful for logging simulation health.
-- `iteration_interval`: How often to update the time step, check stop criteria, and call
-  `progress` function (in number of iterations).
-- `parameters`: Parameters that can be accessed in the `progress` function.
+    - `Δt`: Required keyword argument specifying the simulation time step. Can be a `Number`
+      for constant time steps or a `TimeStepWizard` for adaptive time-stepping.
+
+    - `stop_criteria`: A list of functions or callable objects (each taking a single argument,
+      the `simulation`). If any of the functions return `true` when the stop criteria is
+      evaluated the simulation will stop.
+
+    - `stop_iteration`: Stop the simulation after this many iterations.
+
+    - `stop_time`: Stop the simulation once this much model clock time has passed.
+
+    - `wall_time_limit`: Stop the simulation if it's been running for longer than this many
+       seconds of wall clock time.
+
+    - `progress`: A function with a single argument, the `simulation`. Will be called every
+      `iteration_interval` iterations. Useful for logging simulation health.
+
+    - `iteration_interval`: How often to update the time step, check stop criteria, and call
+      `progress` function (in number of iterations).
+
+    - `parameters`: Parameters that can be accessed in the `progress` function.
 """
 function Simulation(model; Δt,
-        stop_criteria = Any[iteration_limit_exceeded, stop_time_exceeded, wall_time_limit_exceeded],
-       stop_iteration = Inf,
-            stop_time = Inf,
-      wall_time_limit = Inf,
-          diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
-       output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
-            callbacks = OrderedDict{Symbol, Callback}(),
-             progress = default_progress,
-   iteration_interval = 1,
-           parameters = nothing)
+                    stop_criteria = Any[iteration_limit_exceeded, stop_time_exceeded, wall_time_limit_exceeded],
+                    stop_iteration = Inf,
+                    stop_time = Inf,
+                    wall_time_limit = Inf,
+                    diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
+                    output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
+                    callbacks = OrderedDict{Symbol, Callback}(),
+                    progress = default_progress,
+                    iteration_interval = 1,
+                    parameters = nothing)
 
    if stop_iteration == Inf && stop_time == Inf && wall_time_limit == Inf
        @warn "This simulation will run forever as stop iteration = stop time " *
@@ -80,9 +87,8 @@ function Simulation(model; Δt,
 
    run_time = 0.0
 
-   return Simulation(model, Δt, stop_criteria, stop_iteration, stop_time, wall_time_limit,
-                     run_time, diagnostics, output_writers, callbacks, progress, iteration_interval,
-                     parameters)
+   return Simulation(model, Δt, stop_criteria, stop_iteration, stop_time, wall_time_limit, run_time,
+                     diagnostics, output_writers, callbacks, progress, iteration_interval, parameters)
 end
 
 Base.show(io::IO, s::Simulation) =
@@ -95,3 +101,10 @@ Base.show(io::IO, s::Simulation) =
             "├── Stop time: $(prettytime(s.stop_time)), stop iteration: $(s.stop_iteration)\n",
             "├── Diagnostics: $(ordered_dict_show(s.diagnostics, "│"))\n",
             "└── Output writers: $(ordered_dict_show(s.output_writers, "│"))")
+
+#####
+##### Utilities
+#####
+
+Base.time(sim::Simulation) = sim.model.clock.time
+iteration(sim::Simulation) = sim.model.clock.iteration


### PR DESCRIPTION
This PR implements `Callback`, designed to be used with `Simulation`.

Illustration:

```julia
using Oceananigans

model = NonhydrostaticModel(grid = RegularRectilinearGrid(size=(128, 128), extent=(2π, 2π), topology=(Periodic, Periodic, Flat)),
                            timestepper = :RungeKutta3,
                            advection = UpwindBiasedFifthOrder(),
                            buoyancy = nothing,
                            tracers = nothing)

set!(model, u = (x, y, z) -> randn(), v = (x, y, z) -> randn())

simulation = Simulation(model, Δt=0.01, stop_iteration=100)

print_progress(sim) = @info "Iteration: $(sim.model.clock.iteration), time: $(sim.model.clock.time)"
simulation.callbacks[:progress] = Callback(print_progress, schedule=IterationInterval(10))

run!(simulation)
```

we get

```julia
julia> run!(simulation)
[ Info: Iteration: 0, time: 0.0
[ Info: Iteration: 10, time: 0.09999999999999999
[ Info: Iteration: 20, time: 0.19999999999999984
[ Info: Iteration: 30, time: 0.30000000000000004
[ Info: Iteration: 40, time: 0.4000000000000007
[ Info: Iteration: 50, time: 0.5000000000000013
[ Info: Iteration: 60, time: 0.6000000000000003
[ Info: Iteration: 70, time: 0.6999999999999993
[ Info: Iteration: 80, time: 0.7999999999999983
[ Info: Iteration: 90, time: 0.8999999999999972
[ Info: Iteration: 100, time: 0.9999999999999962
[ Info: Simulation is stopping. Model iteration 100 has hit or exceeded simulation stop iteration 100.
```

We also support passing an iterable of callbacks to `run!`:

```julia
progress_callback = Callback(print_progress, schedule=IterationInterval(10))
run!(simulation, callbacks=[progress_callback])
```

just in case someone wants to do that...

I think we could also redesign `TimeStepWizard` to be a special kind of `Callback`, and nuke the `progress` property.

What do others think? Are they ok with this big change to the API?

cc @navidcy @ali-ramadhan @francispoulin 

