### PR TITLE
Show free surface method/solver for `HydrostaticFreeSurfaceModel`s

### DIFF
--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -53,11 +53,12 @@ may be eliminated when `buoyancy=nothing` by specifying `tracers=()`:
 
 ```jldoctest buoyancy
 julia> model = HydrostaticFreeSurfaceModel(grid=grid, buoyancy=nothing, tracers=())
-HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0) 
+HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 ├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── tracers: ()
 ├── closure: Nothing
 ├── buoyancy: Nothing
+├── free surface: ExplicitFreeSurface; gravitational acceleration 9.80665 m s⁻²
 └── coriolis: Nothing
 ```
 
@@ -85,6 +86,7 @@ HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 ├── tracers: (:b,)
 ├── closure: Nothing
 ├── buoyancy: Buoyancy{BuoyancyTracer, Oceananigans.Grids.ZDirection}
+├── free surface: ExplicitFreeSurface; gravitational acceleration 9.80665 m s⁻²
 └── coriolis: Nothing
 ```
 
@@ -118,6 +120,7 @@ HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 ├── tracers: (:T, :S)
 ├── closure: Nothing
 ├── buoyancy: Buoyancy{SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}, Oceananigans.Grids.ZDirection}
+├── free surface: ExplicitFreeSurface; gravitational acceleration 9.80665 m s⁻²
 └── coriolis: Nothing
 ```
 
@@ -130,6 +133,7 @@ HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 ├── tracers: (:T, :S)
 ├── closure: Nothing
 ├── buoyancy: Buoyancy{SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}, Oceananigans.Grids.ZDirection}
+├── free surface: ExplicitFreeSurface; gravitational acceleration 9.80665 m s⁻²
 └── coriolis: Nothing
 ```
 

--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -58,7 +58,7 @@ HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 ├── tracers: ()
 ├── closure: Nothing
 ├── buoyancy: Nothing
-├── free surface: ExplicitFreeSurface; gravitational acceleration 9.80665 m s⁻²
+├── free surface: ExplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 └── coriolis: Nothing
 ```
 
@@ -86,7 +86,7 @@ HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 ├── tracers: (:b,)
 ├── closure: Nothing
 ├── buoyancy: Buoyancy{BuoyancyTracer, Oceananigans.Grids.ZDirection}
-├── free surface: ExplicitFreeSurface; gravitational acceleration 9.80665 m s⁻²
+├── free surface: ExplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 └── coriolis: Nothing
 ```
 
@@ -120,7 +120,7 @@ HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 ├── tracers: (:T, :S)
 ├── closure: Nothing
 ├── buoyancy: Buoyancy{SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}, Oceananigans.Grids.ZDirection}
-├── free surface: ExplicitFreeSurface; gravitational acceleration 9.80665 m s⁻²
+├── free surface: ExplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 └── coriolis: Nothing
 ```
 
@@ -133,7 +133,7 @@ HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
 ├── tracers: (:T, :S)
 ├── closure: Nothing
 ├── buoyancy: Buoyancy{SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}, Oceananigans.Grids.ZDirection}
