### PR TITLE
Adds a small bugfix to calculation in HydrostaticModel

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/compute_vertically_integrated_lateral_areas.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/compute_vertically_integrated_lateral_areas.jl
@@ -1,5 +1,5 @@
 @kernel function _compute_vertically_integrated_lateral_areas!(∫ᶻ_A, grid)
-    i, j, k = @index(Global, NTuple)
+    i, j = @index(Global, NTuple)
 
     @inbounds begin
         ∫ᶻ_A.xᶠᶜᶜ[i, j, 1] = 0
@@ -16,7 +16,7 @@ function compute_vertically_integrated_lateral_areas!(∫ᶻ_A, grid, arch)
 
     event = launch!(arch,
                     grid,
-                    :xyz,
+                    :xy,
                     _compute_vertically_integrated_lateral_areas!,
                     ∫ᶻ_A,
                     grid,


### PR DESCRIPTION
This changes the threading structure in a kernel launch to only launch over the i,j indices to avoid race conditions