### PR TITLE
Bug fix in stretched grid!

### DIFF
--- a/src/Grids/grid_generation.jl
+++ b/src/Grids/grid_generation.jl
@@ -55,15 +55,13 @@ function generate_coordinate(FT, topology, N, H, coord, architecture)
 
     ΔC = [F[i + 1] - F[i] for i = 1:TF-1]
 
-    ΔF = OffsetArray(ΔF, -H)
-    ΔC = OffsetArray(ΔC, -H)
+    ΔF = [ΔF[1], ΔF..., ΔF[end]]
+    for i = length(ΔF):-1:2
+        ΔF[i] = ΔF[i-1]
+    end
 
-    # Seems needed to avoid out-of-bounds error in viscous dissipation
-    # operators wanting to access ΔF[N+2].
-    ΔF = OffsetArray(cat(ΔF[0], ΔF..., ΔF[N], dims=1), -H-1)
-
-    ΔF = OffsetArray(arch_array(architecture, ΔF.parent), ΔF.offsets...)
-    ΔC = OffsetArray(arch_array(architecture, ΔC.parent), ΔC.offsets...)
+    ΔC = OffsetArray(arch_array(architecture, ΔC), -H)
+    ΔF = OffsetArray(arch_array(architecture, ΔF), -H-1)
 
     F = OffsetArray(F, -H)
     C = OffsetArray(C, -H)

--- a/src/Grids/grid_generation.jl
+++ b/src/Grids/grid_generation.jl
@@ -15,11 +15,11 @@ get_coord_face(coord::Nothing, i) = 1
 get_coord_face(coord::Function, i) = coord(i)
 get_coord_face(coord::AbstractVector, i) = CUDA.@allowscalar coord[i]
 
-lower_exterior_Δcoordᶜ(topology,        Fi, Hcoord) = [Fi[end - Hcoord + i] - Fi[end - Hcoord + i - 1] for i = 1:Hcoord]
-lower_exterior_Δcoordᶜ(::Type{Bounded}, Fi, Hcoord) = [Fi[2]  - Fi[1] for i = 1:Hcoord]
+lower_exterior_Δcoordᶠ(topology,        Fi, Hcoord) = [Fi[end - Hcoord + i] - Fi[end - Hcoord + i - 1] for i = 1:Hcoord]
+lower_exterior_Δcoordᶠ(::Type{Bounded}, Fi, Hcoord) = [Fi[2]  - Fi[1] for i = 1:Hcoord]
 
-upper_exterior_Δcoordᶜ(topology,        Fi, Hcoord) = [Fi[i + 1] - Fi[i] for i = 1:Hcoord]
-upper_exterior_Δcoordᶜ(::Type{Bounded}, Fi, Hcoord) = [Fi[end]   - Fi[end - 1] for i = 1:Hcoord]
+upper_exterior_Δcoordᶠ(topology,        Fi, Hcoord) = [Fi[i + 1] - Fi[i] for i = 1:Hcoord]
+upper_exterior_Δcoordᶠ(::Type{Bounded}, Fi, Hcoord) = [Fi[end]   - Fi[end - 1] for i = 1:Hcoord]
 
 # generate a stretched coordinate passing the explicit coord faces as vector of functionL
 function generate_coordinate(FT, topology, N, H, coord, architecture)
@@ -34,34 +34,34 @@ function generate_coordinate(FT, topology, N, H, coord, architecture)
     L = interiorF[N+1] - interiorF[1]
 
     # Build halo regions
-    ΔF₋ = lower_exterior_Δcoordᶜ(topology, interiorF, H)
-    ΔF₊ = reverse(upper_exterior_Δcoordᶜ(topology, interiorF, H))
+    Δᶠ₋ = lower_exterior_Δcoordᶠ(topology, interiorF, H)
+    Δᶠ₊ = reverse(upper_exterior_Δcoordᶠ(topology, interiorF, H))
 
     c¹, cᴺ⁺¹ = interiorF[1], interiorF[N+1]
 
-    F₋ = [c¹   - sum(ΔF₋[i:H]) for i = 1:H]          # locations of faces in lower halo
-    F₊ = reverse([cᴺ⁺¹ + sum(ΔF₊[i:H]) for i = 1:H]) # locations of faces in width of top halo region
+    F₋ = [c¹   - sum(Δᶠ₋[i:H]) for i = 1:H]          # locations of faces in lower halo
+    F₊ = reverse([cᴺ⁺¹ + sum(Δᶠ₊[i:H]) for i = 1:H]) # locations of faces in width of top halo region
 
     F = vcat(F₋, interiorF, F₊)
 
     # Build cell centers, cell center spacings, and cell interface spacings
     TC = total_length(Center, topology, N, H)
      C = [ (F[i + 1] + F[i]) / 2 for i = 1:TC ]
-    ΔF = [  C[i] - C[i - 1]      for i = 2:TC ]
+    Δᶠ = [  C[i] - C[i - 1]      for i = 2:TC ]
 
     # Trim face locations for periodic domains
     TF = total_length(Face, topology, N, H)
     F  = F[1:TF]
 
-    ΔC = [F[i + 1] - F[i] for i = 1:TF-1]
+    Δᶜ = [F[i + 1] - F[i] for i = 1:TF-1]
 
