### PR TITLE
introduces `UpwindBiasedFirstOrder` advection

### DIFF
--- a/docs/src/appendix/library.md
+++ b/docs/src/appendix/library.md
@@ -13,6 +13,7 @@ Pages   = [
     "Advection/momentum_advection_operators.jl",
     "Advection/centered_second_order.jl",
     "Advection/centered_fourth_order.jl",
+    "Advection/upwind_biased_first_order.jl",
     "Advection/upwind_biased_third_order.jl",
     "Advection/upwind_biased_fifth_order.jl",
     "Advection/weno_fifth_order.jl"

--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -17,6 +17,7 @@ export
     advective_tracer_flux_z,
 
     CenteredSecondOrder,
+    UpwindBiasedFirstOrder,
     UpwindBiasedThirdOrder,
     UpwindBiasedFifthOrder,
     CenteredFourthOrder,
@@ -39,6 +40,7 @@ include("centered_advective_fluxes.jl")
 include("upwind_biased_advective_fluxes.jl")
 include("flat_advective_fluxes.jl")
 
+include("upwind_biased_first_order.jl")
 include("centered_second_order.jl")
 include("upwind_biased_third_order.jl")
 include("centered_fourth_order.jl")

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -19,7 +19,7 @@ export
     xnodes, ynodes, znodes, nodes,
 
     # Advection schemes
-    CenteredSecondOrder, CenteredFourthOrder, UpwindBiasedThirdOrder, UpwindBiasedFifthOrder, WENO5,
+    CenteredSecondOrder, CenteredFourthOrder, UpwindBiasedFirstOrder, UpwindBiasedThirdOrder, UpwindBiasedFifthOrder, WENO5,
 
     # Boundary conditions
     BoundaryCondition,

--- a/validation/advection/plot_rates_convergence_advection.jl
+++ b/validation/advection/plot_rates_convergence_advection.jl
@@ -8,36 +8,42 @@ using OffsetArrays
 using Oceananigans
 using Oceananigans.Models: ShallowWaterModel
 
+rate_of_convergence(::UpwindBiasedFirstOrder) = 1
 rate_of_convergence(::CenteredSecondOrder)    = 2
 rate_of_convergence(::UpwindBiasedThirdOrder) = 3
 rate_of_convergence(::CenteredFourthOrder)    = 4
 rate_of_convergence(::UpwindBiasedFifthOrder) = 5
 rate_of_convergence(::WENO5)                  = 5
 
+labels(::UpwindBiasedFirstOrder) = "Upwind1ˢᵗ"
 labels(::CenteredSecondOrder)    = "Center2ⁿᵈ"
 labels(::UpwindBiasedThirdOrder) = "Upwind3ʳᵈ"
 labels(::CenteredFourthOrder)    = "Center4ᵗʰ"
 labels(::UpwindBiasedFifthOrder) = "Upwind5ᵗʰ"
 labels(::WENO5)                  = "WENO5ᵗʰ "
 
+shapes(::UpwindBiasedFirstOrder) = :square
 shapes(::CenteredSecondOrder)    = :diamond
 shapes(::UpwindBiasedThirdOrder) = :dtriangle
 shapes(::CenteredFourthOrder)    = :rect
 shapes(::UpwindBiasedFifthOrder) = :star5
 shapes(::WENO5)                  = :star6
 
+colors(::UpwindBiasedFirstOrder) = :black
 colors(::CenteredSecondOrder)    = :green
 colors(::UpwindBiasedThirdOrder) = :red
 colors(::CenteredFourthOrder)    = :cyan
 colors(::UpwindBiasedFifthOrder) = :magenta
 colors(::WENO5)                  = :purple
 
+halos(::UpwindBiasedFirstOrder) = 1    # should be zero but need > 0
 halos(::CenteredSecondOrder)    = 1
 halos(::UpwindBiasedThirdOrder) = 2
 halos(::CenteredFourthOrder)    = 2
 halos(::UpwindBiasedFifthOrder) = 3
 halos(::WENO5)                  = 3 
 
+L  = 2
 U  = 1
 W  = 0.1
 Ns = 2 .^ (6:10)
@@ -49,6 +55,7 @@ c(x, y, z, t, U, W) = exp( - (x - U * t)^2 / W^2 )
   uh(x, y, z) = U * h(x, y, z)
 
 schemes = (
+ UpwindBiasedFirstOrder(), 
  CenteredSecondOrder(), 
  UpwindBiasedThirdOrder(), 
  CenteredFourthOrder(), 


### PR DESCRIPTION
This introduces `UpwindBiasedFirstOrder` advection, and is in part inspired by #1955.

This scheme is first order accurate but has the advantage of preserving positivity and extrema.

The plot for convergence is updated and we see that it does have the slope that is predicted from the theory.

![convergence_rates](https://user-images.githubusercontent.com/8239041/130524906-d3afbae0-651d-4c9a-aee8-b0fb4d9dc856.png)

I set the `symmetric_interpolate`'s to zero, which I think is true, but not sure if anything else should be done here.