### PR TITLE
Small fix for single column model mode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.68.0"
+version = "0.68.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Grids/conformal_cubed_sphere_face_grid.jl
+++ b/src/Grids/conformal_cubed_sphere_face_grid.jl
@@ -274,7 +274,7 @@ function ConformalCubedSphereFaceGrid(filepath::AbstractString, architecture = C
         Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, radius)
 end
 
-function on_architecture(arch, grid::ConformalCubedSphereFaceGrid)
+function on_architecture(arch::AbstractArchitecture, grid::ConformalCubedSphereFaceGrid)
     horizontal_coordinates = (:λᶜᶜᵃ,
                               :λᶠᶜᵃ,
                               :λᶜᶠᵃ,

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -228,7 +228,7 @@ all_z_nodes(::Type{Face},   grid::LatitudeLongitudeGrid) = grid.zᵃᵃᶠ
 @inline cpu_face_constructor_y(grid::YRegLatLonGrid) = y_domain(grid)
 @inline cpu_face_constructor_z(grid::ZRegLatLonGrid) = z_domain(grid)
 
-function on_architecture(new_arch, old_grid::LatitudeLongitudeGrid)
+function on_architecture(new_arch::AbstractArchitecture, old_grid::LatitudeLongitudeGrid)
     old_properties = (old_grid.Δλᶠᵃᵃ, old_grid.Δλᶜᵃᵃ, old_grid.λᶠᵃᵃ,  old_grid.λᶜᵃᵃ,
                       old_grid.Δφᵃᶠᵃ, old_grid.Δφᵃᶜᵃ, old_grid.φᵃᶠᵃ,  old_grid.φᵃᶜᵃ,
                       old_grid.Δzᵃᵃᶠ, old_grid.Δzᵃᵃᶜ, old_grid.zᵃᵃᶠ,  old_grid.zᵃᵃᶜ,

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -228,6 +228,28 @@ all_z_nodes(::Type{Face},   grid::LatitudeLongitudeGrid) = grid.zᵃᵃᶠ
 @inline cpu_face_constructor_y(grid::YRegLatLonGrid) = y_domain(grid)
 @inline cpu_face_constructor_z(grid::ZRegLatLonGrid) = z_domain(grid)
 
+function with_halo(new_halo, old_grid::LatitudeLongitudeGrid)
+
+    size = (old_grid.Nx, old_grid.Ny, old_grid.Nz)
+    topo = topology(old_grid)
+
+    x = cpu_face_constructor_x(old_grid)
+    y = cpu_face_constructor_y(old_grid)
+    z = cpu_face_constructor_z(old_grid)
+
+    # Remove elements of size and new_halo in Flat directions as expected by grid
+    # constructor
+    size     = pop_flat_elements(size, topo)
+    new_halo = pop_flat_elements(new_halo, topo)
+
+    new_grid = LatitudeLongitudeGrid(architecture(old_grid), eltype(old_grid);
+                                     size = size, halo = new_halo,
+                                     longitude = x, latitude = y, z = z,
+                                     precompute_metrics = metrics_precomputed(old_grid))
+
+    return new_grid
+end
+
 function on_architecture(new_arch::AbstractArchitecture, old_grid::LatitudeLongitudeGrid)
     old_properties = (old_grid.Δλᶠᵃᵃ, old_grid.Δλᶜᵃᵃ, old_grid.λᶠᵃᵃ,  old_grid.λᶜᵃᵃ,
                       old_grid.Δφᵃᶠᵃ, old_grid.Δφᵃᶜᵃ, old_grid.φᵃᶠᵃ,  old_grid.φᵃᶜᵃ,
@@ -375,7 +397,9 @@ end
     end
 end
 
-####### Kernels that precompute the y-metric
+#####
+##### Kernels that precompute the y-metric
+#####
 
 function precompute_Δy_metrics(grid::LatitudeLongitudeGrid, Δyᶠᶜ, Δyᶜᶠ)
     arch = grid.architecture

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -424,7 +424,7 @@ function with_halo(new_halo, old_grid::RectilinearGrid)
     return new_grid
 end
 
-function on_architecture(new_arch, old_grid::RectilinearGrid)
+function on_architecture(new_arch::AbstractArchitecture, old_grid::RectilinearGrid)
     old_properties = (old_grid.Δxᶠᵃᵃ, old_grid.Δxᶜᵃᵃ, old_grid.xᶠᵃᵃ, old_grid.xᶜᵃᵃ,
                       old_grid.Δyᵃᶠᵃ, old_grid.Δyᵃᶜᵃ, old_grid.yᵃᶠᵃ, old_grid.yᵃᶜᵃ,
                       old_grid.Δzᵃᵃᶠ, old_grid.Δzᵃᵃᶜ, old_grid.zᵃᵃᶠ, old_grid.zᵃᵃᶜ)

--- a/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
@@ -33,7 +33,9 @@ function calculate_tendencies!(model::HydrostaticFreeSurfaceModel)
     return nothing
 end
 
-function calculate_free_surface_tendency!(arch, grid, model, dependencies)
+function calculate_free_surface_tendency!(grid, model, dependencies)
+
+    arch = architecture(grid)
 
     Gη_event = launch!(arch, grid, :xy,
                        calculate_hydrostatic_free_surface_Gη!, model.timestepper.Gⁿ.η,
@@ -53,8 +55,8 @@ end
 """ Calculate momentum tendencies if momentum is not prescribed. `velocities` argument eases dispatch on `PrescribedVelocityFields`."""
 function calculate_hydrostatic_momentum_tendencies!(model, velocities; dependencies = device_event(model))
 
-    arch = model.architecture
     grid = model.grid
+    arch = architecture(grid)
 
     momentum_kernel_args = (grid,
                             model.advection.momentum,
@@ -78,7 +80,7 @@ function calculate_hydrostatic_momentum_tendencies!(model, velocities; dependenc
                        calculate_hydrostatic_free_surface_Gv!, model.timestepper.Gⁿ.v, momentum_kernel_args...;
                        dependencies = dependencies)
 
-    Gη_event = calculate_free_surface_tendency!(arch, grid, model, dependencies)
+    Gη_event = calculate_free_surface_tendency!(grid, model, dependencies)
 
     events = [Gu_event, Gv_event, Gη_event]
 

--- a/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
@@ -30,8 +30,8 @@ const SingleColumnGrid = AbstractGrid{<:AbstractFloat, <:Flat, <:Flat, <:Bounded
 #####
 
 PressureField(::SingleColumnGrid) = (; pHY′ = nothing)
-FreeSurface(free_surface::ExplicitFreeSurface{Nothing}, velocities, arch, ::SingleColumnGrid) = nothing
-FreeSurface(free_surface::ImplicitFreeSurface{Nothing}, velocities, arch, ::SingleColumnGrid) = nothing
+FreeSurface(free_surface::ExplicitFreeSurface{Nothing}, velocities, ::SingleColumnGrid) = nothing
+FreeSurface(free_surface::ImplicitFreeSurface{Nothing}, velocities, ::SingleColumnGrid) = nothing
 
 validate_momentum_advection(momentum_advection, ::SingleColumnGrid) = nothing
 validate_tracer_advection(tracer_advection::AbstractAdvectionScheme, ::SingleColumnGrid) = nothing, NamedTuple()
@@ -41,7 +41,7 @@ validate_tracer_advection(tracer_advection::Nothing, ::SingleColumnGrid) = nothi
 ##### Time-step optimizations
 #####
 
-calculate_free_surface_tendency!(arch, ::SingleColumnGrid, args...) = NoneEvent()
+calculate_free_surface_tendency!(::SingleColumnGrid, args...) = NoneEvent()
 
 # Fast state update and halo filling
 


### PR DESCRIPTION
PR #2121 changed some function signatures, which broke functionality provided by `single_column_model_mode.jl` that sets `model.free_surface = nothing`. This PR restores that functionality.

I think we could add a test, but the experimental nature of `single_column_model_mode.jl` could also mean it'd be better to wait.