### PR TITLE
Enhance docstrings + add models & modules in Docs/Appendix/Library

### DIFF
--- a/docs/src/appendix/library.md
+++ b/docs/src/appendix/library.md
@@ -2,6 +2,16 @@
 
 Documenting the public user interface.
 
+## Oceananigans.jl
+
+```@autodocs
+Modules = [Oceananigans]
+Private = false
+Pages   = [
+    "Oceananigans.jl"
+]
+```
+
 ## Advection
 
 ```@autodocs

--- a/docs/src/appendix/library.md
+++ b/docs/src/appendix/library.md
@@ -12,22 +12,18 @@ Pages   = [
 ]
 ```
 
+## Abstract operations
+
+```@autodocs
+Modules = [Oceananigans.AbstractOperations]
+Private = false
+```
+
 ## Advection
 
 ```@autodocs
 Modules = [Oceananigans.Advection]
 Private = false
-Pages   = [
-    "Advection/Advection.jl",
-    "Advection/tracer_advection_operators.jl",
-    "Advection/momentum_advection_operators.jl",
-    "Advection/centered_second_order.jl",
-    "Advection/centered_fourth_order.jl",
-    "Advection/upwind_biased_first_order.jl",
-    "Advection/upwind_biased_third_order.jl",
-    "Advection/upwind_biased_fifth_order.jl",
-    "Advection/weno_fifth_order.jl"
-]
 ```
 
 ## Architectures
@@ -43,22 +39,6 @@ Pages   = ["Architectures.jl"]
 ```@autodocs
 Modules = [Oceananigans.BoundaryConditions]
 Private = false
-Pages   = [
-    "BoundaryConditions/BoundaryConditions.jl",
-    "BoundaryConditions/boundary_condition_classifications.jl",
-    "BoundaryConditions/boundary_condition.jl",
-    "BoundaryConditions/discrete_boundary_function.jl",
-    "BoundaryConditions/continuous_boundary_function.jl",
-    "BoundaryConditions/field_boundary_conditions.jl",
-    "BoundaryConditions/show_boundary_conditions.jl",
-    "BoundaryConditions/fill_halo_regions.jl",
-    "BoundaryConditions/fill_halo_regions_value_gradient.jl",
-    "BoundaryConditions/fill_halo_regions_open.jl",
-    "BoundaryConditions/fill_halo_regions_periodic.jl",
-    "BoundaryConditions/fill_halo_regions_flux.jl",
-    "BoundaryConditions/fill_halo_regions_nothing.jl",
-    "BoundaryConditions/apply_flux_bcs.jl",
-]
 ```
 
 ## BuoyancyModels
@@ -66,17 +46,6 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.BuoyancyModels]
 Private = false
-Pages   = [
-    "BuoyancyModels/no_buoyancy.jl",
-    "BuoyancyModels/buoyancy_tracer.jl",
-    "BuoyancyModels/seawater_buoyancy.jl",
-    "BuoyancyModels/BuoyancyModels.jl",
-    "BuoyancyModels/linear_equation_of_state.jl",
-    "BuoyancyModels/nonlinear_equation_of_state.jl",
-    "BuoyancyModels/roquet_idealized_nonlinear_eos.jl",
-    "BuoyancyModels/show_buoyancy.jl",
-    "BuoyancyModels/buoyancy_utils.jl"
-]
 ```
 
 ## Coriolis
@@ -84,14 +53,6 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.Coriolis]
 Private = false
-Pages   = [
-    "Coriolis/Coriolis.jl",
-    "Coriolis/no_rotation.jl",
-    "Coriolis/f_plane.jl",
-    "Coriolis/beta_plane.jl",
-    "Coriolis/non_traditional_f_plane.jl",
-    "Coriolis/non_traditional_beta_plane.jl"
-]
 ```
 
 ## Diagnostics
@@ -99,15 +60,6 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.Diagnostics]
 Private = false
-Pages   = [
-    "Diagnostics/Diagnostics.jl",
-    "Diagnostics/diagnostics_kernels.jl",
-    "Diagnostics/average.jl",
-    "Diagnostics/time_series.jl",
-    "Diagnostics/cfl.jl",
-    "Diagnostics/field_maximum.jl",
-    "Diagnostics/nan_checker.jl"
-]
 ```
 
 ## Fields
@@ -115,14 +67,6 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.Fields]
 Private = false
-Pages   = [
-    "Fields/Fields.jl",
-    "Fields/field.jl",
-    "Fields/averaged_field.jl",
-    "Fields/set!.jl",
-    "Fields/regridding_fields.jl",
-    "Fields/show_fields.jl",
-]
 ```
 
 ## Forcings
@@ -130,14 +74,6 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.Forcings]
 Private = false
-Pages   = [
-    "Forcings/Forcings.jl",
-    "Forcings/continuous_forcing.jl",
-    "Forcings/discrete_forcing.jl",
-    "Forcings/forcing.jl",
-    "Forcings/model_forcing.jl",
-    "Forcings/relaxation.jl"
-]
 ```
 
 ## Grids
@@ -145,11 +81,13 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.Grids]
 Private = false
-Pages   = [
-    "Grids/Grids.jl",
-    "Grids/grid_utils.jl",
-    "Grids/rectilinear_grid.jl"
-]
+```
+
+## Immersed boundaries
+
+```@autodocs
+Modules = [Oceananigans.ImmersedBoundaries]
+Private = false
 ```
 
 ## Lagrangian particle tracking
@@ -157,10 +95,6 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.LagrangianParticleTracking]
 Private = false
-Pages   = [
-    "LagrangianParticleTracking/LagrangianParticleTracking.jl",
-    "LagrangianParticleTracking/advect_particles.jl"
-]
 ```
 
 ## Logger
@@ -176,9 +110,6 @@ Pages   = ["Logger.jl"]
 ```@autodocs
 Modules = [Oceananigans.Models]
 Private = false
-Pages   = [
-    "Models/Models.jl",
-]
 ```
 
 ### Non-hydrostatic models
@@ -186,9 +117,6 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.Models.NonhydrostaticModels]
 Private = false
-Pages   = [
-    "Models/NonhydrostaticModels/nonhydrostatic_model.jl",
-]
 ```
 
 ### Hydrostatic free-surface models
@@ -196,12 +124,6 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.Models.HydrostaticFreeSurfaceModels]
 Private = false
-Pages   = [
-    "Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl",
-    "Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl",
-    "Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl",
-    "Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl",
-    "Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl",
 ]
 ```
 
@@ -215,31 +137,19 @@ Pages   = [
 ]
 ```
 
+## Output readers
+
+```@autodocs
+Modules = [Oceananigans.OutputReaders]
+Private = false
+]
+```
+
 ## Output writers
 
 ```@autodocs
 Modules = [Oceananigans.OutputWriters]
 Private = false
-Pages   = [
-    "OutputWriters/OutputWriters.jl",
-    "OutputWriters/output_writer_utils.jl",
-    "OutputWriters/jld2_output_writer.jl",
-    "OutputWriters/netcdf_output_writer.jl",
-    "OutputWriters/windowed_time_average.jl",
-    "OutputWriters/checkpointer.jl"
-]
-```
-
-## Time steppers
-
-```@autodocs
-Modules = [Oceananigans.TimeSteppers]
-Private = false
-Pages   = [
-    "TimeSteppers/TimeSteppers.jl",
-    "TimeSteppers/clock.jl",
-    "TimeSteppers/quasi_adams_bashforth_2.jl",
-    "TimeSteppers/runge_kutta_3.jl
 ]
 ```
 
@@ -248,38 +158,27 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.Simulations]
 Private = false
-Pages   = [
-    "Simulations/Simulations.jl",
-    "Simulations/time_step_wizard.jl",
-    "Simulations/simulation.jl",
-    "Simulations/run.jl",
-    "Simulations/callback.jl"
-]
 ```
 
-## Tubrulence closures
+## Stokes drift
+
+```@autodocs
+Modules = [Oceananigans.StokesDrift]
+Private = false
+```
+
+## Time steppers
+
+```@autodocs
+Modules = [Oceananigans.TimeSteppers]
+Private = false
+```
+
+## Turbulence closures
 
 ```@autodocs
 Modules = [Oceananigans.TurbulenceClosures]
 Private = false
