### PR TITLE
Exports KernelFunctionOperation

### DIFF
--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -1,6 +1,7 @@
 module AbstractOperations
 
 export ∂x, ∂y, ∂z, @at, @unary, @binary, @multiary
+export KernelFunctionOperation
 
 using Base: @propagate_inbounds
 

--- a/src/AbstractOperations/kernel_function_operation.jl
+++ b/src/AbstractOperations/kernel_function_operation.jl
@@ -1,3 +1,46 @@
+"""
+    KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid; architecture=nothing,
+                                        computed_dependencies=(), parameters=nothing)
+
+Constructs a `KernelFunctionOperation` at location `(LX, LY, LZ)` on `grid` an with
+an optional iterable of `computed_dependencies` and arbitrary `parameters`.
+
+With `isnothing(parameters)` (the default), `kernel_function` is called
+with
+
+```julia
+kernel_function(i, j, k, grid, computed_dependencies...)
+```
+
+Otherwise `kernel_function` is called with
+
+```julia
+kernel_function(i, j, k, grid, computed_dependencies..., parameters)
+```
+
+Examples
+========
+
+Construct a kernel function operation that returns random numbers:
+
+```julia
+random_kernel_function(i, j, k, grid) = rand() # use CUDA.rand on the GPU
+
+kernel_op = KernelFunctionOperation{Center, Center, Center}(random_kernel_function, grid; architecture=CPU())
+```
+
+Constrcut a kernel function operation using the vertical vorticity operator
+valid on curvilinear and cubed sphere grids:
+
+```julia
+using Oceananigans.Operators: ζ₃ᶠᶠᵃ # called with signature ζ₃ᶠᶠᵃ(i, j, k, grid, u, v)
+
+grid = model.grid
+u, v, w = model.velocities
+
+ζ_op = KernelFunctionOperation{Face, Face, Center}(ζ₃ᶠᶠᵃ, CPU(), grid, computed_dependencies=(u, v))
+```
+"""
 struct KernelFunctionOperation{LX, LY, LZ, P, A, G, T, K, D} <: AbstractOperation{LX, LY, LZ, A, G, T}
     kernel_function :: K
     computed_dependencies :: D
@@ -11,49 +54,6 @@ struct KernelFunctionOperation{LX, LY, LZ, P, A, G, T, K, D} <: AbstractOperatio
         return new{LX, LY, LZ, P, A, G, T, K, D}(kernel_function, computed_dependencies, parameters, architecture, grid)
     end
 
