### PR TITLE
Validate boundary conditions on Fields

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,6 +38,7 @@ steps:
       TEST_GROUP: "init"
       CUDA_VISIBLE_DEVICES: "-1"
       JULIA_BINDIR: "$TARTARUS_HOME/julia-$JULIA_VERSION/bin"
+      TMPDIR: "$TARTARUS_HOME/tmp"
     commands:
       # Download julia binaries
       - "wget -N -P $TARTARUS_HOME https://julialang-s3.julialang.org/bin/linux/x64/$JULIA_MINOR_VERSION/julia-$JULIA_VERSION-linux-x86_64.tar.gz"

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -5,6 +5,7 @@ export
     BoundaryCondition, getbc, setbc!,
     PeriodicBoundaryCondition, OpenBoundaryCondition, NoFluxBoundaryCondition,
     FluxBoundaryCondition, ValueBoundaryCondition, GradientBoundaryCondition,
+    validate_boundary_condition_topology, validate_boundary_condition_architecture,
     FieldBoundaryConditions,
     apply_x_bcs!, apply_y_bcs!, apply_z_bcs!,
     fill_halo_regions!

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -11,9 +11,9 @@ export
     fill_halo_regions!
 
 using CUDA
-using KernelAbstractions
+using KernelAbstractions: @index, @kernel
 
-using Oceananigans.Architectures: device
+using Oceananigans.Architectures: CPU, GPU, device
 using Oceananigans.Utils: work_layout, launch!
 using Oceananigans.Operators: Ax, Ay, Az, volume
 using Oceananigans.Grids

--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -119,7 +119,7 @@ validate_boundary_condition_topology(bc, topo, side) = nothing
 
 validate_boundary_condition_architecture(bc, arch, side) = nothing
 
-validate_boundary_condition_architecture(bc::BoundaryCondition, arch, side)
+validate_boundary_condition_architecture(bc::BoundaryCondition, arch, side) =
     validate_boundary_condition_architecture(bc.condition, arch, bc, side)
 
 validate_boundary_condition_architecture(::Array, ::CPU, bc, side) = nothing

