### PR TITLE
Fix bug in hydrostatic vertical velocity with stretched grid

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.61.0"
+version = "0.61.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Models/HydrostaticFreeSurfaceModels/compute_w_from_continuity.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/compute_w_from_continuity.jl
@@ -27,6 +27,6 @@ end
     i, j = @index(Global, NTuple)
     # U.w[i, j, 1] = 0 is enforced via halo regions.
     @unroll for k in 2:grid.Nz+1
-        @inbounds U.w[i, j, k] = U.w[i, j, k-1] - Δzᵃᵃᶠ(i, j, k, grid) * div_xyᶜᶜᵃ(i, j, k-1, grid, U.u, U.v)
+        @inbounds U.w[i, j, k] = U.w[i, j, k-1] - Δzᵃᵃᶜ(i, j, k-1, grid) * div_xyᶜᶜᵃ(i, j, k-1, grid, U.u, U.v)
     end
 end


### PR DESCRIPTION
Simple fix to use the cell-centered vertical spacing (face-to-face distance) in the continuity equation for determining w in the hydrostatic model.  The code currently uses the face-centered spacing (center-to-center distance), which is the same for the uniform grid but not for the vertically stretched grid.  With help from @sandreza and @jm-c.