### PR TITLE
Quality-of-life improvement for grid constructors

### DIFF
--- a/src/Grids/conformal_cubed_sphere_face_grid.jl
+++ b/src/Grids/conformal_cubed_sphere_face_grid.jl
@@ -40,13 +40,17 @@ struct ConformalCubedSphereFaceGrid{FT, TX, TY, TZ, A, R, Arch} <: AbstractHoriz
        radius :: FT
 end
 
-function ConformalCubedSphereFaceGrid(arch = CPU(), FT = Float64; size, z,
+function ConformalCubedSphereFaceGrid(arch::AbstractArchitecture = CPU(),
+                                      FT::DataType = Float64;
+                                      size,
+                                      z,
                                       topology = (Bounded, Bounded, Bounded),
-                                             ξ = (-1, 1),
-                                             η = (-1, 1),
-                                        radius = R_Earth,
-                                          halo = (1, 1, 1),
+                                      ξ = (-1, 1),
+                                      η = (-1, 1),
+                                      radius = R_Earth,
+                                      halo = (1, 1, 1),
                                       rotation = nothing)
+
     TX, TY, TZ = topology
     Nξ, Nη, Nz = size
     Hx, Hy, Hz = halo
@@ -153,6 +157,10 @@ function ConformalCubedSphereFaceGrid(arch = CPU(), FT = Float64; size, z,
         Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Δyᶜᶜᵃ, Δyᶜᶠᵃ, Δyᶠᶜᵃ, Δyᶠᶠᵃ, Δz,
         Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, radius)
 end
+
+# architecture = CPU() default, assuming that a DataType positional arg
+# is specifying the floating point type.
+ConformalCubedSphereFaceGrid(FT::DataType; kwargs...) = ConformalCubedSphereFaceGrid(CPU(), FT; kwargs...)
 
 function load_and_offset_cubed_sphere_data(file, FT, arch, field_name, loc, topo, N, H)
 

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -53,15 +53,15 @@ or an array or function that specifies the faces (see VerticallyStretchedRectili
 
 """
 
-function LatitudeLongitudeGrid(architecture=CPU(),
-                               FT=Float64; 
-                               precompute_metrics=false,
+function LatitudeLongitudeGrid(architecture::AbstractArchitecture = CPU(),
+                               FT::DataType = Float64; 
+                               precompute_metrics = false,
                                size,
                                latitude,
                                longitude,
                                z,                      
-                               radius=R_Earth,
-                               halo=(1, 1, 1))
+                               radius = R_Earth,
+                               halo = (1, 1, 1))
    
     λ₁, λ₂ = get_domain_extent(longitude, size[1])
     @assert λ₁ < λ₂ && λ₂ - λ₁ ≤ 360
@@ -135,6 +135,10 @@ function LatitudeLongitudeGrid(architecture=CPU(),
             Nλ, Nφ, Nz, Hλ, Hφ, Hz, Lλ, Lφ, Lz, Δλᶠᵃᵃ, Δλᶜᵃᵃ, λᶠᵃᵃ, λᶜᵃᵃ, Δφᵃᶠᵃ, Δφᵃᶜᵃ, φᵃᶠᵃ, φᵃᶜᵃ, Δzᵃᵃᶠ, Δzᵃᵃᶜ, zᵃᵃᶠ, zᵃᵃᶜ,
             Δxᶠᶜ, Δxᶜᶠ, Δxᶠᶠ, Δxᶜᶜ, Δyᶠᶜ, Δyᶜᶠ, Azᶠᶜ, Azᶜᶠ, Azᶠᶠ, Azᶜᶜ, radius)
 end
+
+# architecture = CPU() default, assuming that a DataType positional arg
+# is specifying the floating point type.
+LatitudeLongitudeGrid(FT::DataType; kwargs...) = LatitudeLongitudeGrid(CPU(), FT; kwargs...)
 
 function domain_string(grid::LatitudeLongitudeGrid)
     λ₁, λ₂ = domain(topology(grid, 1), grid.Nx, grid.λᶠᵃᵃ)

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -289,8 +289,9 @@ function RectilinearGrid(architecture::AbstractArchitecture = CPU(),
         Nx, Ny, Nz, Hx, Hy, Hz, Lx, Ly, Lz, Δxᶠᵃᵃ, Δxᶜᵃᵃ, xᶠᵃᵃ, xᶜᵃᵃ, Δyᵃᶜᵃ, Δyᵃᶠᵃ, yᵃᶠᵃ, yᵃᶜᵃ, Δzᵃᵃᶠ, Δzᵃᵃᶜ, zᵃᵃᶠ, zᵃᵃᶜ)
 end
 
-# architecture = CPU default if only one argument is provided, and that argument is a floating point type...
-RectilinearGrid(FT::AbstractFloat; kwargs...) = RectilinearGrid(CPU(), FT; kwargs...)
+# architecture = CPU() default, assuming that a DataType positional arg
+# is specifying the floating point type.
+RectilinearGrid(FT::DataType; kwargs...) = RectilinearGrid(CPU(), FT; kwargs...)
 
 @inline x_domain(grid::RectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TX, grid.Nx, grid.xᶠᵃᵃ)
 @inline y_domain(grid::RectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TY, grid.Ny, grid.yᵃᶠᵃ)

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -39,7 +39,7 @@ const HRegRectilinearGrid = RectilinearGrid{<:Any, <:Any, <:Any, <:Any, <:Number
 const  RegRectilinearGrid = RectilinearGrid{<:Any, <:Any, <:Any, <:Any, <:Number, <:Number, <:Number}
 
 """
-    RectilinearGrid([architecture = CPU()], [FT = Float64];
+    RectilinearGrid([architecture = CPU(), FT = Float64];
                     size,
                     x = nothing,
                     y = nothing,
@@ -253,7 +253,7 @@ RectilinearGrid{Float64, Periodic, Bounded, Bounded}
                 grid in z: Stretched, with spacing min=0.6826950100338962, max=1.8309085743885056
 ```
 """
-function RectilinearGrid(architecture = CPU(),
+function RectilinearGrid(architecture::AbstractArchitecture = CPU(),
                          FT = Float64;
                          size,
                          x = nothing,
@@ -288,6 +288,9 @@ function RectilinearGrid(architecture = CPU(),
     return RectilinearGrid{FT, TX, TY, TZ, FX, FY, FZ, VX, VY, VZ, Arch}(architecture,
         Nx, Ny, Nz, Hx, Hy, Hz, Lx, Ly, Lz, Δxᶠᵃᵃ, Δxᶜᵃᵃ, xᶠᵃᵃ, xᶜᵃᵃ, Δyᵃᶜᵃ, Δyᵃᶠᵃ, yᵃᶠᵃ, yᵃᶜᵃ, Δzᵃᵃᶠ, Δzᵃᵃᶜ, zᵃᵃᶠ, zᵃᵃᶜ)
 end
+
+# architecture = CPU default if only one argument is provided, and that argument is a floating point type...
+RectilinearGrid(FT::AbstractFloat; kwargs...) = RectilinearGrid(CPU(), FT; kwargs...)
 
 @inline x_domain(grid::RectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TX, grid.Nx, grid.xᶠᵃᵃ)
 @inline y_domain(grid::RectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = domain(TY, grid.Ny, grid.yᵃᶠᵃ)
@@ -341,6 +344,7 @@ Adapt.adapt_structure(to, grid::RectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, 
         Adapt.adapt(to, grid.Δzᵃᵃᶜ),
         Adapt.adapt(to, grid.zᵃᵃᶠ),
         Adapt.adapt(to, grid.zᵃᵃᶜ))
+
 
 @inline xnode(::Center, i, grid::RectilinearGrid) = @inbounds grid.xᶜᵃᵃ[i]
 @inline xnode(::Face  , i, grid::RectilinearGrid) = @inbounds grid.xᶠᵃᵃ[i]


### PR DESCRIPTION
This PR adds a new constructor for `RectilinearGrid` that looks something like

```julia
grid = RectilinearGrid(Float64, size = (1, 1, 1), ...)
```

that defaults to `architecture = CPU()`.

This avoids the error observed on #2103. Since users _rarely_ change the floating point type, this alternative constructor probably won't be used all that much. So it's not crucial, but might help a few people.

If others (@navidcy, @simone-silvestri ?) think this is a good idea, I'll add the same for other grid constructors.

If we don't merge this PR, we should probably still validate the positional inputs to grid constructors to make sure they are valid (eg `architecture` needs to be `AbstractArchitecture`, etc).