### PR TITLE
Cute compute! for AbstractOperation

### DIFF
--- a/src/AbstractOperations/computed_field.jl
+++ b/src/AbstractOperations/computed_field.jl
@@ -76,3 +76,6 @@ end
     @inbounds data[i, j, k] = operand[i, j, k]
 end
 
+# It's cute
+compute!(op::AbstractOperand) = compute!(Field(op))
+


### PR DESCRIPTION
Might be useful at the REPL for interactive stuff cause you can write

```julia
julia> N² = compute!(α * ∂z(T) - β * ∂z(S))
```

for example.

If people like, I'll add docs and a test or two.

I guess the equivalent one-liner right now is

```julia
julia> N² = @compute Field(α * ∂z(T) - β * ∂z(S))
```

and the equivalent two-liner is

```julia
julia> N² = Field(α * ∂z(T) - β * ∂z(S))
julia> compute!(N²)
```