### PR TITLE
Minor upgrades to reductions of fields and AbstractOperations

### DIFF
--- a/src/Fields/abstract_field.jl
+++ b/src/Fields/abstract_field.jl
@@ -185,7 +185,7 @@ Base.fill!(f::AbstractDataField, val) = fill!(parent(f), val)
 #####
 
 # Don't use axes(f) to checkbounds; use axes(f.data)
-Base.checkbounds(f::AbstractField, I...) = Base.checkbounds(f.data, I...)
+Base.checkbounds(f::AbstractDataField, I...) = Base.checkbounds(f.data, I...)
 
 @propagate_inbounds Base.getindex(f::AbstractDataField, inds...) = getindex(f.data, inds...)
 


### PR DESCRIPTION
This PR makes a few improvements to reductions of `AbstractField` and `AbstractOperation`. These changes were inspired by the discussion on #2024 (though we don't resolve that issue here).

To do:

- [ ] Tests that allocating reductions of abstract operations work (`maximum(a * b)`, etc)
- [ ] Test that allocating reductions are correct (eg they only reduce over the interior of an array)
- [ ] Benchmark?