### PR TITLE
Add a test to check surface bc continuous functions work with ImmersedBoundary

### DIFF
--- a/src/BoundaryConditions/continuous_boundary_function.jl
+++ b/src/BoundaryConditions/continuous_boundary_function.jl
@@ -92,7 +92,7 @@ end
 #####
 
 # Return ContinuousBoundaryFunction on east or west boundaries.
-@inline function (bc::ContinuousBoundaryFunction{Nothing, LY, LZ, i})(j, k, grid, clock, model_fields) where {LY, LZ, i}
+@inline function (bc::ContinuousBoundaryFunction{Nothing, LY, LZ, i})(j, k, grid, clock, model_fields, args...) where {LY, LZ, i}
     args = user_function_arguments(i, j, k, grid, model_fields, bc.parameters, bc)
 
     i′ = boundary_index(i)
@@ -103,7 +103,7 @@ end
 end
 
 # Return ContinuousBoundaryFunction on south or north boundaries.
-@inline function (bc::ContinuousBoundaryFunction{LX, Nothing, LZ, j})(i, k, grid, clock, model_fields) where {LX, LZ, j}
+@inline function (bc::ContinuousBoundaryFunction{LX, Nothing, LZ, j})(i, k, grid, clock, model_fields, args...) where {LX, LZ, j}
     args = user_function_arguments(i, j, k, grid, model_fields, bc.parameters, bc)
 
     j′ = boundary_index(j)
@@ -114,7 +114,7 @@ end
 end
 
 # Return ContinuousBoundaryFunction on bottom or top boundaries.
-@inline function (bc::ContinuousBoundaryFunction{LX, LY, Nothing, k})(i, j, grid, clock, model_fields) where {LX, LY, k}
+@inline function (bc::ContinuousBoundaryFunction{LX, LY, Nothing, k})(i, j, grid, clock, model_fields, args...) where {LX, LY, k}
     args = user_function_arguments(i, j, k, grid, model_fields, bc.parameters, bc)
 
     k′ = boundary_index(k)

