### PR TITLE
Saves actual `solver_method` name in `ImplicitFreeSurface` (not just `:Default`)

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
@@ -59,8 +59,7 @@ function FreeSurface(free_surface::ImplicitFreeSurface{Nothing}, velocities, gri
     barotropic_y_volume_flux = Field{Center, Face, Nothing}(grid)
     barotropic_volume_flux = (u=barotropic_x_volume_flux, v=barotropic_y_volume_flux)
 
-    solver_method = free_surface.solver_method
-    solver = build_implicit_step_solver(Val(solver_method), grid, gravitational_acceleration, free_surface.solver_settings)
+    solver, solver_method = build_implicit_step_solver(Val(free_surface.solver_method), grid, gravitational_acceleration, free_surface.solver_settings)
 
     return ImplicitFreeSurface(η, gravitational_acceleration,
                                barotropic_volume_flux,
@@ -74,7 +73,7 @@ is_horizontally_regular(::RectilinearGrid{<:Any, <:Any, <:Any, <:Any, <:Number, 
 
 function build_implicit_step_solver(::Val{:Default}, grid, gravitational_acceleration, settings)
     default_method = is_horizontally_regular(grid) ? :FastFourierTransform : :PreconditionedConjugateGradient
-    return build_implicit_step_solver(Val(default_method), grid, gravitational_acceleration, settings)
+    return build_implicit_step_solver(Val(default_method), grid, gravitational_acceleration, settings), default_method
 end
 
 @inline explicit_barotropic_pressure_x_gradient(i, j, k, grid, ::ImplicitFreeSurface) = 0

--- a/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
@@ -59,7 +59,9 @@ function FreeSurface(free_surface::ImplicitFreeSurface{Nothing}, velocities, gri
     barotropic_y_volume_flux = Field{Center, Face, Nothing}(grid)
     barotropic_volume_flux = (u=barotropic_x_volume_flux, v=barotropic_y_volume_flux)
 
-    solver, solver_method = build_implicit_step_solver(Val(free_surface.solver_method), grid, gravitational_acceleration, free_surface.solver_settings)
+    solver_method = is_horizontally_regular(grid) ? :FastFourierTransform : :PreconditionedConjugateGradient
+    
+    solver = build_implicit_step_solver(Val(solver_method), grid, gravitational_acceleration, free_surface.solver_settings)
 
     return ImplicitFreeSurface(η, gravitational_acceleration,
                                barotropic_volume_flux,
@@ -70,11 +72,6 @@ end
 
 is_horizontally_regular(grid) = false
 is_horizontally_regular(::RectilinearGrid{<:Any, <:Any, <:Any, <:Any, <:Number, <:Number}) = true
-
-function build_implicit_step_solver(::Val{:Default}, grid, gravitational_acceleration, settings)
-    default_method = is_horizontally_regular(grid) ? :FastFourierTransform : :PreconditionedConjugateGradient
-    return build_implicit_step_solver(Val(default_method), grid, gravitational_acceleration, settings), default_method
-end
 
 @inline explicit_barotropic_pressure_x_gradient(i, j, k, grid, ::ImplicitFreeSurface) = 0
 @inline explicit_barotropic_pressure_y_gradient(i, j, k, grid, ::ImplicitFreeSurface) = 0

--- a/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
@@ -13,7 +13,7 @@ function Base.show(io::IO, model::HydrostaticFreeSurfaceModel{TS, C, A}) where {
         print(io, "├── free surface: ", typeof(model.free_surface).name.wrapper, " with gravitational acceleration $(model.free_surface.gravitational_acceleration) m s⁻²", '\n')
 
         if typeof(model.free_surface).name.wrapper == ImplicitFreeSurface
-            print(io, "│   └── solver: ", string(typeof(model.free_surface.implicit_step_solver).name.name), '\n')
+            print(io, "│   └── solver: ", string(model.free_surface.solver_method), '\n')
         end
 
         if typeof(model.free_surface).name.wrapper == SplitExplicitFreeSurface

--- a/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
@@ -13,7 +13,7 @@ function Base.show(io::IO, model::HydrostaticFreeSurfaceModel{TS, C, A}) where {
         print(io, "├── free surface: ", typeof(model.free_surface).name.wrapper, " with gravitational acceleration $(model.free_surface.gravitational_acceleration) m s⁻²", '\n')
 
         if typeof(model.free_surface).name.wrapper == ImplicitFreeSurface
-            print(io, "│   └── solver: ", string(model.free_surface.solver_method), '\n')
+            print(io, "│   └── solver: ", string(typeof(model.free_surface.implicit_step_solver).name.name), '\n')
         end
 
         if typeof(model.free_surface).name.wrapper == SplitExplicitFreeSurface

--- a/src/Solvers/preconditioned_conjugate_gradient_solver.jl
+++ b/src/Solvers/preconditioned_conjugate_gradient_solver.jl
@@ -229,7 +229,7 @@ end
 
 function Base.show(io::IO, solver::PreconditionedConjugateGradientSolver)
     print(io, "Oceananigans-compatible preconditioned conjugate gradient solver.\n")
-    print(io, " Problem size = "  , size(solver.q), '\n')
+    print(io, " Problem size = "  , size(solver.grid), '\n')
     print(io, " Grid = "  , solver.grid)
     return nothing
 end


### PR DESCRIPTION
This is a workaround to avoid printing `solver: Default` and instead print `solver: FFTImplicitFreeSurfaceSolver`.