### PR TITLE
Adds a test for broadcasting fields with arrays with singleton dimensions

### DIFF
--- a/src/Fields/broadcasting_abstract_fields.jl
+++ b/src/Fields/broadcasting_abstract_fields.jl
@@ -19,7 +19,7 @@ Base.similar(bc::Broadcasted{FieldBroadcastStyle}, ::Type{ElType}) where ElType 
 
 # Bypass style combining for in-place broadcasting with arrays / scalars to use built-in broadcasting machinery
 @inline Base.Broadcast.materialize!(dest::AbstractField, bc::Broadcasted{<:DefaultArrayStyle}) =
-    Base.Broadcast.materialize!(DefaultArrayStyle{3}(), dest, bc)
+    Base.Broadcast.materialize!(interior(dest), bc)
 
 #####
 ##### Kernels

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -201,19 +201,19 @@ for arch in archs
             #        i Center:        0         1         2         3         4
 
             # ccc: b * ∂x(a) = [             4.5,      4.5      -4.5,            ]
-            # fcc: b * ∂x(a) = [         3,        6,        3,       -6         ]
+            # fcc: b * ∂x(a) = [        1.5,       6,        3,       -6         ]
 
             C = Center
             F = Face
 
             @test times_x_derivative(a, b, (C, C, C), 1, 2, 2, 4.5)
-            @test times_x_derivative(a, b, (F, C, C), 1, 2, 2, 3)
-
             @test times_x_derivative(a, b, (C, C, C), 2, 2, 2, 4.5)
-            @test times_x_derivative(a, b, (F, C, C), 2, 2, 2, 6)
-
             @test times_x_derivative(a, b, (C, C, C), 3, 2, 2, -4.5)
+
+            @test times_x_derivative(a, b, (F, C, C), 1, 2, 2, 1.5)
+            @test times_x_derivative(a, b, (F, C, C), 2, 2, 2, 6)
             @test times_x_derivative(a, b, (F, C, C), 3, 2, 2, 3)
+            @test times_x_derivative(a, b, (F, C, C), 4, 2, 2, -6)
         end
 
         grid = RegularRectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1),

--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -85,12 +85,13 @@
 
         c .= random_column # broadcast to every horizontal column in c
 
-        CUDA.@allowscalar begin
-            @test all(interior(c)[1, 1, :] .== random_column[:])
-            @test all(interior(c)[2, 1, :] .== random_column[:])
-            @test all(interior(c)[1, 2, :] .== random_column[:])
-            @test all(interior(c)[2, 2, :] .== random_column[:])
-        end
+        c_cpu = Array(interior(c))
+        random_column_cpu = Array(random_column)
+
+        @test all(c_cpu[1, 1, :] .== random_column_cpu[:])
+        @test all(c_cpu[2, 1, :] .== random_column_cpu[:])
+        @test all(c_cpu[1, 2, :] .== random_column_cpu[:])
+        @test all(c_cpu[2, 2, :] .== random_column_cpu[:])
     end
 end
 

--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -78,17 +78,19 @@
         ##### Broadcasting with arrays
         #####
 
-        grid = RegularRectilinearGrid(size=(2, 2, 2), extent=(1, 1, 1))
+        two_two_two_grid = RegularRectilinearGrid(size=(2, 2, 2), extent=(1, 1, 1))
 
-        c = CenterField(CPU(), grid)
-        random_column = reshape(rand(2), 1, 1, 2)
+        c = CenterField(arch, two_two_two_grid)
+        random_column = arch_array(arch, reshape(rand(2), 1, 1, 2))
 
         c .= random_column # broadcast to every horizontal column in c
 
-        @test c[1, 1, 2:3] .== random_column
-        @test c[2, 1, 2:3] .== random_column
-        @test c[1, 2, 2:3] .== random_column
-        @test c[2, 2, 2:3] .== random_column
+        CUDA.@allowscalar begin
+            @test all(interior(c)[1, 1, :] .== random_column[:])
+            @test all(interior(c)[2, 1, :] .== random_column[:])
+            @test all(interior(c)[1, 2, :] .== random_column[:])
+            @test all(interior(c)[2, 2, :] .== random_column[:])
+        end
     end
 end
 

--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -2,6 +2,11 @@
     @info "  Testing broadcasting with fields..."
 
     for arch in archs
+
+        #####
+        ##### Basic functionality tests
+        #####
+        
         grid = RegularRectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
         a, b, c = [CenterField(arch, grid) for i = 1:3]
 
@@ -23,7 +28,10 @@
         @test c[1, 1, 0] == 4
         @test c[1, 1, Nz+1] == 4
 
-        # Broadcasting with interpolation
+        #####
+        ##### Broadcasting with interpolation
+        #####
+        
         three_point_grid = RegularRectilinearGrid(size=(1, 1, 3), extent=(1, 1, 1))
 
         a2 = CenterField(arch, three_point_grid)
@@ -49,7 +57,10 @@
         @test a2[1, 1, 2] == 2.0
         @test a2[1, 1, 3] == 1.5
 
-        # Broadcasting with ReducedField
+        #####
+        ##### Broadcasting with ReducedField
+        #####
+        
         r, p, q = [ReducedField(Center, Center, Nothing, arch, grid, dims=3) for i = 1:3]
 
         r .= 2 
@@ -62,6 +73,22 @@
 
         q .= r .* p .+ 1
         @test all(q .== 7) 
+
+        #####
+        ##### Broadcasting with arrays
+        #####
+
+        grid = RegularRectilinearGrid(size=(2, 2, 2), extent=(1, 1, 1))
+
+        c = CenterField(CPU(), grid)
+        random_column = reshape(rand(2), 1, 1, 2)
+
+        c .= random_column # broadcast to every horizontal column in c
+
+        @test c[1, 1, 2:3] .== random_column
+        @test c[2, 1, 2:3] .== random_column
+        @test c[1, 2, 2:3] .== random_column
+        @test c[2, 2, 2:3] .== random_column
     end
 end
 

--- a/test/test_computed_field.jl
+++ b/test/test_computed_field.jl
@@ -61,7 +61,7 @@ function compute_kinetic_energy(model)
 
     kinetic_energy_operation = @at (Center, Center, Center) (u^2 + v^2 + w^2) / 2
     @compute kinetic_energy = ComputedField(kinetic_energy_operation, data=model.pressures.pHY′.data)
-    result = Array(interior(kinetic_energy))
+    result = Array(interior(kinetic_energy))[2:3, 2:3, 2:3]
 
     return all(result .≈ 7)
 end
@@ -327,9 +327,7 @@ for arch in archs
         buoyancy = SeawaterBuoyancy(gravitational_acceleration = 1,
                                              equation_of_state = LinearEquationOfState(α=1, β=1))
 
-        model = NonhydrostaticModel(architecture = arch,
-                                            grid = grid,
-                                        buoyancy = buoyancy)
+        model = NonhydrostaticModel(architecture = arch, grid = grid, buoyancy = buoyancy)
 
         @testset "Derivative computations [$(typeof(arch))]" begin
             @info "      Testing compute! derivatives..."


### PR DESCRIPTION
This adds a test that should fail; but we should be able to fix it by defining 

```julia
@inline Base.Broadcast.materialize!(dest::AbstractField, bc::Broadcasted{<:DefaultArrayStyle}) =
    Base.Broadcast.materialize!(interior(dest), bc)
```