### PR TITLE
Deploy docs with `forcepush = true`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -167,6 +167,7 @@ makedocs(bib,
 deploydocs(
           repo = "github.com/CliMA/OceananigansDocumentation.git",
       versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
+     forcepush = true,
   push_preview = true,
      devbranch = "main"
 )


### PR DESCRIPTION
The docs repo is running out of space. In an attempt to remedy that I'm trying here `forcepush = true` for deploying docs.

https://juliadocs.github.io/Documenter.jl/stable/lib/public/#Documenter.deploydocs