### PR TITLE
Better `show(io, ::AbstractGrid)`

### DIFF
--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -27,9 +27,9 @@ RectilinearGrid{Float64, Periodic, Periodic, Bounded} on the CPU()
                  topology: (Periodic, Periodic, Bounded)
         size (Nx, Ny, Nz): (32, 64, 256)
         halo (Hx, Hy, Hz): (1, 1, 1)
-grid in x: Regular, with spacing 4.0
-grid in y: Regular, with spacing 4.0
-grid in z: Regular, with spacing 2.0
+                grid in x: Regular, with spacing 4.0
+                grid in y: Regular, with spacing 4.0
+                grid in z: Regular, with spacing 2.0
 ```
 
 !!! info "Default domain"
@@ -54,9 +54,9 @@ RectilinearGrid{Float64, Periodic, Bounded, Bounded} on the CPU()
                  topology: (Periodic, Bounded, Bounded)
         size (Nx, Ny, Nz): (64, 64, 32)
         halo (Hx, Hy, Hz): (1, 1, 1)
-grid in x: Regular, with spacing 156.25
-grid in y: Regular, with spacing 156.25
-grid in z: Regular, with spacing 31.25
+                grid in x: Regular, with spacing 156.25
+                grid in y: Regular, with spacing 156.25
+                grid in z: Regular, with spacing 31.25
 ```
 
 The `Flat` topology is useful when running problems with fewer than 3 dimensions. As an example,
@@ -76,9 +76,9 @@ RectilinearGrid{Float64, Periodic, Periodic, Bounded} on the CPU()
                  topology: (Periodic, Periodic, Bounded)
         size (Nx, Ny, Nz): (32, 16, 256)
         halo (Hx, Hy, Hz): (1, 1, 1)
-grid in x: Regular, with spacing 6.25
-grid in y: Regular, with spacing 0.78125
-grid in z: Regular, with spacing 0.02454369260617026
+                grid in x: Regular, with spacing 6.25
+                grid in y: Regular, with spacing 0.78125
+                grid in z: Regular, with spacing 0.02454369260617026
 ```
 
 
@@ -110,9 +110,9 @@ RectilinearGrid{Float64, Periodic, Bounded, Bounded} on the CPU()
                  topology: (Periodic, Bounded, Bounded)
         size (Nx, Ny, Nz): (64, 64, 32)
         halo (Hx, Hy, Hz): (1, 1, 1)
-grid in x: Regular, with spacing 156.25
-grid in y: Stretched, with spacing min=6.022718974138115, max=245.33837163709035
-grid in z: Stretched, with spacing min=2.407636663901485, max=49.008570164780394
+                grid in x: Regular, with spacing 156.25
+                grid in y: Stretched, with spacing min=6.022718974138115, max=245.33837163709035
+                grid in z: Stretched, with spacing min=2.407636663901485, max=49.008570164780394
 ```
 
 ```@setup 1

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -152,9 +152,9 @@ function show(io::IO, g::LatitudeLongitudeGrid{FT, TX, TY, TZ, M}) where {FT, TX
               "                 topology: ", (TX, TY, TZ), '\n',
               "        size (Nx, Ny, Nz): ", (g.Nx, g.Ny, g.Nz), '\n',
               "        halo (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz), '\n',
-              "grid in λ: ", show_coordinate(g.Δλᶜᵃᵃ, TX), '\n',
-              "grid in φ: ", show_coordinate(g.Δφᵃᶜᵃ, TY), '\n',
-              "grid in z: ", show_coordinate(g.Δzᵃᵃᶜ, TZ), '\n',
+              "                grid in λ: ", show_coordinate(g.Δλᶜᵃᵃ, TX), '\n',
+              "                grid in φ: ", show_coordinate(g.Δφᵃᶜᵃ, TY), '\n',
+              "                grid in z: ", show_coordinate(g.Δzᵃᵃᶜ, TZ), '\n',
               "metrics are computed on the fly")
 end
 
@@ -164,9 +164,9 @@ function show(io::IO, g::LatitudeLongitudeGrid{FT, TX, TY, TZ}) where {FT, TX, T
               "                 topology: ", (TX, TY, TZ), '\n',
               "        size (Nx, Ny, Nz): ", (g.Nx, g.Ny, g.Nz), '\n',
               "        halo (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz), '\n',
-              "grid in λ: ", show_coordinate(g.Δλᶜᵃᵃ, TX), '\n',
-              "grid in φ: ", show_coordinate(g.Δφᵃᶜᵃ, TY), '\n',
-              "grid in z: ", show_coordinate(g.Δzᵃᵃᶜ, TZ), '\n',
+              "                grid in λ: ", show_coordinate(g.Δλᶜᵃᵃ, TX), '\n',
+              "                grid in φ: ", show_coordinate(g.Δφᵃᶜᵃ, TY), '\n',
+              "                grid in z: ", show_coordinate(g.Δzᵃᵃᶜ, TZ), '\n',
               "metrics are pre-computed")
 end
 

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -130,9 +130,9 @@ RectilinearGrid{Float64, Periodic, Periodic, Bounded} on the CPU()
                  topology: (Periodic, Periodic, Bounded)
         size (Nx, Ny, Nz): (32, 32, 32)
         halo (Hx, Hy, Hz): (1, 1, 1)
-grid in x: Regular, with spacing 0.03125
-grid in y: Regular, with spacing 0.0625
-grid in z: Regular, with spacing 0.09375
+                grid in x: Regular, with spacing 0.03125
+                grid in y: Regular, with spacing 0.0625
+                grid in z: Regular, with spacing 0.09375
 ```
 
 * A default grid with `Float32` type:
