### PR TITLE
Fixes FFT solver constructor for an ensemble of slice models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.69.4"
+version = "0.69.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Models/HydrostaticFreeSurfaceModels/slice_ensemble_model_mode.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/slice_ensemble_model_mode.jl
@@ -76,7 +76,7 @@ const CoriolisVector = AbstractVector{<:AbstractRotation}
 @inline y_f_cross_U(i, j, k, grid::YZSliceGrid, coriolis::CoriolisVector, U) = @inbounds y_f_cross_U(i, j, k, grid, coriolis[i], U)
 @inline z_f_cross_U(i, j, k, grid::YZSliceGrid, coriolis::CoriolisVector, U) = @inbounds z_f_cross_U(i, j, k, grid, coriolis[i], U)
 
-function FFTImplicitFreeSurfaceSolver(arch, grid::YZSliceGrid, settings)
+function FFTImplicitFreeSurfaceSolver(grid::YZSliceGrid, gravitational_acceleration::Number, settings)
 
     grid isa HRegRectilinearGrid || 
         throw(ArgumentError("FFTImplicitFreeSurfaceSolver requires horizontally-regular rectilinear grids."))
@@ -86,12 +86,13 @@ function FFTImplicitFreeSurfaceSolver(arch, grid::YZSliceGrid, settings)
 
     sz = SliceEnsembleSize(size=(grid.Ny, 1), ensemble=grid.Nx, halo=(grid.Hy, 0))
 
-    horizontal_grid = RectilinearGrid(; topology = (Flat, TY, Flat),
-                                        size = sz,
-                                        halo = grid.Hy,
-                                        y = y_domain(grid))
+    horizontal_grid = RectilinearGrid(architecture(grid);
+                                      topology = (Flat, TY, Flat),
+                                      size = sz,
+                                      halo = grid.Hy,
+                                      y = y_domain(grid))
 
-    solver = FFTBasedPoissonSolver(arch, horizontal_grid)
+    solver = FFTBasedPoissonSolver(horizontal_grid)
     right_hand_side = solver.storage
 
     return FFTImplicitFreeSurfaceSolver(solver, grid, horizontal_grid, right_hand_side)


### PR DESCRIPTION
The signature used to extend `FFTImplicitFreeSurfaceSolver` was not used by `build_implicit_free_surface_solver`; thus, slice ensemble models had incorrect free surface solvers. This PR fixes it.