### PR TITLE
Fixes bug inferring regular dimensions for Average

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.68.2"
+version = "0.68.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/AbstractOperations/grid_metrics.jl
+++ b/src/AbstractOperations/grid_metrics.jl
@@ -154,6 +154,6 @@ end
 GridMetricOperation(L, metric, grid) = GridMetricOperation{L[1], L[2], L[3]}(metric_function(L, metric), grid)
 
 Adapt.adapt_structure(to, gm::GridMetricOperation{LX, LY, LZ}) where {LX, LY, LZ} =
-    GridMericOperation{LX, LY, LZ}(Adapt.adapt(to, gm.metric),
-                                   Adapt.adapt(to, gm.grid))
+    GridMetricOperation{LX, LY, LZ}(Adapt.adapt(to, gm.metric), Adapt.adapt(to, gm.grid))
+                                   
 

--- a/src/AbstractOperations/grid_metrics.jl
+++ b/src/AbstractOperations/grid_metrics.jl
@@ -153,3 +153,7 @@ end
 # Special constructor for BinaryOperation
 GridMetricOperation(L, metric, grid) = GridMetricOperation{L[1], L[2], L[3]}(metric_function(L, metric), grid)
 
+Adapt.adapt_structure(to, gm::GridMetricOperation{LX, LY, LZ}) where {LX, LY, LZ} =
+    GridMericOperation{LX, LY, LZ}(Adapt.adapt(to, gm.metric),
+                                   Adapt.adapt(to, gm.grid))
+

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -29,7 +29,8 @@ function Reduction(avg::Average, field::AbstractField; dims)
     dims = dims isa Colon ? (1, 2, 3) : tupleit(dims)
     dx = reduction_grid_metric(dims)
 
-    if dims === regular_dimensions(field.grid) # shortcut!
+    if all(d in regular_dimensions(field.grid) for d in dims)
+        # Dimensions being reduced are regular; just use mean!
         return Reduction(mean!, field; dims)
     else
         # Compute "size" (length, area, or volume) of averaging region

--- a/test/test_computed_field.jl
+++ b/test/test_computed_field.jl
@@ -78,6 +78,9 @@ function horizontal_average_of_plus(model)
 
     @compute ST = Field(Average(S + T, dims=(1, 2)))
 
+    @test ST.operand isa Reduction
+    @test ST.operand.reduce! === mean!
+
     zC = znodes(Center, model.grid)
     correct_profile = @. sin(π * zC) + 42 * zC
 

--- a/test/test_field_reductions.jl
+++ b/test/test_field_reductions.jl
@@ -2,9 +2,12 @@ include("dependencies_for_runtests.jl")
 
 using Statistics
 using Oceananigans.Architectures: arch_array
+using Oceananigans.AbstractOperations: BinaryOperation
 using Oceananigans.Fields: ReducedField, CenterField, ZFaceField, compute_at!, @compute
 using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.Grids: halo_size
+
+trilinear(x, y, z) = x + y + z
 
 @testset "Fields computed by Reduction" begin
     @info "Testing Fields computed by reductions..."
@@ -12,43 +15,84 @@ using Oceananigans.Grids: halo_size
     for arch in archs
         arch_str = string(typeof(arch))
 
-        grid = RectilinearGrid(arch, size = (2, 2, 2),
-                               x = (0, 2), y = (0, 2), z = (0, 2),
-                               topology = (Periodic, Periodic, Bounded))
+        regular_grid = RectilinearGrid(arch, size = (2, 2, 2),
+                                       x = (0, 2), y = (0, 2), z = (0, 2),
+                                       topology = (Periodic, Periodic, Bounded))
 
-        Nx, Ny, Nz = size(grid)
-
-        w = ZFaceField(grid)
-        T = CenterField(grid)
-
-        trilinear(x, y, z) = x + y + z
-
-        set!(T, trilinear)
-        set!(w, trilinear)
-
-        @compute Txyz = Field(Average(T, dims=(1, 2, 3)))
-
-        # Note: halo regions must be *filled* prior to computing an average
-        # if the average within halo regions is to be correct.
-        fill_halo_regions!(T, arch)
-        @compute Txy = Field(Average(T, dims=(1, 2)))
-
-        fill_halo_regions!(T, arch)
-        @compute Tx = Field(Average(T, dims=1))
-
-        @compute wxyz = Field(Average(w, dims=(1, 2, 3)))
-        @compute wxy = Field(Average(w, dims=(1, 2)))
-        @compute wx = Field(Average(w, dims=1))
+        xy_regular_grid = RectilinearGrid(arch, size=(2, 2, 2),
+                                          x=(0, 2), y=(0, 2), z=[0, 1, 2],
+                                          topology = (Periodic, Periodic, Bounded))
 
         @testset "Averaged fields [$arch_str]" begin
             @info "  Testing averaged Fields [$arch_str]"
 
