### PR TITLE
Adds optional second argument `value` to `mask_immersed_field!`

### DIFF
--- a/src/ImmersedBoundaries/mask_immersed_field.jl
+++ b/src/ImmersedBoundaries/mask_immersed_field.jl
@@ -5,14 +5,13 @@ using Oceananigans.Fields: location, AbstractDataField
 
 instantiate(X) = X()
 
-mask_immersed_field!(field::AbstractField, loc=location(field)) = mask_immersed_field!(field, field.grid, loc)
-mask_immersed_field!(field, grid, loc) = NoneEvent()
+mask_immersed_field!(field::AbstractField, value=zero(eltype(field.grid))) = mask_immersed_field!(field, field.grid, location(field), value)
+mask_immersed_field!(field, grid, loc, value) = NoneEvent()
 
-function mask_immersed_field!(field::AbstractDataField, grid::ImmersedBoundaryGrid, loc)
+function mask_immersed_field!(field::AbstractDataField, grid::ImmersedBoundaryGrid, loc, value)
     arch = architecture(field)
     loc = instantiate.(loc)
-    mask_value = zero(eltype(grid))
-    return launch!(arch, grid, :xyz, _mask_immersed_field!, field, loc, grid, mask_value; dependencies = device_event(arch))
+    return launch!(arch, grid, :xyz, _mask_immersed_field!, field, loc, grid, value; dependencies = device_event(arch))
 end
 
 @kernel function _mask_immersed_field!(field, loc, grid, value)


### PR DESCRIPTION
This optional positional argument can be used to mask a field with a value other than 0.

The syntax is supposed to be

```julia
mask_immersed_field!(c, NaN)
```

to mask a field to `NaN`, for example.

cc @francispoulin @fadaie91