### PR TITLE
Change order in Docs/Numerical Implementations

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -108,10 +108,10 @@ physics_pages = [
 ]
 
 numerical_pages = [
-    "Pressure decomposition" => "numerical_implementation/pressure_decomposition.md",
-    "Time stepping" => "numerical_implementation/time_stepping.md",
     "Finite volume method" => "numerical_implementation/finite_volume.md",
     "Spatial operators" => "numerical_implementation/spatial_operators.md",
+    "Pressure decomposition" => "numerical_implementation/pressure_decomposition.md",
+    "Time stepping" => "numerical_implementation/time_stepping.md",
     "Boundary conditions" => "numerical_implementation/boundary_conditions.md",
     "Poisson solvers" => "numerical_implementation/poisson_solvers.md",
     "Large eddy simulation" => "numerical_implementation/large_eddy_simulation.md"

--- a/docs/src/numerical_implementation/poisson_solvers.md
+++ b/docs/src/numerical_implementation/poisson_solvers.md
@@ -8,7 +8,7 @@ Poisson equation for the non-hydrostatic kinematic pressure
 ```math
    \begin{equation}
    \label{eq:poisson-pressure}
-   \nabla^2 p_{NH} = \frac{\nabla \cdot \boldsymbol{v}^n}{\Delta t} + \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{G}_{\boldsymbol{v}} \equiv \mathscr{F} \, ,
+   \nabla^2 p_{NH} = \frac{\boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{v}^n}{\Delta t} + \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{G}_{\boldsymbol{v}} \equiv \mathscr{F} \, ,
    \end{equation}
 ```
 along with homogenous Neumann boundary conditions ``\boldsymbol{v} \cdot \boldsymbol{\hat{n}} = 0`` 
@@ -218,18 +218,18 @@ integrated continuity equation
 ```math
     \begin{equation}
     \label{eq:vertically-integrated-continuity}
-    \partial_{t} \eta + \partial_{x} H \hat{u} + \partial_{y} H \hat{v} = M \, ,
+    \partial_t \eta + \partial_x (H \hat{u}) + \partial_y (H \hat{v}) = M \, ,
     \end{equation}
 ```
 
-where M is some surface volume flux (e.g terms such as precipitation, evaporation and runoff), 
+where ``M`` is some surface volume flux (e.g., terms such as precipitation, evaporation and runoff); 
 currently ``M=0`` is assumed. To form a linear system that can be solved implicitly we recast
 the continuity equation into a discrete integral form
 
 ```math
     \begin{equation}
     \label{eq:semi-discrete-integral-continuity}
-    A_{z} \partial_{t} \eta + \delta_{x}^{caa}\sum_{k} A_{x} u +\delta_{y}^{caa}\sum_{k} A_{y} v = A_{z} M \, ,
+    A_z \partial_t \eta + \delta_{x}^{caa} \sum_{k} A_{x} u + \delta_y^{caa} \sum_k A_y v = A_z M \, ,
     \end{equation}
 ```
 
@@ -238,7 +238,7 @@ and apply the discrete form to the hydrostatic form of the velocity fractional s
 ```math
     \begin{equation}
     \label{eq:hydrostatic-fractional-step}
-    \boldsymbol{v}^{n+1} = \boldsymbol{v}^{\star} - g\Delta t \boldsymbol{\nabla} \eta^{n+1} \, .
+    \boldsymbol{v}^{n+1} = \boldsymbol{v}^{\star} - g \Delta t \boldsymbol{\nabla} \eta^{n+1} \, .
     \end{equation}
 ```
 
@@ -247,19 +247,18 @@ as follows.
 Assuming ``M=0`` (for now), for the ``n+1`` timestep velocity we want the following to hold
 
 ```math
-    A_{z}\frac{\eta^{n+1}-\eta^{n}}{\Delta t}=-\delta_{x}^{caa}\sum_{k} A_{x} u^{n+1} - \delta_{y}^{caa}\sum_{k} A_{y} v^{n+1} \, ,
+    A_z \frac{\eta^{n+1} - \eta^{n}}{\Delta t} = -\delta_x^{caa} \sum_k A_x u^{n+1} - \delta_y^{caa} \sum_k A_y v^{n+1} \, .
 ```
 
-substituting for ``u^{n+1}`` and ``v^{n+1}`` from the discrete form of the 
-right-hand-side of \eqref{eq:hydrostatic-fractional-step} then gives an implicit equation
-for ``\eta^{n+1}``.
+Substituting ``u^{n+1}`` and ``v^{n+1}`` from the discrete form of the  right-hand-side of
+\eqref{eq:hydrostatic-fractional-step} then gives an implicit equation for ``\eta^{n+1}``,
 
 ```math
 \begin{align}
-   \delta_{x}^{caa}\sum_{k} A_{x} \partial_{x}^{faa}\eta^{n+1} & + \delta_{y}^{aca}\sum_{k} A_{y} \partial_{y}^{afa}\eta^{n+1} - \frac{1}{g\Delta t^{2}}A_{z} \eta^{n+1} = \\
-   & = \frac{1}{g \Delta t}\left( \delta_{x}^{caa}\sum_{k} A_{x} u^{\star} + \delta_{y}^{aca}\sum_{k} A_{y} v^{\star} \right) - \frac{1}{g\Delta t^{2}}A_{z} \eta^{n} \, .
+   \delta_x^{caa}\sum_k A_x \partial_x^{faa} \eta^{n+1} & + \delta_y^{aca} \sum_k A_y \partial_y^{afa} \eta^{n+1} - \frac{1}{g \, \Delta t^2} A_z \eta^{n+1} = \nonumber \\
+   & = \frac{1}{g \, \Delta t} \left( \delta_x^{caa} \sum_k A_x u^{\star} + \delta_y^{aca} \sum_k A_y v^{\star} \right ) - \frac{1}{g \, \Delta t^{2}} A_z \eta^{n} \, .
 \end{align}
 ```
 
-Formulated in this way, the linear operator will be symmetric and so can be solved using a preconditioned conjugate 
-gradient algorithmn.
+Formulated in this way, the linear operator will be symmetric and so can be solved using a
+preconditioned conjugate gradient algorithmn.

--- a/docs/src/numerical_implementation/spatial_operators.md
+++ b/docs/src/numerical_implementation/spatial_operators.md
@@ -29,7 +29,8 @@ projecting it onto the cell faces
     \delta_z^{aaf} f_{i, j, k} &= f_{i, j, k} - f_{i, j, k-1} \, , 
 \end{align}
 ```
-and another for taking the difference of a face-centered variable and projecting it onto the cell centers
+and another for taking the difference of a face-centered variable and projecting it onto the
+cell centers
 ```math
 \begin{align}
     \delta_x^{caa} f_{i, j, k} &= f_{i+1, j, k} - f_{i, j, k} \, , \\
@@ -129,22 +130,22 @@ back onto the cell faces.
 
 An isotropic viscosity operator acting on vertical momentum is discretized via
 ```math
-    \boldsymbol{\nabla} \boldsymbol{\cdot} \left ( \nu_e \boldsymbol{\nabla} w \right )
+    \boldsymbol{\nabla} \boldsymbol{\cdot} \left ( \nu \boldsymbol{\nabla} w \right )
     = \frac{1}{V} \left[
-          \delta_x^{faa} ( \nu_e \overline{A_x}^{caa} \partial_x^{caa} w )
-        + \delta_y^{afa} ( \nu_e \overline{A_y}^{aca} \partial_y^{aca} w )
-        + \delta_z^{aaf} ( \nu_e \overline{A_z}^{aac} \partial_z^{aac} w )
+          \delta_x^{faa} ( \nu \overline{A_x}^{caa} \partial_x^{caa} w )
+        + \delta_y^{afa} ( \nu \overline{A_y}^{aca} \partial_y^{aca} w )
+        + \delta_z^{aaf} ( \nu \overline{A_z}^{aac} \partial_z^{aac} w )
     \right ] \, ,
 ```
 where ``\nu`` is the kinematic viscosity.
 
 An isotropic diffusion operator acting on a tracer ``c``, on the other hand, is discretized via
 ```math
-   \boldsymbol{\nabla} \boldsymbol{\cdot} \left ( \kappa_e \boldsymbol{\nabla} c \right )
-    = \frac{1}{V} \left[ \phantom{\overline{A_x}^{caa}}
-        \delta_x^{caa} ( \kappa_e A_x \partial_x^{faa} c )
-      + \delta_y^{aca} ( \kappa_e A_y \partial_y^{afa} c )
-      + \delta_z^{aac} ( \kappa_e A_z \partial_z^{aaf} c )
+   \boldsymbol{\nabla} \boldsymbol{\cdot} \left ( \kappa \boldsymbol{\nabla} c \right )
+    = \frac{1}{V} \left[ \vphantom{\overline{A_x}^{caa}}
+        \delta_x^{caa} ( \kappa A_x \partial_x^{faa} c )
+      + \delta_y^{aca} ( \kappa A_y \partial_y^{afa} c )
+      + \delta_z^{aac} ( \kappa A_z \partial_z^{aaf} c )
     \right] \, .
 ```
 
@@ -173,8 +174,9 @@ The vertical velocity ``w`` may be computed from ``u`` and ``v`` via the continu
 ```math
     w = - \int_{-L_z}^0 (\partial_x u + \partial_y v) \, \mathrm{d} z \, ,
 ```
-to satisfy the incompressibility condition ``\nabla\cdot\boldsymbol{v} = 0`` to numerical precision. 
-This also involves computing a vertical integral, in this case evaluated from the bottom up
+to satisfy the incompressibility condition ``\boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{v} = 0``
+to numerical precision. This also involves computing a vertical integral, in this case evaluated
+from the bottom up
 ```math
     \begin{equation}
     w_k =


### PR DESCRIPTION
This PR change the order of pages in the Docs/Numerical Implementation section. It starts with "Finite volume method" and "Spatial operators" and then goes on with everything else.

Also fixes some loose ends in formatting. ;)