-            @test Txyz[1, 1, 1] ≈ 3
-            @test Array(interior(Txy))[1, 1, :] ≈ [2.5, 3.5]
-            @test Array(interior(Tx))[1, :, :] ≈ [[2, 3] [3, 4]]
-            @test wxyz[1, 1, 1] ≈ 3
-            @test Array(interior(wxy))[1, 1, :] ≈ [2, 3, 4]
-            @test Array(interior(wx))[1, :, :] ≈ [[1.5, 2.5] [2.5, 3.5] [3.5, 4.5]]
+            for grid in (regular_grid, xy_regular_grid)
+
+                Nx, Ny, Nz = size(grid)
+
+                w = ZFaceField(grid)
+                T = CenterField(grid)
+
+                set!(T, trilinear)
+                set!(w, trilinear)
+
+                @compute Txyz = Field(Average(T, dims=(1, 2, 3)))
+
+                # Note: halo regions must be *filled* prior to computing an average
+                # if the average within halo regions is to be correct.
+                fill_halo_regions!(T, arch)
+                @compute Txy = Field(Average(T, dims=(1, 2)))
+
+                fill_halo_regions!(T, arch)
+                @compute Tx = Field(Average(T, dims=1))
+
+                @compute wxyz = Field(Average(w, dims=(1, 2, 3)))
+                @compute wxy = Field(Average(w, dims=(1, 2)))
+                @compute wx = Field(Average(w, dims=1))
+
+                for T′ in (Tx, Txy)
+                    @test T′.operand.operand === T
+                end
+                
+                for w′ in (wx, wxy)
+                    @test w′.operand.operand === w
+                end
+
+                for f in (wx, wxy, Tx, Txy)
+                    @test f.operand isa Reduction
+                    @test f.operand.reduce! === mean!
+                end
+
+                @test Txyz.operand isa Reduction
+                @test wxyz.operand isa Reduction
+
+                # Different behavior for regular grid z vs not.
+                if grid === regular_grid
+                    @test Txyz.operand.reduce! === mean!
+                    @test wxyz.operand.reduce! === mean!
+                    @test Txyz.operand.operand === T
+                    @test wxyz.operand.operand === w
+                else
+                    @test Txyz.operand.reduce! === sum!
+                    @test wxyz.operand.reduce! === sum!
+                    @test Txyz.operand.operand isa BinaryOperation
+                    @test wxyz.operand.operand isa BinaryOperation
+                end
+
+                @test Tx.operand.dims === tuple(1)
+                @test wx.operand.dims === tuple(1)
+                @test Txy.operand.dims === (1, 2)
+                @test wxy.operand.dims === (1, 2)
+                @test Txyz.operand.dims === (1, 2, 3)
+                @test wxyz.operand.dims === (1, 2, 3)
+
+                @test Txyz[1, 1, 1] ≈ 3
+                @test Array(interior(Txy))[1, 1, :] ≈ [2.5, 3.5]
+                @test Array(interior(Tx))[1, :, :] ≈ [[2, 3] [3, 4]]
+                @test wxyz[1, 1, 1] ≈ 3
+                @test Array(interior(wxy))[1, 1, :] ≈ [2, 3, 4]
+                @test Array(interior(wx))[1, :, :] ≈ [[1.5, 2.5] [2.5, 3.5] [3.5, 4.5]]
+            end
             
             # Test whether a race condition gets hit for averages over large fields
             big_grid = RectilinearGrid(arch,
@@ -71,7 +115,7 @@ using Oceananigans.Grids: halo_size
 
             results = []
             for i = 1:10
-                sum!(C, C.operand.operand)
+                mean!(C, C.operand.operand)
                 push!(results, all(interior(C) .== 1))
             end
 
@@ -80,7 +124,26 @@ using Oceananigans.Grids: halo_size
 
         @testset "Allocating reductions [$arch_str]" begin
             @info "  Testing allocating reductions"
-        
+
+            grid = RectilinearGrid(arch, size = (2, 2, 2),
+                                   x = (0, 2), y = (0, 2), z = (0, 2),
+                                   topology = (Periodic, Periodic, Bounded))
+
+            w = ZFaceField(grid)
+            T = CenterField(grid)
+            set!(T, trilinear)
+            set!(w, trilinear)
+            fill_halo_regions!(T, arch)
+            fill_halo_regions!(w, arch)
+
+            @compute Txyz = Field(Average(T, dims=(1, 2, 3)))
+            @compute Txy = Field(Average(T, dims=(1, 2)))
+            @compute Tx = Field(Average(T, dims=1))
+
+            @compute wxyz = Field(Average(w, dims=(1, 2, 3)))
+            @compute wxy = Field(Average(w, dims=(1, 2)))
+            @compute wx = Field(Average(w, dims=1))
+
             # Mean
             @test Txyz[1, 1, 1] == mean(T)
             @test interior(Txy) == interior(mean(T, dims=(1, 2)))


### PR DESCRIPTION
This PR fixes `Average` to correctly to use `mean!` when reducing over regular dimensions. It also adds a few tests.