@@ -146,9 +146,9 @@ RectilinearGrid{Float32, Periodic, Periodic, Bounded} on the CPU()
                  topology: (Periodic, Periodic, Bounded)
         size (Nx, Ny, Nz): (32, 32, 16)
         halo (Hx, Hy, Hz): (1, 1, 1)
-grid in x: Regular, with spacing 0.25
-grid in y: Regular, with spacing 0.625
-grid in z: Regular, with spacing 0.3926991
+                grid in x: Regular, with spacing 0.25
+                grid in y: Regular, with spacing 0.625
+                grid in z: Regular, with spacing 0.3926991
 ```
 
 * A two-dimenisional, horizontally-periodic grid:
@@ -162,9 +162,9 @@ RectilinearGrid{Float64, Periodic, Periodic, Flat} on the CPU()
                  topology: (Periodic, Periodic, Flat)
         size (Nx, Ny, Nz): (32, 32, 1)
         halo (Hx, Hy, Hz): (1, 1, 0)
-grid in x: Regular, with spacing 0.19634954084936207
-grid in y: Regular, with spacing 0.39269908169872414
-grid in z: Flattened
+                grid in x: Regular, with spacing 0.19634954084936207
+                grid in y: Regular, with spacing 0.39269908169872414
+                grid in z: Flattened
 ```
 
 * A one-dimensional "column" grid:
@@ -178,9 +178,9 @@ RectilinearGrid{Float64, Flat, Flat, Bounded} on the CPU()
                  topology: (Flat, Flat, Bounded)
         size (Nx, Ny, Nz): (1, 1, 256)
         halo (Hx, Hy, Hz): (0, 0, 1)
-grid in x: Flattened
-grid in y: Flattened
-grid in z: Regular, with spacing 0.5
+                grid in x: Flattened
+                grid in y: Flattened
+                grid in z: Regular, with spacing 0.5
 ```
 
 * A horizontally-periodic regular grid with cell interfaces stretched hyperbolically near the top:
@@ -205,9 +205,9 @@ RectilinearGrid{Float64, Periodic, Periodic, Bounded} on the CPU()
                  topology: (Periodic, Periodic, Bounded)
         size (Nx, Ny, Nz): (32, 32, 24)
         halo (Hx, Hy, Hz): (1, 1, 1)
-grid in x: Regular, with spacing 2.0
-grid in y: Regular, with spacing 2.0
-grid in z: Stretched, with spacing min=0.6826950100338962, max=1.8309085743885056
+                grid in x: Regular, with spacing 2.0
+                grid in y: Regular, with spacing 2.0
+                grid in z: Stretched, with spacing min=0.6826950100338962, max=1.8309085743885056
 ```
 
 * A three-dimensional grid with regular spacing in x, cell interfaces that are closely spaced
@@ -237,9 +237,9 @@ RectilinearGrid{Float64, Periodic, Bounded, Bounded} on the CPU()
                  topology: (Periodic, Bounded, Bounded)
         size (Nx, Ny, Nz): (32, 30, 24)
         halo (Hx, Hy, Hz): (1, 1, 1)
-grid in x: Regular, with spacing 6.25
-grid in y: Stretched, with spacing min=0.2739052315863262, max=5.22642316338267
-grid in z: Stretched, with spacing min=0.6826950100338962, max=1.8309085743885056
+                grid in x: Regular, with spacing 6.25
+                grid in y: Stretched, with spacing min=0.2739052315863262, max=5.22642316338267
+                grid in z: Stretched, with spacing min=0.6826950100338962, max=1.8309085743885056
 ```
 """
 function RectilinearGrid(FT = Float64;
@@ -298,9 +298,9 @@ function show(io::IO, g::RectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
               "                 topology: ", (TX, TY, TZ), '\n',
               "        size (Nx, Ny, Nz): ", (g.Nx, g.Ny, g.Nz), '\n',
               "        halo (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz), '\n',
-              "grid in x: ", show_coordinate(g.Δxᶜᵃᵃ, TX), '\n',
-              "grid in y: ", show_coordinate(g.Δyᵃᶜᵃ, TY), '\n',
-              "grid in z: ", show_coordinate(g.Δzᵃᵃᶜ, TZ))
+              "                grid in x: ", show_coordinate(g.Δxᶜᵃᵃ, TX), '\n',
+              "                grid in y: ", show_coordinate(g.Δyᵃᶜᵃ, TY), '\n',
+              "                grid in z: ", show_coordinate(g.Δzᵃᵃᶜ, TZ))
 end
 
 


### PR DESCRIPTION
This PR fixes the alignment issue in `show(io, ::AbstractGrid)`.

Partially addresses #2064.