### PR TITLE
Overhauls `show` and `summary`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -476,6 +476,7 @@ steps:
       JULIA_DEPOT_PATH: "$TARTARUS_HOME/.julia-$BUILDKITE_BUILD_NUMBER"
       CUDA_VISIBLE_DEVICES: "-1"
       JULIA_DEBUG: "Documenter"
+      TMPDIR: "$TARTARUS_HOME/tmp"
     commands:
       - "$TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "$TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate()'"

--- a/benchmark/benchmark_two_dimensional_models.jl
+++ b/benchmark/benchmark_two_dimensional_models.jl
@@ -1,7 +1,6 @@
 pushfirst!(LOAD_PATH, joinpath(@__DIR__, ".."))
 
 using Oceananigans
-using Oceananigans: short_show
 using Oceananigans.TimeSteppers: time_step!
 using BenchmarkTools
 
@@ -34,7 +33,7 @@ for arch in (CPU(), GPU())
         
         time_step!(model, 1e-6) # warmup
 
-        @info "Benchmarking $arch model with $(short_show(grid))..."
+        @info "Benchmarking $arch model with $(summary(grid))..."
         @btime ten_steps!($model)
     end
 end

--- a/docs/src/model_setup/background_fields.md
+++ b/docs/src/model_setup/background_fields.md
@@ -54,8 +54,8 @@ model.background_fields.velocities.u
 
 # output
 FunctionField located at (Face, Center, Center)
-├── func: U
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
+├── func: U (generic function with 1 method)
+├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── clock: Clock(time=0 seconds, iteration=0)
 └── parameters: nothing
 ```
@@ -81,7 +81,7 @@ B_field = BackgroundField(B, parameters=parameters)
 
 # output
 BackgroundField{typeof(B), NamedTuple{(:α, :N, :f), Tuple{Float64, Float64, Float64}}}
-├── func: B
+├── func: B (generic function with 1 method)
 └── parameters: (α = 3.14, N = 1.0, f = 0.1)
 ```
 

--- a/docs/src/model_setup/background_fields.md
+++ b/docs/src/model_setup/background_fields.md
@@ -85,7 +85,7 @@ BackgroundField{typeof(B), NamedTuple{(:α, :N, :f), Tuple{Float64, Float64, Flo
 └── parameters: (α = 3.14, N = 1.0, f = 0.1)
 ```
 
-When inserted into `NonhydrostaticModel`, we get out
+When inserted into `NonhydrostaticModel`, we get
 
 ```jldoctest moar_background
 grid = RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
@@ -97,8 +97,9 @@ model.background_fields.tracers.b
 
 # output
 FunctionField located at (Center, Center, Center)
-├── func: B
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
+├── func: B (generic function with 1 method)
+├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── clock: Clock(time=0 seconds, iteration=0)
 └── parameters: (α = 3.14, N = 1.0, f = 0.1)
 ```
+

--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -295,24 +295,27 @@ julia> c_bcs = FieldBoundaryConditions(top = ValueBoundaryCondition(20),
 
 julia> model = NonhydrostaticModel(grid=grid, boundary_conditions=(u=u_bcs, c=c_bcs), tracers=:c)
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=16, Ny=16, Nz=16)
+├── grid: 16×16×16 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: (:c,)
 ├── closure: Nothing
 ├── buoyancy: Nothing
 └── coriolis: Nothing
 
 julia> model.velocities.u
-Field located at (Face, Center, Center)
-├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (16, 16, 16)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=16, Ny=16, Nz=16)
-└── boundary conditions: west=Periodic, east=Periodic, south=Periodic, north=Periodic, bottom=Value, top=Value, immersed=ZeroFlux
+16×16×16 Field{Face, Center, Center} on RectilinearGrid on CPU
+├── grid: 16×16×16 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
+├── boundary conditions: west=Periodic, east=Periodic, south=Periodic, north=Periodic, bottom=Value, top=Value, immersed=ZeroFlux
+└── data: 18×18×18 OffsetArray(::Array{Float64, 3}, 0:17, 0:17, 0:17) with eltype Float64 with indices 0:17×0:17×0:17
+    └── max=0.0, min=0.0, mean=0.0
 
 julia> model.tracers.c
-Field located at (Center, Center, Center)
-├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (16, 16, 16)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=16, Ny=16, Nz=16)
-└── boundary conditions: west=Periodic, east=Periodic, south=Periodic, north=Periodic, bottom=Gradient, top=Value, immersed=ZeroFlux
+16×16×16 Field{Center, Center, Center} on RectilinearGrid on CPU
+├── grid: 16×16×16 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
+├── boundary conditions: west=Periodic, east=Periodic, south=Periodic, north=Periodic, bottom=Gradient, top=Value, immersed=ZeroFlux
+└── data: 18×18×18 OffsetArray(::Array{Float64, 3}, 0:17, 0:17, 0:17) with eltype Float64 with indices 0:17×0:17×0:17
+    └── max=0.0, min=0.0, mean=0.0
 ```
 
 Notice that the specified non-default boundary conditions have been applied at
 top and bottom of both `model.velocities.u` and `model.tracers.c`.
+

--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -27,31 +27,29 @@ julia> grid = RectilinearGrid(size=(64, 64, 64), extent=(1, 1, 1));
 
 julia> model = NonhydrostaticModel(grid=grid, buoyancy=nothing)
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: ()
 ├── closure: Nothing
 ├── buoyancy: Nothing
 └── coriolis: Nothing
 ```
 
-`buoyancy=nothing` is the default option for`NonhydrostaticModel`, so you can achieve the same
-result by simply creating a `NonhydrostaticModel` without explicitly passing the `buoyancy` flag:
+`buoyancy=nothing` is the default option for`NonhydrostaticModel`, so ommitting `buoyancy`
+from the `NonhydrostaticModel` constructor yields an identical result:
 
 ```jldoctest buoyancy
 julia> model = NonhydrostaticModel(grid=grid)
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: ()
 ├── closure: Nothing
 ├── buoyancy: Nothing
 └── coriolis: Nothing
 ```
 
-
-In order to create a `HydrostaticFreeSurfaceModel` without any buoyancy treatment we need to pass
-explicitly pass the `buoyancy=nothing` flag. Note that by default `HydrostaticFreeSurfaceModel`
-advects temperature `T` and salinity `S` (which aren't necessary without a buoyancy treatment), so
-it is often recommended to explicitly specify the tracers in this case as well:
+To create a `HydrostaticFreeSurfaceModel` without a buoyancy term we explicitly
+specify `buoyancy=nothing` flag. The default tracers `T` and `S` for `HydrostaticFreeSurfaceModel`
+may be eliminated when `buoyancy=nothing` by specifying `tracers=()`:
 
 ```jldoctest buoyancy
 julia> model = HydrostaticFreeSurfaceModel(grid=grid, buoyancy=nothing, tracers=())
@@ -63,22 +61,17 @@ HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 └── coriolis: Nothing
 ```
 
-
-
-
 ## Buoyancy as a tracer
 
-In order to directly evolve buoyancy as a tracer, simply pass `buoyancy = BuoyancyTracer()` to the
-model constructor. Keep in mind that this treatment of buoyancy requires that `:b` be included as a
-tracer, so it needs to be explicitly specified. For example, for a `NonhydrostaticModel`:
+Both `NonhydrostaticModel` and `HydrostaticFreeSurfaceModel` support evolving
+a buoyancy tracer by including `:b` in `tracers` and specifying  `buoyancy = BuoyancyTracer()`:
 
 ```jldoctest buoyancy
-julia> model = NonhydrostaticModel(grid=grid, buoyancy=BuoyancyTracer(), tracers=:b)
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: (:b,)
 ├── closure: Nothing
-├── buoyancy: BuoyancyTracer
+├── buoyancy: Buoyancy{BuoyancyTracer, Oceananigans.Grids.ZDirection}
 └── coriolis: Nothing
 ```
 
@@ -86,54 +79,62 @@ We follow the same pattern to create a `HydrostaticFreeSurfaceModel` with buoyan
 
 ```jldoctest buoyancy
 julia> model = HydrostaticFreeSurfaceModel(grid=grid, buoyancy=BuoyancyTracer(), tracers=:b)
-HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0) 
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: (:b,)
 ├── closure: Nothing
 ├── buoyancy: Buoyancy{BuoyancyTracer, Oceananigans.Grids.ZDirection}
 └── coriolis: Nothing
 ```
 
-
-
 ## Seawater buoyancy
 
-To evolve temperature ``T`` and salinity ``S`` and diagnose the buoyancy, you can pass
-`buoyancy = SeawaterBuoyancy()` to the constructor. This treatment of buoyancy requires that 
-temperature ``T`` and salinity ``S`` be advected as tracers. For example, we can create a
-`NonhydrostaticModel` with this option as (note that `NonhydrostaticModel` advects no tracers by
-default, so we need to explicitly pass `tracers=(:T, :S)` to the constructor):
+`NonhydrostaticModel` and `HydrostaticFreeSurfaceModel` support modeling the buoyancy of seawater
+as a function of gravitational acceleration, conservative temperature ``T`` and absolute salinity ``S``.
+The relationship between ``T``, ``S``, the geopotential height, and the density perturbation from
+a reference value is called the `equation_of_state`.
+Specifying `buoyancy = SeawaterBuoyancy()` (which uses a linear equation of state and
+[Earth standard](https://en.wikipedia.org/wiki/Standard_gravity)
+`gravitational_acceleration = 9.80665 \, \text{m}\,\text{s}^{-2}` by default)
+requires the tracers `:T` and `:S`:
 
 ```jldoctest buoyancy
 julia> model = NonhydrostaticModel(grid=grid, buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
-├── tracers: (:T, :S)
-├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}
-└── coriolis: Nothing
-```
-
-We can similarly create a `HydrostaticFreeSurfaceModel` with the same treatment (in this case the
-tracers don't need to be explicitly defined since this is default option for
-`HydrostaticFreeSurfaceModel`):
-
-```jldoctest buoyancy
-julia> model = HydrostaticFreeSurfaceModel(grid=grid, buoyancy=SeawaterBuoyancy())
-HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0) 
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: (:T, :S)
 ├── closure: Nothing
 ├── buoyancy: Buoyancy{SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}, Oceananigans.Grids.ZDirection}
 └── coriolis: Nothing
 ```
 
-Without any options specified, a value of ``g = 9.80665 \, \text{m}\,\text{s}^{-2}`` is used for the gravitational
-acceleration (corresponding to [standard gravity](https://en.wikipedia.org/wiki/Standard_gravity)) along
-with a linear equation of state with thermal expansion and haline contraction coefficients suitable for seawater.
+With `HydrostaticFreeSurfaceModel`,
 
-If, for example, you wanted to simulate fluids on another worlds, such as Europa, where ``g = 1.3 \, \text{m}\,\text{s}^{-2}``,
-then use
+```jldoctest buoyancy
+julia> model = HydrostaticFreeSurfaceModel(grid=grid, buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
+HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
+├── tracers: (:T, :S)
+├── closure: Nothing
+├── buoyancy: Buoyancy{SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}, Oceananigans.Grids.ZDirection}
+└── coriolis: Nothing
+```
+
+is identical to the default,
+
+```jldoctest buoyancy
+julia> model = HydrostaticFreeSurfaceModel(grid=grid)
+HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
+├── tracers: (:T, :S)
+├── closure: Nothing
+├── buoyancy: Buoyancy{SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}, Oceananigans.Grids.ZDirection}
+└── coriolis: Nothing
+```
+
+To model flows near the surface of Europa where `gravitational_acceleration = 1.3 \, \text{m}\,\text{s}^{-2}`,
+we might alternatively specify
+
 
 ```jldoctest buoyancy
 julia> buoyancy = SeawaterBuoyancy(gravitational_acceleration=1.3)
@@ -142,15 +143,14 @@ SeawaterBuoyancy{Float64}: g = 1.3
 
 julia> model = NonhydrostaticModel(grid=grid, buoyancy=buoyancy, tracers=(:T, :S))
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: (:T, :S)
 ├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}
+├── buoyancy: Buoyancy{SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}, Oceananigans.Grids.ZDirection}
 └── coriolis: Nothing
 ```
 
-and similarly for a `HydrostaticFreeSurfaceModel`.
-
+for example.
 
 ### Linear equation of state
 
@@ -194,15 +194,11 @@ julia> eos = TEOS10EquationOfState()
 SeawaterPolynomials.BoussinesqEquationOfState{TEOS10SeawaterPolynomial{Float64}, Int64}(TEOS10SeawaterPolynomial{Float64}(), 1020)
 ```
 
+## The direction of gravitational acceleration
 
-## Gravity alignment
-
-If you want to simulate a set-up such that gravity doesn't align with the vertical (`z`) coordinate
-(for example when simulating a tilted domain) you can wrap your option for buoyancy treatment in the
-`Buoyancy()` function call, which allows for the option `vertical_unit_vector`. This is only
-available for `NonhydrostaticModel`s, and it works for both `BuoyancyTracer()` and
-`SeawaterBuoyancy()`. For example, a set-up in using buoyancy as a tracer and in which gravity is
-tilted 45 degrees about the `x` axis can be done as
+To simulate gravitational accelerations that don't align with the vertical (`z`) coordinate,
+we wrap the buoyancy model in
+`Buoyancy()` function call, which takes the keyword arguments `model` and `vertical_unit_vector`,
 
 ```jldoctest buoyancy
 julia> θ = 45; # degrees
@@ -212,12 +208,11 @@ julia> g̃ = (0, sind(θ), cosd(θ));
 julia> model = NonhydrostaticModel(grid=grid, 
                                    buoyancy=Buoyancy(model=BuoyancyTracer(), vertical_unit_vector=g̃), 
                                    tracers=:b)
-NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0) 
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: (:b,)
 ├── closure: Nothing
-├── buoyancy: BuoyancyTracer
+├── buoyancy: Buoyancy{BuoyancyTracer, Tuple{Int64, Float64, Float64}}
 └── coriolis: Nothing
 ```
