### PR TITLE
Stores `run_wall_time` in seconds and fixes bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.66.1"
+version = "0.66.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -134,7 +134,7 @@ function time_step!(sim::Simulation)
     end_time_step = time_ns()
 
     # Increment the wall clock
-    sim.run_wall_time += end_time_step - start_time_step
+    sim.run_wall_time += 1e-9 * (end_time_step - start_time_step)
 
     return nothing
 end

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -166,7 +166,7 @@ function stop_time_exceeded(sim)
 end
 
 function wall_time_limit_exceeded(sim)
-    if sim.run_wall_time >= sim.wall_time_limit
+    if sim.run_wall_time >= 1e9 * sim.wall_time_limit
         @info "Simulation is stopping. Simulation run time $(run_wall_time(sim)) " *
               "has hit or exceeded simulation wall time limit $(prettytime(sim.wall_time_limit))."
        sim.running = false 

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -166,7 +166,7 @@ function stop_time_exceeded(sim)
 end
 
 function wall_time_limit_exceeded(sim)
-    if sim.run_wall_time >= 1e9 * sim.wall_time_limit
+    if sim.run_wall_time >= sim.wall_time_limit
         @info "Simulation is stopping. Simulation run time $(run_wall_time(sim)) " *
               "has hit or exceeded simulation wall time limit $(prettytime(sim.wall_time_limit))."
        sim.running = false 


### PR DESCRIPTION
I believe we have a mismatch with `wall_time_limit` since `sim.run_wall_time` measures it in nanoseconds and `sim.wall_time_limit` measures it in seconds:

```julia
julia> grid = RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1));

julia> model = NonhydrostaticModel(grid=grid)
NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0) 
├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
├── tracers: (:T, :S)
├── closure: Nothing
├── buoyancy: SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}
└── coriolis: Nothing

julia> simulation = Simulation(model, Δt=1, wall_time_limit=10minute)
Simulation{typename(NonhydrostaticModel){typename(CPU), Float64}}
├── Model clock: time = 0 seconds, iteration = 0
├── Next time step: 1 second
├── Elapsed wall time: 0 seconds
├── Stop time: Inf years
├── Stop iteration : Inf
├── Wall time limit: 600.0
├── Callbacks: typename(OrderedCollections.OrderedDict) with 4 entries:
│   ├── stop_time_exceeded => typename(Callback)
│   ├── stop_iteration_exceeded => typename(Callback)
│   ├── wall_time_limit_exceeded => typename(Callback)
│   └── nan_checker => typename(Callback)
├── Output writers: typename(OrderedCollections.OrderedDict) with no entries
└── Diagnostics: typename(OrderedCollections.OrderedDict) with no entries

julia> @time run!(simulation)
[ Info: Initializing simulation...
[ Info:     ... simulation initialization complete (175.940 ms)
[ Info: Executing initial time step...
[ Info:     ... initial time step complete (21.218 seconds).
[ Info: Simulation is stopping. Simulation run time 680.309 years has hit or exceeded simulation wall time limit 10 minutes.
 63.464823 seconds (20.03 M allocations: 1.539 GiB, 0.71% gc time, 99.98% compilation time)
```

This PR fixes it (I think) by changing the comparison line, but maybe we should change `simulation.run_wall_time` to store the time in seconds for consistency? Not sure and I'm happy to hear comments. I don't think we should change `simulation.wall_time_limit` to store time in `ns` though, since that's a user-facing argument.