### PR TITLE
Let regridding work on non-`SingleColumnGrid` +  better `total_length` on `Flat` grids

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.68.4"
+version = "0.68.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.68.2"
+version = "0.68.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -41,6 +41,7 @@ validate_boundary_condition_location(bc, loc, side) = # everything else is wrong
     throw(ArgumentError("Cannot specify $side boundary condition $bc on a field at $(loc)!"))
 
 validate_boundary_conditions(loc, grid, ::Missing) = nothing
+validate_boundary_conditions(loc, grid, ::Nothing) = nothing
 
 function validate_boundary_conditions(loc, grid, bcs)
     sides = (:east, :west, :north, :south, :bottom, :top)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -140,21 +140,23 @@ end
 boundary_conditions(field) = nothing
 boundary_conditions(f::Field) = f.boundary_conditions
 
-function interior(a::OffsetArray, (LX, LY, LZ), grid)
+function interior(a::Union{Field, OffsetArray}, (LX, LY, LZ), grid)
     TX, TY, TZ = topology(grid)
     ii = interior_parent_indices(LX, TX, grid.Nx, grid.Hx)
     jj = interior_parent_indices(LY, TY, grid.Ny, grid.Hy)
     kk = interior_parent_indices(LZ, TZ, grid.Nz, grid.Hz)
-    return view(parent(f), ii, jj, kk)
+    return view(parent(a), ii, jj, kk)
 end
 
 "Returns a view of `f` that excludes halo points."
-interior(f::Field) = interior(f.data, location(f), f.grid)
+interior(f::Field) = interior(f, location(f), f.grid)
     
-interior_copy(f::AbstractField{LX, LY, LZ}) where {LX, LY, LZ} =
-    parent(f)[interior_parent_indices(LX, topology(f, 1), f.grid.Nx, f.grid.Hx),
-              interior_parent_indices(LY, topology(f, 2), f.grid.Ny, f.grid.Hy),
-              interior_parent_indices(LZ, topology(f, 3), f.grid.Nz, f.grid.Hz)]
+function interior_copy(f::Field)
+    LX, LY, LZ = location(f)
+    return parent(f)[interior_parent_indices(LX, topology(f, 1), f.grid.Nx, f.grid.Hx),
+                     interior_parent_indices(LY, topology(f, 2), f.grid.Ny, f.grid.Hy),
+                     interior_parent_indices(LZ, topology(f, 3), f.grid.Nz, f.grid.Hz)]
+end
 
 # Don't use axes(f) to checkbounds; use axes(f.data)
 Base.checkbounds(f::Field, I...) = Base.checkbounds(f.data, I...)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -140,16 +140,17 @@ end
 boundary_conditions(field) = nothing
 boundary_conditions(f::Field) = f.boundary_conditions
 
-"Returns a view of `f` that excludes halo points."
-function interior(f::Field)
-    LX, LY, LZ = location(f)
-    TX, TY, TZ = topology(f.grid)
-    ii = interior_parent_indices(LX, TX, f.grid.Nx, f.grid.Hx)
-    jj = interior_parent_indices(LY, TY, f.grid.Ny, f.grid.Hy)
-    kk = interior_parent_indices(LZ, TZ, f.grid.Nz, f.grid.Hz)
+function interior(a::OffsetArray, (LX, LY, LZ), grid)
+    TX, TY, TZ = topology(grid)
+    ii = interior_parent_indices(LX, TX, grid.Nx, grid.Hx)
+    jj = interior_parent_indices(LY, TY, grid.Ny, grid.Hy)
+    kk = interior_parent_indices(LZ, TZ, grid.Nz, grid.Hz)
     return view(parent(f), ii, jj, kk)
 end
 
