### PR TITLE
Neutral boundary layers are not unstable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.62.1"
+version = "0.62.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/TurbulenceClosures/turbulence_closure_implementations/convective_adjustment_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/convective_adjustment_vertical_diffusivity.jl
@@ -101,7 +101,7 @@ end
                     is_unstableᶜᶜᶠ(i, j, k,   grid, tracers, buoyancy)
 
     @inbounds diffusivities.κ[i, j, k] = ifelse(unstable_cell,
-                                                closure.convective_κz
+                                                closure.convective_κz,
                                                 closure.background_κz)
 
     @inbounds diffusivities.ν[i, j, k] = ifelse(unstable_cell,

--- a/src/TurbulenceClosures/turbulence_closure_implementations/convective_adjustment_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/convective_adjustment_vertical_diffusivity.jl
@@ -92,7 +92,7 @@ function calculate_diffusivities!(diffusivities, closure::CAVD, model)
     return nothing
 end
 
-@inline is_stableᶜᶜᶠ(i, j, k, grid, tracers, buoyancy) = ∂z_b(i, j, k, grid, buoyancy, tracers) > 0
+@inline is_stableᶜᶜᶠ(i, j, k, grid, tracers, buoyancy) = ∂z_b(i, j, k, grid, buoyancy, tracers) >= 0
 
 @kernel function compute_convective_adjustment_diffusivities!(diffusivities, grid, closure, tracers, buoyancy)
     i, j, k, = @index(Global, NTuple)


### PR DESCRIPTION
This PR changes the criterion for a "stable" layer from `dbdz > 0` to `dbdz >= 0`.

Resolves #1980 .