-
 

--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -54,7 +54,7 @@ may be eliminated when `buoyancy=nothing` by specifying `tracers=()`:
 ```jldoctest buoyancy
 julia> model = HydrostaticFreeSurfaceModel(grid=grid, buoyancy=nothing, tracers=())
 HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0) 
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: ()
 ├── closure: Nothing
 ├── buoyancy: Nothing

--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -67,6 +67,7 @@ Both `NonhydrostaticModel` and `HydrostaticFreeSurfaceModel` support evolving
 a buoyancy tracer by including `:b` in `tracers` and specifying  `buoyancy = BuoyancyTracer()`:
 
 ```jldoctest buoyancy
+julia> model = NonhydrostaticModel(grid=grid, buoyancy=BuoyancyTracer(), tracers=:b)
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 ├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: (:b,)
@@ -135,7 +136,6 @@ HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 To model flows near the surface of Europa where `gravitational_acceleration = 1.3 \, \text{m}\,\text{s}^{-2}`,
 we might alternatively specify
 
-
 ```jldoctest buoyancy
 julia> buoyancy = SeawaterBuoyancy(gravitational_acceleration=1.3)
 SeawaterBuoyancy{Float64}: g = 1.3
@@ -154,9 +154,8 @@ for example.
 
 ### Linear equation of state
 
-To use non-default thermal expansion and haline contraction coefficients, say
-``\alpha = 2 \times 10^{-3} \; \text{K}^{-1}`` and ``\beta = 5 \times 10^{-4} \text{psu}^{-1}`` corresponding to some other
-fluid, then use
+To specify the thermal expansion and haline contraction coefficients
+``\alpha = 2 \times 10^{-3} \; \text{K}^{-1}`` and ``\beta = 5 \times 10^{-4} \text{psu}^{-1}``,
 
 ```jldoctest
 julia> buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=2e-3, β=5e-4))

--- a/docs/src/model_setup/forcing_functions.md
+++ b/docs/src/model_setup/forcing_functions.md
@@ -27,7 +27,7 @@ model.forcing.u
 
 # output
 ContinuousForcing{Nothing} at (Face, Center, Center)
-├── func: u_forcing
+├── func: u_forcing (generic function with 1 method)
 ├── parameters: nothing
 └── field dependencies: ()
 ```
@@ -70,7 +70,7 @@ model.forcing.T
 
 # output
 ContinuousForcing{NamedTuple{(:μ, :λ, :k, :ω), Tuple{Int64, Float64, Float64, Float64}}} at (Center, Center, Center)
-├── func: T_forcing_func
+├── func: T_forcing_func (generic function with 1 method)
 ├── parameters: (μ = 1, λ = 0.5, k = 6.283185307179586, ω = 12.566370614359172)
 └── field dependencies: ()
 ```
@@ -80,7 +80,7 @@ model.forcing.u
 
 # output
 ContinuousForcing{Float64} at (Face, Center, Center)
-├── func: u_forcing_func
+├── func: u_forcing_func (generic function with 1 method)
 ├── parameters: 0.1
 └── field dependencies: ()
 ```

--- a/docs/src/model_setup/forcing_functions.md
+++ b/docs/src/model_setup/forcing_functions.md
@@ -115,7 +115,7 @@ model.forcing.w
 
 # output
 ContinuousForcing{Nothing} at (Center, Center, Face)
-├── func: w_forcing_func
+├── func: w_forcing_func (generic function with 1 method)
 ├── parameters: nothing
 └── field dependencies: (:u, :v, :w)
 ```
@@ -125,7 +125,7 @@ model.forcing.S
 
 # output
 ContinuousForcing{Float64} at (Center, Center, Center)
-├── func: S_forcing_func
+├── func: S_forcing_func (generic function with 1 method)
 ├── parameters: 0.01
 └── field dependencies: (:S,)
 ```
@@ -194,7 +194,7 @@ model.forcing.b
 
 # output
 DiscreteForcing{Nothing}
-├── func: b_forcing_func
+├── func: b_forcing_func (generic function with 1 method)
 └── parameters: nothing
 ```
 
@@ -203,7 +203,7 @@ model.forcing.u
 
 # output
 DiscreteForcing{Float64}
-├── func: u_forcing_func
+├── func: u_forcing_func (generic function with 1 method)
 └── parameters: 0.001
 ```
 
@@ -276,3 +276,4 @@ ContinuousForcing{Nothing} at (Center, Center, Center)
 ├── parameters: nothing
 └── field dependencies: (:T,)
 ```
+

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -22,15 +22,10 @@ end
 
 ```jldoctest
 julia> grid = RectilinearGrid(size=(32, 64, 256), extent=(128, 256, 512))
-RectilinearGrid{Float64, Periodic, Periodic, Bounded} 
-             architecture: CPU()
-                   domain: x ∈ [0.0, 128.0], y ∈ [0.0, 256.0], z ∈ [-512.0, 0.0]
-                 topology: (Periodic, Periodic, Bounded)
-        size (Nx, Ny, Nz): (32, 64, 256)
-        halo (Hx, Hy, Hz): (1, 1, 1)
-             spacing in x: Regular, with spacing 4.0
-             spacing in y: Regular, with spacing 4.0
-             spacing in z: Regular, with spacing 2.0
+32×64×256 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+├── Periodic x ∈ [0.0, 128.0)  regularly spaced with Δx=4.0
+├── Periodic y ∈ [0.0, 256.0)  regularly spaced with Δy=4.0
+└── Bounded  z ∈ [-512.0, 0.0] regularly spaced with Δz=2.0
 ```
 
 !!! info "Default domain"
@@ -50,15 +45,10 @@ in the ``y``- and ``z``-dimensions is build with,
 
 ```jldoctest
 julia> grid = RectilinearGrid(topology=(Periodic, Bounded, Bounded), size=(64, 64, 32), extent=(1e4, 1e4, 1e3))
-RectilinearGrid{Float64, Periodic, Bounded, Bounded} 
-             architecture: CPU()
-                   domain: x ∈ [0.0, 10000.0], y ∈ [0.0, 10000.0], z ∈ [-1000.0, 0.0]
-                 topology: (Periodic, Bounded, Bounded)
-        size (Nx, Ny, Nz): (64, 64, 32)
-        halo (Hx, Hy, Hz): (1, 1, 1)
-             spacing in x: Regular, with spacing 156.25
-             spacing in y: Regular, with spacing 156.25
-             spacing in z: Regular, with spacing 31.25
+64×64×32 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+├── Periodic x ∈ [0.0, 10000.0) regularly spaced with Δx=156.25
+├── Bounded  y ∈ [0.0, 10000.0] regularly spaced with Δy=156.25
+└── Bounded  z ∈ [-1000.0, 0.0] regularly spaced with Δz=31.25
 ```
 
 The `Flat` topology is useful when running problems with fewer than 3 dimensions. As an example,
@@ -73,17 +63,11 @@ is constructed via
 
 ```jldoctest
 julia> grid = RectilinearGrid(size=(32, 16, 256), x=(-100, 100), y=(0, 12.5), z=(-π, π))
-RectilinearGrid{Float64, Periodic, Periodic, Bounded}  
-             architecture: CPU()
-                   domain: x ∈ [-100.0, 100.0], y ∈ [0.0, 12.5], z ∈ [-3.141592653589793, 3.141592653589793]
-                 topology: (Periodic, Periodic, Bounded)
-        size (Nx, Ny, Nz): (32, 16, 256)
-        halo (Hx, Hy, Hz): (1, 1, 1)
-             spacing in x: Regular, with spacing 6.25
-             spacing in y: Regular, with spacing 0.78125
-             spacing in z: Regular, with spacing 0.02454369260617026
+32×16×256 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+├── Periodic x ∈ [-100.0, 100.0)     regularly spaced with Δx=6.25
+├── Periodic y ∈ [0.0, 12.5)         regularly spaced with Δy=0.78125
+└── Bounded  z ∈ [-3.14159, 3.14159] regularly spaced with Δz=0.0245437
 ```
-
 
 ## Grids with non-regular spacing in some of the directions
 
@@ -108,15 +92,10 @@ julia> grid = RectilinearGrid(size = (Nx, Ny, Nz),
                               x = (0, Lx),
                               y = chebychev_spaced_y_faces,
                               z = chebychev_spaced_z_faces)
-RectilinearGrid{Float64, Periodic, Bounded, Bounded}  
-             architecture: CPU()
-                   domain: x ∈ [0.0, 10000.0], y ∈ [-5000.0, 5000.0], z ∈ [-1000.0, 0.0]
-                 topology: (Periodic, Bounded, Bounded)
-        size (Nx, Ny, Nz): (64, 64, 32)
-        halo (Hx, Hy, Hz): (1, 1, 1)
-             spacing in x: Regular, with spacing 156.25
-             spacing in y: Stretched, with spacing min=6.022719, max=245.338372
-             spacing in z: Stretched, with spacing min=2.407637, max=49.008570
+64×64×32 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+├── Periodic x ∈ [0.0, 10000.0)    regularly spaced with Δx=156.25
+├── Bounded  y ∈ [-5000.0, 5000.0] variably spaced with min(Δy)=6.02272, max(Δy)=245.338
+└── Bounded  z ∈ [-1000.0, 0.0]    variably spaced with min(Δz)=2.40764, max(Δz)=49.0086
 ```
 
 ```@setup 1

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -22,7 +22,7 @@ end
 
 ```jldoctest
 julia> grid = RectilinearGrid(size=(32, 64, 256), extent=(128, 256, 512))
-32×64×256 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+32×64×256 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── Periodic x ∈ [0.0, 128.0)  regularly spaced with Δx=4.0
 ├── Periodic y ∈ [0.0, 256.0)  regularly spaced with Δy=4.0
 └── Bounded  z ∈ [-512.0, 0.0] regularly spaced with Δz=2.0
@@ -45,7 +45,7 @@ in the ``y``- and ``z``-dimensions is build with,
 
 ```jldoctest
 julia> grid = RectilinearGrid(topology=(Periodic, Bounded, Bounded), size=(64, 64, 32), extent=(1e4, 1e4, 1e3))
-64×64×32 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+64×64×32 RectilinearGrid{Float64, Periodic, Bounded, Bounded} on CPU with 1×1×1 halo
 ├── Periodic x ∈ [0.0, 10000.0) regularly spaced with Δx=156.25
 ├── Bounded  y ∈ [0.0, 10000.0] regularly spaced with Δy=156.25
 └── Bounded  z ∈ [-1000.0, 0.0] regularly spaced with Δz=31.25
@@ -63,7 +63,7 @@ is constructed via
 
 ```jldoctest
 julia> grid = RectilinearGrid(size=(32, 16, 256), x=(-100, 100), y=(0, 12.5), z=(-π, π))
-32×16×256 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+32×16×256 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── Periodic x ∈ [-100.0, 100.0)     regularly spaced with Δx=6.25
 ├── Periodic y ∈ [0.0, 12.5)         regularly spaced with Δy=0.78125
 └── Bounded  z ∈ [-3.14159, 3.14159] regularly spaced with Δz=0.0245437
@@ -92,7 +92,7 @@ julia> grid = RectilinearGrid(size = (Nx, Ny, Nz),
                               x = (0, Lx),
                               y = chebychev_spaced_y_faces,
                               z = chebychev_spaced_z_faces)
-64×64×32 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+64×64×32 RectilinearGrid{Float64, Periodic, Bounded, Bounded} on CPU with 1×1×1 halo
 ├── Periodic x ∈ [0.0, 10000.0)    regularly spaced with Δx=156.25
 ├── Bounded  y ∈ [-5000.0, 5000.0] variably spaced with min(Δy)=6.02272, max(Δy)=245.338
 └── Bounded  z ∈ [-1000.0, 0.0]    variably spaced with min(Δz)=2.40764, max(Δz)=49.0086

--- a/docs/src/model_setup/lagrangian_particles.md
+++ b/docs/src/model_setup/lagrangian_particles.md
@@ -40,7 +40,7 @@ model = NonhydrostaticModel(grid=grid, particles=lagrangian_particles)
 
 # output
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=10, Ny=10, Nz=10)
+├── grid: 10×10×10 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: ()
 ├── closure: Nothing
 ├── buoyancy: Nothing

--- a/docs/src/model_setup/tracers.md
+++ b/docs/src/model_setup/tracers.md
@@ -14,23 +14,22 @@ julia> grid = RectilinearGrid(size=(64, 64, 64), extent=(1, 1, 1));
 
 julia> model = NonhydrostaticModel(grid=grid)
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: ()
 ├── closure: Nothing
 ├── buoyancy: Nothing
 └── coriolis: Nothing
 ```
 
