### PR TITLE
Make ab2_step_field! a bit less sketchy

### DIFF
--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -72,9 +72,10 @@ function ab2_step!(model, Δt, χ)
 
     workgroup, worksize = work_layout(model.grid, :xyz)
 
-    barrier = Event(device(model.architecture))
+    arch = model.architecture
+    barrier = device_event(arch)
 
-    step_field_kernel! = ab2_step_field!(device(model.architecture), workgroup, worksize)
+    step_field_kernel! = ab2_step_field!(device(arch), workgroup, worksize)
 
     model_fields = prognostic_fields(model)
 
@@ -85,7 +86,7 @@ function ab2_step!(model, Δt, χ)
         field_event = step_field_kernel!(field, Δt, χ,
                                          model.timestepper.Gⁿ[i],
                                          model.timestepper.G⁻[i],
-                                         dependencies=Event(device(model.architecture)))
+                                         dependencies = device_event(arch))
 
         push!(events, field_event)
 
@@ -110,17 +111,17 @@ end
 """
 Time step via
 
-    `U^{n+1} = U^n + Δt ( (3/2 + χ) * G^{n} - (1/2 + χ) G^{n-1} )`
+    `U^{n+1} = U^n + Δt ((3/2 + χ) * G^{n} - (1/2 + χ) G^{n-1})`
 
 """
-
-@kernel function ab2_step_field!(U, Δt, χ::FT, Gⁿ, G⁻) where FT
+@kernel function ab2_step_field!(u, Δt, χ, Gⁿ, G⁻)
     i, j, k = @index(Global, NTuple)
 
-    @inbounds begin
-        U[i, j, k] += Δt * (  (FT(1.5) + χ) * Gⁿ[i, j, k] - (FT(0.5) + χ) * G⁻[i, j, k] )
+    T = eltype(u)
+    one_point_five = convert(T, 1.5)
+    oh_point_five = convert(T, 0.5)
 
-    end
+    @inbounds u[i, j, k] += Δt * ((one_point_five + χ) * Gⁿ[i, j, k] - (oh_point_five + χ) * G⁻[i, j, k])
 end
 
 @kernel ab2_step_field!(::FunctionField, args...) = nothing

--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -1,5 +1,6 @@
 using Oceananigans.Fields: FunctionField, location
 using Oceananigans.TurbulenceClosures: implicit_step!
+using Oceananigans.Architectures: device_event
 
 struct QuasiAdamsBashforth2TimeStepper{FT, GT, IT} <: AbstractTimeStepper
                   χ :: FT


### PR DESCRIPTION
It was just a little sketchy: we shouldn't derive the "floating point type" from a potentially user-supplied parameter (which might accidentally be an integer, like `0`). It also had weird formatting so I fixed that too.