-    ΔF = [ΔF[1], ΔF..., ΔF[end]]
-    for i = length(ΔF):-1:2
-        ΔF[i] = ΔF[i-1]
+    Δᶠ = [Δᶠ[1], Δᶠ..., Δᶠ[end]]
+    for i = length(Δᶠ):-1:2
+        Δᶠ[i] = Δᶠ[i-1]
     end
 
-    ΔC = OffsetArray(arch_array(architecture, ΔC), -H)
-    ΔF = OffsetArray(arch_array(architecture, ΔF), -H-1)
+    Δᶜ = OffsetArray(arch_array(architecture, Δᶜ), -H)
+    Δᶠ = OffsetArray(arch_array(architecture, Δᶠ), -H-1)
 
     F = OffsetArray(F, -H)
     C = OffsetArray(C, -H)
@@ -70,7 +70,7 @@ function generate_coordinate(FT, topology, N, H, coord, architecture)
     F = OffsetArray(arch_array(architecture, F.parent), F.offsets...)
     C = OffsetArray(arch_array(architecture, C.parent), C.offsets...)
 
-    return L, F, C, ΔF, ΔC
+    return L, F, C, Δᶠ, Δᶜ
 end
 
 # generate a regular coordinate passing the domain extent (2-tuple) and number of points
@@ -83,7 +83,7 @@ function generate_coordinate(FT, topology, N, H, coord::Tuple{<:Number, <:Number
     L = FT(c₂ - c₁)
 
     # Convert to get the correct type also when using single precision
-    ΔF = ΔC = Δ = convert(FT, L / N)
+    Δᶠ = Δᶜ = Δ = convert(FT, L / N)
 
     F₋ = c₁ - H * Δ
     F₊ = F₋ + total_extent(topology, H, Δ, L)
@@ -100,7 +100,7 @@ function generate_coordinate(FT, topology, N, H, coord::Tuple{<:Number, <:Number
     F = OffsetArray(F, -H)
     C = OffsetArray(C, -H)
         
-    return L, F, C, ΔF, ΔC
+    return L, F, C, Δᶠ, Δᶜ
 end
 
 # Flat domains

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -347,7 +347,7 @@ function test_correct_quadratic_grid_spacings(FT, Nz)
      zᵃᵃᶠ(k) = (k-1)^2
      zᵃᵃᶜ(k) = (k^2 + (k-1)^2) / 2
     Δzᵃᵃᶠ(k) = k^2 - (k-1)^2
-    Δzᵃᵃᶜ(k) = zᵃᵃᶜ(k+1) - zᵃᵃᶜ(k)
+    Δzᵃᵃᶜ(k) = zᵃᵃᶜ(k) - zᵃᵃᶜ(k-1)
 
     @test all(isapprox.(  grid.zᵃᵃᶠ[1:Nz+1],  zᵃᵃᶠ.(1:Nz+1) ))
     @test all(isapprox.(  grid.zᵃᵃᶜ[1:Nz],    zᵃᵃᶜ.(1:Nz)   ))
@@ -355,7 +355,7 @@ function test_correct_quadratic_grid_spacings(FT, Nz)
 
     # Note that Δzᵃᵃᶠ[1] involves a halo point, which is not directly determined by
     # the user-supplied zᵃᵃᶠ
-    @test all(isapprox.( grid.Δzᵃᵃᶠ[2:Nz-1], Δzᵃᵃᶜ.(2:Nz-1) ))
+    @test all(isapprox.( grid.Δzᵃᵃᶠ[2:Nz], Δzᵃᵃᶜ.(2:Nz) ))
 
     return nothing
 end
@@ -368,7 +368,7 @@ function test_correct_tanh_grid_spacings(FT, Nz)
 
      zᵃᵃᶜ(k) = (zᵃᵃᶠ(k) + zᵃᵃᶠ(k+1)) / 2
     Δzᵃᵃᶠ(k) = zᵃᵃᶠ(k+1) - zᵃᵃᶠ(k)
-    Δzᵃᵃᶜ(k) = zᵃᵃᶜ(k+1) - zᵃᵃᶜ(k)
+    Δzᵃᵃᶜ(k) = zᵃᵃᶜ(k)   - zᵃᵃᶜ(k-1)
 
     @test all(isapprox.(  grid.zᵃᵃᶠ[1:Nz+1],  zᵃᵃᶠ.(1:Nz+1) ))
     @test all(isapprox.(  grid.zᵃᵃᶜ[1:Nz],    zᵃᵃᶜ.(1:Nz)   ))
@@ -376,7 +376,7 @@ function test_correct_tanh_grid_spacings(FT, Nz)
 
     # Note that Δzᵃᵃᶠ[1] involves a halo point, which is not directly determined by
     # the user-supplied zᵃᵃᶠ
-    @test all(isapprox.( grid.Δzᵃᵃᶠ[2:Nz-1], Δzᵃᵃᶜ.(2:Nz-1) ))
+    @test all(isapprox.( grid.Δzᵃᵃᶠ[2:Nz], Δzᵃᵃᶜ.(2:Nz) ))
 
    return nothing
 end


### PR DESCRIPTION
At the moment 

`ΔF[i-1] = C[i] - C[i-1]` where `C` and `F` are the center and face coordinate, respectively. On the other hand, the derivative on the face `[i]` is calculated with `(c[i] - c[i-1]) / ΔF[i]` (where `c` is the value of the derived variable at the centers)

therefore, it has to be that `ΔF[i] = C[i] - C[i-1]`

Because of how we test, this bug was miraculously eluding all testing