-But tracers can be added with the `tracer` keyword. For example to add temperature `T` and salinity
-`S`:
-
+But tracers can be added with the `tracers` keyword.
+For example, to add conservative temperature `T` and absolute salinity `S`:
 
 ```jldoctest tracers
 julia> grid = RectilinearGrid(size=(64, 64, 64), extent=(1, 1, 1));
 
 julia> model = NonhydrostaticModel(grid=grid, tracers=(:T, :S))
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: (:T, :S)
 ├── closure: Nothing
 ├── buoyancy: Nothing
@@ -41,32 +40,36 @@ whose fields can be accessed via `model.tracers.T` and `model.tracers.S`.
 
 ```jldoctest tracers
 julia> model.tracers.T
-Field located at (Center, Center, Center)
-├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (64, 64, 64)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
-└── boundary conditions: west=Periodic, east=Periodic, south=Periodic, north=Periodic, bottom=ZeroFlux, top=ZeroFlux, immersed=ZeroFlux
+64×64×64 Field{Center, Center, Center} on RectilinearGrid on CPU
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
+├── boundary conditions: west=Periodic, east=Periodic, south=Periodic, north=Periodic, bottom=ZeroFlux, top=ZeroFlux, immersed=ZeroFlux
+└── data: 66×66×66 OffsetArray(::Array{Float64, 3}, 0:65, 0:65, 0:65) with eltype Float64 with indices 0:65×0:65×0:65
+    └── max=0.0, min=0.0, mean=0.0
 
 julia> model.tracers.S
-Field located at (Center, Center, Center)
-├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (64, 64, 64)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
-└── boundary conditions: west=Periodic, east=Periodic, south=Periodic, north=Periodic, bottom=ZeroFlux, top=ZeroFlux, immersed=ZeroFlux
+64×64×64 Field{Center, Center, Center} on RectilinearGrid on CPU
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
+├── boundary conditions: west=Periodic, east=Periodic, south=Periodic, north=Periodic, bottom=ZeroFlux, top=ZeroFlux, immersed=ZeroFlux
+└── data: 66×66×66 OffsetArray(::Array{Float64, 3}, 0:65, 0:65, 0:65) with eltype Float64 with indices 0:65×0:65×0:65
+    └── max=0.0, min=0.0, mean=0.0
 ```
 
-Any number of arbitrary tracers can be appended to this list and passed to a model constructor. For example, to evolve
-quantities ``C_1``, CO₂, and nitrogen as additional passive tracers you could set them up as
+An arbitrary number of tracers may be simulated. For example, to simulate
+``C_1``, ``CO₂``, and `nitrogen` as additional passive tracers,
 
 ```jldoctest tracers
 julia> model = NonhydrostaticModel(grid=grid, tracers=(:T, :S, :C₁, :CO₂, :nitrogen))
 NonhydrostaticModel{CPU, Float64}(time = 0 seconds, iteration = 0)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=64, Ny=64, Nz=64)
+├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: (:T, :S, :C₁, :CO₂, :nitrogen)
 ├── closure: Nothing
 ├── buoyancy: Nothing
 └── coriolis: Nothing
 ```
 
-!!! info "Active vs. passive tracers"
-    An active tracer typically denotes a tracer quantity that affects the fluid dynamics through buoyancy. In the ocean
-    temperature and salinity are active tracers. Passive tracers, on the other hand, typically do not affect the fluid
-    dynamics are are _passively_ advected around by the flow field.
+!!! info "Active versus passive tracers"
+    An active tracer is a tracer whose distribution affects the evolution of momentum and other tracers.
+    Typical ocean models evolve conservative temperature and absolute salinity as active tracers,
+    which effect momentum through buoyancy forces.
+    Passive tracers are "passive" in the sense that their distribution does not affect
+    the evolution of other tracers or flow quantities.

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -159,12 +159,11 @@ julia> c, d = (CenterField(RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))) fo
 
 julia> plus_or_times(c, d)
 BinaryOperation at (Center, Center, Center)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
-│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
+├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 └── tree:
     plus_or_times at (Center, Center, Center)
-    ├── Field located at (Center, Center, Center)
-    └── Field located at (Center, Center, Center)
+    ├── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
+    └── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
 ```
 """
 macro binary(ops...)

--- a/src/AbstractOperations/computed_field.jl
+++ b/src/AbstractOperations/computed_field.jl
@@ -6,7 +6,6 @@ using KernelAbstractions: @kernel, @index
 using Oceananigans.Fields: FieldStatus, show_status, reduced_dimensions
 using Oceananigans.Utils: launch!
 
-import Oceananigans: short_show
 import Oceananigans.Fields: Field, compute!
 
 const ComputedField = Field{<:Any, <:Any, <:Any, <:AbstractOperation}
@@ -77,12 +76,13 @@ end
     @inbounds data[i, j, k] = operand[i, j, k]
 end
 
-short_show(field::ComputedField) = string("Field located at ", show_location(field), " computed from ", short_show(field.operand))
+Base.summary(field::ComputedField) =
+    string("Field located at ", show_location(field), " computed from ", summary(field.operand))
 
 Base.show(io::IO, field::ComputedField) =
-    print(io, "$(short_show(field))\n",
+    print(io, "$(summary(field))\n",
           "├── data: $(typeof(field.data)), size: $(size(field))\n",
-          "├── grid: $(short_show(field.grid))\n",
-          "├── operand: $(short_show(field.operand))\n",
-          "└── status: $(show_status(field.status))")
+          "├── grid: $(summary(field.grid))\n",
+          "├── operand: $(summary(field.operand))\n",
+          "└── status: $(summary(field.status))")
 

--- a/src/AbstractOperations/computed_field.jl
+++ b/src/AbstractOperations/computed_field.jl
@@ -3,7 +3,7 @@
 #####
 
 using KernelAbstractions: @kernel, @index
-using Oceananigans.Fields: FieldStatus, show_status, reduced_dimensions
+using Oceananigans.Fields: FieldStatus, reduced_dimensions
 using Oceananigans.Utils: launch!
 
 import Oceananigans.Fields: Field, compute!
@@ -75,14 +75,4 @@ end
     i, j, k = @index(Global, NTuple)
     @inbounds data[i, j, k] = operand[i, j, k]
 end
-
-Base.summary(field::ComputedField) =
-    string("Field located at ", show_location(field), " computed from ", summary(field.operand))
-
-Base.show(io::IO, field::ComputedField) =
-    print(io, "$(summary(field))\n",
-          "├── data: $(typeof(field.data)), size: $(size(field))\n",
-          "├── grid: $(summary(field.grid))\n",
-          "├── operand: $(summary(field.operand))\n",
-          "└── status: $(summary(field.status))")
 

--- a/src/AbstractOperations/grid_metrics.jl
+++ b/src/AbstractOperations/grid_metrics.jl
@@ -70,11 +70,10 @@ julia> grid = RectilinearGrid(size=(1, 1, 1), extent=(1, 2, 3)); c = CenterField
 
 julia> c_dz = c * Δz # returns BinaryOperation between Field and GridMetricOperation
 BinaryOperation at (Center, Center, Center)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
-│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 2.0], z ∈ [-3.0, 0.0]
+├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 └── tree:
     * at (Center, Center, Center)
-    ├── Field located at (Center, Center, Center)
+    ├── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
     └── Δzᵃᵃᶜ at (Center, Center, Center)
 
 julia> c .= 1;
@@ -111,11 +110,10 @@ julia> c .= 1;
 
 julia> c_dV = c * volume
 BinaryOperation at (Center, Center, Center)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=2, Ny=2, Nz=2)
-│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 2.0], z ∈ [-3.0, 0.0]
+├── grid: 2×2×2 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 └── tree:
     * at (Center, Center, Center)
-    ├── Field located at (Center, Center, Center)
+    ├── 2×2×2 Field{Center, Center, Center} on RectilinearGrid on CPU
     └── Vᶜᶜᶜ at (Center, Center, Center)
 
 julia> c_dV[1, 1, 1]

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -3,7 +3,6 @@ using Statistics: mean!, sum!
 using Oceananigans.Utils: tupleit
 using Oceananigans.Grids: regular_dimensions
 import Oceananigans.Fields: Reduction
-import Oceananigans: short_show
 
 ##### 
 ##### Metric inference
@@ -57,8 +56,6 @@ spatial extent of the interval.
 """
 Average(field::AbstractField; dims=:) = Reduction(Average(), field; dims)
 
-const AveragedField = Field{<:Any, <:Any, <:Any, <:Reduction{<:Average}}
-
 struct Integral end
 
 function Reduction(int::Integral, field::AbstractField; dims)
