### PR TITLE
Fix diffusive flux bug for immersed boundaries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.61.1"
+version = "0.61.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/TurbulenceClosures/diffusion_operators.jl
+++ b/src/TurbulenceClosures/diffusion_operators.jl
@@ -44,9 +44,9 @@ which will end up at the location `ccc`.
 
     disc = time_discretization(closure)
 
-    return 1/Vᶜᶜᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_uᶠᶜᶜ, diffusive_flux_x, disc, closure, c, tracer_index, args...) +
-                                    δyᵃᶜᵃ(i, j, k, grid, Ay_vᶜᶠᶜ, diffusive_flux_y, disc, closure, c, tracer_index, args...) +
-                                    δzᵃᵃᶜ(i, j, k, grid, Az_wᶜᶜᵃ, diffusive_flux_z, disc, closure, c, tracer_index, args...))
+    return 1/Vᶜᶜᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Ax_uᶠᶜᶜ, _diffusive_flux_x, disc, closure, c, tracer_index, args...) +
+                                    δyᵃᶜᵃ(i, j, k, grid, Ay_vᶜᶠᶜ, _diffusive_flux_y, disc, closure, c, tracer_index, args...) +
+                                    δzᵃᵃᶜ(i, j, k, grid, Az_wᶜᶜᵃ, _diffusive_flux_z, disc, closure, c, tracer_index, args...))
 end
 
 #####

--- a/validation/immersed_boundaries/immersed_tracer_1D.jl
+++ b/validation/immersed_boundaries/immersed_tracer_1D.jl
@@ -1,0 +1,85 @@
+pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", ".."))
+
+using Statistics
+using Printf
+using Plots
+using Oceananigans
+using Oceananigans.BoundaryConditions
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary
+
+const κ = 1
+const ν = 1
+const f = 0.2
+const nz = 3
+const H = nz * 5
+const topo = -H + 5
+
+underlying_grid = RegularRectilinearGrid(size=(nz,), halo=(3,), z = (-H,0),
+                                                 topology = (Flat, Flat, Bounded))
+
+solid(x, y, z) = (z <= topo)
+
+immersed_grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBoundary(solid))
+
+model = NonhydrostaticModel(architecture = CPU(),
+                               advection = CenteredSecondOrder(),
+                             timestepper = :RungeKutta3,
+                                    grid = immersed_grid,
+                                 tracers = (:b),
+                                 closure = IsotropicDiffusivity(ν=ν, κ=κ),
+                                coriolis = FPlane(f=f),
+                                buoyancy = BuoyancyTracer())
+
+set!(model, b=1.0, u=0, v=0, w=0)
+
+wizard = TimeStepWizard(cfl=0.09, Δt=0.09 * underlying_grid.Δz, max_change=1.1, max_Δt=10.0, min_Δt=0.0001)
+
+start_time = time_ns()
+stop_time = 8* π/f
+
+progress_message(sim) =
+           @printf("i: %04d, t: %s, Δt: %s, bmax = %.1e ms⁻¹, wall time: %s\n",
+                   sim.model.clock.iteration, prettytime(model.clock.time),
+                   prettytime(wizard.Δt), maximum(abs, sim.model.tracers.b),
+                   prettytime((time_ns() - start_time) * 1e-9))
+
+simulation = Simulation(model, Δt=wizard, stop_time=stop_time, iteration_interval=100, progress= progress_message)
+
+outputs = merge(model.velocities, model.tracers)
+
+data_path = "immersed_wall_tracer_test_1D"
+
+simulation.output_writers[:fields] =
+                   JLD2OutputWriter(model, outputs,
+                                    schedule = TimeInterval(25.0),
+                                    prefix = data_path,
+                                    field_slicer = nothing,
+                                    force = true)
+
+run!(simulation)
+
+filepath = data_path * ".jld2"
+
+b_timeseries = FieldTimeSeries(filepath, "b")
+xb, yb, zb = nodes(b_timeseries)
+
+b1 = b_timeseries[1]
+b1i = interior(b1)[1,1,:]
+
+bend = b_timeseries[length(b_timeseries.times)]
+bendi = interior(bend)[1,1,:]
+Δb = maximum(abs.(b1i - bendi))
+
+@info "Largest change in buoyancy is $(Δb)."
+
+
+bplot = plot(b1i,ones(size(zb),).*topo, label = "", color = :black, lw = 2, xlabel = "b", ylabel = "z", title = @sprintf("Buoyancy, |Δb|ₘₐₓ = %.1f", Δb), legend = :top)
+plot!(b1i,zb, lw = 3, label = "initial", color = :blue)
+scatter!(b1i, zb, markersize = 4, color = :blue, markershape = :diamond, label = "")
+plot!(bendi,zb, lw = 3, label = "final", color = :red, linestyle = :dash)
+scatter!(bendi, zb, markersize = 3, color = :red, markershape = :circle, label = "")
+savefig(bplot, "b_plot1D_tracertest")
+
+
+
+