-Pages   = [
-    "TurbulenceClosures/TurbulenceClosures.jl",
-    "TurbulenceClosures/turbulence_closure_utils.jl",
-    "TurbulenceClosures/closure_operators.jl",
-    "TurbulenceClosures/viscous_dissipation_operators.jl",
-    "TurbulenceClosures/diffusion_operators.jl",
-    "TurbulenceClosures/velocity_tracer_gradients.jl",
-    "TurbulenceClosures/closure_tuples.jl",
-    "TurbulenceClosures/turbulence_closure_diagnostics.jl",
-    "TurbulenceClosures/turbulence_closure_implementations/anisotropic_biharmonic_diffusivity.jl",
-    "TurbulenceClosures/turbulence_closure_implementations/smagorinsky_lilly.jl",
-    "TurbulenceClosures/turbulence_closure_implementations/isotropic_diffusivity.jl",
-    "TurbulenceClosures/turbulence_closure_implementations/anisotropic_diffusivity.jl",
-    "TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl",
-    "TurbulenceClosures/turbulence_closure_implementations/leith_enstrophy_diffusivity.jl",
-    "TurbulenceClosures/turbulence_closure_implementations/convective_adjustment_vertical_diffusivity.jl",
-    "TurbulenceClosures/turbulence_closure_implementations/tke_based_vertical_diffusivity.jl"
-]
 ```
 
 ## Utilities
@@ -287,37 +186,4 @@ Pages   = [
 ```@autodocs
 Modules = [Oceananigans.Utils]
 Private = false
-Pages   = [
-    "Utils/Utils.jl",
-    "Utils/kernel_launcing.jl",
-    "Utils/pretty_time.jl",
-    "Utils/pretty_filesize.jl",
-    "Utils/time_step_wizard.jl",
-    "Utils/tuple_utils.jl",
-    "Utils/ordered_dict_show.jl",
-    "Utils/cell_advection_timescale.jl",
-    "Utils/output_writer_diagnostic_utils.jl",
-    "Utils/user_function_arguments.jl",
-    "Utils/with_tracers.jl",
-    "Utils/schedules.jl"
-]
-```
-
-## Abstract operations
-
-```@autodocs
-Modules = [Oceananigans, Oceananigans.AbstractOperations]
-Private = false
-Pages   = [
-    "AbstractOperations/AbstractOperations.jl",
-    "AbstractOperations/at.jl",
-    "AbstractOperations/binary_operations.jl",
-    "AbstractOperations/derivatives.jl",
-    "AbstractOperations/grid_metrics.jl",
-    "AbstractOperations/grid_validation.jl",
-    "AbstractOperations/kernel_function_operaton.jl",
-    "AbstractOperations/multiary_operations.jl",
-    "AbstractOperations/show_abstract_operations.jl",
-    "AbstractOperations/unary_operations.jl",
-]
 ```

--- a/docs/src/appendix/library.md
+++ b/docs/src/appendix/library.md
@@ -188,6 +188,10 @@ Modules = [Oceananigans.Models.HydrostaticFreeSurfaceModels]
 Private = false
 Pages   = [
     "Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl",
+    "Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl",
+    "Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl",
+    "Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl",
+    "Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl",
 ]
 ```
 

--- a/docs/src/appendix/library.md
+++ b/docs/src/appendix/library.md
@@ -168,8 +168,35 @@ Modules = [Oceananigans.Models]
 Private = false
 Pages   = [
     "Models/Models.jl",
+]
+```
+
+### Non-hydrostatic models
+
+```@autodocs
+Modules = [Oceananigans.Models.NonhydrostaticModels]
+Private = false
+Pages   = [
     "Models/NonhydrostaticModels/nonhydrostatic_model.jl",
+]
+```
+
+### Hydrostatic free-surface models
+
+```@autodocs
+Modules = [Oceananigans.Models.HydrostaticFreeSurfaceModels]
+Private = false
+Pages   = [
     "Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl",
+]
+```
+
+### Shallow-water models
+
+```@autodocs
+Modules = [Oceananigans.Models.ShallowWaterModels]
+Private = false
+Pages   = [
     "Models/ShallowWaterModels/shallow_water_model.jl"
 ]
 ```

--- a/src/Advection/centered_fourth_order.jl
+++ b/src/Advection/centered_fourth_order.jl
@@ -2,6 +2,11 @@
 ##### Centered fourth-order advection scheme
 #####
 
+"""
+    struct CenteredFourthOrder <: AbstractCenteredAdvectionScheme{1}
+
+Centered fourth-order advection scheme.
+"""
 struct CenteredFourthOrder <: AbstractCenteredAdvectionScheme{1} end
 
 const C4 = CenteredFourthOrder

--- a/src/Advection/centered_second_order.jl
+++ b/src/Advection/centered_second_order.jl
@@ -2,6 +2,11 @@
 ##### Centered second-order advection scheme
 #####
 
+"""
+    struct CenteredSecondOrder <: AbstractAdvectionScheme{0}
+
+Centered second-order advection scheme.
+"""
 struct CenteredSecondOrder <: AbstractAdvectionScheme{0} end
 
 boundary_buffer(::CenteredSecondOrder) = 0

--- a/src/Advection/upwind_biased_fifth_order.jl
+++ b/src/Advection/upwind_biased_fifth_order.jl
@@ -2,6 +2,11 @@
 ##### Upwind-biased 3rd-order advection scheme
 #####
 
+"""
+    struct UpwindBiasedFifthOrder <: AbstractUpwindBiasedAdvectionScheme{2}
+
+Upwind-biased fifth-order advection scheme.
+"""
 struct UpwindBiasedFifthOrder <: AbstractUpwindBiasedAdvectionScheme{2} end
 
 const U5 = UpwindBiasedFifthOrder

--- a/src/Advection/upwind_biased_first_order.jl
+++ b/src/Advection/upwind_biased_first_order.jl
@@ -2,6 +2,11 @@
 ##### Upwind-biased 1rd-order advection scheme
 #####
 
+"""
+    struct UpwindBiasedFirstOrder <: AbstractUpwindBiasedAdvectionScheme{1}
+
+Upwind-biased first-order advection scheme.
+"""
 struct UpwindBiasedFirstOrder <: AbstractUpwindBiasedAdvectionScheme{1} end
 
 const U1 = UpwindBiasedFirstOrder

--- a/src/Advection/upwind_biased_third_order.jl
+++ b/src/Advection/upwind_biased_third_order.jl
@@ -2,6 +2,11 @@
 ##### Upwind-biased 3rd-order advection scheme
 #####
 
+"""
+    struct UpwindBiasedThirdOrder <: AbstractUpwindBiasedAdvectionScheme{1}
+
+Upwind-biased third-order advection scheme.
+"""
 struct UpwindBiasedThirdOrder <: AbstractUpwindBiasedAdvectionScheme{1} end
 
 const U3 = UpwindBiasedThirdOrder

--- a/src/Advection/weno_fifth_order.jl
+++ b/src/Advection/weno_fifth_order.jl
@@ -76,11 +76,7 @@ Keyword arguments
 Not providing any keyword argument, `WENO5()` defaults to the uniform 5th-order coefficients ("uniform
 setting) in all directions, using a JS-WENO formulation.
 
-```@meta
-DocTestFilters = [Regex(".*┌ Warning.*\n"), Regex(".*└ @ Oceananigans.*\n")]
-```
-
-```jldoctest
+```jldoctest; filter = [Regex(".*┌ Warning.*\n"), Regex(".*└ @ Oceananigans.*\n")]
 julia> using Oceananigans
 
 julia> WENO5()

--- a/src/Advection/weno_fifth_order.jl
+++ b/src/Advection/weno_fifth_order.jl
@@ -76,7 +76,11 @@ Keyword arguments
 Not providing any keyword argument, `WENO5()` defaults to the uniform 5th-order coefficients ("uniform
 setting) in all directions, using a JS-WENO formulation.
 
-```jldoctest; filter = [Regex(".*┌ Warning.*\n"), Regex(".*└ @ Oceananigans.*\n")]
+```@meta
+DocTestFilters = [Regex(".*┌ Warning.*\n"), Regex(".*└ @ Oceananigans.*\n")]
+```
+
+```jldoctest
 julia> using Oceananigans
 
 julia> WENO5()
@@ -86,6 +90,10 @@ WENO5 advection scheme with:
     ├── X regular
     ├── Y regular
     └── Z regular
+```
+
+```@meta
+DocTestFilters = nothing
 ```
 
 `WENO5(grid = grid)` defaults to uniform interpolation coefficient for each of the grid directions that