-    """
-        KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid; architecture=nothing,
-                                            computed_dependencies=(), parameters=nothing)
- 
-    Constructs a `KernelFunctionOperation` at location `(LX, LY, LZ)` on `grid` an with
-    an optional iterable of `computed_dependencies` and arbitrary `parameters`.
-
-    With `isnothing(parameters)` (the default), `kernel_function` is called
-    with
-
-    ```julia
-    kernel_function(i, j, k, grid, computed_dependencies...)
-    ```
-
-    Otherwise `kernel_function` is called with
-
-    ```julia
-    kernel_function(i, j, k, grid, computed_dependencies..., parameters)
-    ```
-
-    Examples
-    ========
-
-    Construct a kernel function operation that returns random numbers:
-
-    ```julia
-    random_kernel_function(i, j, k, grid) = rand() # use CUDA.rand on the GPU
-
-    kernel_op = KernelFunctionOperation{Center, Center, Center}(random_kernel_function, grid; architecture=CPU())
-    ```
-
-    Constrcut a kernel function operation using the vertical vorticity operator
-    valid on curvilinear and cubed sphere grids:
-
-    ```julia
-    using Oceananigans.Operators: ζ₃ᶠᶠᵃ # called with signature ζ₃ᶠᶠᵃ(i, j, k, grid, u, v)
-
-    grid = model.grid
-    u, v, w = model.velocities
-
-    ζ_op = KernelFunctionOperation{Face, Face, Center}(ζ₃ᶠᶠᵃ, CPU(), grid, computed_dependencies=(u, v))
-    ```
-    """
     function KernelFunctionOperation{LX, LY, LZ}(kernel_function::K,
                                                  grid::G;
                                                  architecture = nothing,

--- a/src/AbstractOperations/kernel_function_operation.jl
+++ b/src/AbstractOperations/kernel_function_operation.jl
@@ -67,7 +67,7 @@ function KernelFunctionOperation{LX, LY, LZ}(kernel_function,
         Oceananigans.Architectures.architecture(computed_dependencies...) :
         architecture
 
-        return KernelFunctionOperation{LX, LY, LZ}(kernel_function, computed_dependencies, parameters, arch, grid)
+    return KernelFunctionOperation{LX, LY, LZ}(kernel_function, computed_dependencies, parameters, arch, grid)
 end
 
 

--- a/src/AbstractOperations/kernel_function_operation.jl
+++ b/src/AbstractOperations/kernel_function_operation.jl
@@ -1,3 +1,19 @@
+struct KernelFunctionOperation{LX, LY, LZ, P, A, G, T, K, D} <: AbstractOperation{LX, LY, LZ, A, G, T}
+    kernel_function :: K
+    computed_dependencies :: D
+    parameters :: P
+    architecture :: A
+    grid :: G
+
+    function KernelFunctionOperation{LX, LY, LZ}(kernel_function::K, computed_dependencies::D,
+                                                 parameters::P, architecture::A, grid::G) where {LX, LY, LZ, K, G, A, D, P}
+        T = eltype(grid)
+        return new{LX, LY, LZ, P, A, G, T, K, D}(kernel_function, computed_dependencies, parameters, architecture, grid)
+    end
+
+end
+
+
 """
     KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid; architecture=nothing,
                                         computed_dependencies=(), parameters=nothing)
@@ -29,7 +45,7 @@ random_kernel_function(i, j, k, grid) = rand() # use CUDA.rand on the GPU
 kernel_op = KernelFunctionOperation{Center, Center, Center}(random_kernel_function, grid; architecture=CPU())
 ```
 
-Constrcut a kernel function operation using the vertical vorticity operator
+Construct a kernel function operation using the vertical vorticity operator
 valid on curvilinear and cubed sphere grids:
 
 ```julia
@@ -38,38 +54,22 @@ using Oceananigans.Operators: ζ₃ᶠᶠᵃ # called with signature ζ₃ᶠᶠ
 grid = model.grid
 u, v, w = model.velocities
 
-ζ_op = KernelFunctionOperation{Face, Face, Center}(ζ₃ᶠᶠᵃ, CPU(), grid, computed_dependencies=(u, v))
+ζ_op = KernelFunctionOperation{Face, Face, Center}(ζ₃ᶠᶠᵃ, grid, computed_dependencies=(u, v))
 ```
 """
-struct KernelFunctionOperation{LX, LY, LZ, P, A, G, T, K, D} <: AbstractOperation{LX, LY, LZ, A, G, T}
-    kernel_function :: K
-    computed_dependencies :: D
-    parameters :: P
-    architecture :: A
-    grid :: G
+function KernelFunctionOperation{LX, LY, LZ}(kernel_function,
+                                             grid;
+                                             architecture = nothing,
+                                             computed_dependencies = (),
+                                             parameters = nothing) where {LX, LY, LZ}
 
-    function KernelFunctionOperation{LX, LY, LZ}(kernel_function::K, computed_dependencies::D,
-                                                 parameters::P, architecture::A, grid::G) where {LX, LY, LZ, K, G, A, D, P}
-        T = eltype(grid)
-        return new{LX, LY, LZ, P, A, G, T, K, D}(kernel_function, computed_dependencies, parameters, architecture, grid)
-    end
+    arch = isnothing(architecture) ?
+        Oceananigans.Architectures.architecture(computed_dependencies...) :
+        architecture
 
-    function KernelFunctionOperation{LX, LY, LZ}(kernel_function::K,
-                                                 grid::G;
-                                                 architecture = nothing,
-                                                 computed_dependencies::D = (),
-                                                 parameters::P = nothing) where {LX, LY, LZ, K, G, D, P}
-        T = eltype(grid)
-
-        arch = isnothing(architecture) ?
-            Oceananigans.Architectures.architecture(computed_dependencies...) :
-            architecture
-
-        A = typeof(arch)
-
-        return new{LX, LY, LZ, P, A, G, T, K, D}(kernel_function, computed_dependencies, parameters, arch, grid)
-    end
+        return KernelFunctionOperation{LX, LY, LZ}(kernel_function, computed_dependencies, parameters, arch, grid)
 end
+
 
 @inline Base.getindex(κ::KernelFunctionOperation, i, j, k) = κ.kernel_function(i, j, k, κ.grid, κ.computed_dependencies..., κ.parameters)
 @inline Base.getindex(κ::KernelFunctionOperation{LX, LY, LZ, <:Nothing}, i, j, k) where {LX, LY, LZ} = κ.kernel_function(i, j, k, κ.grid, κ.computed_dependencies...)

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -85,7 +85,7 @@ export
     FieldTimeSeries, FieldDataset, InMemory, OnDisk,
 
     # Abstract operations
-    ∂x, ∂y, ∂z, @at,
+    ∂x, ∂y, ∂z, @at, KernelFunctionOperation,
 
     # Cubed sphere
     ConformalCubedSphereGrid,


### PR DESCRIPTION
`KernelFunctionOperation` wasn't being exported, so this PR fixes it.

I also moved the docstring to the struct because it was being recognized before. Let me know if this isn't the best solution to this. Before

```julia
help?> Oceananigans.AbstractOperations.KernelFunctionOperation
  No documentation found.

  Oceananigans.AbstractOperations.KernelFunctionOperation is of type UnionAll.

  Summary
  ≡≡≡≡≡≡≡≡≡

  struct UnionAll <: Type{T}

  Fields
  ≡≡≡≡≡≡≡≡

  var  :: TypeVar
  body :: Any

  Supertype Hierarchy
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  UnionAll <: Type{T} <: Any
```

Now:

```julia
help?> KernelFunctionOperation
search: KernelFunctionOperation

  KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid; architecture=nothing,
                                      computed_dependencies=(), parameters=nothing)

  Constructs a KernelFunctionOperation at location (LX, LY, LZ) on grid an with an optional iterable of computed_dependencies and arbitrary parameters.

  With isnothing(parameters) (the default), kernel_function is called with

  kernel_function(i, j, k, grid, computed_dependencies...)

  Otherwise kernel_function is called with

  kernel_function(i, j, k, grid, computed_dependencies..., parameters)

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  Construct a kernel function operation that returns random numbers:

  random_kernel_function(i, j, k, grid) = rand() # use CUDA.rand on the GPU
  
  kernel_op = KernelFunctionOperation{Center, Center, Center}(random_kernel_function, grid; architecture=CPU())

  Constrcut a kernel function operation using the vertical vorticity operator valid on curvilinear and cubed sphere grids:

  using Oceananigans.Operators: ζ₃ᶠᶠᵃ # called with signature ζ₃ᶠᶠᵃ(i, j, k, grid, u, v)
  
  grid = model.grid
  u, v, w = model.velocities
  
  ζ_op = KernelFunctionOperation{Face, Face, Center}(ζ₃ᶠᶠᵃ, CPU(), grid, computed_dependencies=(u, v))
```