### PR TITLE
Add show method for CATKE closure

### DIFF
--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
@@ -288,7 +288,7 @@ end
 ##### Show
 #####
 Base.show(io::IO, closure::CATKEVD{TD}) where TD =
-    print(io, "CATKEVerticalDiffusivity with $(TD) and parameters: \n" *
+    print(io, "CATKEVerticalDiffusivity with $(TD.name.name) and parameters: \n" *
               "    Cᴰ = $(closure.Cᴰ), \n" * 
               "    $(closure.mixing_length), \n" *
               "    $(closure.surface_TKE_flux)")

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
@@ -289,7 +289,7 @@ end
 #####
 Base.show(io::IO, closure::CATKEVD{TD}) where TD =
     print(io, "CATKEVerticalDiffusivity with $(TD) and parameters: \n" *
-              "    Cᴰ=$(closure.Cᴰ), \n" * 
+              "    Cᴰ = $(closure.Cᴰ), \n" * 
               "    $(closure.mixing_length), \n" *
               "    $(closure.surface_TKE_flux)")
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
@@ -287,11 +287,11 @@ end
 #####
 ##### Show
 #####
-Base.show(io::IO, closure::CATKEVD) =
-    print(io, "CATKEVerticalDiffusivity: \n" *
-              "(Cᴰ=$(closure.Cᴰ), \n" * 
-              " $(closure.mixing_length), \n" *
-              " $(closure.surface_TKE_flux)" * ")")
+Base.show(io::IO, closure::CATKEVD{TD}) where TD =
+    print(io, "CATKEVerticalDiffusivity with $(TD) and parameters: \n" *
+              "    Cᴰ=$(closure.Cᴰ), \n" * 
+              "    $(closure.mixing_length), \n" *
+              "    $(closure.surface_TKE_flux)")
 
 end
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
@@ -78,7 +78,8 @@ end
                              Cᴰ = 2.91,
                              mixing_length = MixingLength{FT}(),
                              surface_TKE_flux = SurfaceTKEFlux{FT}(),
-                             time_discretization::TD = VerticallyImplicitTimeDiscretization())
+                             warning = true,
+                             time_discretization::TD = VerticallyImplicitTimeDiscretization()) where TD
 
 Returns the `CATKEVerticalDiffusivity` turbulence closure for vertical mixing by
 small-scale ocean turbulence based on the prognostic evolution of subgrid
@@ -282,4 +283,21 @@ end
                   zero(FT))
 end
 
+
+#####
+##### Show
+#####
+Base.show(io::IO, closure::CATKEVD) =
+    print(io, "CATKEVerticalDiffusivity: \n" *
+              "(Cᴰ=$(closure.Cᴰ), \n" * 
+              " $(closure.mixing_length), \n" *
+              " $(closure.surface_TKE_flux)" * ")")
+
+
+# Base.show(io::IO, closure::CATKEVD) =
+#     print(io, "CATKEVerticalDiffusivity: " *
+#               "(background_κz=$(closure.background_κz), convective_κz=$(closure.convective_κz), " *
+#               "background_νz=$(closure.background_νz), convective_νz=$(closure.convective_νz)" * ")")
+
 end
+

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
@@ -293,11 +293,5 @@ Base.show(io::IO, closure::CATKEVD) =
               " $(closure.mixing_length), \n" *
               " $(closure.surface_TKE_flux)" * ")")
 
-
-# Base.show(io::IO, closure::CATKEVD) =
-#     print(io, "CATKEVerticalDiffusivity: " *
-#               "(background_κz=$(closure.background_κz), convective_κz=$(closure.convective_κz), " *
-#               "background_νz=$(closure.background_νz), convective_νz=$(closure.convective_νz)" * ")")
-
 end
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/mixing_length.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/mixing_length.jl
@@ -206,3 +206,10 @@ end
     return max(Cᴬe * ℓᴬ, Cᵟe * ℓᵟ, σe * ℓ★)
 end
 