--- a/src/Advection/weno_fifth_order.jl
+++ b/src/Advection/weno_fifth_order.jl
@@ -76,7 +76,11 @@ Keyword arguments
 Not providing any keyword argument, `WENO5()` defaults to the uniform 5th-order coefficients ("uniform
 setting) in all directions, using a JS-WENO formulation.
 
-```@example
+```@meta
+DocTestFilters = [Regex(".*┌ Warning.*\n"), Regex(".*└ @ Oceananigans.*\n")]
+```
+
+```jldoctest
 julia> using Oceananigans
 
 julia> WENO5()
@@ -105,32 +109,36 @@ WENO5 advection scheme with:
     └── Z stretched
 ```
 
-`WENO5(grid = grid, stretched_smoothness = true)` behaves similarly to `WENO5(grid = grid)` but, additionally,
-it also computes the smoothness indicators coefficients, ``β₀``, ``β₁``, and ``β₂``, taking into account
-the stretched dimensions.
+`WENO5(grid = grid, stretched_smoothness = true)` behaves similarly to `WENO5(grid = grid)` but,
+additionally, it also computes the smoothness indicators coefficients, ``β₀``, ``β₁``, and ``β₂``,
+taking into account the stretched dimensions.
 
 `WENO5(zweno = true)` implements a Z-WENO formulation for the WENO weights calculation
 
 Comments
 ========
 
-All methods have the roughly the same execution speed except for `stretched_smoothness = true` which requires more memory and
-is less computationally efficeint, especially on GPUs. In addition, it has not been found to be much impactful on the tested cases.
-As such, most of the times we urge users to use `WENO5(grid = grid)`, as this increases accuracy on a stretched mesh  but does decreases
+All methods have the roughly the same execution speed except for `stretched_smoothness = true` that
+requires more memory and is less computationally efficient, especially on GPUs. In addition, it has
+not been found to be much impactful on the tested cases. As such, most of the times we urge users
+to use `WENO5(grid = grid)`, as this increases accuracy on a stretched mesh  but does decreases
 memory utilization (and also results in a slight speed-up).
 
 (The above claims were made after some preliminary tests. Thus, we still users to perform some
 benchmarks/checks before performing, e.g., a large simulation on a "weirdly" stretched grid.)
 
-On the other hand, a Z-WENO formulation is *most of the times* beneficial (also in case of a uniform mesh) with roughly the 
-same performances (just a slight slow/down). The same can be said for the stretched `WENO5(grid = grid)` formulation in case of
-stretched grids.
+On the other hand, a Z-WENO formulation is *most of the times* beneficial (also in case of a uniform
+mesh) with roughly the same performances (just a slight slowdown). The same can be said for the
+stretched `WENO5(grid = grid)` formulation in case of stretched grids.
 
 References
 ==========
 
-- Shu, Essentially Non-Oscillatory and Weighted Essentially Non-Oscillatory Schemes for Hyperbolic Conservation Laws, 1997, NASA/CR-97-206253, ICASE Report No. 97-65
-- Castro et al, High order weighted essentially non-oscillatory WENO-Z schemes for hyperbolic conservation laws, 2011, Journal of Computational Physics 230(5):1766-1792
+Shu, Essentially Non-Oscillatory and Weighted Essentially Non-Oscillatory Schemes for Hyperbolic
+    Conservation Laws, 1997, NASA/CR-97-206253, ICASE Report No. 97-65
+
+Castro et al, High order weighted essentially non-oscillatory WENO-Z schemes for hyperbolic conservation
+    laws, 2011, Journal of Computational Physics, 230(5), 1766-1792
 """
 function WENO5(FT = Float64; grid = nothing, stretched_smoothness = false, zweno = false)
     
@@ -265,7 +273,7 @@ Adapt.adapt_structure(to, scheme::WENO5{FT, XT, YT, ZT, XS, YS, ZS, W}) where {F
 
 #####
 ##### Stretched smoothness indicators gathered from precomputed values.
-##### the stretched values for β coefficients is calculated from 
+##### The stretched values for β coefficients are calculated from 
 ##### Shu, NASA/CR-97-206253, ICASE Report No. 97-65
 ##### by hardcoding that p(x) is a 2nd order polynomial
 #####

--- a/src/BoundaryConditions/boundary_condition_classifications.jl
+++ b/src/BoundaryConditions/boundary_condition_classifications.jl
@@ -6,7 +6,7 @@ Abstract supertype for boundary condition types.
 abstract type AbstractBoundaryConditionClassification end
 
 """
-    Periodic
+    struct Periodic <: AbstractBoundaryConditionClassification
 
 A classification specifying a periodic boundary condition.
 
@@ -15,13 +15,13 @@ A condition may not be specified with a `Periodic` boundary condition.
 struct Periodic <: AbstractBoundaryConditionClassification end
 
 """
-    Flux
+    struct Flux <: AbstractBoundaryConditionClassification
 
 A classification specifying a boundary condition on the flux of a field.
 
 The sign convention is such that a positive flux represents the flux of a quantity in the
 positive direction. For example, a positive vertical flux implies a quantity is fluxed
-upwards, in the +z direction.
+upwards, in the ``+z`` direction.
 
 Due to this convention, a positive flux applied to the top boundary specifies that a quantity
 is fluxed upwards across the top boundary and thus out of the domain. As a result, a positive
@@ -34,7 +34,7 @@ west, north, and south boundaries.
 struct Flux <: AbstractBoundaryConditionClassification end
 
 """
-    Gradient
+    struct Gradient <: AbstractBoundaryConditionClassification
 
 A classification specifying a boundary condition on the derivative or gradient of a field. Also
 called a Neumann boundary condition.
@@ -42,7 +42,7 @@ called a Neumann boundary condition.
 struct Gradient <: AbstractBoundaryConditionClassification end
 
 """
-    Value
+    struct Value <: AbstractBoundaryConditionClassification
 
 A classification specifying a boundary condition on the value of a field. Also called a Dirchlet
 boundary condition.
@@ -50,7 +50,7 @@ boundary condition.
 struct Value <: AbstractBoundaryConditionClassification end
 
 """
-    Open
+    struct Open <: AbstractBoundaryConditionClassification
 
 A classification that specifies the halo regions of a field directly.
 

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -35,25 +35,28 @@ end
 """
     FieldBoundaryConditions(; kwargs...)
 
-Returns a template for boundary conditions on prognostic fields.
+Return a template for boundary conditions on prognostic fields.
+
+Keyword arguments
+=================
 
 Keyword arguments specify boundary conditions on the 7 possible boundaries:
 
-    * `west`, left end point in the `x`-direction where `i=1`
-    * `east`, right end point in the `x`-direction where `i=grid.Nx`
-    * `south`, left end point in the `y`-direction where `j=1`
-    * `north`, right end point in the `y`-direction where `j=grid.Ny`
-    * `bottom`, right end point in the `z`-direction where `k=1`
-    * `top`, right end point in the `z`-direction where `k=grid.Nz`
-    * `immersed`, boundary between solid and fluid for immersed boundaries (experimental support only)
+  - `west`, left end point in the `x`-direction where `i=1`
+  - `east`, right end point in the `x`-direction where `i=grid.Nx`
+  - `south`, left end point in the `y`-direction where `j=1`
+  - `north`, right end point in the `y`-direction where `j=grid.Ny`
+  - `bottom`, right end point in the `z`-direction where `k=1`
+  - `top`, right end point in the `z`-direction where `k=grid.Nz`
+  - `immersed`, boundary between solid and fluid for immersed boundaries (experimental support only)
 
 If a boundary condition is unspecified, the default for prognostic fields
 and the topology in the boundary-normal direction is used:
 
-    * `PeriodicBoundaryCondition` for `Periodic` directions
-    * `NoFluxBoundaryCondition` for `Bounded` directions and `Centered`-located fields
-    * `ImpenetrableBoundaryCondition` for `Bounded` directions and `Face`-located fields
-    * `nothing` for `Flat` directions and/or `Nothing`-located fields
+  - `PeriodicBoundaryCondition` for `Periodic` directions
+  - `NoFluxBoundaryCondition` for `Bounded` directions and `Centered`-located fields
+  - `ImpenetrableBoundaryCondition` for `Bounded` directions and `Face`-located fields
+  - `nothing` for `Flat` directions and/or `Nothing`-located fields
 """
 function FieldBoundaryConditions(;     west = DefaultPrognosticFieldBoundaryCondition(),
                                        east = DefaultPrognosticFieldBoundaryCondition(),
@@ -69,26 +72,28 @@ end
 """
     FieldBoundaryConditions(grid, location; kwargs...)
 
-Returns boundary conditions for auxiliary fields (fields
-whose values are derived from a model's prognostic fields) on `grid`
-and at `location`.
+Return boundary conditions for auxiliary fields (fields whose values are
+derived from a model's prognostic fields) on `grid` and at `location`.
+
+Keyword arguments
+=================
 
 Keyword arguments specify boundary conditions on the 6 possible boundaries:
 
-    * `west`, left end point in the `x`-direction where `i=1`
-    * `east`, right end point in the `x`-direction where `i=grid.Nx`
-    * `south`, left end point in the `y`-direction where `j=1`
-    * `north`, right end point in the `y`-direction where `j=grid.Ny`
-    * `bottom`, right end point in the `z`-direction where `k=1`
-    * `top`, right end point in the `z`-direction where `k=grid.Nz`
+  - `west`, left end point in the `x`-direction where `i=1`
+  - `east`, right end point in the `x`-direction where `i=grid.Nx`
+  - `south`, left end point in the `y`-direction where `j=1`
+  - `north`, right end point in the `y`-direction where `j=grid.Ny`
+  - `bottom`, right end point in the `z`-direction where `k=1`
+  - `top`, right end point in the `z`-direction where `k=grid.Nz`
 
 If a boundary condition is unspecified, the default for auxiliary fields
 and the topology in the boundary-normal direction is used:
 
-    * `PeriodicBoundaryCondition` for `Periodic` directions
-    * `GradientBoundaryCondition(0)` for `Bounded` directions and `Centered`-located fields
-    * `nothing` for `Bounded` directions and `Face`-located fields
-    * `nothing` for `Flat` directions and/or `Nothing`-located fields)
+  - `PeriodicBoundaryCondition` for `Periodic` directions
+  - `GradientBoundaryCondition(0)` for `Bounded` directions and `Centered`-located fields
+  - `nothing` for `Bounded` directions and `Face`-located fields
+  - `nothing` for `Flat` directions and/or `Nothing`-located fields)
 """
 function FieldBoundaryConditions(grid, loc;
                                    west = default_auxiliary_field_boundary_condition(topology(grid, 1)(), loc[1]()),
@@ -115,8 +120,11 @@ regularize_boundary_condition(bc, args...) = bc # fallback
 Compute default boundary conditions and attach field locations to ContinuousBoundaryFunction
 boundary conditions for prognostic model field boundary conditions.
 
-Note: don't regularize immersed boundary conditions: we don't support ContinuousBoundaryFunction
-for immersed boundary conditions.
+!!! warn "No support for `ContinuousBoundaryFunction` for immersed boundary conditions"
+    Do not regularize immersed boundary conditions.
+
+    Currently, there is no support `ContinuousBoundaryFunction` for immersed boundary
+    conditions.
 """
 function regularize_field_boundary_conditions(bcs::FieldBoundaryConditions, grid, field_name, prognostic_field_names=nothing)
 

--- a/src/Fields/computed_field.jl
+++ b/src/Fields/computed_field.jl
@@ -35,7 +35,7 @@ end
     ComputedField(operand [, arch=nothing]; data = nothing, recompute_safely = true,
                   boundary_conditions = ComputedFieldBoundaryConditions(operand.grid, location(operand))
 
-Returns a field whose data is `computed` from `operand`. If `arch`itecture is not supplied it
+Return a field whose data is `computed` from `operand`. If `arch`itecture is not supplied it
 is inferred from `operand`.
 
 If the keyword argument `data` is not provided, memory is allocated to store

--- a/src/Forcings/continuous_forcing.jl
+++ b/src/Forcings/continuous_forcing.jl
@@ -54,7 +54,9 @@ Construct a "continuous form" forcing with optional `parameters` and optional
 If neither `parameters` nor `field_dependencies` are provided, then `func` must be
 callable with the signature
 
-    `func(x, y, z, t)`
+```julia
+func(x, y, z, t)
+```
 
 where `x, y, z` are the east-west, north-south, and vertical spatial coordinates, and `t` is time.
 
@@ -62,7 +64,9 @@ If `field_dependencies` are provided, the signature of `func` must include them.
 For example, if `field_dependencies=(:u, :S)` (and `parameters` are _not_ provided), then
 `func` must be callable with the signature
 
-    `func(x, y, z, t, u, S)`
+```julia
+func(x, y, z, t, u, S)
+```
 
 where `u` is assumed to be the `u`-velocity component, and `S` is a tracer. Note that any field
 which does not have the name `u`, `v`, or `w` is assumed to be a tracer and must be present
@@ -72,12 +76,16 @@ If `parameters` are provided, then the _last_ argument to `func` must be `parame
 For example, if `func` has no `field_dependencies` but does depend on `parameters`, then
 it must be callable with the signature
 
