### PR TITLE
SingleColumn enhancements and "ensemble of columns" abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ docs/src/generated
 
 # VSCode
 .vscode
+
+statprof

--- a/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
@@ -21,6 +21,7 @@ function calculate_tendencies!(model::HydrostaticFreeSurfaceModel)
     # Calculate contributions to momentum and tracer tendencies from user-prescribed fluxes across the
     # boundaries of the domain
     calculate_hydrostatic_boundary_tendency_contributions!(model.timestepper.Gⁿ,
+                                                           model.grid,
                                                            model.architecture,
                                                            model.velocities,
                                                            model.free_surface,
@@ -185,7 +186,7 @@ function apply_flux_bcs!(Gcⁿ, events, c, arch, barrier, args...)
 end
 
 """ Apply boundary conditions by adding flux divergences to the right-hand-side. """
-function calculate_hydrostatic_boundary_tendency_contributions!(Gⁿ, arch, velocities, free_surface, tracers, args...)
+function calculate_hydrostatic_boundary_tendency_contributions!(Gⁿ, grid, arch, velocities, free_surface, tracers, args...)
 
     barrier = device_event(arch)
 

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
@@ -133,7 +133,6 @@ The tendency is called ``G_η`` and defined via
                        + forcings.η(i, j, k_surface, grid, clock, model_fields))
 end
 
-
 @inline function hydrostatic_turbulent_kinetic_energy_tendency(i, j, k, grid,
                                                                val_tracer_index::Val{tracer_index},
                                                                advection,

--- a/src/Models/HydrostaticFreeSurfaceModels/rigid_lid.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/rigid_lid.jl
@@ -2,5 +2,5 @@
 ##### There's no free surface with a rigid lid
 #####
 
-@inline explicit_barotropic_pressure_x_gradient(i, j, k, grid, free_surface::Nothing) = zero(eltype(grid))
-@inline explicit_barotropic_pressure_y_gradient(i, j, k, grid, free_surface::Nothing) = zero(eltype(grid))
+@inline explicit_barotropic_pressure_x_gradient(i, j, k, grid, ::Nothing) = zero(eltype(grid))
+@inline explicit_barotropic_pressure_y_gradient(i, j, k, grid, ::Nothing) = zero(eltype(grid))

--- a/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
@@ -92,7 +92,6 @@ function update_state!(model::HydrostaticFreeSurfaceModel, grid::SingleColumnGri
 end
 
 @inline function fill_halo_regions!(c::OffsetArray, bcs, arch::CPU, grid::SingleColumnGrid, args...; kwargs...)
-    #wait(device(arch), device_event(arch))
     fill_scm_bottom_halo!(c, grid, bcs.bottom, args...)
     fill_scm_top_halo!(c, grid, bcs.top, args...)
     return nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
@@ -1,14 +1,21 @@
 using KernelAbstractions: NoneEvent
+using OffsetArrays: OffsetArray
 
 using Oceananigans.Grids: Flat, Bounded
+using Oceananigans.Architectures: device_event
 
-import Oceananigans.Utils: launch!
+using Oceananigans.BoundaryConditions: fill_bottom_halo!, fill_top_halo!
+import Oceananigans.BoundaryConditions: fill_halo_regions!
 
 #####
 ##### Implements a "single column model mode" for HydrostaticFreeSurfaceModel
 #####
 
 const SingleColumnGrid = AbstractGrid{<:AbstractFloat, <:Flat, <:Flat, <:Bounded}
+
+#####
+##### Model constructor utils
+#####
 
 PressureField(arch, ::SingleColumnGrid) = (pHY′ = nothing,)
 FreeSurface(free_surface::ExplicitFreeSurface{Nothing}, velocities, arch, ::SingleColumnGrid) = nothing
@@ -18,8 +25,91 @@ validate_momentum_advection(momentum_advection, ::SingleColumnGrid) = nothing
 validate_tracer_advection(tracer_advection::AbstractAdvectionScheme, ::SingleColumnGrid) = nothing, NamedTuple()
 validate_tracer_advection(tracer_advection::Nothing, ::SingleColumnGrid) = nothing, NamedTuple()
 
-# @inline launch!(arch, ::SingleColumnGrid, ::Val{:xy},  args...; kwargs...) = NoneEvent()
-# @inline launch!(arch, grid::SingleColumnGrid, ::Val{dims}, args...; kwargs...) where dims = launch!(arch, grid, dims, args...; kwargs...)
+#####
+##### Time-step optimizations
+#####
 
-calculate_hydrostatic_pressure!(model, ::SingleColumnGrid) = nothing
 calculate_free_surface_tendency!(arch, ::SingleColumnGrid, args...) = NoneEvent()
+
+function calculate_hydrostatic_boundary_tendency_contributions!(Gⁿ, grid::SingleColumnGrid, arch, velocities, free_surface, tracers, args...)
+
+    prognostic_field_names = tuple(:u, :v, propertynames(tracers)...)
+    prognostic_fields = merge(velocities, tracers)
+    barrier = device_event(arch)
+
+    # Only apply z bcs
+    events = Tuple(apply_z_bcs!(Gⁿ[i], prognostic_fields[i], arch, barrier, args...) for i in prognostic_field_names)
+
+    wait(device(arch), MultiEvent(events))
+
+    return nothing
+end
+
+function update_state!(model::HydrostaticFreeSurfaceModel, grid::SingleColumnGrid)
+
+    # Fill halos for velocities and tracers. On the CubedSphere, the halo filling for velocity fields is wrong.
+    fill_halo_regions!(prognostic_fields(model), model.architecture, model.clock, fields(model))
+
+    compute_auxiliary_fields!(model.auxiliary_fields)
+
+    # Calculate diffusivities
+    calculate_diffusivities!(model.diffusivity_fields,
+                             model.architecture,
+                             model.grid,
+                             model.closure,
+                             model.buoyancy,
+                             model.velocities,
+                             model.tracers)
+
+    fill_halo_regions!(model.diffusivity_fields,
+                       model.architecture,
+                       model.clock,
+                       fields(model))
+
+    return nothing
+end
+
+function fill_halo_regions!(c::OffsetArray, bcs, arch::CPU, grid::SingleColumnGrid, args...; kwargs...)
+
+    wait(device(arch), device_event(arch))
+
+    fill_scm_bottom_halo!(c, grid, bcs.bottom, args...)
+    fill_scm_top_halo!(c, grid, bcs.top, args...)
+
+    return nothing
+end
+
+using Oceananigans.Operators: Δzᵃᵃᶜ
+using Oceananigans.BoundaryConditions: left_gradient, right_gradient, linearly_extrapolate, FBC, VBC, GBC
+    
+@inline fill_scm_bottom_halo!(c, grid, ::FBC, args...) = @inbounds c[1, 1, 0] = c[1, 1, 1]
+@inline fill_scm_top_halo!(c, grid, ::FBC, args...) = @inbounds c[1, 1, grid.Nz+1] = c[1, 1, grid.Nz]
+        
+@inline function fill_scm_top_halo!(c, grid, bc::Union{VBC, GBC}, args...)
+    i = j = 1
+
+    kᴴ = grid.Nz + 1 #    *    halo cell
+    kᴮ = grid.Nz + 1 #  =====  top boundary 
+    kᴵ = grid.Nz     #    *    interior cell
+
+    Δ = Δzᵃᵃᶜ(i, j, kᴮ, grid) # Δ between first interior and first top halo point, defined at cell face.
+    @inbounds ∇c = right_gradient(bc, c[i, j, kᴵ], Δ, i, j, grid, args...)
+    @inbounds c[i, j, kᴴ] = linearly_extrapolate(c[i, j, kᴵ], ∇c, Δ) # extrapolate upward in +z direction.
+end
+
+@inline function fill_scm_bottom_halo!(c, grid, bc::Union{VBC, GBC}, args...)
+
+    i = j = 1
+
+        #  ↑ z ↑  interior
+           #  -----  interior face
+    kᴵ = 1 #    *    interior cell
+    kᴮ = 1 #  =====  bottom boundary
+    kᴴ = 0 #    *    halo cell
+
+    Δ = Δzᵃᵃᶜ(i, j, kᴮ, grid) # Δ between first interior and first bottom halo point, defined at cell face.
+    @inbounds ∇c = left_gradient(bc, c[i, j, kᴵ], Δ, i, j, grid, args...)
+    @inbounds c[i, j, kᴴ] = linearly_extrapolate(c[i, j, kᴵ], ∇c, -Δ) # extrapolate downward in -z direction.
+
+    return nothing
+end

--- a/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
@@ -18,7 +18,8 @@ validate_momentum_advection(momentum_advection, ::SingleColumnGrid) = nothing
 validate_tracer_advection(tracer_advection::AbstractAdvectionScheme, ::SingleColumnGrid) = nothing, NamedTuple()
 validate_tracer_advection(tracer_advection::Nothing, ::SingleColumnGrid) = nothing, NamedTuple()
 
-@inline hydrostatic_pressure_y_gradient(i, j, k, grid, ::Nothing) = zero(eltype(grid))
+# @inline launch!(arch, ::SingleColumnGrid, ::Val{:xy},  args...; kwargs...) = NoneEvent()
+# @inline launch!(arch, grid::SingleColumnGrid, ::Val{dims}, args...; kwargs...) where dims = launch!(arch, grid, dims, args...; kwargs...)
 
-@inline launch!(arch, ::SingleColumnGrid, ::Val{:xy},  args...; kwargs...) = NoneEvent()
-@inline launch!(arch, ::SingleColumnGrid, ::Val{dims}, args...; kwargs...) where dims = launch!(arch, grid, dims, args...; kwargs...)
+calculate_hydrostatic_pressure!(model, ::SingleColumnGrid) = nothing
+calculate_free_surface_tendency!(arch, ::SingleColumnGrid, args...) = NoneEvent()

--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -101,6 +101,7 @@ function ab2_step!(model, Δt, χ)
                        model.closure,
                        tracer_index,
                        model.diffusivity_fields,
+                       model.tracers,
                        dependencies = field_event)
     end
 

--- a/src/TimeSteppers/runge_kutta_3.jl
+++ b/src/TimeSteppers/runge_kutta_3.jl
@@ -167,6 +167,7 @@ function rk3_substep!(model, Δt, γⁿ, ζⁿ)
                        model.closure,
                        tracer_index,
                        model.diffusivity_fields,
+                       model.tracers,
                        dependencies = field_event)
 
         push!(events, field_event)