--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -107,13 +107,13 @@ Adapt.adapt_structure(to, bc::BoundaryCondition) = BoundaryCondition(Adapt.adapt
 ##### Validation with topology
 #####
 
-validate_boundary_condition_topology(bc::Union{PBC, Nothing}, topo::Periodic, side) = nothing
-validate_boundary_condition_topology(bc, topo::Periodic, side) =
-    throw(ArgumentError("Cannot set $side boundary condition $bc in a `Periodic` direction!"))
+validate_boundary_condition_topology(bc::Union{PBC, Nothing}, topo::Grids.Periodic, side) = nothing
+validate_boundary_condition_topology(bc, topo::Grids.Periodic, side) =
+    throw(ArgumentError("Cannot set $side $bc in a `Periodic` direction!"))
 
 validate_boundary_condition_topology(::Nothing, topo::Flat, side) = nothing
 validate_boundary_condition_topology(bc, topo::Flat, side) =
-    throw(ArgumentError("Cannot set $side boundary condition in a `Flat` direction!"))
+    throw(ArgumentError("Cannot set $side $bc in a `Flat` direction!"))
 
 validate_boundary_condition_topology(bc, topo, side) = nothing
 
@@ -131,7 +131,7 @@ validate_boundary_condition_architecture(::Array, ::CPU, bc, side) = nothing
 validate_boundary_condition_architecture(::CuArray, ::GPU, bc, side) = nothing
 
 validate_boundary_condition_architecture(::CuArray, ::CPU, bc, side) =
-    throw(ArgumentError("$side boundary condition $bc must use `Array` rather than `CuArray` on CPU architectures!"))
+    throw(ArgumentError("$side $bc must use `Array` rather than `CuArray` on CPU architectures!"))
 
 validate_boundary_condition_architecture(::Array, ::GPU, bc, side) =
-    throw(ArgumentError("$side boundary condition $bc must use `CuArray` rather than `Array` on GPU architectures!"))
+    throw(ArgumentError("$side $bc must use `CuArray` rather than `Array` on GPU architectures!"))

--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -117,7 +117,11 @@ validate_boundary_condition_topology(bc, topo::Flat, side) =
 
 validate_boundary_condition_topology(bc, topo, side) = nothing
 
-validate_boundary_condition_architecture(condition, arch, bc, side) = nothing
+validate_boundary_condition_architecture(bc, arch, side) = nothing
+
+validate_boundary_condition_architecture(bc::BoundaryCondition, arch, side)
+    validate_boundary_condition_architecture(bc.condition, arch, bc, side)
+
 validate_boundary_condition_architecture(::Array, ::CPU, bc, side) = nothing
 validate_boundary_condition_architecture(::CuArray, ::GPU, bc, side) = nothing
 

--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -103,13 +103,17 @@ GradientBoundaryCondition(val; kwargs...) = BoundaryCondition(Gradient, val; kwa
 Adapt.adapt_structure(to, bc::BoundaryCondition) = BoundaryCondition(Adapt.adapt(to, bc.classification),
                                                                      Adapt.adapt(to, bc.condition))
 
+#####
+##### Validation
+#####
+
 validate_boundary_condition_topology(bc::Union{PBC, Nothing}, topo::Periodic, side) = nothing
 validate_boundary_condition_topology(bc, topo::Periodic, side) =
     throw(ArgumentError("Cannot set $side boundary condition $bc in a `Periodic` direction!"))
 
 validate_boundary_condition_topology(::Nothing, topo::Flat, side) = nothing
 validate_boundary_condition_topology(bc, topo::Flat, side) =
-    throw(ArgumentError("Cannot set $side boundary condition in a `Flat` direction!")
+    throw(ArgumentError("Cannot set $side boundary condition in a `Flat` direction!"))
 
 validate_boundary_condition_topology(bc, topo, side) = nothing
 

--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -102,3 +102,23 @@ GradientBoundaryCondition(val; kwargs...) = BoundaryCondition(Gradient, val; kwa
 
 Adapt.adapt_structure(to, bc::BoundaryCondition) = BoundaryCondition(Adapt.adapt(to, bc.classification),
                                                                      Adapt.adapt(to, bc.condition))
+
+validate_boundary_condition_topology(bc::Union{PBC, Nothing}, topo::Periodic, side) = nothing
+validate_boundary_condition_topology(bc, topo::Periodic, side) =
+    throw(ArgumentError("Cannot set $side boundary condition $bc in a `Periodic` direction!"))
+
+validate_boundary_condition_topology(::Nothing, topo::Flat, side) = nothing
+validate_boundary_condition_topology(bc, topo::Flat, side) =
+    throw(ArgumentError("Cannot set $side boundary condition in a `Flat` direction!")
+
+validate_boundary_condition_topology(bc, topo, side) = nothing
+
+validate_boundary_condition_architecture(condition, arch, bc, side) = nothing
+validate_boundary_condition_architecture(::Array, ::CPU, bc, side) = nothing
+validate_boundary_condition_architecture(::CuArray, ::GPU, bc, side) = nothing
+
+validate_boundary_condition_architecture(::CuArray, ::CPU, bc, side) =
+    throw(ArgumentError("$side boundary condition $bc must use `Array` rather than `CuArray` on CPU architectures!"))
+
+validate_boundary_condition_architecture(::Array, ::GPU, bc, side) =
+    throw(ArgumentError("$side boundary condition $bc must use `CuArray` rather than `Array` on GPU architectures!"))

--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -104,7 +104,7 @@ Adapt.adapt_structure(to, bc::BoundaryCondition) = BoundaryCondition(Adapt.adapt
                                                                      Adapt.adapt(to, bc.condition))
 
 #####
-##### Validation
+##### Validation with topology
 #####
 
 validate_boundary_condition_topology(bc::Union{PBC, Nothing}, topo::Periodic, side) = nothing
@@ -117,11 +117,16 @@ validate_boundary_condition_topology(bc, topo::Flat, side) =
 
 validate_boundary_condition_topology(bc, topo, side) = nothing
 
+#####
+##### Validation with architecture
+#####
+
 validate_boundary_condition_architecture(bc, arch, side) = nothing
 
 validate_boundary_condition_architecture(bc::BoundaryCondition, arch, side) =
     validate_boundary_condition_architecture(bc.condition, arch, bc, side)
 
+validate_boundary_condition_architecture(condition, arch, bc, side) = nothing
 validate_boundary_condition_architecture(::Array, ::CPU, bc, side) = nothing
 validate_boundary_condition_architecture(::CuArray, ::GPU, bc, side) = nothing
 

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -159,3 +159,4 @@ regularize_field_boundary_conditions(::Missing, grid::AbstractGrid, field_name::
 regularize_field_boundary_conditions(boundary_conditions::NamedTuple, grid::AbstractGrid, prognostic_field_names::Tuple) =
     NamedTuple(field_name => regularize_field_boundary_conditions(field_bcs, grid, field_name, prognostic_field_names)
                for (field_name, field_bcs) in pairs(boundary_conditions))
+

--- a/src/BoundaryConditions/fill_halo_regions_nothing.jl
+++ b/src/BoundaryConditions/fill_halo_regions_nothing.jl
@@ -9,9 +9,7 @@ fill_north_halo!(c,  ::Nothing, args...; kwargs...) = NoneEvent()
 fill_top_halo!(c,    ::Nothing, args...; kwargs...) = NoneEvent()
 fill_bottom_halo!(c, ::Nothing, args...; kwargs...) = NoneEvent()
 
-
 fill_west_and_east_halo!(c,  ::Nothing, ::Nothing, args...; kwargs...) = NoneEvent()
 fill_south_and_north_halo!(c,::Nothing, ::Nothing, args...; kwargs...) = NoneEvent()
 fill_bottom_and_top_halo!(c, ::Nothing, ::Nothing, args...; kwargs...) = NoneEvent()
-
 

--- a/src/CubedSpheres/CubedSpheres.jl
+++ b/src/CubedSpheres/CubedSpheres.jl
@@ -14,7 +14,7 @@ include("immersed_conformal_cubed_sphere_grid.jl")
 ##### Validating cubed sphere stuff
 #####
 
-import Oceananigans.Fields: validate_field_data
+import Oceananigans.Fields: validate_field_data, validate_boundary_conditions
 import Oceananigans.Models.HydrostaticFreeSurfaceModels: validate_vertical_velocity_boundary_conditions
 
 function validate_field_data(loc, data, grid::ConformalCubedSphereGrid)
@@ -25,6 +25,9 @@ function validate_field_data(loc, data, grid::ConformalCubedSphereGrid)
 
     return nothing
 end
+
+validate_boundary_conditions(loc, grid::ConformalCubedSphereGrid, bcs::CubedSphereFaces) =
+    [validate_boundary_conditions(loc, get_face(grid, face), get_face(bcs, face)) for face = 1:length(bcs)]
 
 validate_vertical_velocity_boundary_conditions(w::AbstractCubedSphereField) =
     [validate_vertical_velocity_boundary_conditions(w_face) for w_face in faces(w)]

--- a/src/CubedSpheres/CubedSpheres.jl
+++ b/src/CubedSpheres/CubedSpheres.jl
@@ -26,7 +26,9 @@ function validate_field_data(loc, data, grid::ConformalCubedSphereGrid)
     return nothing
 end
 
+# We don't support validating cubed sphere boundary conditions at this time
 validate_boundary_conditions(loc, grid::ConformalCubedSphereGrid, bcs::CubedSphereFaces) = nothing
+validate_boundary_conditions(loc, grid::ConformalCubedSphereFaceGrid, bcs) = nothing
 
 validate_vertical_velocity_boundary_conditions(w::AbstractCubedSphereField) =
     [validate_vertical_velocity_boundary_conditions(w_face) for w_face in faces(w)]

--- a/src/CubedSpheres/CubedSpheres.jl
+++ b/src/CubedSpheres/CubedSpheres.jl
@@ -26,8 +26,7 @@ function validate_field_data(loc, data, grid::ConformalCubedSphereGrid)
     return nothing
 end
 
-validate_boundary_conditions(loc, grid::ConformalCubedSphereGrid, bcs::CubedSphereFaces) =
-    [validate_boundary_conditions(loc, get_face(grid, face), get_face(bcs, face)) for face = 1:length(grid.faces)]
+validate_boundary_conditions(loc, grid::ConformalCubedSphereGrid, bcs::CubedSphereFaces) = nothing
 
 validate_vertical_velocity_boundary_conditions(w::AbstractCubedSphereField) =
     [validate_vertical_velocity_boundary_conditions(w_face) for w_face in faces(w)]

--- a/src/CubedSpheres/CubedSpheres.jl
+++ b/src/CubedSpheres/CubedSpheres.jl
@@ -27,7 +27,7 @@ function validate_field_data(loc, data, grid::ConformalCubedSphereGrid)
 end
 
 validate_boundary_conditions(loc, grid::ConformalCubedSphereGrid, bcs::CubedSphereFaces) =
-    [validate_boundary_conditions(loc, get_face(grid, face), get_face(bcs, face)) for face = 1:length(bcs)]
+    [validate_boundary_conditions(loc, get_face(grid, face), get_face(bcs, face)) for face = 1:length(grid.faces)]
 
 validate_vertical_velocity_boundary_conditions(w::AbstractCubedSphereField) =
     [validate_vertical_velocity_boundary_conditions(w_face) for w_face in faces(w)]

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -34,8 +34,9 @@ function validate_field_data(loc, data, grid)
     return nothing
 end
 
-validate_boundary_condition_location(::Union{OBC, Nothing}, ::Union{Face, Nothing}, side) = nothing
-validate_boundary_condition_location(::Union{FBC, VBC, GBC}, ::Union{Center, Nothing}, side) = nothing
+validate_boundary_condition_location(bc, ::Center, side) = nothing
+validate_boundary_condition_location(::Nothing, ::Flat, side) = nothing
+validate_boundary_condition_location(::Union{OBC, Nothing}, ::Face, side) = nothing
 validate_boundary_condition_location(bc, loc, side) =
     throw(ArgumentError("Cannot specify $side boundary condition $bc on a field at $loc!"))
 
@@ -52,8 +53,7 @@ function validate_boundary_conditions(loc, grid, bcs)
         validate_boundary_condition_topology(bc, side, topo)
 
         # Check that boundary condition is valid given field location
-        topo isa Bounded &&
-            validate_boundary_condition_location(bc, ℓ, side)
+        topo isa Bounded && validate_boundary_condition_location(bc, ℓ, side)
 
         # Check that boundary condition arrays, if used, are on the right architecture
         validate_boundary_condition_architecture(bc.condition, architecture(grid), bc, side)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -56,7 +56,7 @@ function validate_boundary_conditions(loc, grid, bcs)
         topo isa Bounded && validate_boundary_condition_location(bc, ℓ, side)
 
         # Check that boundary condition arrays, if used, are on the right architecture
-        validate_boundary_condition_architecture(bc.condition, architecture(grid), bc, side)
+        validate_boundary_condition_architecture(bc, architecture(grid), side)
     end
 
     return nothing

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -1,4 +1,5 @@
 using Oceananigans.Architectures: device_event
+using Oceananigans.BoundaryConditions: FBC, VBC, GBC
 
 using Adapt
 using KernelAbstractions: @kernel, @index
@@ -33,10 +34,38 @@ function validate_field_data(loc, data, grid)
     return nothing
 end
 
+validate_boundary_condition_location(::Union{OBC, Nothing}, ::Union{Face, Nothing}, side) = nothing
+validate_boundary_condition_location(::Union{FBC, VBC, GBC}, ::Union{Center, Nothing}, side) = nothing
+validate_boundary_condition_location(bc, loc, side) =
+    throw(ArgumentError("Cannot specify $side boundary condition $bc on a field at $loc!"))
+
+function validate_boundary_conditions(loc, grid, bcs)
+    sides = (:east, :west, :north, :south, :bottom, :top)
+    directions = (1, 1, 2, 2, 3, 3)
+
+    for (side, dir) in zip(sides, directions)
+        topo = topology(grid, dir)()
+        ℓ = loc[dir]()
+        bc = getproperty(bcs, side)
+
+        # Check that boundary condition jives with the grid topology
+        validate_boundary_condition_topology(bc, side, topo)
+
+        # Check that boundary condition is valid given field location
+        topo isa Bounded &&
+            validate_boundary_condition_location(bc, ℓ, side)
+
+        # Check that boundary condition arrays, if used, are on the right architecture
+        validate_boundary_condition_architecture(bc.condition, architecture(grid), bc, side)
+    end
+
+    return nothing
+end
+
 # Common outer constructor for all field flavors that validates data and boundary conditions
 function Field(loc::Tuple, grid::AbstractGrid, data, bcs, op, status)
     validate_field_data(loc, data, grid)
-    # validate_boundary_conditions(loc, grid, bcs)
+    validate_boundary_conditions(loc, grid, bcs)
     LX, LY, LZ = loc
     return Field{LX, LY, LZ}(grid, data, bcs, op, status)
 end

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -34,11 +34,11 @@ function validate_field_data(loc, data, grid)
     return nothing
 end
 
-validate_boundary_condition_location(bc, ::Center, side) = nothing
-validate_boundary_condition_location(::Nothing, ::Flat, side) = nothing
-validate_boundary_condition_location(::Union{OBC, Nothing}, ::Face, side) = nothing
-validate_boundary_condition_location(bc, loc, side) =
-    throw(ArgumentError("Cannot specify $side boundary condition $bc on a field at $loc!"))
+validate_boundary_condition_location(bc, ::Center, side) = nothing                  # anything goes for centers
+validate_boundary_condition_location(::Union{OBC, Nothing}, ::Face, side) = nothing # only open or nothing on faces
+validate_boundary_condition_location(::Nothing, ::Nothing, side) = nothing          # its nothing or nothing
+validate_boundary_condition_location(bc, loc, side) = # everything else is wrong!
+    throw(ArgumentError("Cannot specify $side boundary condition $bc on a field at $(loc)!"))
 
 function validate_boundary_conditions(loc, grid, bcs)
     sides = (:east, :west, :north, :south, :bottom, :top)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -52,7 +52,7 @@ function validate_boundary_conditions(loc, grid, bcs)
         bc = getproperty(bcs, side)
 
         # Check that boundary condition jives with the grid topology
-        validate_boundary_condition_topology(bc, side, topo)
+        validate_boundary_condition_topology(bc, topo, side)
 
         # Check that boundary condition is valid given field location
         topo isa Bounded && validate_boundary_condition_location(bc, ℓ, side)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -1,5 +1,5 @@
 using Oceananigans.Architectures: device_event
-using Oceananigans.BoundaryConditions: FBC, VBC, GBC
+using Oceananigans.BoundaryConditions: OBC
 
 using Adapt
 using KernelAbstractions: @kernel, @index

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -40,6 +40,8 @@ validate_boundary_condition_location(::Nothing, ::Nothing, side) = nothing      
 validate_boundary_condition_location(bc, loc, side) = # everything else is wrong!
     throw(ArgumentError("Cannot specify $side boundary condition $bc on a field at $(loc)!"))
 
+validate_boundary_conditions(loc, grid, ::Missing) = nothing
+
 function validate_boundary_conditions(loc, grid, bcs)
     sides = (:east, :west, :north, :south, :bottom, :top)
     directions = (1, 1, 2, 2, 3, 3)


### PR DESCRIPTION
This PR adds a step in the outer `Field` constructor that validates boundary conditions. We check three things:

1. That boundary conditions are compatible with the topology. Namely, we are restricted to default choices in `Periodic` or `Flat` directions; anything but default throws an error.

2. If a topology is `Bounded`, we check that boundary conditions are compatible with field location. Mostly we cannot support flux, value, or gradient boundary conditions for fields at faces, and we only support `nothing` for fields in `Flat` directions.

3. That boundary condition arrays are on the right architecture.

TODO:

- [x] Test

Resolves #419
Resolves #890

Supercedes #1732