-    `func(x, y, z, t, parameters)`
+```julia
+func(x, y, z, t, parameters)
+```
 
 With `field_dependencies=(:u, :v, :w, :c)` and `parameters`, then `func` must be
 callable with the signature
 
-    `func(x, y, z, t, u, v, w, c, parameters)`
+```julia
+func(x, y, z, t, u, v, w, c, parameters)
+```
 
 """
 ContinuousForcing(func; parameters=nothing, field_dependencies=()) =

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -78,6 +78,11 @@ import Oceananigans.TurbulenceClosures:
 
 export AbstractImmersedBoundary
 
+"""
+AbstractImmersedBoundary
+
+Abstract supertype for immersed boundary grids.
+"""
 abstract type AbstractImmersedBoundary end
 
 struct ImmersedBoundaryGrid{FT, TX, TY, TZ, G, I} <: AbstractGrid{FT, TX, TY, TZ}

--- a/src/Models/HydrostaticFreeSurfaceModels/compute_vertically_integrated_volume_flux.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/compute_vertically_integrated_volume_flux.jl
@@ -1,9 +1,10 @@
 """
-Compute the vertical integrated volume flux from the bottom to z=0 (i.e. linear free-surface)
+Compute the vertical integrated volume flux from the bottom to ``z=0`` (i.e., linear free-surface).
 
 ```
-U★ = ∫ᶻ Ax * u★ dz`
-V★ = ∫ᶻ Ay * v★ dz`
+U★ = ∫ᶻ Ax * u★ dz
+V★ = ∫ᶻ Ay * v★ dz
+```
 """
 ### Note - what we really want is RHS = divergence of the vertically integrated volume flux
 ###        we can optimize this a bit later to do this all in one go to save using intermediate variables.

--- a/src/Models/HydrostaticFreeSurfaceModels/compute_w_from_continuity.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/compute_w_from_continuity.jl
@@ -2,9 +2,11 @@ using Oceananigans.Architectures: device, device_event
 using Oceananigans.Operators: div_xyᶜᶜᵃ, Δzᵃᵃᶜ
 
 """