--- a/validation/immersed_boundaries/immersed_tracer_1D.jl
+++ b/validation/immersed_boundaries/immersed_tracer_1D.jl
@@ -1,10 +1,8 @@
 pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", ".."))
 
-using Statistics
 using Printf
 using Plots
 using Oceananigans
-using Oceananigans.BoundaryConditions
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary
 
 const κ = 1
@@ -13,8 +11,9 @@ const nz = 3
 const H = nz * 5
 const topo = -H + 5
 
-underlying_grid = RegularRectilinearGrid(size=(nz,), halo=(3,), z = (-H,0),
-                                                 topology = (Flat, Flat, Bounded))
+stop_time = 10.
+
+underlying_grid = RegularRectilinearGrid(size=nz, z = (-H,0), topology = (Flat, Flat, Bounded))
 
 solid(x, y, z) = (z <= topo)
 
@@ -28,55 +27,27 @@ model = NonhydrostaticModel(architecture = CPU(),
                                  closure = IsotropicDiffusivity(ν=ν, κ=κ),
                                 buoyancy = BuoyancyTracer())
 
-set!(model, b=1.0, u=0, v=0, w=0)
+set!(model, b=1, u=0, v=0, w=0)
 
-wizard = TimeStepWizard(cfl=0.09, Δt=0.09 * underlying_grid.Δz, max_change=1.1, max_Δt=10.0, min_Δt=0.0001)
+simulation = Simulation(model, Δt=1.0, stop_time=stop_time)
 
-start_time = time_ns()
-stop_time = 25.
+z = znodes(model.tracers.b)
+b = view(interior(model.tracers.b), 1, 1, :)
 
-progress_message(sim) =
-           @printf("i: %04d, t: %s, Δt: %s, bmax = %.1e ms⁻¹, wall time: %s\n",
-                   sim.model.clock.iteration, prettytime(model.clock.time),
-                   prettytime(wizard.Δt), maximum(abs, sim.model.tracers.b),
-                   prettytime((time_ns() - start_time) * 1e-9))
-
-simulation = Simulation(model, Δt=wizard, stop_time=stop_time, iteration_interval=5, progress= progress_message)
-
-outputs = merge(model.velocities, model.tracers)
-
-data_path = "immersed_wall_tracer_test_1D"
-
-simulation.output_writers[:fields] =
-                   JLD2OutputWriter(model, outputs,
-                                    schedule = TimeInterval(25.0),
-                                    prefix = data_path,
-                                    field_slicer = nothing,
-                                    force = true)
+# plot immersed wall and initial buoyancy
+bplot = plot(b, ones(size(z),).*topo, label = "", color = :black, lw = 2, xlabel = "b", ylabel = "z", legend = :top)
+plot!(bplot, b, z, lw = 3, label = "Initial", color = :blue)
 
 run!(simulation)
 