--- a/src/TurbulenceClosures/closure_tuples.jl
+++ b/src/TurbulenceClosures/closure_tuples.jl
@@ -59,27 +59,27 @@ const EC = AbstractTurbulenceClosure{<:ExplicitTimeDiscretization}
 const VIC = AbstractTurbulenceClosure{<:VerticallyImplicitTimeDiscretization}
 
 # Filter explicitly-discretized closures.
-@inline z_diffusivity(clo::Tuple{<:EC},        Ks, ::Val{c_idx}) where {c_idx} = tuple(0)
-@inline z_diffusivity(clo::Tuple{<:VIC},       Ks, ::Val{c_idx}) where {c_idx} = tuple(z_diffusivity(clo[1], Ks[1], Val(c_idx)))
-@inline z_diffusivity(clo::Tuple{<:VIC, <:EC}, Ks, ::Val{c_idx}) where {c_idx} = tuple(z_diffusivity(clo[1], Ks[1], Val(c_idx)))
-@inline z_diffusivity(clo::Tuple{<:EC, <:VIC}, Ks, ::Val{c_idx}) where {c_idx} = tuple(z_diffusivity(clo[2], Ks[2], Val(c_idx)))
+@inline z_diffusivity(clo::Tuple{<:EC},        Ks, ::Val{c_idx}, args...) where {c_idx} = tuple(0)
+@inline z_diffusivity(clo::Tuple{<:VIC},       Ks, ::Val{c_idx}, args...) where {c_idx} = tuple(z_diffusivity(clo[1], Ks[1], Val(c_idx), args...))
+@inline z_diffusivity(clo::Tuple{<:VIC, <:EC}, Ks, ::Val{c_idx}, args...) where {c_idx} = tuple(z_diffusivity(clo[1], Ks[1], Val(c_idx), args...))
+@inline z_diffusivity(clo::Tuple{<:EC, <:VIC}, Ks, ::Val{c_idx}, args...) where {c_idx} = tuple(z_diffusivity(clo[2], Ks[2], Val(c_idx), args...))
 
-@inline z_diffusivity(clo::Tuple{<:VIC, <:VIC}, Ks, ::Val{c_idx}) where {c_idx} = tuple(z_diffusivity(clo[1], Ks[1], Val(c_idx)),
-                                                                                        z_diffusivity(clo[2], Ks[2], Val(c_idx)))
+@inline z_diffusivity(clo::Tuple{<:VIC, <:VIC}, Ks, ::Val{c_idx}, args...) where {c_idx} = tuple(z_diffusivity(clo[1], Ks[1], Val(c_idx), args...),
+                                                                                                 z_diffusivity(clo[2], Ks[2], Val(c_idx), args...))
 
-@inline z_diffusivity(clo::Tuple, Ks, ::Val{c_idx}) where c_idx = tuple(z_diffusivity(clo[1:2],   Ks[1:2], Val(c_idx))...,
-                                                                        z_diffusivity(clo[3:end], Ks[3:end], Val(c_idx))...)
+@inline z_diffusivity(clo::Tuple, Ks, ::Val{c_idx}, args...) where c_idx = tuple(z_diffusivity(clo[1:2],   Ks[1:2], Val(c_idx), args...)...,
+                                                                                 z_diffusivity(clo[3:end], Ks[3:end], Val(c_idx), args...)...)
 
-@inline z_viscosity(clo::Tuple{<:EC},         Ks) = tuple(0)
-@inline z_viscosity(clo::Tuple{<:VIC},        Ks) = tuple(z_viscosity(clo[1], Ks[1]))
-@inline z_viscosity(clo::Tuple{<:VIC, <:EC},  Ks) = tuple(z_viscosity(clo[1], Ks[1]))
-@inline z_viscosity(clo::Tuple{<:EC, <:VIC},  Ks) = tuple(z_viscosity(clo[2], Ks[2]))
+@inline z_viscosity(clo::Tuple{<:EC},         Ks, args...) = tuple(0)
+@inline z_viscosity(clo::Tuple{<:VIC},        Ks, args...) = tuple(z_viscosity(clo[1], Ks[1], args...))
+@inline z_viscosity(clo::Tuple{<:VIC, <:EC},  Ks, args...) = tuple(z_viscosity(clo[1], Ks[1], args...))
+@inline z_viscosity(clo::Tuple{<:EC, <:VIC},  Ks, args...) = tuple(z_viscosity(clo[2], Ks[2], args...))
 
-@inline z_viscosity(clo::Tuple{<:VIC, <:VIC}, Ks) = tuple(z_viscosity(clo[1], Ks[1]),
-                                                          z_viscosity(clo[2], Ks[2]))
+@inline z_viscosity(clo::Tuple{<:VIC, <:VIC}, Ks, args...) = tuple(z_viscosity(clo[1], Ks[1], args...),
+                                                                   z_viscosity(clo[2], Ks[2], args...))
 
-@inline z_viscosity(clo::Tuple, Ks) = tuple(z_viscosity(clo[1:2],   Ks[1:2])...,
-                                            z_viscosity(clo[3:end], Ks[3:end])...)
+@inline z_viscosity(clo::Tuple, Ks, args...) = tuple(z_viscosity(clo[1:2],   Ks[1:2], args...)...,
+                                                     z_viscosity(clo[3:end], Ks[3:end], args...)...)
 
 for coeff in (:νᶜᶜᶜ, :νᶠᶠᶜ, :νᶠᶜᶠ, :νᶜᶠᶠ, :κᶜᶜᶠ, :κᶜᶠᶜ, :κᶠᶜᶜ)
     @eval begin