-Compute the vertical velocity w by integrating the continuity equation from the bottom upwards
+Compute the vertical velocity ``w`` by integrating the continuity equation from the bottom upwards:
 
-    `w^{n+1} = -∫ [∂/∂x (u^{n+1}) + ∂/∂y (v^{n+1})] dz`
+```
+w^{n+1} = -∫ [∂/∂x (u^{n+1}) + ∂/∂y (v^{n+1})] dz
+```
 """
 compute_w_from_continuity!(model) = compute_w_from_continuity!(model.velocities, model.architecture, model.grid)
 

--- a/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
@@ -21,12 +21,12 @@ end
 Return a solver based on the fast Fourier transform for the elliptic equation
     
 ```math
-[∇² - Az / (g H Δt²)] ηⁿ⁺¹ = (∇ʰ ⋅ Q★ - Az ηⁿ / Δt) / (g H Δt)
+[∇² - Az / (g H Δt²)] ηⁿ⁺¹ = (∇ʰ ⋅ Q★ - Az ηⁿ / Δt) / (g H Δt) ,
 ```
 
 representing an implicit time discretization of the linear free surface evolution equation
 for a fluid with constant depth `H`, horizontal areas `Az`, barotropic volume flux `Q★`, time
-step `Δt`, gravitational acceleration `g`, and free surface at time-step `n` `ηⁿ`.
+step `Δt`, gravitational acceleration `g`, and free surface at time-step `n`, `ηⁿ`.
 """
 function FFTImplicitFreeSurfaceSolver(arch, grid, settings)
 

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -72,17 +72,17 @@ Construct an hydrostatic `Oceananigans.jl` model with a free surface on `grid`.
 Keyword arguments
 =================
 
-    - `grid`: (required) The resolution and discrete geometry on which `model` is solved.
-    - `architecture`: `CPU()` or `GPU()`. The computer architecture used to time-step `model`.
-    - `gravitational_acceleration`: The gravitational acceleration applied to the free surface
-    - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
-    - `buoyancy`: The buoyancy model. See `Oceananigans.BuoyancyModels`.
-    - `closure`: The turbulence closure for `model`. See `Oceananigans.TurbulenceClosures`.
-    - `coriolis`: Parameters for the background rotation rate of the model.
-    - `forcing`: `NamedTuple` of user-defined forcing functions that contribute to solution tendencies.
-    - `boundary_conditions`: `NamedTuple` containing field boundary conditions.
-    - `tracers`: A tuple of symbols defining the names of the modeled tracers, or a `NamedTuple` of
-                 preallocated `CenterField`s.
+  - `grid`: (required) The resolution and discrete geometry on which `model` is solved.
+  - `architecture`: `CPU()` or `GPU()`. The computer architecture used to time-step `model`.
+  - `gravitational_acceleration`: The gravitational acceleration applied to the free surface
+  - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
+  - `buoyancy`: The buoyancy model. See `Oceananigans.BuoyancyModels`.
+  - `closure`: The turbulence closure for `model`. See `Oceananigans.TurbulenceClosures`.
+  - `coriolis`: Parameters for the background rotation rate of the model.
+  - `forcing`: `NamedTuple` of user-defined forcing functions that contribute to solution tendencies.
+  - `boundary_conditions`: `NamedTuple` containing field boundary conditions.
+  - `tracers`: A tuple of symbols defining the names of the modeled tracers, or a `NamedTuple` of
+               preallocated `CenterField`s.
 """
 function HydrostaticFreeSurfaceModel(; grid,
                 architecture::AbstractArchitecture = CPU(),

--- a/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
@@ -19,26 +19,27 @@ struct ImplicitFreeSurface{E, G, B, I, M, S}
 end
 
 """
-    ImplicitFreeSurface(; solver=:PreconditionedConjugateGradient, gravitational_acceleration=g_Earth, solver_settings...) =
+    ImplicitFreeSurface(; solver_method=:Default, gravitational_acceleration=g_Earth, solver_settings...)
 
 The implicit free surface equation is
 
 ```math
-(∇ʰ ⋅ H ∇ʰ - 1 / (g Δt²)) ηⁿ⁺¹ = ∇ʰ ⋅ Q★ / (g Δt) - ηⁿ / (g Δt²)
+(∇ʰ ⋅ H ∇ʰ - 1 / (g Δt²)) ηⁿ⁺¹ = ∇ʰ ⋅ Q★ / (g Δt) - ηⁿ / (g Δt²) ,
 ```
 
 where ``H`` is depth, ``g`` is gravitational acceleration, ``Δt`` is time step, and
 ``Q★`` is the barotropic volume flux associated with the predictor velocity field.
 
-This can be solved in general using the `PreconditionedConjugateGradientSolver`.
+This equation be solved in general using the `PreconditionedConjugateGradientSolver`.
 
 In the case that ``H`` is constant, we divide through to obtain
 
 ```math
-(∇² - 1 / (g H Δt²)) ηⁿ⁺¹ = 1 / (g H Δt) * (∇ʰ ⋅ Q★ - ηⁿ / Δt)
+(∇² - 1 / (g H Δt²)) ηⁿ⁺¹ = 1 / (g H Δt) * (∇ʰ ⋅ Q★ - ηⁿ / Δt) ,
 ```
 
