### PR TITLE
Changes parameters name from p to params

### DIFF
--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -54,7 +54,7 @@ grid = RegularRectilinearGrid(size=(64, 64), extent=(64, 64), topology=(Periodic
 #
 # We impose a surface buoyancy flux that's initially constant and then decays to zero,
 
-buoyancy_flux(x, y, t, p) = p.initial_buoyancy_flux * exp(-t^4 / (24 * p.shut_off_time^4))
+buoyancy_flux(x, y, t, params) = params.initial_buoyancy_flux * exp(-t^4 / (24 * params.shut_off_time^4))
 
 buoyancy_flux_parameters = (initial_buoyancy_flux = 1e-8, # m² s⁻³
                                     shut_off_time = 2hours)
@@ -99,7 +99,7 @@ buoyancy_bcs = FieldBoundaryConditions(top = buoyancy_flux_bc, bottom = buoyancy
 # We use a simple model for the growth of phytoplankton in sunlight and decay
 # due to viruses and grazing by zooplankton,
 
-growing_and_grazing(x, y, z, t, P, p) = (p.μ₀ * exp(z / p.λ) - p.m) * P
+growing_and_grazing(x, y, z, t, P, params) = (params.μ₀ * exp(z / params.λ) - params.m) * P
 nothing # hide
 
 # with parameters


### PR DESCRIPTION
The named tuple that contains parameters in named `p` in a couple of functions in the [convecting plankton example](https://github.com/CliMA/Oceananigans.jl/blob/b15d2d0e7204e66a74e51e9ed2a0f2214315b62a/examples/convecting_plankton.jl#L102). I think this is unnecessarily confusing since the plankton concentration `P` appears in the same lines. This fixes that.