@@ -74,12 +71,10 @@ Return a `Reduction` representing a spatial integral of `field` over `dims`.
 """
 Integral(field::AbstractField; dims=:) = Reduction(Integral(), field; dims)
 
-const IntegratedField = Field{<:Any, <:Any, <:Any, <:Reduction{<:Integral}}
-
 #####
 ##### show
 #####
 
-short_show(r::Reduction{<:Average}) = string("Average of ", short_show(r.operand), " over dims ", r.dims)
-short_show(r::Reduction{<:Integral}) = string("Integral of ", short_show(r.operand), " over dims ", r.dims)
+Base.summary(r::Reduction{<:Average}) = string("Average of ", summary(r.operand), " over dims ", r.dims)
+Base.summary(r::Reduction{<:Integral}) = string("Integral of ", summary(r.operand), " over dims ", r.dims)
                                              

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -102,13 +102,12 @@ Set{Any} with 3 elements:
 
 julia> harmonic_plus(c, d, e)
 MultiaryOperation at (Center, Center, Center)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
-│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
+├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 └── tree:
     harmonic_plus at (Center, Center, Center)
-    ├── Field located at (Center, Center, Center)
-    ├── Field located at (Center, Center, Center)
-    └── Field located at (Center, Center, Center)
+    ├── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
+    ├── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
+    └── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
 ```
 """
 macro multiary(ops...)

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -78,21 +78,20 @@ julia> c, d, e = Tuple(CenterField(RectilinearGrid(size=(1, 1, 1), extent=(1, 1,
 
 julia> harmonic_plus(c, d, e) # before magic @multiary transformation
 BinaryOperation at (Center, Center, Center)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
-│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
+├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 └── tree:
     * at (Center, Center, Center)
     ├── 0.3333333333333333
     └── + at (Center, Center, Center)
         ├── / at (Center, Center, Center)
         │   ├── 1
-        │   └── Field located at (Center, Center, Center)
+        │   └── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
         ├── / at (Center, Center, Center)
         │   ├── 1
-        │   └── Field located at (Center, Center, Center)
+        │   └── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
         └── / at (Center, Center, Center)
             ├── 1
-            └── Field located at (Center, Center, Center)
+            └── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
 
 julia> @multiary harmonic_plus
 Set{Any} with 3 elements:

--- a/src/AbstractOperations/show_abstract_operations.jl
+++ b/src/AbstractOperations/show_abstract_operations.jl
@@ -61,7 +61,7 @@ function tree_show(multiary::MultiaryOperation, depth, nesting)
     LX, LY, LZ = location(multiary)
     N = length(multiary.args)
 
-    out = string(multiary.op, " at ", show_location(X, Y, Z), '\n',
+    out = string(multiary.op, " at ", show_location(LX, LY, LZ), '\n',
         ntuple(i -> padding * "├── " * tree_show(multiary.args[i], depth+1, nesting+1) * '\n', Val(N-1))...,
                     padding * "└── " * tree_show(multiary.args[N], depth+1, nesting)
                 )

--- a/src/AbstractOperations/show_abstract_operations.jl
+++ b/src/AbstractOperations/show_abstract_operations.jl
@@ -1,5 +1,4 @@
 import Oceananigans: summary
-using Oceananigans.Grids: domain_string
 using Oceananigans.Fields: show_location
 
 for op_string in ("UnaryOperation", "BinaryOperation", "MultiaryOperation", "Derivative", "KernelFunctionOperation")
@@ -26,7 +25,6 @@ Base.show(io::IO, operation::AbstractOperation) =
     print(io,
           summary(operation), '\n',
           "├── grid: ", summary(operation.grid), '\n',
-          "│   └── domain: ", domain_string(operation.grid), '\n',
           "└── tree: ", "\n", "    ", tree_show(operation, 1, 0))
 
 "Return a representaion of number or function leaf within a tree visualization of an `AbstractOperation`."

--- a/src/AbstractOperations/unary_operations.jl
+++ b/src/AbstractOperations/unary_operations.jl
@@ -68,11 +68,10 @@ julia> c = CenterField(RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1)));
 
 julia> square_it(c)
 UnaryOperation at (Center, Center, Center)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
-│   └── domain: x ∈ [0.0, 1.0], y ∈ [0.0, 1.0], z ∈ [-1.0, 0.0]
+├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 └── tree:
     square_it at (Center, Center, Center) via identity
-    └── Field located at (Center, Center, Center)
+    └── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
 ```
 """
 macro unary(ops...)

--- a/src/BoundaryConditions/show_boundary_conditions.jl
+++ b/src/BoundaryConditions/show_boundary_conditions.jl
@@ -1,5 +1,4 @@
 import Base: show
-import Oceananigans: short_show
 
 const DFBC = DefaultPrognosticFieldBoundaryCondition
 
@@ -33,7 +32,7 @@ show(io::IO, bc::BoundaryCondition) =
 ##### FieldBoundaryConditions
 #####
 
-short_show(fbcs::FieldBoundaryConditions) =
+Base.summary(fbcs::FieldBoundaryConditions) =
     string("west=$(bc_str(fbcs.west)), ",
            "east=$(bc_str(fbcs.east)), ",
            "south=$(bc_str(fbcs.south)), ",

--- a/src/CubedSpheres/conformal_cubed_sphere_grid.jl
+++ b/src/CubedSpheres/conformal_cubed_sphere_grid.jl
@@ -3,7 +3,7 @@ using Oceananigans.Grids
 using Oceananigans.Grids: R_Earth, interior_indices
 
 import Base: show, size, eltype
-import Oceananigans.Grids: topology, domain_string, architecture, halo_size
+import Oceananigans.Grids: topology, architecture, halo_size
 
 struct CubedSphereFaceConnectivityDetails{F, S}
     face :: F
@@ -233,10 +233,6 @@ Base.eltype(grid::ConformalCubedSphereGrid{FT}) where FT = FT
 
 topology(::ConformalCubedSphereGrid) = (Bounded, Bounded, Bounded)
 architecture(grid::ConformalCubedSphereGrid) = grid.architecture
-
-# Not sure what to put. Gonna leave it blank so that Base.show(io::IO, operation::AbstractOperation) doesn't error.
-domain_string(grid::ConformalCubedSphereFaceGrid) = ""
-domain_string(grid::ConformalCubedSphereGrid) = ""
 
 #####
 ##### filling grid halos

--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -9,7 +9,7 @@ using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 import Base: getindex, size, show, minimum, maximum
 import Statistics: mean
 
-import Oceananigans.Fields: AbstractField, Field, minimum, maximum, mean, location, short_show, set!
+import Oceananigans.Fields: AbstractField, Field, minimum, maximum, mean, location, set!
 import Oceananigans.Grids: new_data
 import Oceananigans.BoundaryConditions: FieldBoundaryConditions
 
@@ -92,7 +92,7 @@ function Base.show(io::IO, field::Union{CubedSphereField, AbstractCubedSphereFie
     A = typeof(arch)
     return print(io, "$(typeof(field).name.wrapper) at ($LX, $LY, $LZ)\n",
           "├── architecture: $A\n",
-          "└── grid: $(short_show(field.grid))")
+          "└── grid: $(summary(field.grid))")
 end
 
 @inline function interior(field::AbstractCubedSphereField)

--- a/src/Diagnostics/state_checker.jl
+++ b/src/Diagnostics/state_checker.jl
@@ -1,8 +1,6 @@
 using Printf
 using Statistics
 
-using Oceananigans: short_show
-
 struct StateChecker{T, F} <: AbstractDiagnostic
     schedule :: T
       fields :: F
@@ -19,7 +17,7 @@ StateChecker(model; schedule, fields=fields(model)) = StateChecker(schedule, fie
 function run_diagnostic!(sc::StateChecker, model)
     pad = keys(sc.fields) .|> string .|> length |> maximum
 
-    @info "State check @ $(short_show(model.clock))"
+    @info "State check @ $(summary(model.clock))"
 
     for (name, field) in pairs(sc.fields)
         state_check(field, name, pad)

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -13,8 +13,6 @@ using Oceananigans.Architectures
 using Oceananigans.Grids
 using Oceananigans.BoundaryConditions
 
-import Oceananigans: short_show
-
 include("abstract_field.jl")
 include("zero_field.jl")
 include("function_field.jl")

--- a/src/Fields/background_fields.jl
+++ b/src/Fields/background_fields.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Utils: prettysummary
+
 # TODO: This code belongs in the Models module
 
 function BackgroundVelocityFields(bg, grid, clock)
@@ -74,5 +76,5 @@ end
 
 Base.show(io::IO, field::BackgroundField{F, P}) where {F, P} =
     print(io, "BackgroundField{$F, $P}", '\n',
-          "├── func: $(short_show(field.func))", '\n',
+          "├── func: $(prettysummary(field.func))", '\n',
           "└── parameters: $(field.parameters)")

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -64,10 +64,11 @@ Example
 julia> using Oceananigans
 
 julia> ω = Field{Face, Face, Center}(RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1)))
-Field located at (Face, Face, Center)
-├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (1, 1, 1)
-├── grid: RectilinearGrid{Float64, Periodic, Periodic, Bounded}(Nx=1, Ny=1, Nz=1)
-└── boundary conditions: west=Periodic, east=Periodic, south=Periodic, north=Periodic, bottom=ZeroFlux, top=ZeroFlux, immersed=ZeroFlux
+1×1×1 Field{Face, Face, Center} on RectilinearGrid on CPU
+├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
+├── boundary conditions: west=Periodic, east=Periodic, south=Periodic, north=Periodic, bottom=ZeroFlux, top=ZeroFlux, immersed=ZeroFlux
+└── data: 3×3×3 OffsetArray(::Array{Float64, 3}, 0:2, 0:2, 0:2) with eltype Float64 with indices 0:2×0:2×0:2
+    └── max=0.0, min=0.0, mean=0.0
 ```
 """
 function Field{LX, LY, LZ}(grid::AbstractGrid,

--- a/src/Fields/field_reductions.jl
+++ b/src/Fields/field_reductions.jl
@@ -62,12 +62,12 @@ end
 #####
 
 Base.show(io::IO, field::ReducedComputedField) =
-    print(io, "$(short_show(field))\n",
+    print(io, "$(summary(field))\n",
           "├── data: $(typeof(field.data)), size: $(size(field))\n",
-          "├── grid: $(short_show(field.grid))\n",
-          "├── operand: $(short_show(field.operand))\n",
+          "├── grid: $(summary(field.grid))\n",
+          "├── operand: $(summary(field.operand))\n",
           "└── status: ", show_status(field.status))
 
-short_show(r::Reduction) = string(r.reduce!, 
-                                  " over dims ", r.dims,
-                                  " of ", short_show(r.operand))
+Base.summary(r::Reduction) = string(r.reduce!, 
+                                    " over dims ", r.dims,
+                                    " of ", summary(r.operand))

--- a/src/Fields/field_slicer.jl
+++ b/src/Fields/field_slicer.jl
@@ -111,7 +111,7 @@ slice_parent(::Nothing, field) = parent(field)
 show_index(i) = string(i)
 show_index(i::Colon) = ":"
 
-short_show(fs::FieldSlicer) = string("FieldSlicer(",
-                                     "$(show_index(fs.i)), ",
-                                     "$(show_index(fs.j)), ",
-                                     "$(show_index(fs.k)), with_halos=$(fs.with_halos))")
+Base.summary(fs::FieldSlicer) = string("FieldSlicer(",
+                                       "$(show_index(fs.i)), ",
+                                       "$(show_index(fs.j)), ",
+                                       "$(show_index(fs.k)), with_halos=$(fs.with_halos))")

--- a/src/Fields/function_field.jl
+++ b/src/Fields/function_field.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Utils: prettysummary
+
 struct FunctionField{LX, LY, LZ, C, P, F, G, T} <: AbstractField{LX, LY, LZ, G, T, 3}
           func :: F
           grid :: G
@@ -69,8 +71,8 @@ Adapt.adapt_structure(to, f::FunctionField{LX, LY, LZ}) where {LX, LY, LZ} =
 
 Base.show(io::IO, field::FunctionField) =
     print(io, "FunctionField located at ", show_location(field), '\n',
-          "├── func: $(short_show(field.func))", '\n',
-          "├── grid: $(short_show(field.grid))\n",
-          "├── clock: $(short_show(field.clock))\n",
+          "├── func: $(prettysummary(field.func))", '\n',
+          "├── grid: $(summary(field.grid))\n",
+          "├── clock: $(summary(field.clock))\n",
           "└── parameters: $(field.parameters)")
 

--- a/src/Fields/regridding_fields.jl
+++ b/src/Fields/regridding_fields.jl
@@ -49,8 +49,8 @@ regrid!(a, b) = regrid!(a, a.grid, b.grid, b)
 
 function regrid!(a, target_grid, source_grid, b)
     msg = """Regridding
-             $(short_show(b)) on $(short_show(source_grid))
-             to $(short_show(a)) on $(short_show(target_grid))
+             $(summary(b)) on $(summary(source_grid))
+             to $(summary(a)) on $(summary(target_grid))
              is not supported."""
 
     return throw(ArgumentError(msg))

--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -29,13 +29,13 @@ function set!(u::Field, f::Function)
         set!(u, f_field)
     end
 
-    return nothing
+    return u
 end
 
 function set!(u::Field, f::Union{Array, CuArray, OffsetArray})
     f = arch_array(architecture(u), f)
     u .= f
-    return nothing
+    return u
 end
 
 function set!(u::Field, v::Field)
@@ -52,6 +52,6 @@ function set!(u::Field, v::Field)
         copyto!(u_parent, v_parent)
     end
 
-    return nothing
+    return u
 end
 

--- a/src/Fields/show_fields.jl
+++ b/src/Fields/show_fields.jl
@@ -6,27 +6,25 @@ show_location(LX, LY, LZ) = "($(location_str(LX)), $(location_str(LY)), $(locati
 
 show_location(field::AbstractField{LX, LY, LZ}) where {LX, LY, LZ} = show_location(LX, LY, LZ)
 
-short_show(m::Missing) = "$m"
+Base.summary(m::Missing) = "$m"
 
-short_show(field::AbstractField) = string(typeof(field).name.wrapper, " located at ", show_location(field))
+Base.summary(field::AbstractField) = string(typeof(field).name.wrapper, " located at ", show_location(field))
 
 Base.show(io::IO, field::AbstractField{LX, LY, LZ}) where {LX, LY, LZ} =
-    print(io, "$(short_show(field))\n",
+    print(io, "$(summary(field))\n",
           "├── architecture: $(architecture(field))\n",
-          "└── grid: $(short_show(field.grid))")
+          "└── grid: $(summary(field.grid))")
 
 Base.show(io::IO, field::Field) =
-    print(io, "$(short_show(field))\n",
+    print(io, "$(summary(field))\n",
           "├── data: $(typeof(field.data)), size: $(size(field))\n",
-          "├── grid: $(short_show(field.grid))\n",
-          "└── boundary conditions: $(short_show(field.boundary_conditions))")
+          "├── grid: $(summary(field.grid))\n",
+          "└── boundary conditions: $(summary(field.boundary_conditions))")
 
 show_status(::Nothing) = "nothing"
 show_status(status) = "time=$(status.time)"
 
 Base.show(io::IO, field::ZeroField) = print(io, "ZeroField")
-
-short_show(array::OffsetArray{T, D, A}) where {T, D, A} = string("OffsetArray{$T, $D, $A}")
 
 Base.show(io::IO, ::MIME"text/plain", f::AbstractField) = show(io, f)
 

--- a/src/Fields/show_fields.jl
+++ b/src/Fields/show_fields.jl
@@ -1,30 +1,52 @@
+using Printf
+using Oceananigans.Grids: size_summary, scalar_summary
+
 location_str(::Type{Face})    = "Face"
 location_str(::Type{Center})  = "Center"
 location_str(::Type{Nothing}) = "⋅"
-
 show_location(LX, LY, LZ) = "($(location_str(LX)), $(location_str(LY)), $(location_str(LZ)))"
+show_location(field::AbstractField) = show_location(location(field)...)
 
-show_location(field::AbstractField{LX, LY, LZ}) where {LX, LY, LZ} = show_location(LX, LY, LZ)
+function Base.summary(field::Field)
+    LX, LY, LZ = location(field)
+    prefix = string(size_summary(size(field)), " Field{$LX, $LY, $LZ}")
 
-Base.summary(m::Missing) = "$m"
+    grid_name = typeof(field.grid).name.wrapper
+    reduced_dims = reduced_dimensions(field)
 
-Base.summary(field::AbstractField) = string(typeof(field).name.wrapper, " located at ", show_location(field))
+    suffix = reduced_dims === () ?
+        string(" on ", grid_name, " on ", summary(architecture(field))) :
+        string(" reduced over dims = ", reduced_dims,
+               " on ", grid_name, " on ", summary(architecture(field)))
 
-Base.show(io::IO, field::AbstractField{LX, LY, LZ}) where {LX, LY, LZ} =
-    print(io, "$(summary(field))\n",
-          "├── architecture: $(architecture(field))\n",
-          "└── grid: $(summary(field.grid))")
+    return string(prefix, suffix)
+end
 
-Base.show(io::IO, field::Field) =
-    print(io, "$(summary(field))\n",
-          "├── data: $(typeof(field.data)), size: $(size(field))\n",
-          "├── grid: $(summary(field.grid))\n",
-          "└── boundary conditions: $(summary(field.boundary_conditions))")
+data_summary(field) = string("max=", scalar_summary(maximum(field)), ", ",
+                             "min=", scalar_summary(minimum(field)), ", ",
+                             "mean=", scalar_summary(mean(field)))
 
-show_status(::Nothing) = "nothing"
-show_status(status) = "time=$(status.time)"
+function Base.show(io::IO, field::Field)
 
-Base.show(io::IO, field::ZeroField) = print(io, "ZeroField")
+    prefix =
+        string("$(summary(field))\n",
+               "├── grid: ", summary(field.grid), '\n',
+               "├── boundary conditions: ", summary(field.boundary_conditions), '\n')
+
+    middle = isnothing(field.operand) ? "" :
+        string("├── operand: ", summary(field.operand), '\n',
+               "├── status: ", summary(field.status), '\n')
+
+    suffix = string("└── data: ", summary(field.data), '\n',
+                    "    └── ", data_summary(field))
+
+    print(io, prefix, middle, suffix)
+end
+
+Base.summary(status::FieldStatus) = "time=$(status.time)"
+
+Base.summary(::ZeroField{N}) where N = "ZeroField{$N}"
+Base.show(io::IO, z::ZeroField) = print(io, summary(z))
 
 Base.show(io::IO, ::MIME"text/plain", f::AbstractField) = show(io, f)
 

--- a/src/Forcings/continuous_forcing.jl
+++ b/src/Forcings/continuous_forcing.jl
@@ -3,7 +3,7 @@ import Adapt
 using Oceananigans.Grids: node
 using Oceananigans.Operators: assumed_field_location, index_and_interp_dependencies
 using Oceananigans.Fields: show_location
-using Oceananigans.Utils: user_function_arguments, tupleit
+using Oceananigans.Utils: user_function_arguments, tupleit, prettysummary
 
 """
     ContinuousForcing{LX, LY, LZ, P, F, D, I, ℑ}
@@ -127,7 +127,7 @@ end
 """Show the innards of a `ContinuousForcing` in the REPL."""
 Base.show(io::IO, forcing::ContinuousForcing{LX, LY, LZ, P}) where {LX, LY, LZ, P} =
     print(io, "ContinuousForcing{$P} at ", show_location(LX, LY, LZ), '\n',
-        "├── func: $(summary(forcing.func))", '\n',
+        "├── func: $(prettysummary(forcing.func))", '\n',
         "├── parameters: $(forcing.parameters)", '\n',
         "└── field dependencies: $(forcing.field_dependencies)")
 

--- a/src/Forcings/continuous_forcing.jl
+++ b/src/Forcings/continuous_forcing.jl
@@ -134,7 +134,7 @@ Base.show(io::IO, forcing::ContinuousForcing{LX, LY, LZ, P}) where {LX, LY, LZ, 
 """Show the innards of an "non-regularized" `ContinuousForcing` in the REPL."""
 Base.show(io::IO, forcing::ContinuousForcing{Nothing, Nothing, Nothing, P}) where P =
     print(io, "ContinuousForcing{$P}", '\n',
-        "├── func: $(summary(forcing.func))", '\n',
+        "├── func: $(prettysummary(forcing.func))", '\n',
         "├── parameters: $(forcing.parameters)", '\n',
         "└── field dependencies: $(forcing.field_dependencies)")
 

--- a/src/Forcings/continuous_forcing.jl
+++ b/src/Forcings/continuous_forcing.jl
@@ -1,6 +1,5 @@
 import Adapt
 
-using Oceananigans: short_show
 using Oceananigans.Grids: node
 using Oceananigans.Operators: assumed_field_location, index_and_interp_dependencies
 using Oceananigans.Fields: show_location
@@ -128,14 +127,14 @@ end
 """Show the innards of a `ContinuousForcing` in the REPL."""
 Base.show(io::IO, forcing::ContinuousForcing{LX, LY, LZ, P}) where {LX, LY, LZ, P} =
     print(io, "ContinuousForcing{$P} at ", show_location(LX, LY, LZ), '\n',
-        "├── func: $(short_show(forcing.func))", '\n',
+        "├── func: $(summary(forcing.func))", '\n',
         "├── parameters: $(forcing.parameters)", '\n',
         "└── field dependencies: $(forcing.field_dependencies)")
 
 """Show the innards of an "non-regularized" `ContinuousForcing` in the REPL."""
 Base.show(io::IO, forcing::ContinuousForcing{Nothing, Nothing, Nothing, P}) where P =
     print(io, "ContinuousForcing{$P}", '\n',
-        "├── func: $(short_show(forcing.func))", '\n',
+        "├── func: $(summary(forcing.func))", '\n',
         "├── parameters: $(forcing.parameters)", '\n',
         "└── field dependencies: $(forcing.field_dependencies)")
 

--- a/src/Forcings/discrete_forcing.jl
+++ b/src/Forcings/discrete_forcing.jl
@@ -1,6 +1,6 @@
 import Adapt
 
-using Oceananigans: short_show
+using Oceananigans.Utils: prettysummary
 
 """
     struct DiscreteForcing{P, F}
@@ -51,7 +51,7 @@ end
 """Show the innards of a `DiscreteForcing` in the REPL."""
 Base.show(io::IO, forcing::DiscreteForcing{P}) where P =
     print(io, "DiscreteForcing{$P}", '\n',
-        "├── func: $(short_show(forcing.func))", '\n',
+        "├── func: $(prettysummary(forcing.func))", '\n',
         "└── parameters: $(forcing.parameters)")
 
 Adapt.adapt_structure(to, forcing::DiscreteForcing) =

--- a/src/Forcings/forcing.jl
+++ b/src/Forcings/forcing.jl
@@ -63,7 +63,7 @@ v_forcing = Forcing(parameterized_func, parameters = (μ=42, λ=0.1, ω=π))
 
 # output
 ContinuousForcing{NamedTuple{(:μ, :λ, :ω), Tuple{Int64, Float64, Irrational{:π}}}}
-├── func: parameterized_func
+├── func: parameterized_func (generic function with 1 method)
 ├── parameters: (μ = 42, λ = 0.1, ω = π)
 └── field dependencies: ()
 ```
@@ -79,7 +79,7 @@ model.forcing.v
 
 # output
 ContinuousForcing{NamedTuple{(:μ, :λ, :ω), Tuple{Int64, Float64, Irrational{:π}}}} at (Center, Face, Center)
-├── func: parameterized_func
+├── func: parameterized_func (generic function with 1 method)
 ├── parameters: (μ = 42, λ = 0.1, ω = π)
 └── field dependencies: ()
 ```
@@ -95,7 +95,7 @@ plankton_forcing = Forcing(growth_in_sunlight, field_dependencies=:P)
 
 # output
 ContinuousForcing{Nothing}
-├── func: growth_in_sunlight
+├── func: growth_in_sunlight (generic function with 1 method)
 ├── parameters: nothing
 └── field dependencies: (:P,)
 ```
@@ -110,7 +110,7 @@ c_forcing = Forcing(tracer_relaxation,
 
 # output
 ContinuousForcing{NamedTuple{(:μ, :λ, :H, :dCdz), Tuple{Float64, Int64, Int64, Int64}}}
-├── func: tracer_relaxation
+├── func: tracer_relaxation (generic function with 1 method)
 ├── parameters: (μ = 0.016666666666666666, λ = 10, H = 1000, dCdz = 1)
 └── field dependencies: (:c,)
 ```
@@ -124,7 +124,7 @@ filtered_forcing = Forcing(filtered_relaxation, discrete_form=true)
 
 # output
 DiscreteForcing{Nothing}
-├── func: filtered_relaxation
+├── func: filtered_relaxation (generic function with 1 method)
 └── parameters: nothing
 ```
 
@@ -137,7 +137,7 @@ masked_damping_forcing = Forcing(masked_damping, parameters=(μ=42, λ=π), disc
 
 # output
 DiscreteForcing{NamedTuple{(:μ, :λ), Tuple{Int64, Irrational{:π}}}}
-├── func: masked_damping
+├── func: masked_damping (generic function with 1 method)
 └── parameters: (μ = 42, λ = π)
 ```
 """
@@ -148,3 +148,4 @@ function Forcing(func; parameters=nothing, field_dependencies=(), discrete_form=
         return ContinuousForcing(func; parameters=parameters, field_dependencies=field_dependencies)
     end
 end
+

--- a/src/Forcings/relaxation.jl
+++ b/src/Forcings/relaxation.jl
@@ -1,4 +1,3 @@
-import Oceananigans: short_show
 
 @inline zerofunction(args...) = 0
 @inline onefunction(args...) = 1
@@ -6,8 +5,8 @@ import Oceananigans: short_show
 T_zerofunction = typeof(zerofunction)
 T_onefunction = typeof(onefunction)
 
-short_show(::T_zerofunction) = "0"
-short_show(::T_onefunction) = "1"
+Base.summary(::T_zerofunction) = "0"
+Base.summary(::T_onefunction) = "1"
 
 """
     struct Relaxation{R, M, T}
@@ -88,11 +87,11 @@ end
 Base.show(io::IO, relaxation::Relaxation{R, M, T}) where {R, M, T} =
     print(io, "Relaxation{$R, $M, $T}", '\n',
         "├── rate: $(relaxation.rate)", '\n',
-        "├── mask: $(short_show(relaxation.mask))", '\n',
-        "└── target: $(short_show(relaxation.target))")
+        "├── mask: $(summary(relaxation.mask))", '\n',
+        "└── target: $(summary(relaxation.target))")
 
-short_show(relaxation::Relaxation) =
-    "Relaxation(rate=$(relaxation.rate), mask=$(short_show(relaxation.mask)), target=$(short_show(relaxation.target)))"
+Base.summary(relaxation::Relaxation) =
+    "Relaxation(rate=$(relaxation.rate), mask=$(summary(relaxation.mask)), target=$(summary(relaxation.target)))"
 
 #####
 ##### Sponge layer functions
@@ -131,7 +130,7 @@ show_exp_arg(D, c) = c == 0 ? "$D^2" :
                      c > 0  ? "($D - $c)^2" :
                               "($D + $(-c))^2"
 
-short_show(g::GaussianMask{D}) where D =
+Base.summary(g::GaussianMask{D}) where D =
     "exp(-$(show_exp_arg(D, g.center)) / (2 * $(g.width)^2))"
 
 #####
@@ -168,6 +167,6 @@ end
 @inline (p::LinearTarget{:y})(x, y, z, t) = p.intercept + p.gradient * y
 @inline (p::LinearTarget{:z})(x, y, z, t) = p.intercept + p.gradient * z
 
-short_show(l::LinearTarget{:x}) = "$(l.intercept) + $(l.gradient) * x"
-short_show(l::LinearTarget{:y}) = "$(l.intercept) + $(l.gradient) * y"
-short_show(l::LinearTarget{:z}) = "$(l.intercept) + $(l.gradient) * z"
+Base.summary(l::LinearTarget{:x}) = "$(l.intercept) + $(l.gradient) * x"
+Base.summary(l::LinearTarget{:y}) = "$(l.intercept) + $(l.gradient) * y"
+Base.summary(l::LinearTarget{:z}) = "$(l.intercept) + $(l.gradient) * z"

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -21,7 +21,6 @@ using Oceananigans
 using Oceananigans.Architectures
 
 import Base: size, length, eltype, show
-import Oceananigans: short_show
 import Oceananigans.Architectures: architecture
 
 #####

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -353,8 +353,24 @@ end
 
 struct ZDirection end
 
-@inline show_coordinate(Δ::Number, T)            = "Regular, with spacing $Δ"
-@inline show_coordinate(Δ::Number, ::Type{Flat}) = "Flattened"
-@inline show_coordinate(Δ::AbstractVector, T)    = @sprintf("Stretched, with spacing min=%.6f, max=%.6f",
-                                                            minimum(parent(Δ)), maximum(parent(Δ)))
+#####
+##### Show utils
+#####
+
+size_summary(sz) = string(sz[1], "×", sz[2], "×", sz[3])
+
+dimension_summary(topo::Flat, left, right, spacing, name) = "Flat $name"
+
+function dimension_summary(topo, left, right, spacing, name)
+    interval = topo isa Periodic ? ")" : "]"
+    topo_string = topo isa Periodic ? "Periodic " :
+                                      "Bounded  "
+    return string(topo_string,
+                  name, " ∈ [", left, ", ", right, interval, " ",
+                  coordinate_summary(spacing, name))
+end
+
+coordinate_summary(Δ::Number, name)         = @sprintf("with Δ%s = %s", name, Δ)
+coordinate_summary(Δ::AbstractVector, name) = @sprintf("with min(Δ%s) = %.6f, max(Δ%s) = %.6f",
+                                                       name, minimum(parent(Δ)), name, maximum(parent(Δ)))
 

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -1,5 +1,6 @@
 using CUDA
 using Printf
+using Base.Ryu: writeshortest
 
 #####
 ##### Convenience functions
@@ -358,19 +359,27 @@ struct ZDirection end
 #####
 
 size_summary(sz) = string(sz[1], "×", sz[2], "×", sz[3])
+scalar_summary(σ) = writeshortest(σ, false, false, true, -1, UInt8('e'), false, UInt8('.'), false, true)
+dimension_summary(topo::Flat, name, args...) = "Flat $name"
 
-dimension_summary(topo::Flat, left, right, spacing, name) = "Flat $name"
-
-function dimension_summary(topo, left, right, spacing, name)
+function domain_summary(topo, name, left, right)
     interval = topo isa Periodic ? ")" : "]"
     topo_string = topo isa Periodic ? "Periodic " :
                                       "Bounded  "
-    return string(topo_string,
-                  name, " ∈ [", left, ", ", right, interval, " ",
-                  coordinate_summary(spacing, name))
+
+    prefix = string(topo_string, name, " ∈ [",
+                    scalar_summary(left), ", ",
+                    scalar_summary(right), interval)
 end
 
-coordinate_summary(Δ::Number, name)         = @sprintf("with Δ%s = %s", name, Δ)
-coordinate_summary(Δ::AbstractVector, name) = @sprintf("with min(Δ%s) = %.6f, max(Δ%s) = %.6f",
-                                                       name, minimum(parent(Δ)), name, maximum(parent(Δ)))
+function dimension_summary(topo, name, left, right, spacing, pad_domain=0)
+    prefix = domain_summary(topo, name, left, right)
+    padding = " "^(pad_domain+1) 
+    return string(prefix, padding, coordinate_summary(spacing, name))
+end
+
+coordinate_summary(Δ::Number, name) = @sprintf("regularly spaced with Δ%s=%s", name, scalar_summary(Δ))
+coordinate_summary(Δ::AbstractVector, name) = @sprintf("variably spaced with min(Δ%s)=%s, max(Δ%s)=%s",
+                                                       name, scalar_summary(minimum(parent(Δ))),
+                                                       name, scalar_summary(maximum(parent(Δ))))
 

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -197,11 +197,20 @@ function Base.show(io::IO, grid::LatitudeLongitudeGrid)
     φ₁, φ₂ = domain(topology(grid, 2), grid.Ny, grid.φᵃᶠᵃ)
     z₁, z₂ = domain(topology(grid, 3), grid.Nz, grid.zᵃᵃᶠ)
 
-    print(io,
-          summary(grid), '\n',
-          "    ", dimension_summary(TX(), λ₁, λ₂, grid.Δλᶜᵃᵃ, "λ"), '\n',  
-          "    ", dimension_summary(TY(), φ₁, φ₂, grid.Δφᵃᶜᵃ, "φ"), '\n',  
-          "    ", dimension_summary(TZ(), z₁, z₂, grid.Δzᵃᵃᶜ, "z"))
+    x_summary = domain_summary(TX(), "λ", λ₁, λ₂)
+    y_summary = domain_summary(TY(), "φ", φ₁, φ₂)
+    z_summary = domain_summary(TZ(), "z", z₁, z₂)
+
+    longest = max(length(x_summary), length(y_summary), length(z_summary)) 
+
+    x_summary = dimension_summary(TX(), "λ", λ₁, λ₂, grid.Δλᶜᵃᵃ, longest - length(x_summary))
+    y_summary = dimension_summary(TY(), "φ", φ₁, φ₂, grid.Δφᵃᶜᵃ, longest - length(y_summary))
+    z_summary = dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary))
+
+    print(io, summary(grid), '\n',
+          "├── ", x_summary, '\n',
+          "├── ", y_summary, '\n',
+          "└── ", z_summary)
 end
 
 # Node by node

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -182,7 +182,7 @@ end
 function Base.summary(grid::LatitudeLongitudeGrid)
     FT = eltype(grid)
     TX, TY, TZ = topology(grid)
-    metric_computation = isnothing(g.Δxᶠᶜᵃ) ? "without precomputed metrics" : "with precomputed metrics"
+    metric_computation = isnothing(grid.Δxᶠᶜᵃ) ? "without precomputed metrics" : "with precomputed metrics"
 
     return string(size_summary(size(grid)),
                   " LatitudeLongitudeGrid{$FT, $TX, $TY, $TZ} on ", summary(architecture(grid)),

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -179,30 +179,29 @@ function validate_lat_lon_grid_args(latitude, longitude, size, halo)
     return Nλ, Nφ, Nz, Hλ, Hφ, Hz, latitude, longitude, topo
 end
 
-function domain_string(grid::LatitudeLongitudeGrid)
+function Base.summary(grid::LatitudeLongitudeGrid)
+    FT = eltype(grid)
+    TX, TY, TZ = topology(grid)
+    metric_computation = isnothing(g.Δxᶠᶜᵃ) ? "without precomputed metrics" : "with precomputed metrics"
+
+    return string(size_summary(size(grid)),
+                  " LatitudeLongitudeGrid{$FT, $TX, $TY, $TZ} on ", summary(architecture(grid)),
+                  " with ", size_summary(halo_size(grid)), " halo",
+                  " and ", metric_computation)
+end
+
+function Base.show(io::IO, grid::LatitudeLongitudeGrid)
+    TX, TY, TZ = topology(grid)
+
     λ₁, λ₂ = domain(topology(grid, 1), grid.Nx, grid.λᶠᵃᵃ)
     φ₁, φ₂ = domain(topology(grid, 2), grid.Ny, grid.φᵃᶠᵃ)
     z₁, z₂ = domain(topology(grid, 3), grid.Nz, grid.zᵃᵃᶠ)
-    return "longitude λ ∈ [$λ₁, $λ₂], latitude ∈ [$φ₁, $φ₂], z ∈ [$z₁, $z₂]"
-end
 
-function show(io::IO, g::LatitudeLongitudeGrid)
-    FT = eltype(g)
-    TX, TY, TZ = topology(g)
-
-    show_metrics = isnothing(g.Δxᶠᶜᵃ) ? "metrics are computed on the fly" : 
-                                        "metrics are pre-computed"
-
-    return print(io, "LatitudeLongitudeGrid{$FT, $TX, $TY, $TZ} \n",
-                     "             architecture: $(g.architecture)\n",
-                     "                   domain: $(domain_string(g))\n",
-                     "                 topology: ", (TX, TY, TZ), '\n',
-                     "        size (Nx, Ny, Nz): ", (g.Nx, g.Ny, g.Nz), '\n',
-                     "        halo (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz), '\n',
-                     "             spacing in λ: ", show_coordinate(g.Δλᶜᵃᵃ, TX), '\n',
-                     "             spacing in φ: ", show_coordinate(g.Δφᵃᶜᵃ, TY), '\n',
-                     "             spacing in z: ", show_coordinate(g.Δzᵃᵃᶜ, TZ), '\n',
-                     show_metrics)
+    print(io,
+          summary(grid), '\n',
+          "    ", dimension_summary(TX(), λ₁, λ₂, grid.Δλᶜᵃᵃ, "λ"), '\n',  
+          "    ", dimension_summary(TY(), φ₁, φ₂, grid.Δφᵃᶜᵃ, "φ"), '\n',  
+          "    ", dimension_summary(TZ(), z₁, z₂, grid.Δzᵃᵃᶜ, "z"))
 end
 
 # Node by node

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -82,12 +82,43 @@ const HRegLatLonGrid = LatitudeLongitudeGrid{<:Any, <:Any, <:Any, <:Any, <:Any, 
 regular_dimensions(::ZRegLatLonGrid) = tuple(3)
 
 """
+    LatitudeLongitudeGrid([architecture = CPU(), FT = Float64];
+                          size,
+                          latitude,
+                          longitude,
+                          z,
+                          radius = R_Earth,
+                          precompute_metrics = false,
+                          halo = (1, 1, 1))
 
-latitude, longitude and z can be a 2-tuple that specifies the end of the domain (see RegularRectilinearDomain)
-or an array or function that specifies the faces (see VerticallyStretchedRectilinearGrid)
+Creates a `LatitudeLongitudeGrid` with `size = (Nx, Ny, Nz)` grid points.
 
+Positional arguments
+=================
+
+- `architecture`: Specifies whether arrays of coordinates and spacings are stored
+                  on the CPU or GPU. Default: `architecture = CPU()`.
+
+- `FT` : Floating point data type. Default: `FT = Float64`.
+
+Keyword arguments
+=================
+
+- `size` (required): A 3-tuple prescribing the number of grid points each direction.
+
+- `latitude`, `longitude`, `z`: Each is either a
+                                (i) 2-tuple that specify the end points of the domain,
+                                (ii) one-dimensional array specifying the cell interface locations or
+                                (iii) a single-argument function that takes an index and returns
+                                      cell interface location.
+
+- `precompute_metrics`: Boolean specifying whether to precompute horizontal spacings and areas.
+                        If `!precompute_metrics` (the default), horizontal spacings and areas
+                        are computed on-the-fly during a simulation.
+
+- `halo`: A 3-tuple of integers specifying the size of the halo region of cells surrounding
+          the physical interior.
 """
-
 function LatitudeLongitudeGrid(architecture::AbstractArchitecture = CPU(),
                                FT::DataType = Float64;
                                precompute_metrics = false,

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -335,26 +335,26 @@ z_domain(grid::RectilinearGrid) = domain(topology(grid, 3), grid.Nz, grid.zᵃ�
 # is specifying the floating point type.
 RectilinearGrid(FT::DataType; kwargs...) = RectilinearGrid(CPU(), FT; kwargs...)
 
-Base.summary(grid::RectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
-    "RectilinearGrid{$FT, $TX, $TY, $TZ}(Nx=$(grid.Nx), Ny=$(grid.Ny), Nz=$(grid.Nz))"
+function Base.summary(grid::RectilinearGrid)
+    FT = eltype(grid)
 
-function domain_string(grid::RectilinearGrid)
+    return string(size_summary(size(grid)),
+                  " RectilinearGrid{$FT} on ", summary(architecture(grid)),
+                  " with ", size_summary(halo_size(grid)), " halo")
+end
+
+function Base.show(io::IO, grid::RectilinearGrid)
+    TX, TY, TZ = topology(grid)
+
     x₁, x₂ = domain(topology(grid, 1), grid.Nx, grid.xᶠᵃᵃ)
     y₁, y₂ = domain(topology(grid, 2), grid.Ny, grid.yᵃᶠᵃ)
     z₁, z₂ = domain(topology(grid, 3), grid.Nz, grid.zᵃᵃᶠ)
-    return "x ∈ [$x₁, $x₂], y ∈ [$y₁, $y₂], z ∈ [$z₁, $z₂]"
-end
 
-function show(io::IO, g::RectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
-    print(io, "RectilinearGrid{$FT, $TX, $TY, $TZ}\n",
-              "             architecture: $(g.architecture)\n",
-              "                   domain: $(domain_string(g))\n",
-              "                 topology: ", (TX, TY, TZ), '\n',
-              "        size (Nx, Ny, Nz): ", (g.Nx, g.Ny, g.Nz), '\n',
-              "        halo (Hx, Hy, Hz): ", (g.Hx, g.Hy, g.Hz), '\n',
-              "             spacing in x: ", show_coordinate(g.Δxᶜᵃᵃ, TX), '\n',
-              "             spacing in y: ", show_coordinate(g.Δyᵃᶜᵃ, TY), '\n',
-              "             spacing in z: ", show_coordinate(g.Δzᵃᵃᶜ, TZ))
+    print(io,
+          summary(grid), '\n',
+          "    ", dimension_summary(TX(), x₁, x₂, grid.Δxᶜᵃᵃ, "x"), '\n',  
+          "    ", dimension_summary(TY(), y₁, y₂, grid.Δyᵃᶜᵃ, "y"), '\n',  
+          "    ", dimension_summary(TZ(), z₁, z₂, grid.Δzᵃᵃᶜ, "z"))
 end
 
 #####

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -155,10 +155,10 @@ Examples
 julia> using Oceananigans
 
 julia> grid = RectilinearGrid(size=(32, 32, 32), extent=(1, 2, 3))
-32×32×16 RectilinearGrid{Float32} on CPU with 1×1×1 halo
-├── Periodic x ∈ [0.0, 8.0)          regularly spaced with Δx=0.25
-├── Periodic y ∈ [-10.0, 10.0)       regularly spaced with Δy=0.625
-└── Bounded  z ∈ [-3.14159, 3.14159] regularly spaced with Δz=0.392699
+32×32×32 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
+├── Periodic x ∈ [0.0, 1.0)  regularly spaced with Δx=0.03125
+├── Periodic y ∈ [0.0, 2.0)  regularly spaced with Δy=0.0625
+└── Bounded  z ∈ [-3.0, 0.0] regularly spaced with Δz=0.09375
 ```
 
 * A default grid with `Float32` type:
@@ -167,7 +167,7 @@ julia> grid = RectilinearGrid(size=(32, 32, 32), extent=(1, 2, 3))
 julia> using Oceananigans
 
 julia> grid = RectilinearGrid(Float32; size=(32, 32, 16), x=(0, 8), y=(-10, 10), z=(-π, π))
-32×32×16 RectilinearGrid{Float32} on CPU with 1×1×1 halo
+32×32×16 RectilinearGrid{Float32, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── Periodic x ∈ [0.0, 8.0)          regularly spaced with Δx=0.25
 ├── Periodic y ∈ [-10.0, 10.0)       regularly spaced with Δy=0.625
 └── Bounded  z ∈ [-3.14159, 3.14159] regularly spaced with Δz=0.392699
@@ -179,7 +179,7 @@ julia> grid = RectilinearGrid(Float32; size=(32, 32, 16), x=(0, 8), y=(-10, 10),
 julia> using Oceananigans
 
 julia> grid = RectilinearGrid(size=(32, 32), extent=(2π, 4π), topology=(Periodic, Periodic, Flat))
-32×32×1 RectilinearGrid{Float64} on CPU with 1×1×0 halo
+32×32×1 RectilinearGrid{Float64, Periodic, Periodic, Flat} on CPU with 1×1×0 halo
 ├── Periodic x ∈ [0.0, 6.28319) regularly spaced with Δx=0.19635
 ├── Periodic y ∈ [0.0, 12.5664) regularly spaced with Δy=0.392699
 └── Flat z
@@ -191,7 +191,7 @@ julia> grid = RectilinearGrid(size=(32, 32), extent=(2π, 4π), topology=(Period
 julia> using Oceananigans
 
 julia> grid = RectilinearGrid(size=256, z=(-128, 0), topology=(Flat, Flat, Bounded))
-1×1×256 RectilinearGrid{Float64} on CPU with 0×0×1 halo
+1×1×256 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×1 halo
 ├── Flat x
 ├── Flat y
 └── Bounded  z ∈ [-128.0, 0.0] regularly spaced with Δz=0.5
@@ -212,7 +212,7 @@ julia> hyperbolically_spaced_faces(k) = - Lz * (1 - tanh(σ * (k - 1) / Nz) / ta
 
 julia> grid = RectilinearGrid(size = (32, 32, Nz), x = (0, 64),
                               y = (0, 64), z = hyperbolically_spaced_faces)
-32×32×24 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+32×32×24 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── Periodic x ∈ [0.0, 64.0)   regularly spaced with Δx=2.0
 ├── Periodic y ∈ [0.0, 64.0)   regularly spaced with Δy=2.0
 └── Bounded  z ∈ [-32.0, -0.0] variably spaced with min(Δz)=0.682695, max(Δz)=1.83091
@@ -240,7 +240,7 @@ julia> grid = RectilinearGrid(size = (Nx, Ny, Nz),
                               x = (0, Lx),
                               y = chebychev_nodes,
                               z = hyperbolically_spaced_faces)
-32×30×24 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+32×30×24 RectilinearGrid{Float64, Periodic, Bounded, Bounded} on CPU with 1×1×1 halo
 ├── Periodic x ∈ [0.0, 200.0)  regularly spaced with Δx=6.25
 ├── Bounded  y ∈ [-50.0, 50.0] variably spaced with min(Δy)=0.273905, max(Δy)=5.22642
 └── Bounded  z ∈ [-32.0, -0.0] variably spaced with min(Δz)=0.682695, max(Δz)=1.83091
@@ -300,9 +300,10 @@ RectilinearGrid(FT::DataType; kwargs...) = RectilinearGrid(CPU(), FT; kwargs...)
 
 function Base.summary(grid::RectilinearGrid)
     FT = eltype(grid)
+    TX, TY, TZ = topology(grid)
 
     return string(size_summary(size(grid)),
-                  " RectilinearGrid{$FT} on ", summary(architecture(grid)),
+                  " RectilinearGrid{$FT, $TX, $TY, $TZ} on ", summary(architecture(grid)),
                   " with ", size_summary(halo_size(grid)), " halo")
 end
 

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -162,15 +162,10 @@ Examples
 julia> using Oceananigans
 
 julia> grid = RectilinearGrid(size=(32, 32, 32), extent=(1, 2, 3))
-RectilinearGrid{Float64, Periodic, Periodic, Bounded}
-             architecture: CPU()
-                   domain: x ∈ [0.0, 1.0], y ∈ [0.0, 2.0], z ∈ [-3.0, 0.0]
-                 topology: (Periodic, Periodic, Bounded)
-        size (Nx, Ny, Nz): (32, 32, 32)
-        halo (Hx, Hy, Hz): (1, 1, 1)
-             spacing in x: Regular, with spacing 0.03125
-             spacing in y: Regular, with spacing 0.0625
-             spacing in z: Regular, with spacing 0.09375
+32×32×16 RectilinearGrid{Float32} on CPU with 1×1×1 halo
+├── Periodic x ∈ [0.0, 8.0)          regularly spaced with Δx=0.25
+├── Periodic y ∈ [-10.0, 10.0)       regularly spaced with Δy=0.625
+└── Bounded  z ∈ [-3.14159, 3.14159] regularly spaced with Δz=0.392699
 ```
 
 * A default grid with `Float32` type:
@@ -179,15 +174,10 @@ RectilinearGrid{Float64, Periodic, Periodic, Bounded}
 julia> using Oceananigans
 
 julia> grid = RectilinearGrid(Float32; size=(32, 32, 16), x=(0, 8), y=(-10, 10), z=(-π, π))
-RectilinearGrid{Float32, Periodic, Periodic, Bounded} 
-             architecture: CPU()
-                   domain: x ∈ [0.0, 8.0], y ∈ [-10.0, 10.0], z ∈ [-3.1415927, 3.1415927]
-                 topology: (Periodic, Periodic, Bounded)
-        size (Nx, Ny, Nz): (32, 32, 16)
-        halo (Hx, Hy, Hz): (1, 1, 1)
-             spacing in x: Regular, with spacing 0.25
-             spacing in y: Regular, with spacing 0.625
-             spacing in z: Regular, with spacing 0.3926991
+32×32×16 RectilinearGrid{Float32} on CPU with 1×1×1 halo
+├── Periodic x ∈ [0.0, 8.0)          regularly spaced with Δx=0.25
+├── Periodic y ∈ [-10.0, 10.0)       regularly spaced with Δy=0.625
+└── Bounded  z ∈ [-3.14159, 3.14159] regularly spaced with Δz=0.392699
 ```
 
 * A two-dimenisional, horizontally-periodic grid:
@@ -196,15 +186,10 @@ RectilinearGrid{Float32, Periodic, Periodic, Bounded}
 julia> using Oceananigans
 
 julia> grid = RectilinearGrid(size=(32, 32), extent=(2π, 4π), topology=(Periodic, Periodic, Flat))
-RectilinearGrid{Float64, Periodic, Periodic, Flat} 
-             architecture: CPU()
-                   domain: x ∈ [0.0, 6.283185307179586], y ∈ [0.0, 12.566370614359172], z ∈ [1.0, 1.0]
-                 topology: (Periodic, Periodic, Flat)
-        size (Nx, Ny, Nz): (32, 32, 1)
-        halo (Hx, Hy, Hz): (1, 1, 0)
-             spacing in x: Regular, with spacing 0.19634954084936207
-             spacing in y: Regular, with spacing 0.39269908169872414
-             spacing in z: Flattened
+32×32×1 RectilinearGrid{Float64} on CPU with 1×1×0 halo
+├── Periodic x ∈ [0.0, 6.28319) regularly spaced with Δx=0.19635
+├── Periodic y ∈ [0.0, 12.5664) regularly spaced with Δy=0.392699
+└── Flat z
 ```
 
 * A one-dimensional "column" grid:
@@ -213,15 +198,10 @@ RectilinearGrid{Float64, Periodic, Periodic, Flat}
 julia> using Oceananigans
 
 julia> grid = RectilinearGrid(size=256, z=(-128, 0), topology=(Flat, Flat, Bounded))
-RectilinearGrid{Float64, Flat, Flat, Bounded}
-             architecture: CPU()
-                   domain: x ∈ [1.0, 1.0], y ∈ [1.0, 1.0], z ∈ [-128.0, 0.0]
-                 topology: (Flat, Flat, Bounded)
-        size (Nx, Ny, Nz): (1, 1, 256)
-        halo (Hx, Hy, Hz): (0, 0, 1)
-             spacing in x: Flattened
-             spacing in y: Flattened
-             spacing in z: Regular, with spacing 0.5
+1×1×256 RectilinearGrid{Float64} on CPU with 0×0×1 halo
+├── Flat x
+├── Flat y
+└── Bounded  z ∈ [-128.0, 0.0] regularly spaced with Δz=0.5
 ```
 
 * A horizontally-periodic regular grid with cell interfaces stretched hyperbolically near the top:
@@ -239,19 +219,14 @@ julia> hyperbolically_spaced_faces(k) = - Lz * (1 - tanh(σ * (k - 1) / Nz) / ta
 
 julia> grid = RectilinearGrid(size = (32, 32, Nz), x = (0, 64),
                               y = (0, 64), z = hyperbolically_spaced_faces)
-RectilinearGrid{Float64, Periodic, Periodic, Bounded}
-             architecture: CPU()
-                   domain: x ∈ [0.0, 64.0], y ∈ [0.0, 64.0], z ∈ [-32.0, -0.0]
-                 topology: (Periodic, Periodic, Bounded)
-        size (Nx, Ny, Nz): (32, 32, 24)
-        halo (Hx, Hy, Hz): (1, 1, 1)
-             spacing in x: Regular, with spacing 2.0
-             spacing in y: Regular, with spacing 2.0
-             spacing in z: Stretched, with spacing min=0.682695, max=1.830909
+32×32×24 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+├── Periodic x ∈ [0.0, 64.0)   regularly spaced with Δx=2.0
+├── Periodic y ∈ [0.0, 64.0)   regularly spaced with Δy=2.0
+└── Bounded  z ∈ [-32.0, -0.0] variably spaced with min(Δz)=0.682695, max(Δz)=1.83091
 ```
 
-* A three-dimensional grid with regular spacing in x, cell interfaces that are closely spaced
-  close to the boundaries in y (closely mimicing the Chebychev nodes) and cell interfaces
+* A three-dimensional grid with regular spacing in x,
+  cell interfaces at Chebyshev nodes in y, and cell interfaces
   stretched in z hyperbolically near the top:
 
 ```jldoctest
@@ -261,7 +236,7 @@ julia> Nx, Ny, Nz = 32, 30, 24;
 
 julia> Lx, Ly, Lz = 200, 100, 32; # (m)
 
-julia> chebychev_like_spaced_faces(j) = - Ly/2 * cos(π * (j - 1) / Ny);
+julia> chebychev_nodes(j) = - Ly/2 * cos(π * (j - 1) / Ny);
 
 julia> σ = 1.1; # stretching factor
 
@@ -270,17 +245,12 @@ julia> hyperbolically_spaced_faces(k) = - Lz * (1 - tanh(σ * (k - 1) / Nz) / ta
 julia> grid = RectilinearGrid(size = (Nx, Ny, Nz),
                               topology=(Periodic, Bounded, Bounded),
                               x = (0, Lx),
-                              y = chebychev_like_spaced_faces,
+                              y = chebychev_nodes,
                               z = hyperbolically_spaced_faces)
-RectilinearGrid{Float64, Periodic, Bounded, Bounded}
-             architecture: CPU()
-                   domain: x ∈ [0.0, 200.0], y ∈ [-50.0, 50.0], z ∈ [-32.0, -0.0]
-                 topology: (Periodic, Bounded, Bounded)
-        size (Nx, Ny, Nz): (32, 30, 24)
-        halo (Hx, Hy, Hz): (1, 1, 1)
-             spacing in x: Regular, with spacing 6.25
-             spacing in y: Stretched, with spacing min=0.273905, max=5.226423
-             spacing in z: Stretched, with spacing min=0.682695, max=1.830909
+32×30×24 RectilinearGrid{Float64} on CPU with 1×1×1 halo
+├── Periodic x ∈ [0.0, 200.0)  regularly spaced with Δx=6.25
+├── Bounded  y ∈ [-50.0, 50.0] variably spaced with min(Δy)=0.273905, max(Δy)=5.22642
+└── Bounded  z ∈ [-32.0, -0.0] variably spaced with min(Δz)=0.682695, max(Δz)=1.83091
 ```
 """
 function RectilinearGrid(architecture::AbstractArchitecture = CPU(),

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -1,10 +1,3 @@
-"""
-    RectilinearGrid{FT, TX, TY, TZ, FX, FY, FZ, VX, VY, VZ, Arch} <: AbstractRectilinearGrid{FT, TX, TY, TZ}
-
-A rectilinear grid with with either constant or varying grid spacings between cell centers and cell faces
-in all directions. Grid elements of type `FT`, topology `{TX, TY, TZ}`, grid spacings of type `{FX, FY, FZ}`
-and coordinates in each direction of type `{VX, VY, VZ}`. 
-"""
 struct RectilinearGrid{FT, TX, TY, TZ, FX, FY, FZ, VX, VY, VZ, Arch} <: AbstractRectilinearGrid{FT, TX, TY, TZ, Arch}
     architecture :: Arch
     Nx :: Int

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -350,11 +350,20 @@ function Base.show(io::IO, grid::RectilinearGrid)
     y₁, y₂ = domain(topology(grid, 2), grid.Ny, grid.yᵃᶠᵃ)
     z₁, z₂ = domain(topology(grid, 3), grid.Nz, grid.zᵃᵃᶠ)
 
-    print(io,
-          summary(grid), '\n',
-          "    ", dimension_summary(TX(), x₁, x₂, grid.Δxᶜᵃᵃ, "x"), '\n',  
-          "    ", dimension_summary(TY(), y₁, y₂, grid.Δyᵃᶜᵃ, "y"), '\n',  
-          "    ", dimension_summary(TZ(), z₁, z₂, grid.Δzᵃᵃᶜ, "z"))
+    x_summary = domain_summary(TX(), "x", x₁, x₂)
+    y_summary = domain_summary(TY(), "y", y₁, y₂)
+    z_summary = domain_summary(TZ(), "z", z₁, z₂)
+
+    longest = max(length(x_summary), length(y_summary), length(z_summary)) 
+
+    x_summary = dimension_summary(TX(), "x", x₁, x₂, grid.Δxᶜᵃᵃ, longest - length(x_summary))
+    y_summary = dimension_summary(TY(), "y", y₁, y₂, grid.Δyᵃᶜᵃ, longest - length(y_summary))
+    z_summary = dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary))
+
+    return print(io, summary(grid), '\n',
+                 "├── ", x_summary, '\n',
+                 "├── ", y_summary, '\n',
+                 "└── ", z_summary)
 end
 
 #####

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -335,7 +335,7 @@ z_domain(grid::RectilinearGrid) = domain(topology(grid, 3), grid.Nz, grid.záµƒáµ
 # is specifying the floating point type.
 RectilinearGrid(FT::DataType; kwargs...) = RectilinearGrid(CPU(), FT; kwargs...)
 
-short_show(grid::RectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
+Base.summary(grid::RectilinearGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
     "RectilinearGrid{$FT, $TX, $TY, $TZ}(Nx=$(grid.Nx), Ny=$(grid.Ny), Nz=$(grid.Nz))"
 
 function domain_string(grid::RectilinearGrid)

--- a/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
@@ -6,8 +6,8 @@ function Base.show(io::IO, model::HydrostaticFreeSurfaceModel{TS, C, A}) where {
         "(time = $(prettytime(model.clock.time)), iteration = $(model.clock.iteration)) \n",
         "├── grid: $(summary(model.grid))\n",
         "├── tracers: $(tracernames(model.tracers))\n",
-        "├── closure: $(typeof(model.closure))\n",
-        "├── buoyancy: $(typeof(model.buoyancy))\n")
+        "├── closure: ", summary(model.closure), '\n',
+        "├── buoyancy: ", summary(model.buoyancy), '\n')
 
     if isnothing(model.particles)
         print(io, "└── coriolis: $(typeof(model.coriolis))")

--- a/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
@@ -1,11 +1,10 @@
 using Oceananigans.Utils: prettytime, ordered_dict_show
-using Oceananigans: short_show
 
 """Show the innards of a `Model` in the REPL."""
 function Base.show(io::IO, model::HydrostaticFreeSurfaceModel{TS, C, A}) where {TS, C, A}
     print(io, "HydrostaticFreeSurfaceModel{$A, $(eltype(model.grid))}",
         "(time = $(prettytime(model.clock.time)), iteration = $(model.clock.iteration)) \n",
-        "├── grid: $(short_show(model.grid))\n",
+        "├── grid: $(summary(model.grid))\n",
         "├── tracers: $(tracernames(model.tracers))\n",
         "├── closure: $(typeof(model.closure))\n",
         "├── buoyancy: $(typeof(model.buoyancy))\n")

--- a/src/Models/NonhydrostaticModels/show_nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/show_nonhydrostatic_model.jl
@@ -1,11 +1,10 @@
-using Oceananigans: short_show
 using Oceananigans.Utils: prettytime, ordered_dict_show
 
 """Show the innards of a `Model` in the REPL."""
 function Base.show(io::IO, model::NonhydrostaticModel{TS, C, A}) where {TS, C, A}
     print(io, "NonhydrostaticModel{"*string(Base.nameof(A))*", $(eltype(model.grid))}",
         "(time = $(prettytime(model.clock.time)), iteration = $(model.clock.iteration)) \n",
-        "├── grid: $(short_show(model.grid))\n",
+        "├── grid: $(summary(model.grid))\n",
         "├── tracers: $(tracernames(model.tracers))\n",
         "├── closure: $(typeof(model.closure))\n",
         "├── buoyancy: $(typeof(isnothing(model.buoyancy) ? model.buoyancy : model.buoyancy.model))\n")

--- a/src/Models/NonhydrostaticModels/show_nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/show_nonhydrostatic_model.jl
@@ -6,15 +6,15 @@ function Base.show(io::IO, model::NonhydrostaticModel{TS, C, A}) where {TS, C, A
         "(time = $(prettytime(model.clock.time)), iteration = $(model.clock.iteration)) \n",
         "├── grid: $(summary(model.grid))\n",
         "├── tracers: $(tracernames(model.tracers))\n",
-        "├── closure: $(typeof(model.closure))\n",
-        "├── buoyancy: $(typeof(isnothing(model.buoyancy) ? model.buoyancy : model.buoyancy.model))\n")
+        "├── closure: ", summary(model.closure), '\n',
+        "├── buoyancy: ", summary(model.buoyancy), '\n')
 
     if isnothing(model.particles)
-        print(io, "└── coriolis: $(typeof(model.coriolis))")
+        print(io, "└── coriolis: ", summary(model.coriolis))
     else
         particles = model.particles.properties
         properties = propertynames(particles)
-        print(io, "├── coriolis: $(typeof(model.coriolis))\n")
+        print(io, "├── coriolis: ", summary(model.coriolis), '\n')
         print(io, "└── particles: $(length(particles)) Lagrangian particles with $(length(properties)) properties: $properties")
     end
 end

--- a/src/Models/ShallowWaterModels/show_shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/show_shallow_water_model.jl
@@ -1,10 +1,9 @@
 using Oceananigans.Utils: prettytime
-using Oceananigans: short_show
 
 """Show the innards of a `Model` in the REPL."""
 Base.show(io::IO, model::ShallowWaterModel{G, A, T}) where {G, A, T} =
     print(io, "ShallowWaterModel{$(Base.typename(A)), $T}",
         "(time = $(prettytime(model.clock.time)), iteration = $(model.clock.iteration)) \n",
-        "├── grid: $(short_show(model.grid))\n",
+        "├── grid: $(summary(model.grid))\n",
         "├── tracers: $(tracernames(model.tracers))\n",
         "└── coriolis: $(typeof(model.coriolis))")

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -162,7 +162,6 @@ function write_output! end
 function location end
 function instantiated_location end
 function tupleit end
-function short_show end
 
 function fields end
 function prognostic_fields end

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -10,7 +10,6 @@ using Oceananigans.Fields
 using Oceananigans.Grids: topology, total_size, interior_parent_indices
 using Oceananigans.Fields: show_location
 
-import Oceananigans: short_show
 import Oceananigans.Fields: Field, set!, interior
 import Oceananigans.Architectures: architecture
 
@@ -301,11 +300,11 @@ backend_str(::OnDisk) = "OnDisk"
 ##### show
 #####
 
-short_show(fts::FieldTimeSeries{LX, LY, LZ, K}) where {LX, LY, LZ, K} =
+Base.summary(fts::FieldTimeSeries{LX, LY, LZ, K}) where {LX, LY, LZ, K} =
     string("$(join(size(fts), "×")) FieldTimeSeries{$(backend_str(K()))} located at $(show_location(fts))")
 
 Base.show(io::IO, fts::FieldTimeSeries{LX, LY, LZ, K, A}) where {LX, LY, LZ, K, A} =
-    print(io, "$(short_show(fts))\n",
+    print(io, "$(summary(fts))\n",
           "├── architecture: $A\n",
-          "└── grid: $(short_show(fts.grid))")
+          "└── grid: $(summary(fts.grid))")
 

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -321,7 +321,7 @@ function Base.show(io::IO, ow::JLD2OutputWriter)
     print(io, "JLD2OutputWriter scheduled on $(summary(ow.schedule)):", '\n',
         "├── filepath: $(ow.filepath)", '\n',
         "├── $(length(ow.outputs)) outputs: $(keys(ow.outputs))", show_averaging_schedule(averaging_schedule), '\n',
-        "├── field slicer: $(short_show(ow.field_slicer))", '\n',
+        "├── field slicer: $(summary(ow.field_slicer))", '\n',
         "├── array type: ", show_array_type(ow.array_type), '\n',
         "├── including: ", ow.including, '\n',
         "└── max filesize: ", pretty_filesize(ow.max_filesize))

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -4,8 +4,6 @@ using Dates: AbstractTime, now
 
 using Oceananigans.Fields
 
-using Oceananigans: short_show
-using Oceananigans.Utils: summary
 using Oceananigans.Grids: topology, halo_size, all_x_nodes, all_y_nodes, all_z_nodes
 using Oceananigans.Utils: versioninfo_with_gpu, oceananigans_versioninfo
 using Oceananigans.TimeSteppers: float_or_date_time
@@ -498,6 +496,6 @@ function Base.show(io::IO, ow::NetCDFOutputWriter)
         "├── filepath: $(ow.filepath)", '\n',
         "├── dimensions: $dims", '\n',
         "├── $(length(ow.outputs)) outputs: $(keys(ow.outputs))", show_averaging_schedule(averaging_schedule), '\n',
-        "├── field slicer: $(short_show(ow.field_slicer))", '\n',
+        "├── field slicer: $(summary(ow.field_slicer))", '\n',
         "└── array type: ", show_array_type(ow.array_type))
 end

--- a/src/OutputWriters/windowed_time_average.jl
+++ b/src/OutputWriters/windowed_time_average.jl
@@ -3,7 +3,7 @@ using Oceananigans.Fields: FieldSlicer
 using Oceananigans.OutputWriters: fetch_output
 using Oceananigans.Utils: AbstractSchedule, prettytime
 
-import Oceananigans: short_show, run_diagnostic!
+import Oceananigans: run_diagnostic!
 import Oceananigans.Utils: TimeInterval
 import Oceananigans.Fields: location
 
@@ -215,14 +215,14 @@ function (wta::WindowedTimeAverage)(model)
     return wta.result
 end
 
-Base.show(io::IO, schedule::AveragedTimeInterval) = print(io, short_show(schedule))
+Base.show(io::IO, schedule::AveragedTimeInterval) = print(io, summary(schedule))
 
-short_show(schedule::AveragedTimeInterval) = string("AveragedTimeInterval(",
-                                                    "window=", prettytime(schedule.window), ", ",
-                                                    "stride=", schedule.stride, ", ",
-                                                    "interval=", prettytime(schedule.interval),  ")")
+Base.summary(schedule::AveragedTimeInterval) = string("AveragedTimeInterval(",
+                                                      "window=", prettytime(schedule.window), ", ",
+                                                      "stride=", schedule.stride, ", ",
+                                                      "interval=", prettytime(schedule.interval),  ")")
 
 show_averaging_schedule(schedule) = ""
-show_averaging_schedule(schedule::AveragedTimeInterval) = string(" averaged on ", short_show(schedule))
+show_averaging_schedule(schedule::AveragedTimeInterval) = string(" averaged on ", summary(schedule))
 
 output_averaging_schedule(output::WindowedTimeAverage) = output.schedule

--- a/src/Solvers/fft_based_poisson_solver.jl
+++ b/src/Solvers/fft_based_poisson_solver.jl
@@ -1,5 +1,4 @@
 using Oceananigans.Architectures: device_event
-using Oceananigans: short_show
 
 import Oceananigans.Architectures: architecture
 
@@ -24,7 +23,7 @@ end
 
 Base.show(io::IO, solver::FFTBasedPoissonSolver) =
 print(io, "FFTBasedPoissonSolver on ", string(typeof(architecture(solver))), ": \n",
-          "├── grid: $(short_show(solver.grid))\n",
+          "├── grid: $(summary(solver.grid))\n",
           "├── storage: $(typeof(solver.storage))\n",
           "├── buffer: $(typeof(solver.buffer))\n",
           "└── transforms:\n",

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -3,7 +3,6 @@ using Dates: AbstractTime, DateTime, Nanosecond, Millisecond
 using Oceananigans.Utils: prettytime
 
 import Base: show
-import Oceananigans: short_show
 
 """
     Clock{T<:Number}
@@ -34,7 +33,7 @@ Returns a `Clock` initialized to the zeroth iteration and first time step stage.
 """
 Clock(; time, iteration=0, stage=1) = Clock{typeof(time)}(time, iteration, stage)
 
-short_show(clock::Clock) = string("Clock(time=$(prettytime(clock.time)), iteration=$(clock.iteration))")
+Base.summary(clock::Clock) = string("Clock(time=$(prettytime(clock.time)), iteration=$(clock.iteration))")
 
 Base.show(io::IO, c::Clock{T}) where T =
     println(io, "Clock{$T}: time = $(prettytime(c.time)), iteration = $(c.iteration), stage = $(c.stage)")

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -14,8 +14,6 @@ export TimeInterval, IterationInterval, WallTimeInterval, SpecifiedTimes, AndSch
 
 import CUDA  # To avoid name conflicts
 
-import Oceananigans: short_show
-
 #####
 ##### Misc. small utils
 #####
@@ -23,13 +21,11 @@ import Oceananigans: short_show
 instantiate(x) = x
 instantiate(X::DataType) = X()
 
-short_show(a) = string(a) # fallback
-short_show(f::Function) = string(Symbol(f))
-
 #####
 ##### Include utils
 #####
 
+include("prettysummary.jl")
 include("kernel_launching.jl")
 include("cell_advection_timescale.jl")
 include("pretty_time.jl")

--- a/src/Utils/prettysummary.jl
+++ b/src/Utils/prettysummary.jl
@@ -11,3 +11,4 @@ function prettysummary(f::Function)
 end
 
 prettysummary(x) = summary(x)
+

--- a/src/Utils/prettysummary.jl
+++ b/src/Utils/prettysummary.jl
@@ -5,9 +5,9 @@ function prettysummary(f::Function)
     n = length(methods(f))
     m = n==1 ? "method" : "methods"
     sname = string(name)
+    isself = isdefined(ft.name.module, name) && ft == typeof(getfield(ft.name.module, name))
     ns = (isself || '#' in sname) ? sname : string("(::", ft, ")")
-    what = startswith(ns, '@') ? "macro" : "generic function"
-    return string(ns, " (", what, " with $n $m)")
+    return string(ns, " (", "generic function", " with $n $m)")
 end
 
 prettysummary(x) = summary(x)

--- a/src/Utils/prettysummary.jl
+++ b/src/Utils/prettysummary.jl
@@ -1,0 +1,13 @@
+function prettysummary(f::Function)
+    ft = typeof(f)
+    mt = ft.name.mt
+    name = mt.name
+    n = length(methods(f))
+    m = n==1 ? "method" : "methods"
+    sname = string(name)
+    ns = (isself || '#' in sname) ? sname : string("(::", ft, ")")
+    what = startswith(ns, '@') ? "macro" : "generic function"
+    return string(ns, " (", what, " with $n $m)")
+end
+
+prettysummary(x) = summary(x)


### PR DESCRIPTION
This PR translates `short_show` to `Base.summary`, overhauls `show` and `summary` for grids and fields, and implements `prettysummary` for functions that returns a string that's similar to what we get at the REPL:

```julia
julia> hello_world(x) = x
hello_world (generic function with 1 method)

julia> hello_world
hello_world (generic function with 1 method)
```

Closes #2064 
Closes #1612 