+Base.show(io::IO, ML::MixingLength) =
+    print(io, "MixingLength: (Cᴸᵇ=$(ML.Cᴸᵇ), \n" *
+              "                Cᵟu=$(ML.Cᵟu), Cᵟc=$(ML.Cᵟc), Cᵟe=$(ML.Cᵟe), \n" *
+              "                Cᴬu=$(ML.Cᴬu), Cᴬc=$(ML.Cᴬc), Cᴬe=$(ML.Cᴬe), \n" *
+              "                Cᴷu⁻=$(ML.Cᴷu⁻), Cᴷc⁻=$(ML.Cᴷc⁻), Cᴷe⁻=$(ML.Cᴷe⁻), \n" *
+              "                Cᴷuʳ=$(ML.Cᴷuʳ), Cᴷcʳ=$(ML.Cᴷcʳ), Cᴷeʳ=$(ML.Cᴷeʳ), \n" *
+              "                CᴷRiʷ=$(ML.CᴷRiʷ), CᴷRiᶜ=$(ML.CᴷRiᶜ)" * ")")

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/mixing_length.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/mixing_length.jl
@@ -208,18 +208,18 @@ end
 
 Base.show(io::IO, ML::MixingLength) =
     print(io, "MixingLength: \n" *
-              "        Cᴸᵇ=$(ML.Cᴸᵇ), \n" *
-              "        Cᵟu=$(ML.Cᵟu), \n" *
-              "        Cᵟc=$(ML.Cᵟc), \n" *
-              "        Cᵟe=$(ML.Cᵟe), \n" *
-              "        Cᴬu=$(ML.Cᴬu), \n" *
-              "        Cᴬc=$(ML.Cᴬc), \n" *
-              "        Cᴬe=$(ML.Cᴬe), \n" *
-              "        Cᴷu⁻=$(ML.Cᴷu⁻), \n" *
-              "        Cᴷc⁻=$(ML.Cᴷc⁻), \n" *
-              "        Cᴷe⁻=$(ML.Cᴷe⁻), \n" *
-              "        Cᴷuʳ=$(ML.Cᴷuʳ), \n" *
-              "        Cᴷcʳ=$(ML.Cᴷcʳ), \n" *
-              "        Cᴷeʳ=$(ML.Cᴷeʳ), \n" *
-              "        CᴷRiʷ=$(ML.CᴷRiʷ), \n" *
-              "        CᴷRiᶜ=$(ML.CᴷRiᶜ)")
+              "          Cᴸᵇ = $(ML.Cᴸᵇ), \n" *
+              "          Cᵟu = $(ML.Cᵟu), \n" *
+              "          Cᵟc = $(ML.Cᵟc), \n" *
+              "          Cᵟe = $(ML.Cᵟe), \n" *
+              "          Cᴬu = $(ML.Cᴬu), \n" *
+              "          Cᴬc = $(ML.Cᴬc), \n" *
+              "          Cᴬe = $(ML.Cᴬe), \n" *
+              "         Cᴷu⁻ = $(ML.Cᴷu⁻), \n" *
+              "         Cᴷc⁻ = $(ML.Cᴷc⁻), \n" *
+              "         Cᴷe⁻ = $(ML.Cᴷe⁻), \n" *
+              "         Cᴷuʳ = $(ML.Cᴷuʳ), \n" *
+              "         Cᴷcʳ = $(ML.Cᴷcʳ), \n" *
+              "         Cᴷeʳ = $(ML.Cᴷeʳ), \n" *
+              "        CᴷRiʷ = $(ML.CᴷRiʷ), \n" *
+              "        CᴷRiᶜ = $(ML.CᴷRiᶜ)")

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/mixing_length.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/mixing_length.jl
@@ -207,9 +207,19 @@ end
 end
 
 Base.show(io::IO, ML::MixingLength) =
