### PR TITLE
Updates simulation tips

### DIFF
--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -94,7 +94,7 @@ fixes the issue by indicating to the compiler that `T₀` will not change.
 Note that the _literal_ `2π / 86400` is not an issue -- it's only the
 _variable_ `T₀` that must be declared `const`.
 
-Alternatively passing the variable as a parameter to `GradientBoundaryConditions` also works:
+Alternatively passing the variable as a parameter to `GradientBoundaryCondition also works:
 
 ```julia
 T₀ = 20 # ᵒC

--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -322,7 +322,8 @@ forcing functions on a GPU. To learn more about working with `CuArray`s, see the
 [array programming](https://juliagpu.github.io/CUDA.jl/dev/usage/array/) section
 of the CUDA.jl documentation.
 
-### Avoid trigonometric functions in GPUs
+
+### Avoid trigonometric functions on GPUs
 
 Trigonometric functions are slow to compute in GPUs, so it's best to avoid them inside functions
 that need to be computed on GPUs. For example, when running on GPUs, definiting a backgrouund field

--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -323,22 +323,3 @@ forcing functions on a GPU. To learn more about working with `CuArray`s, see the
 of the CUDA.jl documentation.
 
 
-### Avoid trigonometric functions on GPUs
-
-Trigonometric functions can be slow to compute in GPUs, so it's best to avoid them inside functions
-that need to be computed on GPUs. For example, when running on GPUs, definiting a backgrouund field
-as seen below:
-
-```julia
-b∞(x, y, z, t, p) = p.N2 * (x * sin(p.θ_rad) + z * cos(p.θ_rad))
-B_field = BackgroundField(b∞, parameters=(N2=1e-5, θ_rad=0.05))
-```
-
-can run much slower than the alternative using parameters:
-
-```julia
-b∞(x, y, z, t, p) = p.N2 * (x * p.sinθ + z * p.cosθ)
-B_field = BackgroundField(b∞, parameters=(N2=1e-5, 
-                                          cosθ=cos(0.05), 
-                                          sinθ=sin(0.05),))
-```

--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -325,7 +325,7 @@ of the CUDA.jl documentation.
 
 ### Avoid trigonometric functions on GPUs
 
-Trigonometric functions are slow to compute in GPUs, so it's best to avoid them inside functions
+Trigonometric functions can be slow to compute in GPUs, so it's best to avoid them inside functions
 that need to be computed on GPUs. For example, when running on GPUs, definiting a backgrouund field
 as seen below:
 
@@ -334,7 +334,7 @@ b∞(x, y, z, t, p) = p.N2 * (x * sin(p.θ_rad) + z * cos(p.θ_rad))
 B_field = BackgroundField(b∞, parameters=(N2=1e-5, θ_rad=0.05))
 ```
 
-runs much slow (by about two orders of magnitude!) than the alternative using parameters:
+can run much slower than the alternative using parameters:
 
 ```julia
 b∞(x, y, z, t, p) = p.N2 * (x * p.sinθ + z * p.cosθ)

--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -70,7 +70,7 @@ GPU computing (and Julia) is again desirable, an inexperienced user can also ach
 in GPU simulations by following a few simple principles.
 
 
-### Variables that need to be used in GPU computations need to be defined as constants
+### Global variables that need to be used in GPU computations need to be defined as constants or passed as parameters
 
 Any global variable that needs to be accessed by the GPU needs to be a constant or the simulation
 will crash. This includes any variables that are referenced as global variables in functions
@@ -93,6 +93,14 @@ fixes the issue by indicating to the compiler that `T₀` will not change.
 
 Note that the _literal_ `2π / 86400` is not an issue -- it's only the
 _variable_ `T₀` that must be declared `const`.
+
+Alternatively passing the variable as a parameter to `GradientBoundaryConditions` also works:
+
+```julia
+T₀ = 20 # ᵒC
+surface_temperature(x, y, t, p) = p.T₀ * sin(2π / 86400 * t)
+T_bcs = FieldBoundaryConditions(bottom = GradientBoundaryCondition(surface_temperature, parameters=(T₀=T₀,)))
+```
 
 ### Complex diagnostics using `ComputedField`s may not work on GPUs
 
@@ -313,3 +321,23 @@ to define initial conditions, boundary conditions or
 forcing functions on a GPU. To learn more about working with `CuArray`s, see the
 [array programming](https://juliagpu.github.io/CUDA.jl/dev/usage/array/) section
 of the CUDA.jl documentation.
+
+### Avoid trigonometric functions in GPUs
+
+Trigonometric functions are slow to compute in GPUs, so it's best to avoid them inside functions
+that need to be computed on GPUs. For example, when running on GPUs, definiting a backgrouund field
+as seen below:
+
+```julia
+b∞(x, y, z, t, p) = p.N2 * (x * sin(p.θ_rad) + z * cos(p.θ_rad))
+B_field = BackgroundField(b∞, parameters=(N2=1e-5, θ_rad=0.05))
+```
+
+runs much slow (by about two orders of magnitude!) than the alternative using parameters:
+
+```julia
+b∞(x, y, z, t, p) = p.N2 * (x * p.sinθ + z * p.cosθ)
+B_field = BackgroundField(b∞, parameters=(N2=1e-5, 
+                                          cosθ=cos(0.05), 
+                                          sinθ=sin(0.05),))
+```

--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -94,7 +94,7 @@ fixes the issue by indicating to the compiler that `T₀` will not change.
 Note that the _literal_ `2π / 86400` is not an issue -- it's only the
 _variable_ `T₀` that must be declared `const`.
 
-Alternatively passing the variable as a parameter to `GradientBoundaryCondition` also works:
+Alternatively, passing the variable as a parameter to `GradientBoundaryCondition` also works:
 
 ```julia
 T₀ = 20 # ᵒC

--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -94,7 +94,7 @@ fixes the issue by indicating to the compiler that `T₀` will not change.
 Note that the _literal_ `2π / 86400` is not an issue -- it's only the
 _variable_ `T₀` that must be declared `const`.
 
-Alternatively passing the variable as a parameter to `GradientBoundaryCondition also works:
+Alternatively passing the variable as a parameter to `GradientBoundaryCondition` also works:
 
 ```julia
 T₀ = 20 # ᵒC

--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -321,5 +321,3 @@ to define initial conditions, boundary conditions or
 forcing functions on a GPU. To learn more about working with `CuArray`s, see the
 [array programming](https://juliagpu.github.io/CUDA.jl/dev/usage/array/) section
 of the CUDA.jl documentation.
-
-


### PR DESCRIPTION
Updating this with some info I just found out: trigonometric functions are super slow on GPUs.

I should say, I couldn't find anything mentioning this issue online. So if you anyone thinks this is a bug of some sort, let me know and I'll open an issue.