--- a/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
@@ -565,7 +565,7 @@ const VITD = VerticallyImplicitTimeDiscretization
 @inline z_viscosity(closure::Union{TKEVD, TKEVDArray}, diffusivities, args...) = diffusivities.Kᵘ
 
 @inline function z_diffusivity(closure::Union{TKEVD, TKEVDArray}, ::Val{tracer_index},
-                               diffusivities, velocities, tracers, args...) where tracer_index
+                               diffusivities, tracers, args...) where tracer_index
 
     tke_index = findfirst(name -> name === :e, keys(tracers))
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
@@ -100,7 +100,7 @@ function TKEBasedVerticalDiffusivity(FT=Float64;
                                      dissipation_parameter = 2.91,
                                      mixing_length_parameter = 1.16,
                                      surface_model = TKESurfaceFlux{FT}(),
-                                     time_discretization::TD = ExplicitTimeDiscretization()) where TD
+                                     time_discretization::TD = VerticallyImplicitTimeDiscretization()) where TD
 
     @warn "TKEBasedVerticalDiffusivity is an experimental turbulence closure that \n" *
           "is unvalidated and whose default parameters are not calibrated for \n" * 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
@@ -562,14 +562,10 @@ end
 
 const VITD = VerticallyImplicitTimeDiscretization
 
-@inline z_viscosity(closure::Union{TKEVD, TKEVDArray}, diffusivities, velocities, tracers, buoyancy) = diffusivities.Kᵘ
+@inline z_viscosity(closure::Union{TKEVD, TKEVDArray}, diffusivities, args...) = diffusivities.Kᵘ
 
-@inline function z_diffusivity(closure::Union{TKEVD, TKEVDArray},
-                               ::Val{tracer_index},
-                               diffusivities,
-                               velocities,
-                               tracers,
-                               buoyancy) where tracer_index
+@inline function z_diffusivity(closure::Union{TKEVD, TKEVDArray}, ::Val{tracer_index},
+                               diffusivities, args...) where tracer_index
 
     tke_index = findfirst(name -> name === :e, keys(tracers))
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
@@ -8,7 +8,6 @@ using Oceananigans.BoundaryConditions: BoundaryCondition, FieldBoundaryCondition
 using Oceananigans.BuoyancyModels: ∂z_b, top_buoyancy_flux
 using Oceananigans.Operators: ℑzᵃᵃᶜ
 
-
 function hydrostatic_turbulent_kinetic_energy_tendency end
 
 struct TKEBasedVerticalDiffusivity{TD, CK, CD, CL, CQ} <: AbstractTurbulenceClosure{TD}
@@ -16,16 +15,16 @@ struct TKEBasedVerticalDiffusivity{TD, CK, CD, CL, CQ} <: AbstractTurbulenceClos
     dissipation_parameter :: CD
     mixing_length_parameter :: CL
     surface_model :: CQ
-
-    function TKEBasedVerticalDiffusivity{TD}(
-        diffusivity_scaling :: CK,
-        dissipation_parameter :: CD,
-        mixing_length_parameter :: CL,
-        surface_model :: CQ) where {TD, CK, CD, CL, CQ}
-
-        return new{TD, CK, CD, CL, CQ}(diffusivity_scaling, dissipation_parameter, mixing_length_parameter, surface_model)
-    end
 end
