### PR TITLE
Makes FieldBoundaryConditions mutable

### DIFF
--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -22,7 +22,7 @@ default_auxiliary_field_boundary_condition(::Bounded, ::Face) = nothing
 ##### Field boundary conditions
 #####
 
-struct FieldBoundaryConditions{W, E, S, N, B, T, I}
+mutable struct FieldBoundaryConditions{W, E, S, N, B, T, I}
         west :: W
         east :: E
        south :: S


### PR DESCRIPTION
This is a (somewhat minor) convenience for parameter studies, because it means that if `u` was constructed with

```julia
u_boundary_conditions = FieldBoundaryConditions(top = FluxBoundaryCondition(1.0))
```

we can later write things like

```julia
u.boundary_conditions.top = FluxBoundaryCondition(2.0)
```

to change the value of the boundary condition. Note that the _type_ of the boundary condition can't change. 

Just opening this PR to see if tests pass with this change. If so it seem positive to me (I don't think `FieldBoundaryConditions` needs to be immutable for performance reasons, but please speak up if anyone thinks/knows otherwise).

