### PR TITLE
Change regridding criterion to check field size rather than grid size

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.68.7"
+version = "0.68.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Fields/regridding_fields.jl
+++ b/src/Fields/regridding_fields.jl
@@ -50,9 +50,9 @@ regrid!(a, b) = regrid!(a, a.grid, b.grid, b)
 function we_can_regrid(a, target_grid, source_grid, b)
     # Only 1D regridding in the vertical is supported, so check that
     #   1. source and target grid are in the same "class" and
-    #   2. source and target grid have same horizontal size
+    #   2. source and target Field have same horizontal size
     typeof(source_grid).name.wrapper === typeof(target_grid).name.wrapper &&
-        size(source_grid)[1:2] === size(target_grid)[1:2] && return true
+        size(a)[1:2] === size(b)[1:2] && return true
 
     return false
 end

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -468,6 +468,7 @@ end
 
             # Fine-graining from reduction
             fine_stretched_c_mean_xy = Field(Reduction(mean!, fine_stretched_c, dims=(1, 2)))
+            compute!(fine_stretched_c_mean_xy)
 
             regrid!(super_fine_from_reduction_regular_c, fine_stretched_c_mean_xy)
             

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -1,5 +1,7 @@
 include("dependencies_for_runtests.jl")
 
+using Statistics
+
 using Oceananigans.Fields: cpudata, FieldSlicer, interior_copy
 using Oceananigans.Fields: regrid!, ReducedField, has_velocities
 using Oceananigans.Fields: VelocityFields, TracerFields, interpolate
@@ -392,6 +394,8 @@ end
         topology = (Flat, Flat, Bounded)
         
         for arch in archs
+            fine_regular_grid                = RectilinearGrid(arch, size=(4, 6, 2), x=(0, 1), y=(0, 2), z=(0, Lz), topology=(Periodic, Periodic, Bounded))
+            fine_stretched_grid              = RectilinearGrid(arch, size=(4, 6, 2), x=(0, 1), y=(0, 2), z = [0, ℓz, Lz], topology=(Periodic, Periodic, Bounded))
             coarse_column_regular_grid       = RectilinearGrid(arch, size=1, z=(0, Lz), topology=topology)
             fine_column_regular_grid         = RectilinearGrid(arch, size=2, z=(0, Lz), topology=topology)
             fine_column_stretched_grid       = RectilinearGrid(arch, size=2, z = [0, ℓz, Lz], topology=topology)
@@ -399,12 +403,14 @@ end
             super_fine_column_stretched_grid = RectilinearGrid(arch, size=4, z = [0, 0.1, 0.3, 0.65, Lz], topology=topology)
             super_fine_column_regular_grid   = RectilinearGrid(arch, size=5, z=(0, Lz), topology=topology)
             
+            fine_stretched_c              = CenterField(fine_stretched_grid)
             coarse_column_regular_c       = CenterField(coarse_column_regular_grid)
             fine_column_regular_c         = CenterField(fine_column_regular_grid)
             fine_column_stretched_c       = CenterField(fine_column_stretched_grid)
             very_fine_column_stretched_c  = CenterField(very_fine_column_stretched_grid)
             super_fine_column_stretched_c = CenterField(super_fine_column_stretched_grid)
             super_fine_column_regular_c   = CenterField(super_fine_column_regular_grid)
+            super_fine_from_reduction_regular_c = CenterField(super_fine_column_regular_grid)
 
             # we initialize an array on the `fine_column_stretched_grid`, regrid it to the rest
             # grids, and check whether we get the anticipated results
@@ -414,6 +420,9 @@ end
                 fine_column_stretched_c[1, 1, 1] = c₁
                 fine_column_stretched_c[1, 1, 2] = c₂
             end
+
+            fine_stretched_c[:, :, 1] .= c₁
+            fine_stretched_c[:, :, 2] .= c₂
 
             # Coarse-graining
             regrid!(coarse_column_regular_c, fine_column_stretched_c)
@@ -455,6 +464,19 @@ end
                 @test super_fine_column_regular_c[1, 1, 3] ≈ (3 - ℓz/(Lz/5)) * c₂ + (-2 + ℓz/(Lz/5)) * c₁
                 @test super_fine_column_regular_c[1, 1, 4] ≈ c₂
                 @test super_fine_column_regular_c[1, 1, 5] ≈ c₂
+            end
+
+            # Fine-graining from reduction
+            fine_stretched_c_mean_xy = Field(Reduction(mean!, fine_stretched_c, dims=(1, 2)))
+
+            regrid!(super_fine_from_reduction_regular_c, fine_stretched_c_mean_xy)
+            
+            CUDA.@allowscalar begin
+                @test super_fine_from_reduction_regular_c[1, 1, 1] ≈ c₁
+                @test super_fine_from_reduction_regular_c[1, 1, 2] ≈ c₁
+                @test super_fine_from_reduction_regular_c[1, 1, 3] ≈ (3 - ℓz/(Lz/5)) * c₂ + (-2 + ℓz/(Lz/5)) * c₁
+                @test super_fine_from_reduction_regular_c[1, 1, 4] ≈ c₂
+                @test super_fine_from_reduction_regular_c[1, 1, 5] ≈ c₂
             end
         end
     end


### PR DESCRIPTION
~Also bumps to 0.68.8.~

The application for this kind of regridding is from a field that, while living on a 3D grid, is reduced in x and y. Because the field is reduced in x and y it's a valid source field for a target field that's on a 1D grid.

We should probably add a test to this PR (regridding from a reduced field on a 3D grid to a non-reduced field on a 1D grid).

cc @adelinehillier @navidcy 