-    print(io, "MixingLength: (Cᴸᵇ=$(ML.Cᴸᵇ), \n" *
-              "                Cᵟu=$(ML.Cᵟu), Cᵟc=$(ML.Cᵟc), Cᵟe=$(ML.Cᵟe), \n" *
-              "                Cᴬu=$(ML.Cᴬu), Cᴬc=$(ML.Cᴬc), Cᴬe=$(ML.Cᴬe), \n" *
-              "                Cᴷu⁻=$(ML.Cᴷu⁻), Cᴷc⁻=$(ML.Cᴷc⁻), Cᴷe⁻=$(ML.Cᴷe⁻), \n" *
-              "                Cᴷuʳ=$(ML.Cᴷuʳ), Cᴷcʳ=$(ML.Cᴷcʳ), Cᴷeʳ=$(ML.Cᴷeʳ), \n" *
-              "                CᴷRiʷ=$(ML.CᴷRiʷ), CᴷRiᶜ=$(ML.CᴷRiᶜ)" * ")")
+    print(io, "MixingLength: \n" *
+              "        Cᴸᵇ=$(ML.Cᴸᵇ), \n" *
+              "        Cᵟu=$(ML.Cᵟu), \n" *
+              "        Cᵟc=$(ML.Cᵟc), \n" *
+              "        Cᵟe=$(ML.Cᵟe), \n" *
+              "        Cᴬu=$(ML.Cᴬu), \n" *
+              "        Cᴬc=$(ML.Cᴬc), \n" *
+              "        Cᴬe=$(ML.Cᴬe), \n" *
+              "        Cᴷu⁻=$(ML.Cᴷu⁻), \n" *
+              "        Cᴷc⁻=$(ML.Cᴷc⁻), \n" *
+              "        Cᴷe⁻=$(ML.Cᴷe⁻), \n" *
+              "        Cᴷuʳ=$(ML.Cᴷuʳ), \n" *
+              "        Cᴷcʳ=$(ML.Cᴷcʳ), \n" *
+              "        Cᴷeʳ=$(ML.Cᴷeʳ), \n" *
+              "        CᴷRiʷ=$(ML.CᴷRiʷ), \n" *
+              "        CᴷRiᶜ=$(ML.CᴷRiᶜ)")

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/surface_TKE_flux.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/surface_TKE_flux.jl
@@ -143,5 +143,5 @@ end
 
 Base.show(io::IO, SurfaceTKEFlux::SurfaceTKEFlux) =
     print(io, "SurfaceTKEFlux: \n" *
-              "        Cᵂu★=$(SurfaceTKEFlux.Cᵂu★), \n" *
-              "        CᵂwΔ=$(SurfaceTKEFlux.CᵂwΔ)")
+              "         Cᵂu★ = $(SurfaceTKEFlux.Cᵂu★), \n" *
+              "         CᵂwΔ = $(SurfaceTKEFlux.CᵂwΔ)")

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/surface_TKE_flux.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/surface_TKE_flux.jl
@@ -142,5 +142,6 @@ function add_closure_specific_boundary_conditions(closure::Union{CATKEVD, CATKEV
 end
 
 Base.show(io::IO, SurfaceTKEFlux::SurfaceTKEFlux) =
-    print(io, "SurfaceTKEFlux: " *
-              "(Cᵂu★=$(SurfaceTKEFlux.Cᵂu★), CᵂwΔ=$(SurfaceTKEFlux.CᵂwΔ)" * ")")
+    print(io, "SurfaceTKEFlux: \n" *
+              "        Cᵂu★=$(SurfaceTKEFlux.Cᵂu★), \n" *
+              "        CᵂwΔ=$(SurfaceTKEFlux.CᵂwΔ)")

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/surface_TKE_flux.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/surface_TKE_flux.jl
@@ -141,3 +141,6 @@ function add_closure_specific_boundary_conditions(closure::Union{CATKEVD, CATKEV
     return new_boundary_conditions
 end
 
+Base.show(io::IO, SurfaceTKEFlux::SurfaceTKEFlux) =
+    print(io, "SurfaceTKEFlux: " *
+              "(Cᵂu★=$(SurfaceTKEFlux.Cᵂu★), CᵂwΔ=$(SurfaceTKEFlux.CᵂwΔ)" * ")")


### PR DESCRIPTION
### before this PR

```Julia
julia> using Oceananigans

julia> using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities: CATKEVerticalDiffusivity

julia> catke = CATKEVerticalDiffusivity()
┌ Warning: CATKEVerticalDiffusivity is an experimental turbulence closure that
│ is unvalidated and whose default parameters are not calibrated for
│ realistic ocean conditions or for use in a three-dimensional
│ simulation. Use with caution and report bugs and problems with physics
│ to https://github.com/CliMA/Oceananigans.jl/issues.
└ @ Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities /g/data/v45/nc3020/.julia/packages/Oceananigans/Bks9B/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl:95
CATKEVerticalDiffusivity{Oceananigans.TurbulenceClosures.VerticallyImplicitTimeDiscretization, Float64, Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities.MixingLength{Float64}, Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities.SurfaceTKEFlux{Float64}}(2.91, Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities.MixingLength{Float64}(1.16, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.15, 3.87, 0.4, 0.77, 0.13, 1.11, 0.72, 0.76), Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities.SurfaceTKEFlux{Float64}(3.62, 1.31))
```

### after this PR

```julia
julia> using Oceananigans
[ Info: Oceananigans will use 48 threads

julia> using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities: CATKEVerticalDiffusivity

julia> catke = CATKEVerticalDiffusivity()
┌ Warning: CATKEVerticalDiffusivity is an experimental turbulence closure that
│ is unvalidated and whose default parameters are not calibrated for
│ realistic ocean conditions or for use in a three-dimensional
│ simulation. Use with caution and report bugs and problems with physics
│ to https://github.com/CliMA/Oceananigans.jl/issues.
└ @ Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities /g/data/v45/nc3020/.julia/packages/Oceananigans/Bks9B/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl:95
CATKEVerticalDiffusivity:
(Cᴰ=2.91,
 MixingLength: (Cᴸᵇ=1.16,
                Cᵟu=0.5, Cᵟc=0.5, Cᵟe=0.5,
                Cᴬu=0.0, Cᴬc=0.0, Cᴬe=0.0,
                Cᴷu⁻=0.15, Cᴷc⁻=0.4, Cᴷe⁻=0.13,
                Cᴷuʳ=3.87, Cᴷcʳ=0.77, Cᴷeʳ=1.11,
                CᴷRiʷ=0.72, CᴷRiᶜ=0.76),
 SurfaceTKEFlux: (Cᵂu★=3.62, CᵂwΔ=1.31))
```
