### PR TITLE
Fixes grid equality for GPUs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.63.3"
+version = "0.63.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -119,8 +119,8 @@ function Base.:(==)(grid1::AbstractGrid, grid2::AbstractGrid)
 
     topology(grid1) !== topology(grid2) && return false
 
-    x1, y1, z1 = nodes((Face, Face, Face), grid1)
-    x2, y2, z2 = nodes((Face, Face, Face), grid2)
+    x1, y1, z1 = Adapt.adapt(CPU(), nodes((Face, Face, Face), grid1))
+    x2, y2, z2 = Adapt.adapt(CPU(), nodes((Face, Face, Face), grid2))
 
     return x1 == x2 && y1 == y2 && z1 == z2
 end

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -122,7 +122,6 @@ function Base.:(==)(grid1::AbstractGrid, grid2::AbstractGrid)
     x1, y1, z1 = nodes((Face, Face, Face), grid1)
     x2, y2, z2 = nodes((Face, Face, Face), grid2)
 
-    @info "DEBUG" typeof(x1)
     CUDA.@allowscalar return x1 == x2 && y1 == y2 && z1 == z2
 end
 

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -121,10 +121,9 @@ function Base.:(==)(grid1::AbstractGrid, grid2::AbstractGrid)
 
     x1, y1, z1 = nodes((Face, Face, Face), grid1)
     x2, y2, z2 = nodes((Face, Face, Face), grid2)
-    
-    x1, y1, z1, x2, y2, z2 = Tuple(Array(x) for x in (x1, y1, z1, x2, y2, z2))
 
-    return x1 == x2 && y1 == y2 && z1 == z2
+    @info "DEBUG" typeof(x1)
+    CUDA.@allowscalar return x1 == x2 && y1 == y2 && z1 == z2
 end
 
 halo_size(grid) = (grid.Hx, grid.Hy, grid.Hz)

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -119,8 +119,10 @@ function Base.:(==)(grid1::AbstractGrid, grid2::AbstractGrid)
 
     topology(grid1) !== topology(grid2) && return false
 
-    x1, y1, z1 = Adapt.adapt(CPU(), nodes((Face, Face, Face), grid1))
-    x2, y2, z2 = Adapt.adapt(CPU(), nodes((Face, Face, Face), grid2))
+    x1, y1, z1 = nodes((Face, Face, Face), grid1)
+    x2, y2, z2 = nodes((Face, Face, Face), grid2)
+    
+    x1, y1, z1, x2, y2, z2 = Tuple(Array(x) for x in (x1, y1, z1, x2, y2, z2))
 
     return x1 == x2 && y1 == y2 && z1 == z2
 end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -277,12 +277,12 @@ function test_flat_size_regular_rectilinear_grid(FT)
     return nothing
 end
 
-function test_grid_equality()
+function test_grid_equality(arch)
     topo = (Periodic, Periodic, Bounded)
     Nx, Ny, Nz = 4, 7, 9
     grid1 = RegularRectilinearGrid(topology=topo, size=(Nx, Ny, Nz), x=(0, 1), y=(-1, 1), z=(0, Nz))
-    grid2 = VerticallyStretchedRectilinearGrid(architecture=CPU(), topology=topo, size=(Nx, Ny, Nz), x=(0, 1), y=(-1, 1), z_faces=0:Nz)
-    grid3 = VerticallyStretchedRectilinearGrid(architecture=CPU(), topology=topo, size=(Nx, Ny, Nz), x=(0, 1), y=(-1, 1), z_faces=0:Nz)
+    grid2 = VerticallyStretchedRectilinearGrid(architecture=arch, topology=topo, size=(Nx, Ny, Nz), x=(0, 1), y=(-1, 1), z_faces=0:Nz)
+    grid3 = VerticallyStretchedRectilinearGrid(architecture=arch, topology=topo, size=(Nx, Ny, Nz), x=(0, 1), y=(-1, 1), z_faces=0:Nz)
 
     return grid1==grid1 && grid2 == grid3 && grid1 !== grid3
 end
@@ -566,7 +566,9 @@ end
         @testset "Grid equality" begin
             @info "    Testing grid equality operator (==)..."
             
-            test_grid_equality()
+            for arch in archs
+                test_grid_equality(arch)
+            end
 
             if CUDA.has_cuda()
                 test_grid_equality_over_architectures()


### PR DESCRIPTION
For some reason when I tested the code after merging https://github.com/CliMA/Oceananigans.jl/pull/2028 it didn't really work on my main code for GPUs. 

It worked for a MWE when I tested it [here](https://github.com/CliMA/Oceananigans.jl/pull/2028#issuecomment-952089949) but I guess I must have done something wrong? In any case, I apologize!

I also expanded the test to test grids on GPUs (which would have caught this error) so I think this'll help.

Given that we _just_ released a new version, I didn't bump this to 0.63.4 here. But let me know if I should do that.

CC: @navidcy 