+
+function TKEBasedVerticalDiffusivity{TD}(diffusivity_scaling :: CK,
+                                         dissipation_parameter :: CD,
+                                         mixing_length_parameter :: CL,
+                                         surface_model :: CQ) where {TD, CK, CD, CL, CQ}
+
+    return TKEBasedVerticalDiffusivity{TD, CK, CD, CL, CQ}(diffusivity_scaling, dissipation_parameter, mixing_length_parameter, surface_model)
+end
+
 
 """
     TKEBasedVerticalDiffusivity(FT=Float64;

--- a/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
@@ -565,7 +565,7 @@ const VITD = VerticallyImplicitTimeDiscretization
 @inline z_viscosity(closure::Union{TKEVD, TKEVDArray}, diffusivities, args...) = diffusivities.Kᵘ
 
 @inline function z_diffusivity(closure::Union{TKEVD, TKEVDArray}, ::Val{tracer_index},
-                               diffusivities, args...) where tracer_index
+                               diffusivities, velocities, tracers, args...) where tracer_index
 
     tke_index = findfirst(name -> name === :e, keys(tracers))
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl
@@ -296,8 +296,8 @@ function add_closure_specific_boundary_conditions(closure::TKEVD,
     top_tke_bc = FluxBoundaryCondition(top_tke_flux, discrete_form=true, parameters=parameters)
 
     if :e ∈ keys(user_bcs)
-        @warn "Replacing top boundary conditions for tracer `e` with " *
-              "boundary condition specific to $(typeof(closure).name.wrapper)"
+        # @warn "Replacing top boundary conditions for tracer `e` with " *
+        #       "boundary condition specific to $(typeof(closure).name.wrapper)"
 
         e_bcs = user_bcs[:e]
         

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -72,8 +72,7 @@ function launch!(arch, grid, dims, kernel!, args...;
                  dependencies = nothing,
                  include_right_boundaries = false,
                  reduced_dimensions = (),
-                 location = nothing,
-                 kwargs...)
+                 location = nothing)
 
     workgroup, worksize = work_layout(grid, dims,
                                       include_right_boundaries = include_right_boundaries,
@@ -84,7 +83,7 @@ function launch!(arch, grid, dims, kernel!, args...;
 
     @debug "Launching kernel $kernel! with worksize $worksize"
 
-    event = loop!(args...; dependencies=dependencies, kwargs...)
+    event = loop!(args...; dependencies=dependencies)
 
     return event
 end

--- a/validation/vertical_mixing_closures/Manifest.toml
+++ b/validation/vertical_mixing_closures/Manifest.toml
@@ -5,6 +5,12 @@ git-tree-sha1 = "03e0550477d86222521d254b741d470ba17ea0b5"
 uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 version = "0.3.4"
 
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "84918055d15b3114ede17ac6a7182f68870c16f7"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.3.1"
+
 [[ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 
@@ -20,6 +26,24 @@ git-tree-sha1 = "c31ebabde28d102b602bada60ce8922c266d205b"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 version = "1.1.1"
 
+[[Bzip2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c3598e525718abcc440f69cc6d5f60dda0a1b61e"
+uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
+version = "1.0.6+5"
+
+[[Cairo_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "e2f47f6d8337369411569fd45ae5753ca10394c6"
+uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
+version = "1.16.0+6"
+
+[[ColorSchemes]]
+deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random", "StaticArrays"]
+git-tree-sha1 = "ed268efe58512df8c7e224d2e170afd76dd6a417"
+uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+version = "3.13.0"
+
 [[ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
 git-tree-sha1 = "024fe24d83e4a5bf5fc80501a314ce0d1aa35597"
@@ -32,19 +56,67 @@ git-tree-sha1 = "417b0ed7b8b838aa6ca0a87aadf1bb9eb111ce40"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
 version = "0.12.8"
 
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[Contour]]
+deps = ["StaticArrays"]
+git-tree-sha1 = "9f02045d934dc030edad45944ea80dbd1f0ebea7"
+uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
+version = "0.5.7"
+
+[[DataAPI]]
+git-tree-sha1 = "ee400abb2298bd13bfc3df1c412ed228061a2385"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.7.0"
+
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
 git-tree-sha1 = "88d48e133e6d3dd68183309877eac74393daa7eb"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 version = "0.17.20"
 
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
 [[Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[EarCut_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "92d8f9f208637e8d2d28c664051a00569c01493d"
+uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
+version = "2.1.5+1"
+
+[[Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b3bfd02e98aedfa5cf885665493c5598c350cd2f"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.2.10+0"
+
+[[FFMPEG]]
+deps = ["FFMPEG_jll"]
+git-tree-sha1 = "b57e3acbe22f8484b4b5ff66a7499717fe1a9cc8"
+uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
+version = "0.4.1"
+
+[[FFMPEG_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "LibVPX_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "Pkg", "Zlib_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "3cc57ad0a213808473eafef4845a74766242e05f"
+uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
+version = "4.3.1+4"
 
 [[FileIO]]
 deps = ["Pkg", "Requires", "UUIDs"]
@@ -64,26 +136,148 @@ git-tree-sha1 = "99c43a8765095efa6ef76233d44a89e68073bd10"
 uuid = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 version = "0.2.5"
 
+[[Fontconfig_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "35895cf184ceaab11fd778b4590144034a167a2f"
+uuid = "a3f928ae-7b40-5064-980b-68af3947d34b"
+version = "2.13.1+14"
+
+[[Formatting]]
+deps = ["Printf"]
+git-tree-sha1 = "8339d61043228fdd3eb658d86c926cb282ae72a8"
+uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
+version = "0.4.2"
+
+[[FreeType2_jll]]
+deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "cbd58c9deb1d304f5a245a0b7eb841a2560cfec6"
+uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
+version = "2.10.1+5"
+
+[[FriBidi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "aa31987c2ba8704e23c6c8ba8a4f769d5d7e4f91"
+uuid = "559328eb-81f9-559d-9380-de523a88c83c"
+version = "1.0.10+0"
+
+[[GLFW_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Pkg", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll"]
+git-tree-sha1 = "dba1e8614e98949abfa60480b13653813d8f0157"
+uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
+version = "3.3.5+0"
+
+[[GR]]
+deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
+git-tree-sha1 = "182da592436e287758ded5be6e32c406de3a2e47"
+uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
+version = "0.58.1"
+
+[[GR_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "d59e8320c2747553788e4fc42231489cc602fa50"
+uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
+version = "0.58.1+0"
+
+[[GeometryBasics]]
+deps = ["EarCut_jll", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
+git-tree-sha1 = "58bcdf5ebc057b085e58d95c138725628dd7453c"
+uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+version = "0.4.1"
+
+[[Gettext_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
+git-tree-sha1 = "9b02998aba7bf074d14de89f9d37ca24a1a0b046"
+uuid = "78b55507-aeef-58d4-861c-77aaff3498b1"
+version = "0.21.0+0"
+
+[[Glib_jll]]
+deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "7bf67e9a481712b3dbe9cb3dac852dc4b1162e02"
+uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
+version = "2.68.3+0"
+
+[[Grisu]]
+git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
+uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
+version = "1.0.2"
+
 [[HAML]]
 deps = ["DataStructures", "Markdown", "Requires"]
 git-tree-sha1 = "68865ba44b5c21599e3d5fdacf280a430b57d0f5"
 uuid = "0bc81568-2411-4001-9bf1-c899fa54f385"
 version = "0.3.4"
 
+[[HTTP]]
+deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
+git-tree-sha1 = "44e3b40da000eab4ccb1aecdc4801c040026aeb5"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.9.13"
+
 [[IndirectArrays]]
 git-tree-sha1 = "c2a145a145dc03a7620af1444e0264ef907bd44f"
 uuid = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 version = "0.5.1"
 
+[[IniFile]]
+deps = ["Test"]
+git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.0"
+
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IterTools]]
+git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.3.0"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.3.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.1"
+
+[[JpegTurbo_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "d735490ac75c5cb9f1b00d8b5509c11984dc6943"
+uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
+version = "2.1.0+0"
+
+[[LAME_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f6250b16881adf048549549fba48b1161acdac8c"
+uuid = "c1c5ebd0-6772-5130-a774-d5fcae4a789d"
+version = "3.100.1+0"
+
+[[LZO_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "e5b909bcf985c5e2605737d2ce278ed791b89be6"
+uuid = "dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
+version = "2.10.1+0"
+
+[[LaTeXStrings]]
+git-tree-sha1 = "c7f1c695e06c01b95a67f0cd1d34994f3e7db104"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.2.1"
+
+[[Latexify]]
+deps = ["Formatting", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "Printf", "Requires"]
+git-tree-sha1 = "a4b12a1bd2ebade87891ab7e36fdbce582301a92"
+uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+version = "0.15.6"
 
 [[LeftChildRightSiblingTrees]]
 deps = ["AbstractTrees"]
@@ -107,8 +301,62 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
+[[LibVPX_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "12ee7e23fa4d18361e7c2cde8f8337d4c3101bc7"
+uuid = "dd192d2f-8180-539f-9fb4-cc70b1dcf69a"
+version = "1.10.0+0"
+
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Libffi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "761a393aeccd6aa92ec3515e428c26bf99575b3b"
+uuid = "e9f186c6-92d2-5b65-8a66-fee21dc1b490"
+version = "3.2.2+0"
+
+[[Libgcrypt_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgpg_error_jll", "Pkg"]
+git-tree-sha1 = "64613c82a59c120435c067c2b809fc61cf5166ae"
+uuid = "d4300ac3-e22c-5743-9152-c294e39db1e4"
+version = "1.8.7+0"
+
+[[Libglvnd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll", "Xorg_libXext_jll"]
+git-tree-sha1 = "7739f837d6447403596a75d19ed01fd08d6f56bf"
+uuid = "7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
+version = "1.3.0+3"
+
+[[Libgpg_error_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c333716e46366857753e273ce6a69ee0945a6db9"
+uuid = "7add5ba3-2f88-524e-9cd5-f83b8a55f7b8"
+version = "1.42.0+0"
+
+[[Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.16.1+1"
+
+[[Libmount_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "9c30530bf0effd46e15e0fdcf2b8636e78cbbd73"
+uuid = "4b2f31a3-9ecc-558c-b454-b3730dcb73e9"
+version = "2.35.0+0"
+
+[[Libtiff_jll]]
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Pkg", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "340e257aada13f95f98ee352d316c3bed37c8ab9"
+uuid = "89763e89-9b03-5906-acba-b20f662cd828"
+version = "4.3.0+0"
+
+[[Libuuid_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "7f3efec06033682db852f8b3bc3c1d2b0a0ab066"
+uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
+version = "2.36.0+0"
 
 [[LinearAlgebra]]
 deps = ["Libdl"]
@@ -117,13 +365,36 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "0fb723cd8c45858c22169b2e42269e53271a6df7"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.7"
+
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
+git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.0.3"
+
 [[MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[Measures]]
+git-tree-sha1 = "e498ddeee6f9fdb4551ce855a46f54dbd900245f"
+uuid = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
+version = "0.3.1"
+
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "4ea90bd5d3985ae1f9a908bd4500ae88921c5ce7"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.0.0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -131,13 +402,42 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 [[MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
+[[NaNMath]]
+git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.5"
+
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[Ogg_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "7937eda4681660b4d6aeeecc2f7e1c81c8ee4e2f"
+uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
+version = "1.3.5+0"
+
+[[OpenSSL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "15003dcb7d8db3c6c857fda14891a539a8f2705a"
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "1.1.10+0"
+
+[[Opus_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "51a08fb14ec28da2ec7a927c4337e4332c2a4720"
+uuid = "91d4177d-7536-5919-b921-800302f37372"
+version = "1.3.2+0"
 
 [[OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
+
+[[PCRE_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b2a7af664e098055a7529ad1a900ded962bca488"
+uuid = "2f80f16e-611a-54ab-bc61-aa92de5b98fc"
+version = "8.44.0+0"
 
 [[Parsers]]
 deps = ["Dates"]
@@ -145,9 +445,39 @@ git-tree-sha1 = "bfd7d8c7fd87f04543810d9cbd3995972236ba1b"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "1.1.2"
 
+[[Pixman_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b4f5d02549a10e20780a24fce72bea96b6329e29"
+uuid = "30392449-352a-5448-841d-b1acce4e97dc"
+version = "0.40.1+0"
+
 [[Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PlotThemes]]
+deps = ["PlotUtils", "Requires", "Statistics"]
+git-tree-sha1 = "a3a964ce9dc7898193536002a6dd892b1b5a6f1d"
+uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
+version = "2.0.1"
+
+[[PlotUtils]]
+deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
+git-tree-sha1 = "501c20a63a34ac1d015d5304da0e645f42d91c9f"
+uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
+version = "1.0.11"
+
+[[Plots]]
+deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
+git-tree-sha1 = "e39bea10478c6aff5495ab522517fae5134b40e3"
+uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+version = "1.20.0"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.2"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -157,6 +487,12 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 deps = ["Printf"]
 uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 
+[[Qt5Base_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "xkbcommon_jll"]
+git-tree-sha1 = "ad368663a5e20dbb8d6dc2fddeefe4dae0781ae8"
+uuid = "ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
+version = "5.15.3+0"
+
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
@@ -164,6 +500,17 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[RecipesBase]]
+git-tree-sha1 = "b3fb709f3c97bfc6e948be68beeecb55a0b340ae"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.1.1"
+
+[[RecipesPipeline]]
+deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
+git-tree-sha1 = "2a7a2469ed5d94a98dea0e85c46fa653d76be0cd"
+uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
+version = "0.3.4"
 
 [[Reexport]]
 git-tree-sha1 = "5f6c21241f0f655da3952fd60aa18477cf96c220"
@@ -179,11 +526,29 @@ version = "1.1.3"
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
+[[Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "0b4b7f1393cff97c33891da2a0bf69c6ed241fda"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.1.0"
+
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[Showoff]]
+deps = ["Dates", "Grisu"]
+git-tree-sha1 = "91eddf657aca81df9ae6ceb20b959ae5653ad1de"
+uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
+version = "1.0.3"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.0.1"
 
 [[SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
@@ -195,13 +560,48 @@ git-tree-sha1 = "936380cb0efc66b996a5b93780c6b8f773f7f57b"
 uuid = "a8a75453-ed82-57c9-9e16-4cd1196ecbf5"
 version = "1.2.1"
 
+[[StaticArrays]]
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "3fedeffc02e47d6e3eb479150c8e5cd8f15a77a0"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.2.10"
+
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[[StatsAPI]]
+git-tree-sha1 = "1958272568dc176a1d881acb797beb909c785510"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.0.0"
+
+[[StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "fed1ec1e65749c4d96fc20dd13bea72b55457e62"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.33.9"
+
+[[StructArrays]]
+deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
+git-tree-sha1 = "000e168f5cc9aded17b6999a560b7c11dda69095"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.6.0"
+
 [[TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "d0c690d37c73aeb5ca063056283fde5585a41710"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.5.0"
 
 [[Tar]]
 deps = ["ArgTools", "SHA"]
@@ -211,6 +611,11 @@ uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[URIs]]
+git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.3.0"
+
 [[UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
@@ -218,9 +623,189 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[[Wayland_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]
+git-tree-sha1 = "3e61f0b86f90dacb0bc0e73a0c5a83f6a8636e23"
+uuid = "a2964d1f-97da-50d4-b82a-358c7fce9d89"
+version = "1.19.0+0"
+
+[[Wayland_protocols_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Wayland_jll"]
+git-tree-sha1 = "2839f1c1296940218e35df0bbb220f2a79686670"
+uuid = "2381bf8a-dfd0-557d-9999-79630e7b1b91"
+version = "1.18.0+4"
+
+[[XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.9.12+0"
+
+[[XSLT_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Libiconv_jll", "Pkg", "XML2_jll", "Zlib_jll"]
+git-tree-sha1 = "91844873c4085240b95e795f692c4cec4d805f8a"
+uuid = "aed1982a-8fda-507f-9586-7b0439959a61"
+version = "1.1.34+0"
+
+[[Xorg_libX11_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
+git-tree-sha1 = "5be649d550f3f4b95308bf0183b82e2582876527"
+uuid = "4f6342f7-b3d2-589e-9d20-edeb45f2b2bc"
+version = "1.6.9+4"
+
+[[Xorg_libXau_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "4e490d5c960c314f33885790ed410ff3a94ce67e"
+uuid = "0c0b7dd1-d40b-584c-a123-a41640f87eec"
+version = "1.0.9+4"
+
+[[Xorg_libXcursor_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXfixes_jll", "Xorg_libXrender_jll"]
+git-tree-sha1 = "12e0eb3bc634fa2080c1c37fccf56f7c22989afd"
+uuid = "935fb764-8cf2-53bf-bb30-45bb1f8bf724"
+version = "1.2.0+4"
+
+[[Xorg_libXdmcp_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "4fe47bd2247248125c428978740e18a681372dd4"
+uuid = "a3789734-cfe1-5b06-b2d0-1dd0d9d62d05"
+version = "1.1.3+4"
+
+[[Xorg_libXext_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "b7c0aa8c376b31e4852b360222848637f481f8c3"
+uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
+version = "1.3.4+4"
+
+[[Xorg_libXfixes_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "0e0dc7431e7a0587559f9294aeec269471c991a4"
+uuid = "d091e8ba-531a-589c-9de9-94069b037ed8"
+version = "5.0.3+4"
+
+[[Xorg_libXi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll", "Xorg_libXfixes_jll"]
+git-tree-sha1 = "89b52bc2160aadc84d707093930ef0bffa641246"
+uuid = "a51aa0fd-4e3c-5386-b890-e753decda492"
+version = "1.7.10+4"
+
+[[Xorg_libXinerama_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll"]
+git-tree-sha1 = "26be8b1c342929259317d8b9f7b53bf2bb73b123"
+uuid = "d1454406-59df-5ea1-beac-c340f2130bc3"
+version = "1.1.4+4"
+
+[[Xorg_libXrandr_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll"]
+git-tree-sha1 = "34cea83cb726fb58f325887bf0612c6b3fb17631"
+uuid = "ec84b674-ba8e-5d96-8ba1-2a689ba10484"
+version = "1.5.2+4"
+
+[[Xorg_libXrender_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "19560f30fd49f4d4efbe7002a1037f8c43d43b96"
+uuid = "ea2f1a96-1ddc-540d-b46f-429655e07cfa"
+version = "0.9.10+4"
+
+[[Xorg_libpthread_stubs_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "6783737e45d3c59a4a4c4091f5f88cdcf0908cbb"
+uuid = "14d82f49-176c-5ed1-bb49-ad3f5cbd8c74"
+version = "0.1.0+3"
+
+[[Xorg_libxcb_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "XSLT_jll", "Xorg_libXau_jll", "Xorg_libXdmcp_jll", "Xorg_libpthread_stubs_jll"]
+git-tree-sha1 = "daf17f441228e7a3833846cd048892861cff16d6"
+uuid = "c7cfdc94-dc32-55de-ac96-5a1b8d977c5b"
+version = "1.13.0+3"
+
+[[Xorg_libxkbfile_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "926af861744212db0eb001d9e40b5d16292080b2"
+uuid = "cc61e674-0454-545c-8b26-ed2c68acab7a"
+version = "1.1.0+4"
+
+[[Xorg_xcb_util_image_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "0fab0a40349ba1cba2c1da699243396ff8e94b97"
+uuid = "12413925-8142-5f55-bb0e-6d7ca50bb09b"
+version = "0.4.0+1"
+
+[[Xorg_xcb_util_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxcb_jll"]
+git-tree-sha1 = "e7fd7b2881fa2eaa72717420894d3938177862d1"
+uuid = "2def613f-5ad1-5310-b15b-b15d46f528f5"
+version = "0.4.0+1"
+
+[[Xorg_xcb_util_keysyms_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "d1151e2c45a544f32441a567d1690e701ec89b00"
+uuid = "975044d2-76e6-5fbe-bf08-97ce7c6574c7"
+version = "0.4.0+1"
+
+[[Xorg_xcb_util_renderutil_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "dfd7a8f38d4613b6a575253b3174dd991ca6183e"
+uuid = "0d47668e-0667-5a69-a72c-f761630bfb7e"
+version = "0.3.9+1"
+
+[[Xorg_xcb_util_wm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "e78d10aab01a4a154142c5006ed44fd9e8e31b67"
+uuid = "c22f9ab0-d5fe-5066-847c-f4bb1cd4e361"
+version = "0.4.1+1"
+
+[[Xorg_xkbcomp_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxkbfile_jll"]
+git-tree-sha1 = "4bcbf660f6c2e714f87e960a171b119d06ee163b"
+uuid = "35661453-b289-5fab-8a00-3d9160c6a3a4"
+version = "1.4.2+4"
+
+[[Xorg_xkeyboard_config_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xkbcomp_jll"]
+git-tree-sha1 = "5c8424f8a67c3f2209646d4425f3d415fee5931d"
+uuid = "33bec58e-1273-512f-9401-5d533626f822"
+version = "2.27.0+4"
+
+[[Xorg_xtrans_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "79c31e7844f6ecf779705fbc12146eb190b7d845"
+uuid = "c5fb5394-a638-5e4d-96e5-b29de1b5cf10"
+version = "1.4.0+3"
+
 [[Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[Zstd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "cc4bf3fdde8b7e3e9fa0351bdeedba1cf3b7f6e6"
+uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
+version = "1.5.0+0"
+
+[[libass_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "acc685bcf777b2202a904cdcb49ad34c2fa1880c"
+uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
+version = "0.14.0+4"
+
+[[libfdk_aac_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "7a5780a0d9c6864184b3a2eeeb833a0c871f00ab"
+uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
+version = "0.1.6+4"
+
+[[libpng_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "94d180a6d2b5e55e447e2d27a29ed04fe79eb30c"
+uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
+version = "1.6.38+0"
+
+[[libvorbis_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll", "Pkg"]
+git-tree-sha1 = "c45f4e40e7aafe9d086379e5578947ec8b95a8fb"
+uuid = "f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
+version = "1.3.7+0"
 
 [[nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -229,3 +814,21 @@ uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 [[p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+
+[[x264_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "d713c1ce4deac133e3334ee12f4adff07f81778f"
+uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
+version = "2020.7.14+2"
+
+[[x265_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "487da2f8f2f0c8ee0e83f39d13037d6bbf0a45ab"
+uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
+version = "3.0.0+3"
+
+[[xkbcommon_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Wayland_jll", "Wayland_protocols_jll", "Xorg_libxcb_jll", "Xorg_xkeyboard_config_jll"]
+git-tree-sha1 = "ece2350174195bb31de1a63bea3a41ae1aa593b6"
+uuid = "d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
+version = "0.9.1+5"

--- a/validation/vertical_mixing_closures/Manifest.toml
+++ b/validation/vertical_mixing_closures/Manifest.toml
@@ -1,0 +1,210 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[AbstractTrees]]
+git-tree-sha1 = "03e0550477d86222521d254b741d470ba17ea0b5"
+uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+version = "0.3.4"
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[ColorTypes]]
+deps = ["FixedPointNumbers", "Random"]
+git-tree-sha1 = "024fe24d83e4a5bf5fc80501a314ce0d1aa35597"
+uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+version = "0.11.0"
+
+[[Colors]]
+deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
+git-tree-sha1 = "417b0ed7b8b838aa6ca0a87aadf1bb9eb111ce40"
+uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
+version = "0.12.8"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "88d48e133e6d3dd68183309877eac74393daa7eb"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.17.20"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[FileIO]]
+deps = ["Pkg", "Requires", "UUIDs"]
+git-tree-sha1 = "256d8e6188f3f1ebfa1a5d17e072a0efafa8c5bf"
+uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+version = "1.10.1"
+
+[[FixedPointNumbers]]
+deps = ["Statistics"]
+git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
+uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+version = "0.8.4"
+
+[[FlameGraphs]]
+deps = ["AbstractTrees", "Colors", "FileIO", "FixedPointNumbers", "IndirectArrays", "LeftChildRightSiblingTrees", "Profile"]
+git-tree-sha1 = "99c43a8765095efa6ef76233d44a89e68073bd10"
+uuid = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
+version = "0.2.5"
+
+[[HAML]]
+deps = ["DataStructures", "Markdown", "Requires"]
+git-tree-sha1 = "68865ba44b5c21599e3d5fdacf280a430b57d0f5"
+uuid = "0bc81568-2411-4001-9bf1-c899fa54f385"
+version = "0.3.4"
+
+[[IndirectArrays]]
+git-tree-sha1 = "c2a145a145dc03a7620af1444e0264ef907bd44f"
+uuid = "9b13fd28-a010-5f03-acff-a1bbcff69959"
+version = "0.5.1"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LeftChildRightSiblingTrees]]
+deps = ["AbstractTrees"]
+git-tree-sha1 = "71be1eb5ad19cb4f61fa8c73395c0338fd092ae0"
+uuid = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
+version = "0.1.2"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Profile]]
+deps = ["Printf"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+git-tree-sha1 = "5f6c21241f0f655da3952fd60aa18477cf96c220"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.1.0"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "4036a3bd08ac7e968e27c203d45f5fff15020621"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.1.3"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[StatProfilerHTML]]
+deps = ["Base64", "DataStructures", "Dates", "FlameGraphs", "HAML", "Profile", "Test"]
+git-tree-sha1 = "936380cb0efc66b996a5b93780c6b8f773f7f57b"
+uuid = "a8a75453-ed82-57c9-9e16-4cd1196ecbf5"
+version = "1.2.1"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/validation/vertical_mixing_closures/Manifest.toml
+++ b/validation/vertical_mixing_closures/Manifest.toml
@@ -14,6 +14,12 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[BenchmarkTools]]
+deps = ["JSON", "Logging", "Printf", "Statistics", "UUIDs"]
+git-tree-sha1 = "c31ebabde28d102b602bada60ce8922c266d205b"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "1.1.1"
+
 [[ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
 git-tree-sha1 = "024fe24d83e4a5bf5fc80501a314ce0d1aa35597"
@@ -73,6 +79,12 @@ version = "0.5.1"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.1"
+
 [[LeftChildRightSiblingTrees]]
 deps = ["AbstractTrees"]
 git-tree-sha1 = "71be1eb5ad19cb4f61fa8c73395c0338fd092ae0"
@@ -113,6 +125,9 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
 [[MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
@@ -123,6 +138,12 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
+
+[[Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "bfd7d8c7fd87f04543810d9cbd3995972236ba1b"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.1.2"
 
 [[Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]

--- a/validation/vertical_mixing_closures/Project.toml
+++ b/validation/vertical_mixing_closures/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+StatProfilerHTML = "a8a75453-ed82-57c9-9e16-4cd1196ecbf5"

--- a/validation/vertical_mixing_closures/Project.toml
+++ b/validation/vertical_mixing_closures/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 StatProfilerHTML = "a8a75453-ed82-57c9-9e16-4cd1196ecbf5"

--- a/validation/vertical_mixing_closures/Project.toml
+++ b/validation/vertical_mixing_closures/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 StatProfilerHTML = "a8a75453-ed82-57c9-9e16-4cd1196ecbf5"

--- a/validation/vertical_mixing_closures/gpu_tkevd_ensemble.jl
+++ b/validation/vertical_mixing_closures/gpu_tkevd_ensemble.jl
@@ -1,0 +1,50 @@
+pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", ".."))
+
+using Oceananigans
+using Oceananigans.Units
+using Oceananigans.TimeSteppers: time_step!
+using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization, TKEBasedVerticalDiffusivity
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: ColumnEnsembleSize
+
+using CUDA
+using BenchmarkTools
+
+Ex, Ey = (400, 20)
+sz = ColumnEnsembleSize(Nz=128, ensemble=(Ex, Ey))
+halo = ColumnEnsembleSize(Nz=sz.Nz)
+
+grid = RegularRectilinearGrid(size=sz, halo=halo, z=(-128, 0), topology=(Flat, Flat, Bounded))
+
+closure = CuArray([TKEBasedVerticalDiffusivity() for i=1:Ex, j=1:Ey])
+                                      
+Qᵇ = CuArray([+1e-8 for i=1:Ex, j=1:Ey])
+Qᵘ = CuArray([-1e-4 for i=1:Ex, j=1:Ey])
+Qᵛ = CuArray([0.0   for i=1:Ex, j=1:Ey])
+
+u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
+v_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵛ))
+b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ))
+
+model = HydrostaticFreeSurfaceModel(architecture = GPU(),
+                                    grid = grid,
+                                    tracers = (:b, :e),
+                                    buoyancy = BuoyancyTracer(),
+                                    coriolis = FPlane(f=1e-4),
+                                    boundary_conditions = (b=b_bcs, u=u_bcs, v=v_bcs),
+                                    closure = closure)
+                                    
+N² = 1e-5
+bᵢ(x, y, z) = N² * z
+set!(model, b = bᵢ)
+
+
+function one_step!(model)
+    CUDA.@sync time_step!(model, 1e-9)
+    return nothing
+end
+
+@info "Running one time-step..."
+one_step!(model)
+
+@info "Benchmarking..."
+@btime one_step!(model)

--- a/validation/vertical_mixing_closures/many_tke_based_free_convection.jl
+++ b/validation/vertical_mixing_closures/many_tke_based_free_convection.jl
@@ -1,0 +1,81 @@
+pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", ".."))
+
+using Plots
+using Printf
+using Oceananigans
+using Oceananigans.Units
+using Oceananigans.TurbulenceClosures: TKEBasedVerticalDiffusivity, TKESurfaceFlux
+using Oceananigans.TurbulenceClosures: RiDependentDiffusivityScaling
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: EnsembleSize
+
+Nz = 16
+Ex, Ey = (1, 3)
+sz = EnsembleSize(Nz=Nz, ensemble=(Ex, Ey))
+ensemble_grid = RegularRectilinearGrid(size=sz, halo=EnsembleSize(Nz=1), z=(-64, 0), topology=(Flat, Flat, Bounded))
+scm_grid = RegularRectilinearGrid(size=Nz, halo=1, z=(-64, 0), topology=(Flat, Flat, Bounded))
+
+default_closure = TKEBasedVerticalDiffusivity()
+
+closure_ensemble = [default_closure for i = 1:Ex, j = 1:Ey]
+Qᵇ_ensemble = [1e-8 for i = 1:Ex, j = 1:Ey]
+
+closure_ensemble[1, 2] = TKEBasedVerticalDiffusivity(surface_model=TKESurfaceFlux(CᵂwΔ=3.0))
+closure_ensemble[1, 3] = TKEBasedVerticalDiffusivity(surface_model=TKESurfaceFlux(CᵂwΔ=10.0))
+                                      
+Qᵘ = 0.0
+Qᵛ = 0.0
+
+u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
+v_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵛ))
+b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ_ensemble))
+
+model_kwargs = (tracers = (:b, :e),
+                buoyancy = BuoyancyTracer(),
+                boundary_conditions = (; b=b_bcs))
+
+ensemble_model = HydrostaticFreeSurfaceModel(; grid = ensemble_grid, closure = closure_ensemble, model_kwargs...)
+scm_model = HydrostaticFreeSurfaceModel(; grid = scm_grid, closure = closure_ensemble[1, 1], model_kwargs...)
+
+models = (ensemble_model, scm_model)
+                                    
+N² = 1e-5
+bᵢ(x, y, z) = N² * z
+
+for model in models
+    set!(model, b = bᵢ)
+end
+
+z = znodes(scm_model.tracers.b)
+
+b1 = view(interior(scm_model.tracers.b), 1, 1, :)
+
+b2 = view(interior(ensemble_model.tracers.b), 1, 1, :)
+b3 = view(interior(ensemble_model.tracers.b), 1, 2, :)
+b4 = view(interior(ensemble_model.tracers.b), 1, 3, :)
+
+Kc1 = view(interior(scm_model.diffusivity_fields.Kᶜ), 1, 1, :)
+
+Kc2 = view(interior(ensemble_model.diffusivity_fields.Kᶜ), 1, 1, :)
+Kc3 = view(interior(ensemble_model.diffusivity_fields.Kᶜ), 1, 2, :)
+Kc4 = view(interior(ensemble_model.diffusivity_fields.Kᶜ), 1, 3, :)
+
+for model in models
+    simulation = Simulation(model, Δt = 20.0, stop_iteration = 10)
+    run!(simulation)
+end
+
+time = scm_model.clock.time
+
+b_plot = plot(b1, z, linewidth = 2, label = @sprintf("scm t = %s", prettytime(time)), xlabel = "Buoyancy 1", ylabel = "z", legend=:bottomright)
+plot!(b_plot, b2, z, linewidth = 2, linestyle=:dash, label = @sprintf("ensemble t = %s", prettytime(time)))
+plot!(b_plot, b3, z, linewidth = 2, linestyle=:dash, label = @sprintf("ensemble t = %s", prettytime(time)))
+plot!(b_plot, b4, z, linewidth = 2, linestyle=:dash, label = @sprintf("ensemble t = %s", prettytime(time)))
+
+K_plot = plot(Kc1, z, linewidth = 2, linestyle=:solid, label = @sprintf("scm Kᶜ, t = %s", prettytime(time)), legend=:bottomright, xlabel="Diffusivities")
+plot!(K_plot, Kc2, z, linewidth = 2, linestyle=:dash, label = @sprintf("ensemble Kᶜ, t = %s", prettytime(time)))
+plot!(K_plot, Kc3, z, linewidth = 2, linestyle=:dash, label = @sprintf("ensemble Kᶜ, t = %s", prettytime(time)))
+plot!(K_plot, Kc4, z, linewidth = 2, linestyle=:dash, label = @sprintf("ensemble Kᶜ, t = %s", prettytime(time)))
+
+bK_plot = plot(b_plot, K_plot, layout=(1, 2), size=(1200, 600))
+
+display(bK_plot)

--- a/validation/vertical_mixing_closures/many_tke_based_free_convection.jl
+++ b/validation/vertical_mixing_closures/many_tke_based_free_convection.jl
@@ -17,6 +17,8 @@ scm_grid = RegularRectilinearGrid(size=Nz, halo=1, z=(-64, 0), topology=(Flat, F
 default_closure = TKEBasedVerticalDiffusivity()
 
 closure_ensemble = [default_closure for i = 1:Ex, j = 1:Ey]
+
+Qᵇ = 1e-8
 Qᵇ_ensemble = [1e-8 for i = 1:Ex, j = 1:Ey]
 
 closure_ensemble[1, 2] = TKEBasedVerticalDiffusivity(surface_model=TKESurfaceFlux(CᵂwΔ=3.0))
@@ -27,14 +29,14 @@ Qᵛ = 0.0
 
 u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
 v_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵛ))
-b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ_ensemble))
+ensemble_b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ_ensemble))
+b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ))
 
 model_kwargs = (tracers = (:b, :e),
-                buoyancy = BuoyancyTracer(),
-                boundary_conditions = (; b=b_bcs))
+                buoyancy = BuoyancyTracer())
 
-ensemble_model = HydrostaticFreeSurfaceModel(; grid = ensemble_grid, closure = closure_ensemble, model_kwargs...)
-scm_model = HydrostaticFreeSurfaceModel(; grid = scm_grid, closure = closure_ensemble[1, 1], model_kwargs...)
+ensemble_model = HydrostaticFreeSurfaceModel(; grid = ensemble_grid, closure = closure_ensemble,       boundary_conditions = (; b=ensemble_b_bcs), model_kwargs...)
+scm_model      = HydrostaticFreeSurfaceModel(; grid = scm_grid,      closure = closure_ensemble[1, 1], boundary_conditions = (; b=b_bcs),          model_kwargs...)
 
 models = (ensemble_model, scm_model)
                                     

--- a/validation/vertical_mixing_closures/many_tke_based_free_convection.jl
+++ b/validation/vertical_mixing_closures/many_tke_based_free_convection.jl
@@ -6,14 +6,14 @@ using Oceananigans
 using Oceananigans.Units
 using Oceananigans.TurbulenceClosures: TKEBasedVerticalDiffusivity
 using Oceananigans.TurbulenceClosures: TKESurfaceFlux, RiDependentDiffusivityScaling
-using Oceananigans.Models.HydrostaticFreeSurfaceModels: EnsembleSize
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: ColumnEnsembleSize
 
 Nz = 64
 Ex, Ey = (1, 3)
-sz = EnsembleSize(Nz=Nz, ensemble=(Ex, Ey))
+sz = ColumnEnsembleSize(Nz=Nz, ensemble=(Ex, Ey))
 
 ensemble_grid = RegularRectilinearGrid(size = sz,
-                                       halo = EnsembleSize(Nz=1),
+                                       halo = ColumnEnsembleSize(Nz=1),
                                        z = (-128, 0),
                                        topology = (Flat, Flat, Bounded))
 

--- a/validation/vertical_mixing_closures/profile_tke_based_vertical_diffusivity.jl
+++ b/validation/vertical_mixing_closures/profile_tke_based_vertical_diffusivity.jl
@@ -1,0 +1,47 @@
+pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", ".."))
+
+using Oceananigans
+using Oceananigans.Units
+using Oceananigans.TimeSteppers: time_step!
+using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization, TKEBasedVerticalDiffusivity
+
+using StatProfilerHTML
+
+grid = RegularRectilinearGrid(size=64, z=(-64, 0), topology=(Flat, Flat, Bounded))
+
+closure = TKEBasedVerticalDiffusivity(time_discretization=VerticallyImplicitTimeDiscretization())
+                                      
+Qᵇ = 1e-8
+Qᵘ = - 1e-4
+Qᵛ = 0.0
+
+u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
+v_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵛ))
+b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ))
+
+model = HydrostaticFreeSurfaceModel(grid = grid,
+                                    tracers = (:b, :e),
+                                    buoyancy = BuoyancyTracer(),
+                                    coriolis = FPlane(f=1e-4),
+                                    boundary_conditions = (b=b_bcs, u=u_bcs, v=v_bcs),
+                                    closure = closure)
+                                    
+N² = 1e-5
+bᵢ(x, y, z) = N² * z
+set!(model, b = bᵢ)
+
+function nsteps!(model, n)
+    for _ = 1:n
+        time_step!(model, 1e-9)
+    end
+    return nothing
+end
+
+@info "Running one time-step..."
+nsteps!(model, 1) # warmup
+
+n = 100
+@info "Profiling $n time-steps..."
+@profile nsteps!(model, n)
+
+statprofilehtml()

--- a/validation/vertical_mixing_closures/profile_tke_based_vertical_diffusivity.jl
+++ b/validation/vertical_mixing_closures/profile_tke_based_vertical_diffusivity.jl
@@ -5,7 +5,9 @@ using Oceananigans.Units
 using Oceananigans.TimeSteppers: time_step!
 using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization, TKEBasedVerticalDiffusivity
 
+using Profile
 using StatProfilerHTML
+using BenchmarkTools
 
 grid = RegularRectilinearGrid(size=64, z=(-64, 0), topology=(Flat, Flat, Bounded))
 
@@ -39,6 +41,9 @@ end
 
 @info "Running one time-step..."
 nsteps!(model, 1) # warmup
+
+@info "Benchmarking..."
+@btime time_step!(model, 1e-9)
 
 n = 100
 @info "Profiling $n time-steps..."

--- a/validation/vertical_mixing_closures/profile_tkevd_ensemble.jl
+++ b/validation/vertical_mixing_closures/profile_tkevd_ensemble.jl
@@ -1,0 +1,57 @@
+pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", ".."))
+
+using Oceananigans
+using Oceananigans.Units
+using Oceananigans.TimeSteppers: time_step!
+using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization, TKEBasedVerticalDiffusivity
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: EnsembleSize
+
+using Profile
+using StatProfilerHTML
+using BenchmarkTools
+
+Ex, Ey = (1, 1)
+sz = EnsembleSize(Nz=64, ensemble=(Ex, Ey))
+halo = EnsembleSize(Nz=sz.Nz)
+
+grid = RegularRectilinearGrid(size=sz, halo=halo, z=(-64, 0), topology=(Flat, Flat, Bounded))
+
+closure = [TKEBasedVerticalDiffusivity() for i=1:Ex, j=1:Ey]
+                                      
+Qᵇ = 1e-8
+Qᵘ = - 1e-4
+Qᵛ = 0.0
+
+u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
+v_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵛ))
+b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ))
+
+model = HydrostaticFreeSurfaceModel(grid = grid,
+                                    tracers = (:b, :e),
+                                    buoyancy = BuoyancyTracer(),
+                                    coriolis = FPlane(f=1e-4),
+                                    boundary_conditions = (b=b_bcs, u=u_bcs, v=v_bcs),
+                                    closure = closure)
+                                    
+N² = 1e-5
+bᵢ(x, y, z) = N² * z
+set!(model, b = bᵢ)
+
+function nsteps!(model, n)
+    for _ = 1:n
+        time_step!(model, 1e-9)
+    end
+    return nothing
+end
+
+@info "Running one time-step..."
+nsteps!(model, 1) # warmup
+
+@info "Benchmarking..."
+@btime time_step!(model, 1e-9)
+
+n = 100
+@info "Profiling $n time-steps..."
+@profile nsteps!(model, n)
+
+statprofilehtml()

--- a/validation/vertical_mixing_closures/profile_tkevd_ensemble.jl
+++ b/validation/vertical_mixing_closures/profile_tkevd_ensemble.jl
@@ -11,16 +11,16 @@ using StatProfilerHTML
 using BenchmarkTools
 
 Ex, Ey = (1, 1)
-sz = ColumnEnsembleSize(Nz=64, ensemble=(Ex, Ey))
+sz = ColumnEnsembleSize(Nz=128, ensemble=(Ex, Ey))
 halo = ColumnEnsembleSize(Nz=sz.Nz)
 
-grid = RegularRectilinearGrid(size=sz, halo=halo, z=(-64, 0), topology=(Flat, Flat, Bounded))
+grid = RegularRectilinearGrid(size=sz, halo=halo, z=(-128, 0), topology=(Flat, Flat, Bounded))
 
 closure = [TKEBasedVerticalDiffusivity() for i=1:Ex, j=1:Ey]
                                       
-Qᵇ = 1e-8
-Qᵘ = - 1e-4
-Qᵛ = 0.0
+Qᵇ = [+1e-8 for i=1:Ex, j=1:Ey]
+Qᵘ = [-1e-4 for i=1:Ex, j=1:Ey]
+Qᵛ = [0.0   for i=1:Ex, j=1:Ey]
 
 u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
 v_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵛ))

--- a/validation/vertical_mixing_closures/profile_tkevd_ensemble.jl
+++ b/validation/vertical_mixing_closures/profile_tkevd_ensemble.jl
@@ -4,15 +4,15 @@ using Oceananigans
 using Oceananigans.Units
 using Oceananigans.TimeSteppers: time_step!
 using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization, TKEBasedVerticalDiffusivity
-using Oceananigans.Models.HydrostaticFreeSurfaceModels: EnsembleSize
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: ColumnEnsembleSize
 
 using Profile
 using StatProfilerHTML
 using BenchmarkTools
 
 Ex, Ey = (1, 1)
-sz = EnsembleSize(Nz=64, ensemble=(Ex, Ey))
-halo = EnsembleSize(Nz=sz.Nz)
+sz = ColumnEnsembleSize(Nz=64, ensemble=(Ex, Ey))
+halo = ColumnEnsembleSize(Nz=sz.Nz)
 
 grid = RegularRectilinearGrid(size=sz, halo=halo, z=(-64, 0), topology=(Flat, Flat, Bounded))
 

--- a/validation/vertical_mixing_closures/tke_based_free_convection.jl
+++ b/validation/vertical_mixing_closures/tke_based_free_convection.jl
@@ -5,7 +5,7 @@ using Oceananigans.Units
 using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization, TKEBasedVerticalDiffusivity
 using Oceananigans.TurbulenceClosures: RiDependentDiffusivityScaling
 
-grid = RegularRectilinearGrid(size=32, z=(-64, 0), topology=(Flat, Flat, Bounded))
+grid = RegularRectilinearGrid(size=16, z=(-64, 0), topology=(Flat, Flat, Bounded))
 
 closure = TKEBasedVerticalDiffusivity(time_discretization=VerticallyImplicitTimeDiscretization())
                                       


### PR DESCRIPTION
This PR makes some changes to the `HydrostaticFreeSurfaceModel` to permit the simulation of an "ensemble of columns". This abstraction uses a `Flat, Flat, Bounded` topology but non-zero resolution in `x, y`, leading to a model of `Nx, Ny` independent, non-communicating columns. In addition, we support using a 2D array of turbulence closures with this "column ensemble" abstraction (but only with this abstraction, not generally, to hopefully minimize unexpected behavior) so that each column can simulate a different surface boundary condition and parameterization independently. An example of usage is implemented in `validation/vertical_mixing_closures/many_tke_based_free_convection.jl` and `validation/vertical_mixing_closures/gpu_tkevd_ensemble.jl`.

The result is a model that can simulate thousands of columns simultaneously on the GPU efficiently. A small benchmark for an ensemble of 8000 columns (400 by 20) achieves

```julia
[ Info: Benchmarking...
  3.265 ms (6015 allocations: 2.54 MiB)
```

per time-step on a Titan V. This is a speed up of 1800x over a single column simulation with Oceananigans. This will hopefully prove useful for calibrating boundary layer parameterizations.

@xiaozhour we can use a similar "slice ensemble" abstraction to simulate independent 2D slices for the purpose of calibrating mesoscale parameterizations, potentially.