### PR TITLE
Fixes bug in `TimeStepWizard`'s diffusive timescale calculation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.69.2"
+version = "0.69.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -1,3 +1,6 @@
+using Oceananigans: TurbulenceClosures
+
+
 mutable struct TimeStepWizard{FT, C, D}
                          cfl :: FT
                diffusive_cfl :: FT
@@ -47,9 +50,10 @@ function TimeStepWizard(FT=Float64; cfl = 0.2,
                                     cell_advection_timescale = cell_advection_timescale,
                                     cell_diffusion_timescale = infinite_diffusion_timescale)
 
-    isfinite(diffusive_cfl) && # user wants to limit by diffusive CFL
-    !(cell_diffusion_timescale === infinite_diffusion_timescale) && # user did not provide custom timescale
-        (cell_diffusion_timescale = Oceananigans.TurbulenceClosures.cell_diffusion_timescale)
+    # user wants to limit by diffusive CFL and did not provide custom function to calculate timescale
+    if isfinite(diffusive_cfl) && (cell_diffusion_timescale === infinite_diffusion_timescale)
+       cell_diffusion_timescale = TurbulenceClosures.cell_diffusion_timescale
+    end
 
     C = typeof(cell_advection_timescale)
     D = typeof(cell_diffusion_timescale)

--- a/test/test_simulations.jl
+++ b/test/test_simulations.jl
@@ -8,9 +8,10 @@ using Dates: DateTime
 
 function wall_time_step_wizard_tests(arch)
     grid = RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 1, 1))
+    Δx = grid.Δxᶜᵃᵃ
+
     model = NonhydrostaticModel(grid=grid)
 
-    Δx = grid.Δxᶜᵃᵃ
     CFL = 0.45
     u₀ = 7
     Δt = 2.5
@@ -37,6 +38,15 @@ function wall_time_step_wizard_tests(arch)
     wizard = TimeStepWizard(cfl=CFL, max_change=Inf, min_change=0, max_Δt=3.99)
     Δt = new_time_step(Δt, wizard, model)
     @test Δt ≈ 3.99
+
+
+    model = NonhydrostaticModel(grid=grid, closure=IsotropicDiffusivity(ν=1))
+    diff_CFL = 0.45
+
+    wizard = TimeStepWizard(cfl=Inf, diffusive_cfl=diff_CFL, max_change=Inf, min_change=0)
+    Δt = new_time_step(Δt, wizard, model)
+    @test Δt ≈ diff_CFL * Δx^2 / model.closure.ν
+
 
     grid_stretched = RectilinearGrid(arch, 
                                     size = (1, 1, 1),


### PR DESCRIPTION
The clause that controls the definition of `cell_diffusion_timescale` in `TimeStepWizard` had a bug. I re-wrote in a way that's clearer to understand and that fixes the bug.

Consider the MWE below:

```julia
using Oceananigans

grid = RectilinearGrid(size=(8, 8, 8), extent = (1,1,1),
                       topology=(Periodic, Periodic, Bounded))

closure = IsotropicDiffusivity(ν=1)
model = NonhydrostaticModel(grid = grid,
                            closure = closure)
@info "" model
                            
wizard = TimeStepWizard(diffusive_cfl=0.1,)
```

Before this PR:

```julia
julia> wizard.cell_diffusion_timescale(model)
Inf

julia> @which wizard.cell_diffusion_timescale(model)
infinite_diffusion_timescale(args...) in Oceananigans.Simulations at /home/tomas/.julia/packages/Oceananigans/IHPoE/src/Simulations/time_step_wizard.jl:12
```

After this PR:

```julia
julia> wizard.cell_diffusion_timescale(model)
0.015625

julia> @which wizard.cell_diffusion_timescale(model)
cell_diffusion_timescale(model) in Oceananigans.TurbulenceClosures at /home/tomas/repos/Oceananigans.jl/src/TurbulenceClosures/turbulence_closure_diagnostics.jl:15
```

I'll also add a test to catch this in the future, since there are no tests for `diffusive_cfl` that I could tell.