### PR TITLE
More support for broadcasting to reduced fields

### DIFF
--- a/src/Fields/broadcasting_abstract_fields.jl
+++ b/src/Fields/broadcasting_abstract_fields.jl
@@ -30,42 +30,10 @@ const BroadcastedArrayOrCuArray = Union{Broadcasted{<:DefaultArrayStyle},
 ##### Kernels
 #####
 
-@kernel function broadcast_xyz!(dest, bc)
+@kernel function broadcast_kernel!(dest, bc)
     i, j, k = @index(Global, NTuple)
     @inbounds dest[i, j, k] = bc[i, j, k]
 end
-
-@kernel function broadcast_xy!(dest, bc)
-    i, j = @index(Global, NTuple)
-    @inbounds dest[i, j, 1] = bc[i, j, 1]
-end
-
-@kernel function broadcast_xz!(dest, bc)
-    i, k = @index(Global, NTuple)
-    @inbounds dest[i, 1, k] = bc[i, 1, k]
-end
-
-@kernel function broadcast_yz!(dest, bc)
-    j, k = @index(Global, NTuple)
-    @inbounds dest[1, j, k] = bc[1, j, k]
-end
-
-# Three-dimensional general case
-
-launch_configuration(::AbstractField) = :xyz
-broadcast_kernel(::AbstractField) = broadcast_xyz!
-
-# Two dimensional reduced field
-
-const Loc = Union{Center, Face}
-
-broadcast_kernel(::Field{Nothing, <:Loc, <:Loc}) = broadcast_yz!
-broadcast_kernel(::Field{<:Loc, Nothing, <:Loc}) = broadcast_xz!
-broadcast_kernel(::Field{<:Loc, <:Loc, Nothing}) = broadcast_xy!
-
-launch_configuration(::Field{Nothing, <:Loc, <:Loc}) = :yz
-launch_configuration(::Field{<:Loc, Nothing, <:Loc}) = :xz
-launch_configuration(::Field{<:Loc, <:Loc, Nothing}) = :xy
 
 broadcasted_to_abstract_operation(loc, grid, a) = a
 
@@ -74,21 +42,21 @@ broadcasted_to_abstract_operation(loc, grid, a) = a
                                     dest::AbstractField,
                                     bc::Broadcasted{<:FieldBroadcastStyle}) = copyto!(dest, convert(Broadcasted{Nothing}, bc))
 
-@inline function Base.copyto!(dest::AbstractField{X, Y, Z}, bc::Broadcasted{Nothing}) where {X, Y, Z}
+@inline function Base.copyto!(dest::Field, bc::Broadcasted{Nothing})
 
     grid = dest.grid
     arch = architecture(dest)
-    config = launch_configuration(dest)
-    kernel = broadcast_kernel(dest)
 
     bc′ = broadcasted_to_abstract_operation(location(dest), grid, bc)
 
-    event = launch!(arch, grid, config, kernel, dest, bc′,
+    event = launch!(arch, grid, :xyz, broadcast_kernel!, dest, bc′,
                     include_right_boundaries = true,
                     dependencies = device_event(arch),
-                    location = (X, Y, Z))
+                    reduced_dimensions = reduced_dimensions(dest),
+                    location = location(dest))
 
     wait(device(arch), event)
 
     return dest
 end
+

--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -1,3 +1,5 @@
+include("dependencies_for_runtests.jl")
+
 @testset "Field broadcasting" begin
     @info "  Testing broadcasting with fields..."
 
@@ -61,18 +63,32 @@
         ##### Broadcasting with ReducedField
         #####
         
-        r, p, q = [Field{Center, Center, Nothing}(grid) for i = 1:3]
+        for loc in [
+                    (Nothing, Center, Center),
+                    (Center, Nothing, Center),
+                    (Center, Center, Nothing),
+                    (Center, Nothing, Nothing),
+                    (Nothing, Center, Nothing),
+                    (Nothing, Nothing, Center),
+                    (Nothing, Nothing, Nothing),
+                   ]
 
-        r .= 2 
-        @test all(r .== 2) 
+            @info "    Testing broadcasting to location $loc..."
 
-        p .= 3 
+            r, p, q = [Field(loc, grid) for i = 1:3]
 
-        q .= r .* p
-        @test all(q .== 6) 
+            r .= 2 
+            @test all(r .== 2) 
 
-        q .= r .* p .+ 1
-        @test all(q .== 7) 
+            p .= 3 
+
+            q .= r .* p
+            @test all(q .== 6) 
+
+            q .= r .* p .+ 1
+            @test all(q .== 7) 
+        end
+
 
         #####
         ##### Broadcasting with arrays


### PR DESCRIPTION
This PR generalizes the broadcasting implementation to work with fields reduced in any direction. The changes mean that, for example, if broadcasting to a field that's reduced in _two_ directions (eg a 1D field on a 3D grid), the kernel that's launched to do the computation will be 1D and therefore will not "waste" computation. It also turns out that the "generalization" requires less code than the original implementation (doh). This PR also adds more tests for broadcasting to reduced fields.