### PR TITLE
Add parameters to Callback

### DIFF
--- a/src/Simulations/callback.jl
+++ b/src/Simulations/callback.jl
@@ -1,15 +1,20 @@
-struct Callback{F, S}
+struct Callback{P, F, S}
     func :: F
     schedule :: S
+    parameters :: P
 end
 
-(callback::Callback)(sim) = callback.func(sim)
+@inline (callback::Callback)(sim) = callback.func(sim, callback.parameters)
+@inline (callback::Callback{<:Nothing})(sim) = callback.func(sim)
 
 """
-    Callback(func, schedule)
+    Callback(func, schedule=IterationInterval(1); parameters=nothing)
 
-Return `Callback` that executes `func(sim::Simulation)` on `schedule`.
+Return `Callback` that executes `func` on `schedule`
+with optional `parameters`. `schedule = IterationInterval(1)` by default.
 
-`schedule = IterationInterval(1)` by default.
+If `isnothing(parameters)`, `func(sim::Simulation)` is called.
+Otherwise, `func` is called via `func(sim::Simulation, parameteres)`.
 """
-Callback(func) = Callback(func, IterationInterval(1))
+Callback(func, schedule=IterationInterval(1); parameters=nothing) =
+    Callback(func, schedule, parameters)

--- a/test/test_simulations.jl
+++ b/test/test_simulations.jl
@@ -136,8 +136,8 @@ function run_basic_simulation_tests(arch)
 
     called_at = Float64[]
     schedule = TimeInterval(0.31)
-    capture_call_time(sim) = push!(called_at, sim.model.clock.time)
-    simulation.callbacks[:tester] = Callback(capture_call_time, schedule)
+    capture_call_time(sim, data) = push!(data, sim.model.clock.time)
+    simulation.callbacks[:tester] = Callback(capture_call_time, schedule, parameters=called_at)
     run!(simulation)
 
     @show called_at


### PR DESCRIPTION
This allows users to build `Callback`s with optional parameters. This feature addition resolves #2127 .