-├── free surface: ExplicitFreeSurface; gravitational acceleration 9.80665 m s⁻²
+├── free surface: ExplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 └── coriolis: Nothing
 ```
 

--- a/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
@@ -7,7 +7,12 @@ function Base.show(io::IO, model::HydrostaticFreeSurfaceModel{TS, C, A}) where {
         "├── grid: $(summary(model.grid))\n",
         "├── tracers: $(tracernames(model.tracers))\n",
         "├── closure: ", summary(model.closure), '\n',
-        "├── buoyancy: ", summary(model.buoyancy), '\n')
+        "├── buoyancy: ", summary(model.buoyancy), '\n',
+        "├── free surface: ", typeof(model.free_surface).name.wrapper, ", with gravitational acceleration $(model.free_surface.gravitational_acceleration) m s⁻²", '\n')
+
+    if typeof(model.free_surface).name.wrapper == ImplicitFreeSurface
+        print(io, "│   └── solver: ", string(model.free_surface.solver_method), '\n')
+    end
 
     if isnothing(model.particles)
         print(io, "└── coriolis: $(typeof(model.coriolis))")

--- a/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
@@ -8,7 +8,7 @@ function Base.show(io::IO, model::HydrostaticFreeSurfaceModel{TS, C, A}) where {
         "├── tracers: $(tracernames(model.tracers))\n",
         "├── closure: ", summary(model.closure), '\n',
         "├── buoyancy: ", summary(model.buoyancy), '\n',
-        "├── free surface: ", typeof(model.free_surface).name.wrapper, ", with gravitational acceleration $(model.free_surface.gravitational_acceleration) m s⁻²", '\n')
+        "├── free surface: ", typeof(model.free_surface).name.wrapper, "; gravitational acceleration $(model.free_surface.gravitational_acceleration) m s⁻²", '\n')
 
     if typeof(model.free_surface).name.wrapper == ImplicitFreeSurface
         print(io, "│   └── solver: ", string(model.free_surface.solver_method), '\n')

--- a/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
@@ -8,10 +8,14 @@ function Base.show(io::IO, model::HydrostaticFreeSurfaceModel{TS, C, A}) where {
         "├── tracers: $(tracernames(model.tracers))\n",
         "├── closure: ", summary(model.closure), '\n',
         "├── buoyancy: ", summary(model.buoyancy), '\n',
-        "├── free surface: ", typeof(model.free_surface).name.wrapper, "; gravitational acceleration $(model.free_surface.gravitational_acceleration) m s⁻²", '\n')
+        "├── free surface: ", typeof(model.free_surface).name.wrapper, " with gravitational acceleration $(model.free_surface.gravitational_acceleration) m s⁻²", '\n')
 
     if typeof(model.free_surface).name.wrapper == ImplicitFreeSurface
         print(io, "│   └── solver: ", string(model.free_surface.solver_method), '\n')
+    end
+
+    if typeof(model.free_surface).name.wrapper == SplitExplicitFreeSurface
+        print(io, "│   └── number of substeps: $(model.free_surface.settings.substeps)", '\n')
     end
 
     if isnothing(model.particles)


### PR DESCRIPTION
After this PR

```Julia
julia> using Oceananigans

julia> grid = RectilinearGrid(topology=(Periodic, Bounded, Bounded), size=(1, 1, 1), extent=(1, 2, 3))
1×1×1 RectilinearGrid{Float64, Periodic, Bounded, Bounded} on CPU with 1×1×1 halo
├── Periodic x ∈ [0.0, 1.0)  regularly spaced with Δx=1.0
├── Bounded  y ∈ [0.0, 2.0]  regularly spaced with Δy=2.0
└── Bounded  z ∈ [-3.0, 0.0] regularly spaced with Δz=3.0

julia> model = HydrostaticFreeSurfaceModel(grid=grid)
HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Bounded, Bounded} on CPU with 1×1×1 halo
├── tracers: (:T, :S)
├── closure: Nothing
├── buoyancy: Buoyancy{SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}, Oceananigans.Grids.ZDirection}
├── free surface: ExplicitFreeSurface; gravitational acceleration 9.80665 m s⁻²
└── coriolis: Nothing

julia> model = HydrostaticFreeSurfaceModel(grid=grid, free_surface = ImplicitFreeSurface(solver_method = :HeptadiagonalIterativeSolver))
HydrostaticFreeSurfaceModel{CPU, Float64}(time = 0 seconds, iteration = 0)
├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Bounded, Bounded} on CPU with 1×1×1 halo
├── tracers: (:T, :S)
├── closure: Nothing
├── buoyancy: Buoyancy{SeawaterBuoyancy{Float64, LinearEquationOfState{Float64}, Nothing, Nothing}, Oceananigans.Grids.ZDirection}
├── free surface: ImplicitFreeSurface; gravitational acceleration 9.80665 m s⁻²
│   └── solver: HeptadiagonalIterativeSolver
└── coriolis: Nothing
```

Closes #2197.