### PR TITLE
Grids, meet architecture

### DIFF
--- a/src/Grids/regular_rectilinear_grid.jl
+++ b/src/Grids/regular_rectilinear_grid.jl
@@ -7,7 +7,8 @@ A rectilinear grid with with constant grid spacings `Δx`, `Δy`, and `Δz` betw
 and cell faces, elements of type `FT`, topology `{TX, TY, TZ}`, and coordinate ranges
 of type `R`.
 """
-struct RegularRectilinearGrid{FT, TX, TY, TZ, R} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
+struct RegularRectilinearGrid{FT, TX, TY, TZ, R, Arch} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
+    architecture :: Arch
     # Number of grid points in (x,y,z).
     Nx :: Int
     Ny :: Int
@@ -152,12 +153,14 @@ grid spacing (Δx, Δy, Δz): (0.0, 0.0, 0.5)
 ```
 """
 function RegularRectilinearGrid(FT=Float64;
-                                  size,
-                                     x = nothing, y = nothing, z = nothing,
+                                size,
+                                architecture = CPU(),
+                                x = nothing,
+                                y = nothing,
+                                z = nothing,
                                 extent = nothing,
-                              topology = (Periodic, Periodic, Bounded),
-                                  halo = nothing
-                              )
+                                topology = (Periodic, Periodic, Bounded),
+                                halo = nothing)
 
     TX, TY, TZ = validate_topology(topology)
     size = validate_size(TX, TY, TZ, size)
@@ -200,7 +203,7 @@ function RegularRectilinearGrid(FT=Float64;
     yF = OffsetArray(yF, -Hy)
     zF = OffsetArray(zF, -Hz)
 
-    return RegularRectilinearGrid{FT, TX, TY, TZ, typeof(xC)}(
+    return RegularRectilinearGrid{FT, TX, TY, TZ, typeof(xC)}(architecture,
         Nx, Ny, Nz, Hx, Hy, Hz, Lx, Ly, Lz, Δx, Δy, Δz, xC, yC, zC, xF, yF, zF)
 end
 


### PR DESCRIPTION
This PR adds an `architecture` property to the `RegularRectilinearGrid` and `VerticallyStretchedRectilinearGrid`. Eventually, this PR will remove the `architecture` property from all models and fields. The new API will require `architecture` to be specified once when building the grid and never thereafter.

This major change to the API is crucial for supporting a clean, simple API for grid metrics stored in arrays (all cases except the edge case of a fully regular grid). In the new API, both the architecture and floating point type are exclusive properties of `grid`. In addition this change will simplify the construction of models on distributed architectures and will eliminate the need for special model constructors for that case.

Ultimately, we hope to go beyond this change to support just three grids:

1. `RectilinearGrid`
2. `LatitudeLongitudeGrid`
3. `OrthogonalSphericalShellGrid`

In the first two cases, "regularity" is established if the grid metrics are numbers (rather than arrays or functions). This is another major change to the API (and a major internal refactor) that will hopefully reduce, simplify, and generalize grid constructors and applications.

Closes #1825.