### PR TITLE
Add compat entry for Literate in `docs/Project.toml`

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -14,4 +14,5 @@ Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [compat]
+Literate = "≥2.9.0"
 Plots = "≥1.10.1"


### PR DESCRIPTION
This PR adds a compat entry for Literate.jl since there was breaking syntax from [v.2.9.0 onwards](https://github.com/fredrikekre/Literate.jl/blob/master/CHANGELOG.md#290---2021-07-09).
