### PR TITLE
Remove `length(::AbstractGrid)` and tidies up grid-related utility functions

### DIFF
--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -114,33 +114,6 @@ Abstract supertype for horizontally-curvilinear grids with elements of type `FT`
 abstract type AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Arch} <: AbstractCurvilinearGrid{FT, TX, TY, TZ, Arch} end
 
 
-
-"""
-    Constant Grid Definitions 
-
-"""
-
-Base.eltype(::AbstractGrid{FT}) where FT = FT
-Base.length(grid::AbstractGrid) = (grid.Lx, grid.Ly, grid.Lz)
-
-function Base.:(==)(grid1::AbstractGrid, grid2::AbstractGrid)
-    #check if grids are of the same type
-    !isa(grid2, typeof(grid1).name.wrapper) && return false
-
-    topology(grid1) !== topology(grid2) && return false
-
-    x1, y1, z1 = nodes((Face, Face, Face), grid1)
-    x2, y2, z2 = nodes((Face, Face, Face), grid2)
-
-    CUDA.@allowscalar return x1 == x2 && y1 == y2 && z1 == z2
-end
-
-halo_size(grid) = (grid.Hx, grid.Hy, grid.Hz)
-
-topology(::AbstractGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = (TX, TY, TZ)
-topology(grid, dim) = topology(grid)[dim]
-architecture(grid::AbstractGrid) = grid.architecture
-
 include("grid_utils.jl")
 include("zeros.jl")
 include("new_data.jl")

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -9,6 +9,45 @@ Base.length(::Type{Face}, ::Type{Bounded}, N) = N+1
 Base.length(::Type{Center}, topo, N) = N
 Base.length(::Type{Nothing}, topo, N) = 1
 
+"""
+    topology(grid)
+
+Return a tuple with the topology of the `grid` for each dimension.
+"""
+@inline topology(::AbstractGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} = (TX, TY, TZ)
+
+"""
+    topology(grid, dim)
+
+Return the topology of the `grid` for the `dim`-th dimension.
+"""
+@inline topology(grid, dim) = topology(grid)[dim]
+
+"""
+    architecture(grid::AbstractGrid)
+
+Return the architecture (CPU or GPU) that the `grid` lives on.
+"""
+@inline architecture(grid::AbstractGrid) = grid.architecture
+
+
+"""
+    Constant Grid Definitions 
+"""
+
+Base.eltype(::AbstractGrid{FT}) where FT = FT
+
+function Base.:(==)(grid1::AbstractGrid, grid2::AbstractGrid)
+    #check if grids are of the same type
+    !isa(grid2, typeof(grid1).name.wrapper) && return false
+
+    topology(grid1) !== topology(grid2) && return false
+
+    x1, y1, z1 = nodes((Face, Face, Face), grid1)
+    x2, y2, z2 = nodes((Face, Face, Face), grid2)
+
+    CUDA.@allowscalar return x1 == x2 && y1 == y2 && z1 == z2
+end
 
 """
     size(loc, grid)
@@ -36,6 +75,13 @@ corresponding to the number of grid points along `x, y, z`.
 @inline total_size(loc, grid) = (total_length(loc[1], topology(grid, 1), grid.Nx, grid.Hx),
                                  total_length(loc[2], topology(grid, 2), grid.Ny, grid.Hy),
                                  total_length(loc[3], topology(grid, 3), grid.Nz, grid.Hz))
+
+"""
+    halo_size(grid)
+
+Return a tuple with the size of the halo in each dimension.
+"""
+halo_size(grid) = (grid.Hx, grid.Hy, grid.Hz)
 
 """
     total_extent(topology, H, Δ, L)


### PR DESCRIPTION
Resolves #2115.