### PR TITLE
Support for tuples with arrays of closures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.69.3"
+version = "0.69.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/TurbulenceClosures/closure_tuples.jl
+++ b/src/TurbulenceClosures/closure_tuples.jl
@@ -65,8 +65,11 @@ end
 ##### Support for VerticallyImplicitTimeDiscretization
 #####
 
-const EC = AbstractTurbulenceClosure{<:ExplicitTimeDiscretization}
-const VIC = AbstractTurbulenceClosure{<:VerticallyImplicitTimeDiscretization}
+const SingleExplicitClosure = AbstractTurbulenceClosure{<:ExplicitTimeDiscretization}
+const SingleImplicitClosure = AbstractTurbulenceClosure{<:VerticallyImplicitTimeDiscretization}
+
+const EC = Union{SingleExplicitClosure, AbstractArray{<:SingleExplicitClosure}}
+const VIC = Union{SingleImplicitClosure, AbstractArray{<:SingleImplicitClosure}}
 
 # Filter explicitly-discretized closures.
 @inline z_diffusivity(clo::Tuple{<:EC},        iᶜ, Ks, args...) = tuple(0)


### PR DESCRIPTION
This is a wilderness of the code with not many tests. This is part of ongoing work to build infrastructure for calibrating mesoscale parameterizations in conjunction with `OceanTurbulenceParameterEstimation.jl`.

cc @sandreza