-The above can be solved with the `FastFourierTransformPoissonSolver` on grids with regular spacing in x and y.
+The above can be solved with the `FFTImplicitFreeSurfaceSolver` on grids with regular spacing
+in ``x`` and ``y``.
 """
 ImplicitFreeSurface(; solver_method=:Default, gravitational_acceleration=g_Earth, solver_settings...) =
     ImplicitFreeSurface(nothing, gravitational_acceleration, nothing, nothing, solver_method, solver_settings)

--- a/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
+++ b/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
@@ -1,5 +1,7 @@
 module NonhydrostaticModels
 
+export NonhydrostaticModel
+
 using KernelAbstractions: @index, @kernel, Event, MultiEvent
 using KernelAbstractions.Extras.LoopInfo: @unroll
 

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -73,18 +73,18 @@ when `buoyancy != nothing`. By default, all Bounded directions are rigid and imp
 Keyword arguments
 =================
 
-    - `grid`: (required) The resolution and discrete geometry on which `model` is solved.
-    - `architecture`: `CPU()` or `GPU()`. The computer architecture used to time-step `model`.
-    - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
-    - `buoyancy`: The buoyancy model. See `Oceananigans.BuoyancyModels`.
-    - `closure`: The turbulence closure for `model`. See `Oceananigans.TurbulenceClosures`.
-    - `coriolis`: Parameters for the background rotation rate of the model.
-    - `forcing`: `NamedTuple` of user-defined forcing functions that contribute to solution tendencies.
-    - `boundary_conditions`: `NamedTuple` containing field boundary conditions.
-    - `tracers`: A tuple of symbols defining the names of the modeled tracers, or a `NamedTuple` of
-                 preallocated `CenterField`s.
-    - `timestepper`: A symbol that specifies the time-stepping method. Either `:QuasiAdamsBashforth2` or
-                     `:RungeKutta3`.
+  - `grid`: (required) The resolution and discrete geometry on which `model` is solved.
+  - `architecture`: `CPU()` or `GPU()`. The computer architecture used to time-step `model`.
+  - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
+  - `buoyancy`: The buoyancy model. See `Oceananigans.BuoyancyModels`.
+  - `closure`: The turbulence closure for `model`. See `Oceananigans.TurbulenceClosures`.
+  - `coriolis`: Parameters for the background rotation rate of the model.
+  - `forcing`: `NamedTuple` of user-defined forcing functions that contribute to solution tendencies.
+  - `boundary_conditions`: `NamedTuple` containing field boundary conditions.
+  - `tracers`: A tuple of symbols defining the names of the modeled tracers, or a `NamedTuple` of
+               preallocated `CenterField`s.
+  - `timestepper`: A symbol that specifies the time-stepping method. Either `:QuasiAdamsBashforth2` or
+                   `:RungeKutta3`.
 """
 function NonhydrostaticModel(;    grid,
     architecture::AbstractArchitecture = CPU(),

--- a/src/Models/ShallowWaterModels/ShallowWaterModels.jl
+++ b/src/Models/ShallowWaterModels/ShallowWaterModels.jl
@@ -1,5 +1,7 @@
 module ShallowWaterModels
 
+export ShallowWaterModel
+
 using KernelAbstractions: @index, @kernel, Event, MultiEvent
 using KernelAbstractions.Extras.LoopInfo: @unroll
 

--- a/src/Models/ShallowWaterModels/shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_model.jl
@@ -68,21 +68,21 @@ Construct a shallow water `Oceananigans.jl` model on `grid` with `gravitational_
 Keyword arguments
 =================
 
-    - `grid`: (required) The resolution and discrete geometry on which `model` is solved.
-    - `gravitational_acceleration`: (required) The gravitational accelaration constant.
-    - `architecture`: `CPU()` or `GPU()`. The computer architecture used to time-step `model`.
-    - `clock`: The `clock` for the model
-    - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
-    - `coriolis`: Parameters for the background rotation rate of the model.
-    - `forcing`: `NamedTuple` of user-defined forcing functions that contribute to solution tendencies.
-    - `bathymetry`: The bottom bathymetry.
-    - `tracers`: A tuple of symbols defining the names of the modeled tracers, or a `NamedTuple` of
-                 preallocated `CenterField`s.
-    - `diffusivity_fields`: Stores diffusivity fields when the closures require a diffusivity to be
-                            calculated at each timestep.
-    - `boundary_conditions`: `NamedTuple` containing field boundary conditions.
-    - `timestepper`: A symbol that specifies the time-stepping method. Either `:QuasiAdamsBashforth2`,
-                     `:RungeKutta3`.
+  - `grid`: (required) The resolution and discrete geometry on which `model` is solved.
+  - `gravitational_acceleration`: (required) The gravitational accelaration constant.
+  - `architecture`: `CPU()` or `GPU()`. The computer architecture used to time-step `model`.
+  - `clock`: The `clock` for the model
+  - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
+  - `coriolis`: Parameters for the background rotation rate of the model.
+  - `forcing`: `NamedTuple` of user-defined forcing functions that contribute to solution tendencies.
+  - `bathymetry`: The bottom bathymetry.
+  - `tracers`: A tuple of symbols defining the names of the modeled tracers, or a `NamedTuple` of
+               preallocated `CenterField`s.
+  - `diffusivity_fields`: Stores diffusivity fields when the closures require a diffusivity to be
+                          calculated at each timestep.
+  - `boundary_conditions`: `NamedTuple` containing field boundary conditions.
+  - `timestepper`: A symbol that specifies the time-stepping method. Either `:QuasiAdamsBashforth2`,
+                   `:RungeKutta3`.
 """
 function ShallowWaterModel(;
                            grid,

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -1,9 +1,6 @@
 """
 Main module for `Oceananigans.jl` -- a Julia software for fast, friendly, flexible,
-data-driven, ocean-flavored fluid dynamics on CPUs and GPUs."
- 
-# Exports
-$(EXPORTS)
+data-driven, ocean-flavored fluid dynamics on CPUs and GPUs.
 """
 module Oceananigans
 
@@ -47,7 +44,7 @@ export
 
     # BuoyancyModels and equations of state
     Buoyancy, BuoyancyTracer, SeawaterBuoyancy,
-    LinearEquationOfState, RoquetIdealizedNonlinearEquationOfState, TEOS10,
+    LinearEquationOfState, TEOS10,
     BuoyancyField,
 
     # Surface wave Stokes drift via Craik-Leibovich equations

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -1,3 +1,10 @@
+"""
+Main module for `Oceananigans.jl` -- a Julia software for fast, friendly, flexible,
+data-driven, ocean-flavored fluid dynamics on CPUs and GPUs."
+ 
+# Exports
+$(EXPORTS)
+"""
 module Oceananigans
 
 if VERSION < v"1.6"
@@ -101,6 +108,7 @@ using LinearAlgebra
 
 using CUDA
 using Adapt
+using DocStringExtensions
 using OffsetArrays
 using FFTW
 using JLD2

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -11,9 +11,9 @@ On the staggered grid, there are 7 cells additional to the "reference cell"
 that are staggered with respect to the reference cell in x, y, and/or z.
 
 The staggering is denoted by the locations "Center" and "Face":
-    - "Center" is shared with the reference cell;
-    - "Face" lies between reference cell centers, roughly at the interface between
-      reference cells.
+  - "Center" is shared with the reference cell;
+  - "Face" lies between reference cell centers, roughly at the interface between
+    reference cells.
 
 The three-dimensional location of an object is defined by a 3-tuple of locations, and
 denoted by a triplet of superscripts. For example, an object `φ` whose cell is located at

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -56,53 +56,53 @@ functions, or callable objects.
 Keyword arguments
 =================
 
-    ## Filenaming
+  ## Filenaming
 
-    - `prefix` (required): Descriptive filename prefixed to all output files.
+  - `prefix` (required): Descriptive filename prefixed to all output files.
 
-    - `dir`: Directory to save output to.
-             Default: "." (current working directory).
+  - `dir`: Directory to save output to.
+           Default: "." (current working directory).
 
-    ## Output frequency and time-averaging
+  ## Output frequency and time-averaging
 
-    - `schedule` (required): `AbstractSchedule` that determines when output is saved.
+  - `schedule` (required): `AbstractSchedule` that determines when output is saved.
 
-    ## Slicing and type conversion prior to output
+  ## Slicing and type conversion prior to output
 
-    - `field_slicer`: An object for slicing field output in ``(x, y, z)``, including omitting halos.
-                      Has no effect on output that is not a field. `field_slicer = nothing` means
-                      no slicing occurs, so that all field data, including halo regions, is saved.
-                      Default: FieldSlicer(), which slices halo regions.
+  - `field_slicer`: An object for slicing field output in ``(x, y, z)``, including omitting halos.
+                    Has no effect on output that is not a field. `field_slicer = nothing` means
+                    no slicing occurs, so that all field data, including halo regions, is saved.
+                    Default: `FieldSlicer()`, which slices halo regions.
 
-    - `array_type`: The array type to which output arrays are converted to prior to saving.
-                    Default: Array{Float32}.
+  - `array_type`: The array type to which output arrays are converted to prior to saving.
+                  Default: `Array{Float32}`.
 
-    ## File management
+  ## File management
 
-    - `max_filesize`: The writer will stop writing to the output file once the file size exceeds `max_filesize`,
-                      and write to a new one with a consistent naming scheme ending in `part1`, `part2`, etc.
-                      Defaults to `Inf`.
+  - `max_filesize`: The writer will stop writing to the output file once the file size exceeds `max_filesize`,
+                    and write to a new one with a consistent naming scheme ending in `part1`, `part2`, etc.
+                    Defaults to `Inf`.
 
-    - `force`: Remove existing files if their filenames conflict.
+  - `force`: Remove existing files if their filenames conflict.
+             Default: `false`.
+
+  ## Output file metadata management
+
+  - `init`: A function of the form `init(file, model)` that runs when a JLD2 output file is initialized.
+            Default: `noinit(args...) = nothing`.
+
+  - `including`: List of model properties to save with every file.
+                 Default: `[:grid, :coriolis, :buoyancy, :closure]`
+
+  ## Miscellaneous keywords
+
+  - `verbose`: Log what the output writer is doing with statistics on compute/write times and file sizes.
                Default: `false`.
 
-    ## Output file metadata management
+  - `part`: The starting part number used if `max_filesize` is finite.
+            Default: 1.
 
-    - `init`: A function of the form `init(file, model)` that runs when a JLD2 output file is initialized.
-              Default: `noinit(args...) = nothing`.
-
-    - `including`: List of model properties to save with every file.
-                   Default: `[:grid, :coriolis, :buoyancy, :closure]`
-
-    ## Miscellaneous keywords
-
-    - `verbose`: Log what the output writer is doing with statistics on compute/write times and file sizes.
-                 Default: `false`.
-
-    - `part`: The starting part number used if `max_filesize` is finite.
-              Default: 1.
-
-    - `jld2_kw`: Dict of kwargs to be passed to `jldopen` when data is written.
+  - `jld2_kw`: Dict of kwargs to be passed to `jldopen` when data is written.
 
 Example
 =======

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -73,13 +73,13 @@ leaving all other model properties unchanged.
 
 Possible values for `pickup` are:
 
-    * `pickup=true` picks a simulation up from the latest checkpoint associated with
-      the `Checkpointer` in `simulation.output_writers`.
+  * `pickup=true` picks a simulation up from the latest checkpoint associated with
+    the `Checkpointer` in `simulation.output_writers`.
 
-    * `pickup=iteration::Int` picks a simulation up from the checkpointed file associated
-       with `iteration` and the `Checkpointer` in `simulation.output_writers`.
+  * `pickup=iteration::Int` picks a simulation up from the checkpointed file associated
+     with `iteration` and the `Checkpointer` in `simulation.output_writers`.
 
-    * `pickup=filepath::String` picks a simulation up from checkpointer data in `filepath`.
+  * `pickup=filepath::String` picks a simulation up from checkpointer data in `filepath`.
 
 Note that `pickup=true` and `pickup=iteration` fails if `simulation.output_writers` contains
 more than one checkpointer.

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -53,8 +53,7 @@ end
 addzero(args...) = 0
 
 """
-    UniformStokesDrift(; ∂z_uˢ=addzero, ∂z_vˢ=addzero,
-                                    ∂t_uˢ=addzero, ∂t_vˢ=addzero)
+    UniformStokesDrift(; ∂z_uˢ=addzero, ∂z_vˢ=addzero, ∂t_uˢ=addzero, ∂t_vˢ=addzero)
 
 Construct a set of functions that describes the Stokes drift field beneath
 a uniform surface gravity wave field.

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
@@ -41,29 +41,29 @@ turbulence closure.
 
 Keyword arguments
 =================
-    - `C` : Poincaré constant for both eddy viscosity and eddy diffusivities. `C` is overridden
-            for eddy viscosity or eddy diffusivity if `Cν` or `Cκ` are set, respecitvely.
+  - `C`: Poincaré constant for both eddy viscosity and eddy diffusivities. `C` is overridden
+         for eddy viscosity or eddy diffusivity if `Cν` or `Cκ` are set, respecitvely.
 
-    - `Cν` : Poincaré constant for momentum eddy viscosity.
+  - `Cν`: Poincaré constant for momentum eddy viscosity.
 
-    - `Cκ` : Poincaré constant for tracer eddy diffusivities. If one number or function, the same
-             number or function is applied to all tracers. If a `NamedTuple`, it must possess
-             a field specifying the Poncaré constant for every tracer.
+  - `Cκ`: Poincaré constant for tracer eddy diffusivities. If one number or function, the same
+          number or function is applied to all tracers. If a `NamedTuple`, it must possess
+          a field specifying the Poncaré constant for every tracer.
 
-    - `Cb` : Buoyancy modification multiplier (`Cb = nothing` turns it off, `Cb = 1` was used by [Abkar16](@cite)).
-             *Note*: that we _do not_ subtract the horizontally-average component before computing this
-             buoyancy modification term. This implementation differs from [Abkar16](@cite)'s proposal
-             and the impact of this approximation has not been tested or validated.
+  - `Cb`: Buoyancy modification multiplier (`Cb = nothing` turns it off, `Cb = 1` was used by [Abkar16](@cite)).
+          *Note*: that we _do not_ subtract the horizontally-average component before computing this
+          buoyancy modification term. This implementation differs from [Abkar16](@cite)'s proposal
+          and the impact of this approximation has not been tested or validated.
 
-    - `ν` : Constant background viscosity for momentum.
+  - `ν`: Constant background viscosity for momentum.
 
-    - `κ` : Constant background diffusivity for tracer. If a single number, the same background
-            diffusivity is applied to all tracers. If a `NamedTuple`, it must possess a field
-            specifying a background diffusivity for every tracer.
+  - `κ`: Constant background diffusivity for tracer. If a single number, the same background
+         diffusivity is applied to all tracers. If a `NamedTuple`, it must possess a field
+         specifying a background diffusivity for every tracer.
 
-    - `time_discretization` : Either `ExplicitTimeDiscretization()` or `VerticallyImplicitTimeDiscretization()`, 
-                              which integrates the terms involving only z-derivatives in the
-                              viscous and diffusive fluxes with an implicit time discretization.
+  - `time_discretization`: Either `ExplicitTimeDiscretization()` or `VerticallyImplicitTimeDiscretization()`, 
+                           which integrates the terms involving only z-derivatives in the
+                           viscous and diffusive fluxes with an implicit time discretization.
 
 By default: `C = Cν = Cκ` = 1/12, which is appropriate for a finite-volume method employing a
 second-order advection scheme, `Cb = nothing`, which terms off the buoyancy modification term.

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
@@ -70,10 +70,10 @@ second-order advection scheme, `Cb = nothing`, which terms off the buoyancy modi
 
 `Cν` or `Cκ` may be constant numbers, or functions of `x, y, z`.
 
-Example
-=======
+Examples
+========
 
-```julia
+```jldoctest
 julia> pretty_diffusive_closure = AnisotropicMinimumDissipation(C=1/2)
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.5
@@ -81,11 +81,12 @@ AnisotropicMinimumDissipation{Float64} turbulence closure with:
                         Buoyancy modification multiplier Cb: nothing
                 Background diffusivit(ies) for tracer(s), κ: 0.0
              Background kinematic viscosity for momentum, ν: 0.0
+```
 
+```jldoctest
 julia> const Δz = 0.5; # grid resolution at surface
 
-julia> surface_enhanced_tracer_C(x, y, z) = 1/12 * (1 + exp((z + Δz/2) / 8Δz))
-surface_enhanced_tracer_C (generic function with 1 method)
+julia> surface_enhanced_tracer_C(x, y, z) = 1/12 * (1 + exp((z + Δz/2) / 8Δz));
 
 julia> fancy_closure = AnisotropicMinimumDissipation(Cκ=surface_enhanced_tracer_C)
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
@@ -94,7 +95,9 @@ AnisotropicMinimumDissipation{Float64} turbulence closure with:
                         Buoyancy modification multiplier Cb: nothing
                 Background diffusivit(ies) for tracer(s), κ: 0.0
              Background kinematic viscosity for momentum, ν: 0.0
+```
 
+```jldoctest
 julia> tracer_specific_closure = AnisotropicMinimumDissipation(Cκ=(c₁=1/12, c₂=1/6))
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.08333333333333333

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
@@ -74,6 +74,8 @@ Examples
 ========
 
 ```jldoctest
+julia> using Oceananigans
+
 julia> pretty_diffusive_closure = AnisotropicMinimumDissipation(C=1/2)
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.5
@@ -84,6 +86,8 @@ AnisotropicMinimumDissipation{Float64} turbulence closure with:
 ```
 
 ```jldoctest
+julia> using Oceananigans
+
 julia> const Δz = 0.5; # grid resolution at surface
 
 julia> surface_enhanced_tracer_C(x, y, z) = 1/12 * (1 + exp((z + Δz/2) / 8Δz));
@@ -98,6 +102,8 @@ AnisotropicMinimumDissipation{Float64} turbulence closure with:
 ```
 
 ```jldoctest
+julia> using Oceananigans
+
 julia> tracer_specific_closure = AnisotropicMinimumDissipation(Cκ=(c₁=1/12, c₂=1/6))
 AnisotropicMinimumDissipation{Float64} turbulence closure with:
            Poincaré constant for momentum eddy viscosity Cν: 0.08333333333333333

--- a/src/TurbulenceClosures/turbulence_closure_implementations/horizontally_curvilinear_anisotropic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/horizontally_curvilinear_anisotropic_diffusivity.jl
@@ -23,18 +23,18 @@ const HCAD = HorizontallyCurvilinearAnisotropicDiffusivity
 
 Returns parameters for an anisotropic diffusivity model on curvilinear grids.
 
-Keyword args
-============
+Keyword arguments
+=================
 
-    * `νh`: Horizontal viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
+  - `νh`: Horizontal viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
 
-    * `νz`: Vertical viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
+  - `νz`: Vertical viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
 
-    * `κh`: Horizontal diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
-            `NamedTuple` of diffusivities with entries for each tracer.
+  - `κh`: Horizontal diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
+          `NamedTuple` of diffusivities with entries for each tracer.
 
-    * `κz`: Vertical diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
-            `NamedTuple` of diffusivities with entries for each tracer.
+  - `κz`: Vertical diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
+          `NamedTuple` of diffusivities with entries for each tracer.
 """
 function HorizontallyCurvilinearAnisotropicDiffusivity(FT=Float64; νh=0, κh=0, νz=0, κz=0,
                                                        time_discretization = ExplicitTimeDiscretization())

--- a/src/TurbulenceClosures/turbulence_closure_implementations/leith_enstrophy_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/leith_enstrophy_diffusivity.jl
@@ -31,13 +31,13 @@ and `C` is a model constant.
 
 Keyword arguments
 =================
-    - `C`      : Model constant
-    - `C_Redi` : Coefficient for down-gradient tracer diffusivity for each tracer.
-                 Either a constant applied to every tracer, or a `NamedTuple` with fields
-                 for each tracer individually.
-    - `C_GM`   : Coefficient for down-gradient tracer diffusivity for each tracer.
-                 Either a constant applied to every tracer, or a `NamedTuple` with fields
-                 for each tracer individually.
+  - `C`: Model constant
+  - `C_Redi`: Coefficient for down-gradient tracer diffusivity for each tracer.
+              Either a constant applied to every tracer, or a `NamedTuple` with fields
+              for each tracer individually.
+  - `C_GM`: Coefficient for down-gradient tracer diffusivity for each tracer.
+            Either a constant applied to every tracer, or a `NamedTuple` with fields
+            for each tracer individually.
 
 References
 ==========
@@ -56,6 +56,7 @@ TwoDimensionalLeith(FT=Float64; C=0.3, C_Redi=1, C_GM=1) = TwoDimensionalLeith{F
 function with_tracers(tracers, closure::TwoDimensionalLeith{FT}) where FT
     C_Redi = tracer_diffusivities(tracers, closure.C_Redi)
     C_GM = tracer_diffusivities(tracers, closure.C_GM)
+    
     return TwoDimensionalLeith{FT}(closure.C, C_Redi, C_GM)
 end
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/leith_enstrophy_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/leith_enstrophy_diffusivity.jl
@@ -22,11 +22,13 @@ end
 Return a `TwoDimensionalLeith` type associated with the turbulence closure proposed by
 Leith (1965) and Fox-Kemper & Menemenlis (2008) which has an eddy viscosity of the form
 
-    `νₑ = (C * Δᶠ)³ * √(|∇h ζ|² + |∇h ∂z w|²)`
+```julia
+νₑ = (C * Δᶠ)³ * √(|∇ₕ ζ|² + |∇ₕ ∂w/∂z|²)
+```
 
 and an eddy diffusivity of the form...
 
-where `Δᶠ` is the filter width, `ζ = ∂x v - ∂y u` is the vertical vorticity,
+where `Δᶠ` is the filter width, `ζ = ∂v/∂x - ∂u/∂y` is the vertical vorticity,
 and `C` is a model constant.
 
 Keyword arguments

--- a/src/TurbulenceClosures/turbulence_closure_implementations/smagorinsky_lilly.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/smagorinsky_lilly.jl
@@ -37,18 +37,18 @@ modification to the eddy viscosity.
 
 Keyword arguments
 =================
-    - `C`  : Smagorinsky constant. Default value is 0.16 as obtained by Lilly (1966).
-    - `Cb` : Buoyancy term multipler based on Lilly (1962) (`Cb = 0` turns it off, `Cb ≠ 0` turns it on.
-             Typically, and according to the original work by Lilly (1962), `Cb=1/Pr`.)
-    - `Pr` : Turbulent Prandtl numbers for each tracer. Either a constant applied to every
-             tracer, or a `NamedTuple` with fields for each tracer individually.
-    - `ν`  : Constant background viscosity for momentum
-    - `κ`  : Constant background diffusivity for tracer. Can either be a single number
-             applied to all tracers, or `NamedTuple` of diffusivities corresponding to each
-             tracer.
-    - `time_discretization` : Either `ExplicitTimeDiscretization()` or `VerticallyImplicitTimeDiscretization()`, 
-                              which integrates the terms involving only z-derivatives in the
-                              viscous and diffusive fluxes with an implicit time discretization.
+  - `C`: Smagorinsky constant. Default value is 0.16 as obtained by Lilly (1966).
+  - `Cb`: Buoyancy term multipler based on Lilly (1962) (`Cb = 0` turns it off, `Cb ≠ 0` turns it on.
+          Typically, and according to the original work by Lilly (1962), `Cb=1/Pr`.)
+  - `Pr`: Turbulent Prandtl numbers for each tracer. Either a constant applied to every
+          tracer, or a `NamedTuple` with fields for each tracer individually.
+  - `ν`: Constant background viscosity for momentum.
+  - `κ`: Constant background diffusivity for tracer. Can either be a single number
+         applied to all tracers, or `NamedTuple` of diffusivities corresponding to each
+         tracer.
+  - `time_discretization`: Either `ExplicitTimeDiscretization()` or `VerticallyImplicitTimeDiscretization()`, 
+                           which integrates the terms involving only ``z``-derivatives in the
+                           viscous and diffusive fluxes with an implicit time discretization.
 
 References
 ==========

--- a/src/TurbulenceClosures/turbulence_closure_implementations/smagorinsky_lilly.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/smagorinsky_lilly.jl
@@ -24,11 +24,15 @@ end
 Return a `SmagorinskyLilly` type associated with the turbulence closure proposed by
 Lilly (1962) and Smagorinsky (1958, 1963), which has an eddy viscosity of the form
 
-    `νₑ = (C * Δᶠ)² * √(2Σ²) * √(1 - Cb * N² / Σ²) + ν`,
+```
+    νₑ = (C * Δᶠ)² * √(2Σ²) * √(1 - Cb * N² / Σ²) + ν,
+```
 
 and an eddy diffusivity of the form
 
-    `κₑ = (νₑ - ν) / Pr + κ`
+```
+κₑ = (νₑ - ν) / Pr + κ ,
+```
 
 where `Δᶠ` is the filter width, `Σ² = ΣᵢⱼΣᵢⱼ` is the double dot product of
 the strain tensor `Σᵢⱼ`, `Pr` is the turbulent Prandtl number, and `N²` is


### PR DESCRIPTION
This PR simplifies the Docs/Appandix/Library and also adds missing modules in it. 

Furthermore, it enhances formatting in several docstrings and converts some examples to doctests.

Closes  #2080.

For example, regarding 2 vs 4 spaces in markdown formatting,

**before this PR**

<img width="994" alt="Screen Shot 2021-11-25 at 4 03 01 pm" src="https://user-images.githubusercontent.com/7112768/143382619-b30f8312-fd64-4240-a59a-d8b3d6e50484.png">

while **after this PR**

<img width="861" alt="Screen Shot 2021-11-25 at 4 02 41 pm" src="https://user-images.githubusercontent.com/7112768/143382640-469f9d58-07cc-4a42-97f4-1c6c4bdeb43b.png">
