### PR TITLE
`OneField`, `ConstantField`, and generalized `ZeroField`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -476,6 +476,7 @@ steps:
       JULIA_DEPOT_PATH: "$TARTARUS_HOME/.julia-$BUILDKITE_BUILD_NUMBER"
       CUDA_VISIBLE_DEVICES: "-1"
       JULIA_DEBUG: "Documenter"
+      TMPDIR: "$TARTARUS_HOME/tmp"
     commands:
       - "$TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'"
       - "$TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate()'"

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -16,7 +16,7 @@ using Oceananigans.BoundaryConditions
 import Oceananigans: short_show
 
 include("abstract_field.jl")
-include("zero_field.jl")
+include("constant_field.jl")
 include("function_field.jl")
 include("field.jl")
 include("field_reductions.jl")

--- a/src/Fields/constant_field.jl
+++ b/src/Fields/constant_field.jl
@@ -2,7 +2,7 @@ struct ZeroField{T, N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, T, N
 struct OneField{T, N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, T, N} end
 
 ZeroField(T=Int) = ZeroField{T, 3}() # default 3D, integer 0
-OneField(T=Int) = OneField{T, 3}() # default 3D, integer 0
+OneField(T=Int) = OneField{T, 3}() # default 3D, integer 1
 
 @inline Base.getindex(::ZeroField{T, N}, ind...) where {N, T} = zero(T)
 @inline Base.getindex(::OneField{T, N}, ind...) where {N, T} = one(T)

--- a/src/Fields/constant_field.jl
+++ b/src/Fields/constant_field.jl
@@ -9,7 +9,7 @@ OneField(T=Int) = OneField{T, 3}() # default 3D, integer 0
 
 struct ConstantField{T, N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, T, N}
     constant :: T
-    ConstantField{N}(constant::T) where T = new{T, N}(constant)
+    ConstantField{N}(constant::T) where {T, N} = new{T, N}(constant)
 end
 
 # Default 3-dimensional field

--- a/src/Fields/constant_field.jl
+++ b/src/Fields/constant_field.jl
@@ -1,8 +1,11 @@
 struct ZeroField{T, N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, T, N} end
+struct OneField{T, N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, T, N} end
 
 ZeroField(T=Int) = ZeroField{T, 3}() # default 3D, integer 0
+OneField(T=Int) = OneField{T, 3}() # default 3D, integer 0
 
 @inline Base.getindex(::ZeroField{T, N}, ind...) where {N, T} = zero(T)
+@inline Base.getindex(::OneField{T, N}, ind...) where {N, T} = one(T)
 
 struct ConstantField{T, N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, T, N}
     constant :: T

--- a/src/Fields/constant_field.jl
+++ b/src/Fields/constant_field.jl
@@ -1,0 +1,16 @@
+struct ZeroField{T, N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, T, N} end
+
+ZeroField(T=Int) = ZeroField{T, 3}() # default 3D, integer 0
+
+@inline Base.getindex(::ZeroField{T, N}, ind...) where {N, T} = zero(T)
+
+struct ConstantField{T, N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, T, N}
+    constant :: T
+    ConstantField{N}(constant::T) where T = new{T, N}(constant)
+end
+
+# Default 3-dimensional field
+ConstantField(constant) = ConstantField{3}(constant)
+
+@inline Base.getindex(f::ConstantField, ind...) = f.constant
+

--- a/src/Fields/zero_field.jl
+++ b/src/Fields/zero_field.jl
@@ -1,6 +1,0 @@
-struct ZeroField{N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, Nothing, N} end
-
-ZeroField() = ZeroField{3}() # default
-
-@inline Base.getindex(::ZeroField, ind...) = 0
-


### PR DESCRIPTION
This PR adds `OneField` and `ConstantField` and generalizes `ZeroField` to be capable of producing zeros of any type. In particular it may be useful to use a `ZeroField(Bool)` since `false` is a "strong" zero.

@simone-silvestri you may find `OneField` useful for estimating lengths efficiently, along with `ConditionalOperation`.