### PR TITLE
Changes stokes drift nomenclature from `v` to `u` in nonhydrostatic model description

### DIFF
--- a/docs/src/physics/nonhydrostatic_model.md
+++ b/docs/src/physics/nonhydrostatic_model.md
@@ -32,7 +32,7 @@ at the top of the domain via the Craik-Leibovich approximation are
 where ``b \boldsymbol{\hat g}`` the is the buoyancy (a vector whose default direction is upward), 
 ``\boldsymbol{\tau}`` is the kinematic stress tensor, ``\boldsymbol{F_v}``
 denotes an internal forcing of the velocity field ``\boldsymbol{v}``, ``p`` is the kinematic 
-pressure, ``\boldsymbol{u}^S`` is the two-dimensional 'Stokes drift' velocity field associated with surface gravity 
+pressure, ``\boldsymbol{u}^S`` is the horizontal, two-dimensional 'Stokes drift' velocity field associated with surface gravity 
 waves, and ``\boldsymbol{f}`` is the Coriolis parameter, or the background vorticity associated 
 with the specified rate of rotation of the frame of reference.
 


### PR DESCRIPTION
Closes https://github.com/CliMA/Oceananigans.jl/issues/2007