### PR TITLE
Minor change to Ocean mixing and convection example

### DIFF
--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -61,7 +61,7 @@ grid = RectilinearGrid(size = (32, 32, Nz),
 
 # We plot vertical spacing versus depth to inspect the prescribed grid stretching:
 
-plot(grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz],
+plot(grid.Δzᵃᵃᶜ[1:grid.Nz], grid.zᵃᵃᶜ[1:grid.Nz],
      marker = :circle,
      ylabel = "Depth (m)",
      xlabel = "Vertical spacing (m)",


### PR DESCRIPTION
This is a very minor update just to make the plotting command in the Ocean mixing and convection example a bit more general and self-contained. This makes it easier for people to copy-paste that snippet and have it work out of box (I do that frequently for example).