### PR TITLE
Adds a sentence to the Anisotropic diffusivity section of the docs

### DIFF
--- a/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
+++ b/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
@@ -45,6 +45,9 @@ isotropy: Oceananigans.TurbulenceClosures.Vertical
 
 ```
 
+After that you can set `closure = (horizontal_closure, vertical_closure)` when constructing the model so that
+all components will be taken into account when calculating the diffusivity term.
+
 ## Smagorinsky-Lilly
 
 To use the Smagorinsky-Lilly LES closure, no parameters are required


### PR DESCRIPTION
I think the docs weren't 100% clear before on how to actually use different horizontal and vertical components in a single closure. I also couldn't figure out how to set `νx` different from `νy`, but I'm assuming that possible. So if anyone knows, I think we could also add that there.