--- a/src/Forcings/continuous_forcing.jl
+++ b/src/Forcings/continuous_forcing.jl
@@ -7,7 +7,7 @@ using Oceananigans.Fields: show_location
 using Oceananigans.Utils: user_function_arguments, tupleit
 
 """
-    ContinuousForcing{LX, LY, LZ, P, F, D, I}
+    ContinuousForcing{LX, LY, LZ, P, F, D, I, ℑ}
 
 A callable object that implements a "continuous form" forcing function
 on a field at the location `LX, LY, LZ` with optional parameters.
@@ -106,11 +106,9 @@ end
 ##### Functions for calling ContinuousForcing in a time-stepping kernel
 #####
 
-@inline function (forcing::ContinuousForcing{LX, LY, LZ, F})(i, j, k, grid, clock, model_fields) where {LX, LY, LZ, F}
-
+@inline function (forcing::ContinuousForcing{LX, LY, LZ, P, F})(i, j, k, grid, clock, model_fields) where {LX, LY, LZ, P, F}
     args = user_function_arguments(i, j, k, grid, model_fields, forcing.parameters, forcing)
-
-    return @inbounds forcing.func(node(LX(), LY(), LZ(), i, j, k, grid)..., clock.time, args...)
+    return forcing.func(node(LX(), LY(), LZ(), i, j, k, grid)..., clock.time, args...)
 end
 
 """Show the innards of a `ContinuousForcing` in the REPL."""

--- a/src/Forcings/continuous_forcing.jl
+++ b/src/Forcings/continuous_forcing.jl
@@ -108,7 +108,12 @@ end
 
 @inline function (forcing::ContinuousForcing{LX, LY, LZ, P, F})(i, j, k, grid, clock, model_fields) where {LX, LY, LZ, P, F}
     args = user_function_arguments(i, j, k, grid, model_fields, forcing.parameters, forcing)
-    return forcing.func(node(LX(), LY(), LZ(), i, j, k, grid)..., clock.time, args...)
+
+    x = xnode(LX(), LY(), LZ(), i, j, k, grid)
+    y = ynode(LX(), LY(), LZ(), i, j, k, grid)
+    z = znode(LX(), LY(), LZ(), i, j, k, grid)
+
+    return forcing.func(x, y, z, clock.time, args...)
 end
 
 """Show the innards of a `ContinuousForcing` in the REPL."""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,6 +130,7 @@ group = get(ENV, "TEST_GROUP", :all) |> Symbol
             include("test_hydrostatic_free_surface_immersed_boundaries.jl")
             include("test_vertical_vorticity_field.jl")
             include("test_implicit_free_surface_solver.jl")
+            include("test_hydrostatic_free_surface_immersed_boundaries_apply_surf_bc.jl")
         end
     end
 

--- a/test/test_hydrostatic_free_surface_immersed_boundaries_apply_surf_bc.jl
+++ b/test/test_hydrostatic_free_surface_immersed_boundaries_apply_surf_bc.jl
@@ -48,8 +48,6 @@ using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization
         v_bcs = FieldBoundaryConditions(bottom = v_bottom_drag_bc)
 
         νh₀ = 5e3 * (60 / grid.Nx)^2
-        νh(λ, φ, z, t) = νh₀ * cos(π * φ / 180)
-        variable_horizontal_diffusivity = HorizontallyCurvilinearAnisotropicDiffusivity(νh=νh)
         constant_horizontal_diffusivity = HorizontallyCurvilinearAnisotropicDiffusivity(νh=νh₀)
 
         model = HydrostaticFreeSurfaceModel(grid = grid,

--- a/test/test_hydrostatic_free_surface_immersed_boundaries_apply_surf_bc.jl
+++ b/test/test_hydrostatic_free_surface_immersed_boundaries_apply_surf_bc.jl
@@ -1,0 +1,79 @@
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary, RasterDepthMask
+using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization
+
+@testset "Immersed boundaries with hydrostatic free surface models" begin
+    @info "Testing immersed boundaries with hydrostatic free surface models..."
+
+    for arch in archs
+        Nx = 60
+        Ny = 60
+
+        # A spherical domain
+        underlying_grid = RegularLatitudeLongitudeGrid(size = (Nx, Ny, 1),
+                                               longitude = (-30, 30),
+                                               latitude = (15, 75),
+                                               z = (-4000, 0))
+
+        @inline raster_depth(i, j) = 30 < i < 35 && 42 < j < 48
+
+        grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBoundary(raster_depth, mask_type=RasterDepthMask()))
+
+        free_surface = ImplicitFreeSurface(gravitational_acceleration=0.1)
+        coriolis = HydrostaticSphericalCoriolis(scheme = VectorInvariantEnstrophyConserving())
+
+        surface_wind_stress_parameters = (τ₀ = 1e-4,
+                                          Lφ = grid.Ly,
+                                          φ₀ = 15)
+        surface_wind_stress(λ, φ, t, p) = p.τ₀ * cos(2π * (φ - p.φ₀) / p.Lφ)
+
+        surface_wind_stress_bc = FluxBoundaryCondition(surface_wind_stress,
+                                               parameters = surface_wind_stress_parameters)
+
+        μ = 1 / 60days
+
+        @inline u_bottom_drag(i, j, grid, clock, fields, μ) = @inbounds - μ * fields.u[i, j, 1]
+        @inline v_bottom_drag(i, j, grid, clock, fields, μ) = @inbounds - μ * fields.v[i, j, 1]
+
+        u_bottom_drag_bc = FluxBoundaryCondition(u_bottom_drag,
+                                         discrete_form = true,
+                                         parameters = μ)
+
+        v_bottom_drag_bc = FluxBoundaryCondition(v_bottom_drag,
+                                         discrete_form = true,
+                                         parameters = μ)
+
+        u_bcs = FieldBoundaryConditions(top = surface_wind_stress_bc,
+                                bottom = u_bottom_drag_bc)
+
+        v_bcs = FieldBoundaryConditions(bottom = v_bottom_drag_bc)
+
+        νh₀ = 5e3 * (60 / grid.Nx)^2
+        νh(λ, φ, z, t) = νh₀ * cos(π * φ / 180)
+        variable_horizontal_diffusivity = HorizontallyCurvilinearAnisotropicDiffusivity(νh=νh)
+        constant_horizontal_diffusivity = HorizontallyCurvilinearAnisotropicDiffusivity(νh=νh₀)
+
+        model = HydrostaticFreeSurfaceModel(grid = grid,
+                                    architecture = CPU(),
+                                    momentum_advection = VectorInvariant(),
+                                    free_surface = free_surface,
+                                    coriolis = coriolis,
+                                    boundary_conditions = (u=u_bcs, v=v_bcs),
+                                    closure = constant_horizontal_diffusivity,
+                                    tracers = nothing,
+                                    buoyancy = nothing)
+
+
+        simulation = Simulation(model,
+                        Δt = 3600,
+                        stop_time = 3600,
+                        iteration_interval = 100)
+
+        run!(simulation)
+
+
+        # If reached here it didn't error, so pass for now!
+        @test true
+
+    end
+end
+


### PR DESCRIPTION
This test is to stop the error below from reappearing (once the test is fixed!). 

```
      nested task error: MethodError: no method matching (::Oceananigans.BoundaryConditions.ContinuousBoundaryFunction{Face, Center, Nothing, 1, var"#surface_wind_stress#28", NamedTuple{(:τ₀, :Lφ, :φ₀), Tuple{Float64, Float64, Int64}}, Tuple{}, Tuple{}, Tuple{}})(::Int64, ::Int64, ::ImmersedBoundaryGrid{Float64, Bounded, Bounded, Bounded, RegularLatitudeLongitudeGrid{Float64, Bounded, Bounded, Bounded, OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}}, GridFittedBoundary{RasterDepthMask, var"#raster_depth#27"}}, ::Clock{Float64}, ::NamedTuple{(:u, :v, :η), Tuple{Field{Face, Center, Center, CPU, OffsetArray{Float64, 3, Array{Float64, 3}}, ImmersedBoundaryGrid{Float64, Bounded, Bounded, Bounded, RegularLatitudeLongitudeGrid{Float64, Bounded, Bounded, Bounded, OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}}, GridFittedBoundary{RasterDepthMask, var"#raster_depth#27"}}, Float64, FieldBoundaryConditions{BoundaryCondition{Open, Nothing}, BoundaryCondition{Open, Nothing}, BoundaryCondition{Flux, Nothing}, BoundaryCondition{Flux, Nothing}, BoundaryCondition{Flux, Oceananigans.BoundaryConditions.DiscreteBoundaryFunction{Float64, var"#u_bottom_drag#29"}}, BoundaryCondition{Flux, Oceananigans.BoundaryConditions.ContinuousBoundaryFunction{Face, Center, Nothing, 1, var"#surface_wind_stress#28", NamedTuple{(:τ₀, :Lφ, :φ₀), Tuple{Float64, Float64, Int64}}, Tuple{}, Tuple{}, Tuple{}}}, BoundaryCondition{Flux, Nothing}}}, Field{Center, Face, Center, CPU, OffsetArray{Float64, 3, Array{Float64, 3}}, ImmersedBoundaryGrid{Float64, Bounded, Bounded, Bounded, RegularLatitudeLongitudeGrid{Float64, Bounded, Bounded, Bounded, OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}}, GridFittedBoundary{RasterDepthMask, var"#raster_depth#27"}}, Float64, FieldBoundaryConditions{BoundaryCondition{Flux, Nothing}, BoundaryCondition{Flux, Nothing}, BoundaryCondition{Open, Nothing}, BoundaryCondition{Open, Nothing}, BoundaryCondition{Flux, Oceananigans.BoundaryConditions.DiscreteBoundaryFunction{Float64, var"#v_bottom_drag#30"}}, BoundaryCondition{Flux, Nothing}, BoundaryCondition{Flux, Nothing}}}, ReducedField{Center, Center, Nothing, CPU, OffsetArray{Float64, 3, Array{Float64, 3}}, ImmersedBoundaryGrid{Float64, Bounded, Bounded, Bounded, RegularLatitudeLongitudeGrid{Float64, Bounded, Bounded, Bounded, OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}}, GridFittedBoundary{RasterDepthMask, var"#raster_depth#27"}}, Float64, 1, FieldBoundaryConditions{BoundaryCondition{Flux, Nothing}, BoundaryCondition{Flux, Nothing}, BoundaryCondition{Flux, Nothing}, BoundaryCondition{Flux, Nothing}, Nothing, Nothing, BoundaryCondition{Flux, Nothing}}}}}, ::HorizontallyCurvilinearAnisotropicDiffusivity{Oceananigans.TurbulenceClosures.ExplicitTimeDiscretization, Float64, Float64, NamedTuple{(), Tuple{}}, NamedTuple{(), Tuple{}}}, ::Nothing)
      Closest candidates are:
        (::Oceananigans.BoundaryConditions.ContinuousBoundaryFunction{LX, LY, Nothing, k, F, P, D, N, ℑ} where {F, P, D, N, ℑ})(::Any, ::Any, ::Any, ::Any, ::Any) where {LX, LY, k} at /home/chris/projects/onan-2021-08-06/src/BoundaryConditions/continuous_boundary_function.jl:117

```