+"Returns a view of `f` that excludes halo points."
+interior(f::Field) = interior(f.data, location(f), f.grid)
+    
 interior_copy(f::AbstractField{LX, LY, LZ}) where {LX, LY, LZ} =
     parent(f)[interior_parent_indices(LX, topology(f, 1), f.grid.Nx, f.grid.Hx),
               interior_parent_indices(LY, topology(f, 2), f.grid.Ny, f.grid.Hy),

--- a/src/Fields/regridding_fields.jl
+++ b/src/Fields/regridding_fields.jl
@@ -47,27 +47,38 @@ output_field[1, 1, :]
 """
 regrid!(a, b) = regrid!(a, a.grid, b.grid, b)
 
-function regrid!(a, target_grid, source_grid, b)
-    msg = """Regridding
-             $(summary(b)) on $(summary(source_grid))
-             to $(summary(a)) on $(summary(target_grid))
-             is not supported."""
+function we_can_regrid(a, target_grid, source_grid, b)
+    # Only 1D regridding is supported, so check that
+    #   1. source and target grid are in the same "class" and
+    #   2. source and target grid have same horizontal size
+    typeof(source_grid).name.wrapper === typeof(target_grid).name.wrapper &&
+        size(source_grid)[1:2] === size(target_grid)[1:2] && return true
 
-    return throw(ArgumentError(msg))
+    return false
+end
+
+function regrid!(a, target_grid, source_grid, b)
+    if we_can_regrid(a, target_grid, source_grid, b)
+        arch = architecture(a)
+        source_z_faces = znodes(Face, source_grid)
+
+        event = launch!(arch, target_grid, :xy, _regrid!, a, b, target_grid, source_grid, source_z_faces)
+        wait(device(arch), event)
+
+        return a
+    else
+        msg = """Regridding
+                 $(summary(b)) on $(summary(source_grid))
+                 to $(summary(a)) on $(summary(target_grid))
+                 is not supported."""
+
+        return throw(ArgumentError(msg))
+    end
 end
 
 #####
 ##### Regridding for single column grids
 #####
-
-function regrid!(a, target_grid::SingleColumnGrid, source_grid::SingleColumnGrid, b)
-    arch = architecture(a)
-    source_z_faces = znodes(Face, source_grid)
-
-    event = launch!(arch, target_grid, :xy, _regrid!, a, b, target_grid, source_grid, source_z_faces)
-    wait(device(arch), event)
-    return nothing
-end
 
 @kernel function _regrid!(target_field, source_field, target_grid, source_grid, source_z_faces)
     i, j = @index(Global, NTuple)

--- a/src/Fields/regridding_fields.jl
+++ b/src/Fields/regridding_fields.jl
@@ -48,7 +48,7 @@ output_field[1, 1, :]
 regrid!(a, b) = regrid!(a, a.grid, b.grid, b)
 
 function we_can_regrid(a, target_grid, source_grid, b)
-    # Only 1D regridding is supported, so check that
+    # Only 1D regridding in the vertical is supported, so check that
     #   1. source and target grid are in the same "class" and
     #   2. source and target grid have same horizontal size
     typeof(source_grid).name.wrapper === typeof(target_grid).name.wrapper &&

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -73,9 +73,9 @@ total_size(a) = size(a) # fallback
 Return the "total" size of a `grid` at `loc`. This is a 3-tuple of integers
 corresponding to the number of grid points along `x, y, z`.
 """
-@inline total_size(loc, grid) = (total_length(loc[1], topology(grid, 1), grid.Nx, grid.Hx),
-                                 total_length(loc[2], topology(grid, 2), grid.Ny, grid.Hy),
-                                 total_length(loc[3], topology(grid, 3), grid.Nz, grid.Hz))
+@inline total_size(loc, grid) = (total_length(loc[1](), topology(grid, 1)(), grid.Nx, grid.Hx),
+                                 total_length(loc[2](), topology(grid, 2)(), grid.Ny, grid.Hy),
+                                 total_length(loc[3](), topology(grid, 3)(), grid.Nz, grid.Hz))
 
 """
     halo_size(grid)
@@ -92,38 +92,19 @@ Return the total extent, including halo regions, of constant-spaced
 constant grid spacing `Δ`, and interior extent `L`.
 """
 @inline total_extent(topology, H, Δ, L) = L + (2H - 1) * Δ
-
-"""
-    total_extent(::Type{Bounded}, H, Δ, L)
-
-Return the total extent of, including halo regions, of constant-spaced
-`Bounded` and `Flat` dimensions with number of halo points `H`,
-constant grid spacing `Δ`, and interior extent `L`.
-"""
 @inline total_extent(::Type{Bounded}, H, Δ, L) = L + 2H * Δ
 
 """
     total_length(loc, topo, N, H=0)
 
-Return the total length (number of nodes), including halo points, of a field
-located at `Center` centers along a grid dimension of length `N` and with halo points `H`.
+Return the total length of a field at `loc`ation along
+one dimension of `topo`logy with `N` centered cells and
+`H` halo cells.
 """
-@inline total_length(loc, topo, N, H=0) = N + 2H
-
-"""
-    total_length(::Type{Face}, ::Type{Bounded}, N, H=0)
-
-Return the total length, including halo points, of a field located at
-cell `Face`s along a grid dimension of length `N` and with halo points `H`.
-"""
-@inline total_length(::Type{Face}, ::Type{Bounded}, N, H=0) = N + 1 + 2H
-
-"""
-    total_length(::Type{Nothing}, topo, N, H=0)
-
-Return 1, which is the 'length' of a field along a reduced dimension.
-"""
-@inline total_length(::Type{Nothing}, topo, N, H=0) = 1
+@inline total_length(loc,       topo,      N, H=0) = N + 2H
+@inline total_length(::Face,    ::Bounded, N, H=0) = N + 1 + 2H
+@inline total_length(::Nothing, topo,      N, H=0) = 1
+@inline total_length(::Nothing, ::Flat,    N, H=0) = N
 
 # Grid domains
 @inline domain(topo, N, ξ) = CUDA.@allowscalar ξ[1], ξ[N+1]

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -105,6 +105,8 @@ one dimension of `topo`logy with `N` centered cells and
 @inline total_length(::Type{Face},    ::Type{Bounded}, N, H=0) = N + 1 + 2H
 @inline total_length(::Type{Nothing}, topo,            N, H=0) = 1
 @inline total_length(::Type{Nothing}, ::Type{Flat},    N, H=0) = N
+@inline total_length(::Type{Face},    ::Type{Flat},    N, H=0) = N
+@inline total_length(::Type{Center},  ::Type{Flat},    N, H=0) = N
 
 # Grid domains
 @inline domain(topo, N, ξ) = CUDA.@allowscalar ξ[1], ξ[N+1]

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -11,6 +11,10 @@ Base.length(::Type{Face}, ::Type{Bounded}, N) = N+1
 Base.length(::Type{Center}, topo, N) = N
 Base.length(::Type{Nothing}, topo, N) = 1
 
+Base.length(::Type{Nothing}, ::Type{Flat}, N) = N
+Base.length(::Type{Face},    ::Type{Flat}, N) = N
+Base.length(::Type{Center},  ::Type{Flat}, N) = N
+
 """
     topology(grid)
 

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -73,9 +73,9 @@ total_size(a) = size(a) # fallback
 Return the "total" size of a `grid` at `loc`. This is a 3-tuple of integers
 corresponding to the number of grid points along `x, y, z`.
 """
-@inline total_size(loc, grid) = (total_length(loc[1](), topology(grid, 1)(), grid.Nx, grid.Hx),
-                                 total_length(loc[2](), topology(grid, 2)(), grid.Ny, grid.Hy),
-                                 total_length(loc[3](), topology(grid, 3)(), grid.Nz, grid.Hz))
+@inline total_size(loc, grid) = (total_length(loc[1], topology(grid, 1), grid.Nx, grid.Hx),
+                                 total_length(loc[2], topology(grid, 2), grid.Ny, grid.Hy),
+                                 total_length(loc[3], topology(grid, 3), grid.Nz, grid.Hz))
 
 """
     halo_size(grid)
@@ -101,10 +101,10 @@ Return the total length of a field at `loc`ation along
 one dimension of `topo`logy with `N` centered cells and
 `H` halo cells.
 """
-@inline total_length(loc,       topo,      N, H=0) = N + 2H
-@inline total_length(::Face,    ::Bounded, N, H=0) = N + 1 + 2H
-@inline total_length(::Nothing, topo,      N, H=0) = 1
-@inline total_length(::Nothing, ::Flat,    N, H=0) = N
+@inline total_length(loc,             topo,            N, H=0) = N + 2H
+@inline total_length(::Type{Face},    ::Type{Bounded}, N, H=0) = N + 1 + 2H
+@inline total_length(::Type{Nothing}, topo,            N, H=0) = 1
+@inline total_length(::Type{Nothing}, ::Type{Flat},    N, H=0) = N
 
 # Grid domains
 @inline domain(topo, N, ξ) = CUDA.@allowscalar ξ[1], ξ[N+1]

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -136,30 +136,46 @@ regular_dimensions(grid) = ()
 @inline underlying_right_halo_indices(::Type{Face}, ::Type{Bounded}, N, H) = N+2+H:N+1+2H
 @inline underlying_right_halo_indices(::Type{Nothing}, topo, N, H) = 1:0 # empty
 
-@inline interior_indices(loc, topo, N) = 1:N
-@inline interior_indices(::Type{Face}, ::Type{Bounded}, N) = 1:N+1
-@inline interior_indices(::Type{Nothing}, topo, N) = 1:1
+@inline interior_indices(loc,             topo,            N) = 1:N
+@inline interior_indices(::Type{Face},    ::Type{Bounded}, N) = 1:N+1
+@inline interior_indices(::Type{Nothing}, topo,            N) = 1:1
+
+@inline interior_indices(::Type{Nothing}, topo::Type{Flat}, N) = 1:N
+@inline interior_indices(::Type{Face},    topo::Type{Flat}, N) = 1:N
+@inline interior_indices(::Type{Center},  topo::Type{Flat}, N) = 1:N
 
 @inline interior_x_indices(loc, grid) = interior_indices(loc, topology(grid, 1), grid.Nx)
 @inline interior_y_indices(loc, grid) = interior_indices(loc, topology(grid, 2), grid.Ny)
 @inline interior_z_indices(loc, grid) = interior_indices(loc, topology(grid, 3), grid.Nz)
 
-@inline interior_parent_indices(loc, topo, N, H) = 1+H:N+H
-@inline interior_parent_indices(::Type{Face}, ::Type{Bounded}, N, H) = 1+H:N+1+H
-@inline interior_parent_indices(::Type{Nothing}, topo, N, H) = 1:1
+@inline interior_parent_indices(loc,             topo,            N, H) = 1+H:N+H
+@inline interior_parent_indices(::Type{Face},    ::Type{Bounded}, N, H) = 1+H:N+1+H
+@inline interior_parent_indices(::Type{Nothing}, topo,            N, H) = 1:1
+
+@inline interior_parent_indices(::Type{Nothing}, topo::Type{Flat}, N, H) = 1:N
+@inline interior_parent_indices(::Type{Face},    topo::Type{Flat}, N, H) = 1:N
+@inline interior_parent_indices(::Type{Center},  topo::Type{Flat}, N, H) = 1:N
 
 # All indices including halos.
-@inline all_indices(loc, topo, N, H) = 1-H:N+H
-@inline all_indices(::Type{Face}, ::Type{Bounded}, N, H) = 1-H:N+1+H
-@inline all_indices(::Type{Nothing}, topo, N, H) = 1:1
+@inline all_indices(loc,             topo,            N, H) = 1-H:N+H
+@inline all_indices(::Type{Face},    ::Type{Bounded}, N, H) = 1-H:N+1+H
+@inline all_indices(::Type{Nothing}, topo,            N, H) = 1:1
+
+@inline all_indices(::Type{Nothing}, ::Type{Flat}, N, H) = 1:N
+@inline all_indices(::Type{Face},    ::Type{Flat}, N, H) = 1:N
+@inline all_indices(::Type{Center},  ::Type{Flat}, N, H) = 1:N
 
 @inline all_x_indices(loc, grid) = all_indices(loc, topology(grid, 1), grid.Nx, grid.Hx)
 @inline all_y_indices(loc, grid) = all_indices(loc, topology(grid, 2), grid.Ny, grid.Hy)
 @inline all_z_indices(loc, grid) = all_indices(loc, topology(grid, 3), grid.Nz, grid.Hz)
 
-@inline all_parent_indices(loc, topo, N, H) = 1:N+2H
-@inline all_parent_indices(::Type{Face}, ::Type{Bounded}, N, H) = 1:N+1+2H
-@inline all_parent_indices(::Type{Nothing}, topo, N, H) = 1:1
+@inline all_parent_indices(loc,             topo,            N, H) = 1:N+2H
+@inline all_parent_indices(::Type{Face},    ::Type{Bounded}, N, H) = 1:N+1+2H
+@inline all_parent_indices(::Type{Nothing}, topo,            N, H) = 1:1
+
+@inline all_parent_indices(::Type{Nothing}, ::Type{Flat}, N, H) = 1:N
+@inline all_parent_indices(::Type{Face},    ::Type{Flat}, N, H) = 1:N
+@inline all_parent_indices(::Type{Center},  ::Type{Flat}, N, H) = 1:N
 
 @inline all_parent_x_indices(loc, grid) = all_parent_indices(loc, topology(grid, 1), grid.Nx, grid.Hx)
 @inline all_parent_y_indices(loc, grid) = all_parent_indices(loc, topology(grid, 2), grid.Ny, grid.Hy)


### PR DESCRIPTION
This PR checks whether two grids are only different in the vertical dimension using runtime information, rather then relying on both fields being `SingleColumnGrid`.

It also extends `total_length` for directions that are `Flat`, but have non-zero grid points (for simulations representing ensembles of simulations).

Closes #2067