-filepath = data_path * ".jld2"
-
-b_timeseries = FieldTimeSeries(filepath, "b")
-xb, yb, zb = nodes(b_timeseries)
-
-b1 = b_timeseries[1]
-b1i = interior(b1)[1,1,:]
-
-bend = b_timeseries[length(b_timeseries.times)]
-bendi = interior(bend)[1,1,:]
-Δb = maximum(abs.(b1i - bendi))
-
+Δb = abs(maximum(b .-1))
 @info "Largest change in buoyancy is $(Δb)."
 
+# plotting final buoyancy
 
-bplot = plot(b1i,ones(size(zb),).*topo, label = "", color = :black, lw = 2, xlabel = "b", ylabel = "z", title = @sprintf("Buoyancy, |Δb|ₘₐₓ = %.1f", Δb), legend = :top)
-plot!(b1i,zb, lw = 3, label = "initial", color = :blue)
-scatter!(b1i, zb, markersize = 4, color = :blue, markershape = :diamond, label = "")
-plot!(bendi,zb, lw = 3, label = "final", color = :red, linestyle = :dash)
-scatter!(bendi, zb, markersize = 3, color = :red, markershape = :circle, label = "")
-savefig(bplot, "b_plot1D_tracertest")
+plot!(bplot, b, z, lw = 3, label = "Final", color = :red, linestyle = :dash, title = @sprintf("Buoyancy, |Δb|ₘₐₓ = %.1f", Δb))
+
+display(bplot)
 
 
 

--- a/validation/immersed_boundaries/immersed_tracer_1D.jl
+++ b/validation/immersed_boundaries/immersed_tracer_1D.jl
@@ -9,7 +9,6 @@ using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary
 
 const κ = 1
 const ν = 1
-const f = 0.2
 const nz = 3
 const H = nz * 5
 const topo = -H + 5
@@ -27,7 +26,6 @@ model = NonhydrostaticModel(architecture = CPU(),
                                     grid = immersed_grid,
                                  tracers = (:b),
                                  closure = IsotropicDiffusivity(ν=ν, κ=κ),
-                                coriolis = FPlane(f=f),
                                 buoyancy = BuoyancyTracer())
 
 set!(model, b=1.0, u=0, v=0, w=0)
@@ -35,7 +33,7 @@ set!(model, b=1.0, u=0, v=0, w=0)
 wizard = TimeStepWizard(cfl=0.09, Δt=0.09 * underlying_grid.Δz, max_change=1.1, max_Δt=10.0, min_Δt=0.0001)
 
 start_time = time_ns()
-stop_time = 8* π/f
+stop_time = 25.
 
 progress_message(sim) =
            @printf("i: %04d, t: %s, Δt: %s, bmax = %.1e ms⁻¹, wall time: %s\n",
@@ -43,7 +41,7 @@ progress_message(sim) =
                    prettytime(wizard.Δt), maximum(abs, sim.model.tracers.b),
                    prettytime((time_ns() - start_time) * 1e-9))
 
-simulation = Simulation(model, Δt=wizard, stop_time=stop_time, iteration_interval=100, progress= progress_message)
+simulation = Simulation(model, Δt=wizard, stop_time=stop_time, iteration_interval=5, progress= progress_message)
 
 outputs = merge(model.velocities, model.tracers)
 


### PR DESCRIPTION
This PR fixes the diffusive flux argument in the divergence of diffusive flux, `∇_dot_qᶜ`,
https://github.com/CliMA/Oceananigans.jl/blob/e929631eb3a233ae3f3358d2146e5d6004f9a06c/src/TurbulenceClosures/diffusion_operators.jl#L47  to allow for the immersed boundary version using `_diffusive_flux_x`. This will make the tracer equations feel the immersed boundaries correctly. This also adds a very small 1D validation to test this. With a uniform buoyancy, validation checks if the buoyancy changes in time (it shouldn't). Below are the results before and after the fix. We can, of course, not include the validation and instead add a test for this.
![b_plot1D_tracertest_bad](https://user-images.githubusercontent.com/67593861/129624223-70449ca0-5efb-4037-914a-20e1b565d4ca.png)
![b_plot1D_tracertest](https://user-images.githubusercontent.com/67593861/129624224-1eac8bae-7e78-4cc2-8b39-a202def6e975.png)
