### PR TITLE
More docstrings

### DIFF
--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -2,7 +2,6 @@ module AbstractOperations
 
 export ∂x, ∂y, ∂z, @at, @unary, @binary, @multiary
 export KernelFunctionOperation
-export testfunction
 
 using Base: @propagate_inbounds
 

--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -8,8 +8,6 @@ using Base: @propagate_inbounds
 import Adapt
 using CUDA
 
-using DocStringExtensions
-
 using Oceananigans
 using Oceananigans.Architectures
 using Oceananigans.Grids

--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -2,11 +2,14 @@ module AbstractOperations
 
 export ∂x, ∂y, ∂z, @at, @unary, @binary, @multiary
 export KernelFunctionOperation
+export testfunction
 
 using Base: @propagate_inbounds
 
 import Adapt
 using CUDA
+
+using DocStringExtensions
 
 using Oceananigans
 using Oceananigans.Architectures
@@ -43,7 +46,7 @@ const operators = Set()
 """
     at(loc, abstract_operation)
 
-Returns `abstract_operation` relocated to `loc`ation.
+Return `abstract_operation` relocated to `loc`ation.
 """
 at(loc, f) = f # fallback
 

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -9,7 +9,7 @@ struct BinaryOperation{X, Y, Z, O, A, B, IA, IB, R, G, T} <: AbstractOperation{X
     architecture :: R
             grid :: G
 
-    """
+    @doc """
         BinaryOperation{X, Y, Z}(op, a, b, ▶a, ▶b, arch, grid)
 
     Returns an abstract representation of the binary operation `op(▶a(a), ▶b(b))`.

--- a/src/AbstractOperations/derivatives.jl
+++ b/src/AbstractOperations/derivatives.jl
@@ -8,7 +8,7 @@ struct Derivative{X, Y, Z, D, A, I, AD, R, G, T} <: AbstractOperation{X, Y, Z, R
     architecture :: R
             grid :: G
 
-    """
+    @doc """
         Derivative{X, Y, Z}(∂, arg, ▶, grid)
 
     Returns an abstract representation of the derivative `∂` on `arg`,
@@ -59,8 +59,8 @@ push!(operators, derivative_operators...)
 """
     ∂x(L::Tuple, a::AbstractField)
 
-Return an abstract representation of an x-derivative acting on `a` followed by
-interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
+Return an abstract representation of an x-derivative acting on field `a` followed
+by interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
 """
 ∂x(L::Tuple, arg::AF{X, Y, Z}) where {X, Y, Z} =
     _derivative(L, ∂x(X, Y, Z), arg, (flip(X), Y, Z), ∂x, arg.grid)
@@ -68,8 +68,10 @@ interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
 """
     ∂y(L::Tuple, a::AbstractField)
 
-Return an abstract representation of a y-derivative acting on `a` followed by
-interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
+    $(SIGNATURES)
+
+Return an abstract representation of a y-derivative acting on field `a` followed
+by interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
 """
 ∂y(L::Tuple, arg::AF{X, Y, Z}) where {X, Y, Z} =
     _derivative(L, ∂y(X, Y, Z), arg, (X, flip(Y), Z), ∂y, arg.grid)
@@ -77,8 +79,8 @@ interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
 """
     ∂z(L::Tuple, a::AbstractField)
 
-Return an abstract representation of a z-derivative acting on `a` followed by
-interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
+Return an abstract representation of a z-derivative acting on field `a` followed
+by  interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
 """
 ∂z(L::Tuple, arg::AF{X, Y, Z}) where {X, Y, Z} =
     _derivative(L, ∂z(X, Y, Z), arg, (X, Y, flip(Z)), ∂z, arg.grid)
@@ -87,20 +89,20 @@ interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
 """
     ∂x(a::AbstractField)
 
-Return an abstract representation of a x-derivative acting on `a`.
+Return an abstract representation of a x-derivative acting on field `a`.
 """
 ∂x(arg::AF{X, Y, Z}) where {X, Y, Z} = ∂x((flip(X), Y, Z), arg)
 
 """
     ∂y(a::AbstractField)
 
-Return an abstract representation of a y-derivative acting on `a`.
+Return an abstract representation of a y-derivative acting on field `a`.
 """
 ∂y(arg::AF{X, Y, Z}) where {X, Y, Z} = ∂y((X, flip(Y), Z), arg)
 """
     ∂z(a::AbstractField)
 
-Return an abstract representation of a z-derivative acting on `a`.
+Return an abstract representation of a z-derivative acting on field `a`.
 """
 ∂z(arg::AF{X, Y, Z}) where {X, Y, Z} = ∂z((X, Y, flip(Z)), arg)
 

--- a/src/AbstractOperations/derivatives.jl
+++ b/src/AbstractOperations/derivatives.jl
@@ -68,8 +68,6 @@ by interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
 """
     ∂y(L::Tuple, a::AbstractField)
 
-    $(SIGNATURES)
-
 Return an abstract representation of a y-derivative acting on field `a` followed
 by interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Center`s.
 """

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -63,9 +63,9 @@ Turn each multiary operator in the list `(op1, op2, op3...)`
 into a multiary operator on `Oceananigans.Fields` for use in `AbstractOperations`.
 
 Note that a multiary operator:
-    * is a function with two or more arguments: for example, `+(x, y, z)` is a multiary function;
-    * must be imported to be extended if part of `Base`: use `import Base: op; @multiary op`;
-    * can only be called on `Oceananigans.Field`s if the "location" is noted explicitly; see example.
+  * is a function with two or more arguments: for example, `+(x, y, z)` is a multiary function;
+  * must be imported to be extended if part of `Base`: use `import Base: op; @multiary op`;
+  * can only be called on `Oceananigans.Field`s if the "location" is noted explicitly; see example.
 
 Example
 =======

--- a/src/AbstractOperations/unary_operations.jl
+++ b/src/AbstractOperations/unary_operations.jl
@@ -7,7 +7,7 @@ struct UnaryOperation{X, Y, Z, O, A, I, R, G, T} <: AbstractOperation{X, Y, Z, R
     architecture :: R
             grid :: G
 
-    """
+    @doc """
         UnaryOperation{X, Y, Z}(op, arg, ▶, grid)
 
     Returns an abstract `UnaryOperation` representing the action of `op` on `arg`,

--- a/src/BuoyancyModels/buoyancy_field.jl
+++ b/src/BuoyancyModels/buoyancy_field.jl
@@ -19,7 +19,7 @@ struct BuoyancyField{B, S, A, D, G, T, C} <: AbstractDataField{Center, Center, C
          tracers :: C
           status :: S
 
-    """
+    @doc """
         BuoyancyField(data, grid, buoyancy, tracers)
 
     Returns a `BuoyancyField` with `data` on `grid` corresponding to

--- a/src/Fields/function_field.jl
+++ b/src/Fields/function_field.jl
@@ -5,7 +5,7 @@ struct FunctionField{X, Y, Z, C, P, F, G, T} <: AbstractField{X, Y, Z, Nothing, 
          clock :: C
     parameters :: P
 
-    """
+    @doc """
         FunctionField{X, Y, Z}(func, grid; clock=nothing, parameters=nothing) where {X, Y, Z}
 
     Returns a `FunctionField` on `grid` and at location `X, Y, Z`.
@@ -14,7 +14,7 @@ struct FunctionField{X, Y, Z, C, P, F, G, T} <: AbstractField{X, Y, Z, Nothing, 
     `func(x, y, z)`. If clock is specified, `func` must be a function with signature
     `func(x, y, z, t)`, where `t` is internally determined from `clock.time`.
 
-    A FunctionField will return the result of `func(x, y, z [, t])` at `X, Y, Z` on
+    A `FunctionField` will return the result of `func(x, y, z [, t])` at `X, Y, Z` on
     `grid` when indexed at `i, j, k`.
     """
     function FunctionField{X, Y, Z}(func::F, grid::G; clock::C=nothing, parameters::P=nothing) where {X, Y, Z, F, G, C, P}
@@ -22,7 +22,7 @@ struct FunctionField{X, Y, Z, C, P, F, G, T} <: AbstractField{X, Y, Z, Nothing, 
         return new{X, Y, Z, C, P, F, G, T}(func, grid, clock, parameters)
     end
 
-    """
+    @doc """
         FunctionField{X, Y, Z}(func::FunctionField, grid; clock) where {X, Y, Z}
 
     Adds `clock` to an existing `FunctionField` and relocates it to `(X, Y, Z)` on `grid`.

--- a/src/Fields/reduced_field.jl
+++ b/src/Fields/reduced_field.jl
@@ -53,7 +53,7 @@ struct ReducedField{X, Y, Z, A, D, G, T, N, B} <: AbstractReducedField{X, Y, Z, 
                    dims :: NTuple{N, Int}
     boundary_conditions :: B
 
-    """
+    @doc """
         ReducedField{X, Y, Z}(data, grid, dims)
 
     Returns a `ReducedField` at location `(X, Y, Z)` with `data` on `grid`

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -17,7 +17,7 @@ mutable struct Clock{T}
     iteration :: Int
         stage :: Int
 
-    """
+    @doc """
         Clock{T}(time, iteration, stage=1)
 
     Returns a `Clock` with time of type `T`, initialized to the first stage.

--- a/src/TurbulenceClosures/turbulence_closure_implementations/horizontally_curvilinear_anisotropic_biharmonic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/horizontally_curvilinear_anisotropic_biharmonic_diffusivity.jl
@@ -13,22 +13,22 @@ end
 const HCABD = HorizontallyCurvilinearAnisotropicBiharmonicDiffusivity
 
 """
-    HorizontallyCurvilinearAnisotropicBiharmonicDiffusivity([FT=Float64;] νh=0, κh=0, νz=0, κz=0)
+    HorizontallyCurvilinearAnisotropicBiharmonicDiffusivity(FT=Float64; νh=0, κh=0, νz=nothing, κz=nothing)
 
 Returns parameters for an anisotropic biharmonic diffusivity model on curvilinear grids.
 
-Keyword args
-============
+Keyword arguments
+=================
 
-    * `νh`: Horizontal viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
+  - `νh`: Horizontal viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
 
-    * `νz`: Vertical viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
+  - `νz`: Vertical viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
 
-    * `κh`: Horizontal diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
-            `NamedTuple` of diffusivities with entries for each tracer.
+  - `κh`: Horizontal diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
+          `NamedTuple` of diffusivities with entries for each tracer.
 
-    * `κz`: Vertical diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
-            `NamedTuple` of diffusivities with entries for each tracer.
+  - `κz`: Vertical diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
+          `NamedTuple` of diffusivities with entries for each tracer.
 """
 function HorizontallyCurvilinearAnisotropicBiharmonicDiffusivity(FT=Float64; νh=0, κh=0, νz=nothing, κz=nothing)
     νh = convert_diffusivity(FT, νh)


### PR DESCRIPTION
Inner constructor docstrings need to be preceded by `@doc`.