### PR TITLE
Tentative changes to `ScalarDiffusivity`

### DIFF
--- a/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
+++ b/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
@@ -17,36 +17,39 @@ julia> closure = ScalarDiffusivity(ν=1e-2, κ=1e-2)
 ScalarDiffusivity:
 ν=0.01, κ=0.01
 time discretization: Oceananigans.TurbulenceClosures.Explicit()
-isotropy: Oceananigans.TurbulenceClosures.ThreeDimensional
+isotropy: Oceananigans.TurbulenceClosures.XYZDirections
 ```
 
 ## Constant anisotropic diffusivity
 
 To specify constant values for the horizontal and vertical viscosities, ``\nu_h`` and ``\nu_z``, and horizontal and vertical
-diffusivities, ``\kappa_h`` and ``\kappa_z``, you can use [`ScalarDiffusivity(isotropy = Horizontal())`](@ref) and
-[`ScalarDiffusivity(isotropy = Vertical())`](@ref)
+diffusivities, ``\kappa_h`` and ``\kappa_z``, you can use [`ScalarDiffusivity(isotropy = XYDirections())`](@ref) and
+[`ScalarDiffusivity(isotropy = ZDirection())`](@ref)
 
 ```jldoctest
 julia> using Oceananigans.TurbulenceClosures
 
-julia> using Oceananigans.TurbulenceClosures: Horizontal, Vertical
+julia> using Oceananigans.TurbulenceClosures: XYDirections, ZDirection
 
-julia> horizontal_closure = ScalarDiffusivity(ν=1e-3, κ=2e-3, isotropy=Horizontal())
+julia> horizontal_closure = ScalarDiffusivity(ν=1e-3, κ=2e-3, isotropy=XYDirections())
 ScalarDiffusivity:
 ν=0.001, κ=0.002
 time discretization: Oceananigans.TurbulenceClosures.Explicit()
-isotropy: Oceananigans.TurbulenceClosures.Horizontal
+isotropy: Oceananigans.TurbulenceClosures.XYDirections
 
-julia> vertical_closure = ScalarDiffusivity(ν=1e-3, κ=2e-3, isotropy=Vertical())
+julia> vertical_closure = ScalarDiffusivity(ν=1e-3, κ=2e-3, isotropy=ZDirection())
 ScalarDiffusivity:
 ν=0.001, κ=0.002
 time discretization: Oceananigans.TurbulenceClosures.Explicit()
-isotropy: Oceananigans.TurbulenceClosures.Vertical
+isotropy: Oceananigans.TurbulenceClosures.ZDirection
 
 ```
 
-After that you can set `closure = (horizontal_closure, vertical_closure)` when constructing the model so that
-all components will be taken into account when calculating the diffusivity term.
+After that you can set `closure = (horizontal_closure, vertical_closure)` when constructing the
+model so that all components will be taken into account when calculating the diffusivity term. Note
+that `ScalarDiffusivity`s with `isotropy=XYDirections()` are implemented using a [different
+scheme](https://mitgcm.readthedocs.io/en/latest/algorithm/algorithm.html#horizontal-dissipation)
+from `isotropy=XYZDirections()` and `isotropy=ZDirections()` that conserves potential vorticity.
 
 ## Smagorinsky-Lilly
 

--- a/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
+++ b/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
@@ -29,8 +29,6 @@ diffusivities, ``\kappa_h`` and ``\kappa_z``, you can use [`ScalarDiffusivity(is
 ```jldoctest
 julia> using Oceananigans.TurbulenceClosures
 
-julia> using Oceananigans.TurbulenceClosures: XYDirections, ZDirection
-
 julia> horizontal_closure = ScalarDiffusivity(ν=1e-3, κ=2e-3, isotropy=XYDirections())
 ScalarDiffusivity:
 ν=0.001, κ=0.002

--- a/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
+++ b/docs/src/model_setup/turbulent_diffusivity_closures_and_les_models.md
@@ -33,13 +33,13 @@ julia> horizontal_closure = ScalarDiffusivity(ν=1e-3, κ=2e-3, isotropy=XYDirec
 ScalarDiffusivity:
 ν=0.001, κ=0.002
 time discretization: Oceananigans.TurbulenceClosures.Explicit()
-isotropy: Oceananigans.TurbulenceClosures.XYDirections
+isotropy: XYDirections
 
 julia> vertical_closure = ScalarDiffusivity(ν=1e-3, κ=2e-3, isotropy=ZDirection())
 ScalarDiffusivity:
 ν=0.001, κ=0.002
 time discretization: Oceananigans.TurbulenceClosures.Explicit()
-isotropy: Oceananigans.TurbulenceClosures.ZDirection
+isotropy: ZDirection
 
 ```
 

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -120,7 +120,7 @@
 using Printf
 using Oceananigans
 using Oceananigans.Units: hours, day, days
-using Oceananigans.TurbulenceClosures: Horizontal, Vertical
+using Oceananigans.Grids: XYDirections, ZDirection
 
 # ## The grid
 #
@@ -181,8 +181,8 @@ v_bcs = FieldBoundaryConditions(bottom = drag_bc_v)
 κ₂z = 1e-2 # [m² s⁻¹] Laplacian vertical viscosity and diffusivity
 κ₄h = 1e-1 / day * grid.Δxᶜᵃᵃ^4 # [m⁴ s⁻¹] horizontal hyperviscosity and hyperdiffusivity
 
-Laplacian_vertical_diffusivity = ScalarDiffusivity(ν=κ₂z, κ=κ₂z, isotropy=Vertical())
-biharmonic_horizontal_diffusivity = ScalarBiharmonicDiffusivity(ν=κ₄h, κ=κ₄h, isotropy=Vertical())
+Laplacian_vertical_diffusivity = ScalarDiffusivity(ν=κ₂z, κ=κ₂z, isotropy=ZDirection())
+biharmonic_horizontal_diffusivity = ScalarBiharmonicDiffusivity(ν=κ₄h, κ=κ₄h, isotropy=ZDirection())
 
 # ## Model instantiation
 #

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -120,7 +120,6 @@
 using Printf
 using Oceananigans
 using Oceananigans.Units: hours, day, days
-using Oceananigans.Grids: XYDirections, ZDirection
 
 # ## The grid
 #

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -12,6 +12,7 @@ export ConformalCubedSphereFaceGrid, ConformalCubedSphereGrid
 export node, xnode, ynode, znode, xnodes, ynodes, znodes, nodes
 export offset_data, new_data
 export on_architecture
+export XYZDirections, XYDirections, ZDirection
 
 using CUDA
 using Adapt

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -352,10 +352,14 @@ function pop_flat_elements(tup, topo)
 end
 
 #####
-##### Directions (for tilted domains)
+##### Directions (for tilted domains and scalar diffusivity turbulence closures)
 #####
 
 struct ZDirection end
+
+struct XYDirections end
+
+struct XYZDirections end
 
 #####
 ##### Show utils

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -22,6 +22,7 @@ export
     LatitudeLongitudeGrid,
     ConformalCubedSphereFaceGrid,
     xnodes, ynodes, znodes, nodes,
+    XYZDirections, XYDirections, ZDirection,
 
     # Advection schemes
     CenteredSecondOrder, CenteredFourthOrder, UpwindBiasedFirstOrder, UpwindBiasedThirdOrder, UpwindBiasedFifthOrder, WENO5,

--- a/src/TurbulenceClosures/abstract_scalar_biharmonic_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_scalar_biharmonic_diffusivity_closure.jl
@@ -13,9 +13,9 @@ abstract type AbstractScalarBiharmonicDiffusivity{Iso} <: AbstractTurbulenceClos
 ##### Stress divergences
 #####
 
-const AIBD = AbstractScalarBiharmonicDiffusivity{<:ThreeDimensional}
-const AHBD = AbstractScalarBiharmonicDiffusivity{<:Horizontal}
-const AVBD = AbstractScalarBiharmonicDiffusivity{<:Vertical}
+const AIBD = AbstractScalarBiharmonicDiffusivity{<:XYZDirections}
+const AHBD = AbstractScalarBiharmonicDiffusivity{<:XYDirections}
+const AVBD = AbstractScalarBiharmonicDiffusivity{<:ZDirection}
 
 @inline viscous_flux_ux(i, j, k, grid, closure::AIBD, clock, U, args...) = + ν_σᶜᶜᶜ(i, j, k, grid, clock, viscosity(closure, args...), ∂xᶜᶜᶜ, biharmonic_mask_x, ∇²ᶠᶜᶜ, U.u)
 @inline viscous_flux_vx(i, j, k, grid, closure::AIBD, clock, U, args...) = + ν_σᶠᶠᶜ(i, j, k, grid, clock, viscosity(closure, args...), biharmonic_mask_x, ∂xᶠᶠᶜ, ∇²ᶜᶠᶜ, U.v)

--- a/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
@@ -1,3 +1,4 @@
+using Oceananigans.Grids: XYZDirections, XYDirections, ZDirection
 """
     abstract type AbstractScalarDiffusivity <: AbstractTurbulenceClosure end
 
@@ -5,26 +6,6 @@ Abstract type for closures with *isotropic* diffusivities.
 """
 abstract type AbstractScalarDiffusivity{TD, Iso} <: AbstractTurbulenceClosure{TD} end
 
-"""
-    struct ThreeDimensional end
-
-Specifies a three-dimensionally-isotropic `ScalarDiffusivity`.
-"""
-struct ThreeDimensional end
-
-"""
-    struct Horizontal end
-
-Specifies a horizontally-isotropic, `VectorInvariant`, `ScalarDiffusivity`.
-"""
-struct Horizontal end
-
-"""
-    struct Vertical end
-
-Specifies a `ScalarDiffusivity` acting only in the vertical direction.
-"""
-struct Vertical end
 
 """
     viscosity(closure, diffusivities)
@@ -32,6 +13,7 @@ struct Vertical end
 Returns the isotropic viscosity associated with `closure`.
 """
 function viscosity end 
+
 
 """
     diffusivity(closure, diffusivities, tracer_indedx) where tracer_index
@@ -46,9 +28,9 @@ function diffusivity end
 ##### Stress divergences
 #####
 
-const AID = AbstractScalarDiffusivity{<:Any, <:ThreeDimensional}
-const AHD = AbstractScalarDiffusivity{<:Any, <:Horizontal}
-const AVD = AbstractScalarDiffusivity{<:Any, <:Vertical}
+const AID = AbstractScalarDiffusivity{<:Any, <:XYZDirections}
+const AHD = AbstractScalarDiffusivity{<:Any, <:XYDirections}
+const AVD = AbstractScalarDiffusivity{<:Any, <:ZDirection}
 
 @inline viscous_flux_ux(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶜᶜᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₁₁, U.u, U.v, U.w)
 @inline viscous_flux_vx(i, j, k, grid, closure::AID, clock, U, args...) = - 2 * ν_σᶠᶠᶜ(i, j, k, grid, clock, viscosity(closure, args...), Σ₂₁, U.u, U.v, U.w)

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -4,20 +4,20 @@
 
 using Oceananigans.Grids: topology, min_Δx, min_Δy, min_Δz
 
-function min_Δxyz(grid, ::ThreeDimensional)
+function min_Δxyz(grid, ::XYZDirections)
     Δx = min_Δx(grid)
     Δy = min_Δy(grid)
     Δz = min_Δz(grid)
     return min(Δx, Δy, Δz)
 end
 
-function min_Δxyz(grid, ::Horizontal)
+function min_Δxyz(grid, ::XYDirections)
     Δx = min_Δx(grid)
     Δy = min_Δy(grid)
     return min(Δx, Δy)
 end
 
-min_Δxyz(grid, ::Vertical) = min_Δz(grid)
+min_Δxyz(grid, ::ZDirection) = min_Δz(grid)
 
 
 cell_diffusion_timescale(model) = cell_diffusion_timescale(model.closure, model.diffusivity_fields, model.grid)
@@ -75,7 +75,7 @@ function cell_diffusion_timescale(closure::AnisotropicMinimumDissipation, diffus
 end
 
 function cell_diffusion_timescale(closure::TwoDimensionalLeith, diffusivities, grid)
-    Δ = min_Δxyz(grid, ThreeDimensional())
+    Δ = min_Δxyz(grid, XYZDirections())
     max_ν = maximum(diffusivities.νₑ.data.parent)
     return Δ^2 / max_ν
 end

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
@@ -18,9 +18,7 @@ using Oceananigans.TurbulenceClosures:
     AbstractScalarDiffusivity,
     Explicit,
     VerticallyImplicit,
-    ThreeDimensional, 
-    Horizontal,
-    Vertical
+    XYZDirections
 
 import Oceananigans.BoundaryConditions: getbc
 import Oceananigans.Utils: with_tracers
@@ -240,7 +238,7 @@ const ATC = AbstractTurbulenceClosure
 @inline diffusive_flux_z(i, j, k, grid, clo::ATC, e, ::TKETracerIndex{N}, args...) where N = diffusive_flux_z(i, j, k, grid, clo, e, Val(N), args...)
 
 # Disambiguiate
-const AID = AbstractScalarDiffusivity{<:Any, <:ThreeDimensional}
+const AID = AbstractScalarDiffusivity{<:Any, <:XYZDirections}
 @inline diffusive_flux_x(i, j, k, grid, clo::AID, e, ::TKETracerIndex{N}, args...) where N = diffusive_flux_x(i, j, k, grid, clo, e, Val(N), args...)
 @inline diffusive_flux_y(i, j, k, grid, clo::AID, e, ::TKETracerIndex{N}, args...) where N = diffusive_flux_y(i, j, k, grid, clo, e, Val(N), args...)
 @inline diffusive_flux_z(i, j, k, grid, clo::AID, e, ::TKETracerIndex{N}, args...) where N = diffusive_flux_z(i, j, k, grid, clo, e, Val(N), args...)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
@@ -7,7 +7,7 @@ Parameters for the "anisotropic minimum dissipation" turbulence closure for larg
 proposed originally by [Rozema15](@cite) and [Abkar16](@cite), and then modified
 by [Verstappen18](@cite), and finally described and validated for by [Vreugdenhil18](@cite).
 """
-struct AnisotropicMinimumDissipation{TD, FT, PK, PN, K, PB} <: AbstractEddyViscosityClosure{TD, ThreeDimensional}
+struct AnisotropicMinimumDissipation{TD, FT, PK, PN, K, PB} <: AbstractEddyViscosityClosure{TD, XYZDirections}
     Cν :: PN
     Cκ :: PK
     Cb :: PB

--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_biharmonic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_biharmonic_diffusivity.jl
@@ -17,24 +17,25 @@ end
 required_halo_size(::ScalarBiharmonicDiffusivity) = 2
 
 """
-    ScalarBiharmonicDiffusivity(FT=Float64; νh=0, κh=0, νz=nothing, κz=nothing)
+    ScalarBiharmonicDiffusivity(FT=Float64; ν=0, κ=0, discrete_diffusivity = false, isotropy::Iso = XYDirections())
 
 Returns parameters for a scalar biharmonic diffusivity model.
 
 Keyword arguments
 =================
 
-  - `νh`: Horizontal viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
+  - `ν`: Viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
 
-  - `νz`: Vertical viscosity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`.
-
-  - `κh`: Horizontal diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
+  - `κ`: Tracer diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
           `NamedTuple` of diffusivities with entries for each tracer.
 
-  - `κz`: Vertical diffusivity. `Number`, `AbstractArray`, or `Function(x, y, z, t)`, or
-          `NamedTuple` of diffusivities with entries for each tracer.
+  - `discrete_diffusivity`: `Boolean`.
+
+  - `isotropy`: Directions over which to apply diffusivity operator. Options are 
+          `XYDirections()`, `ZDirection()` and `XYZDirections()`.
+
 """
-function ScalarBiharmonicDiffusivity(FT=Float64; ν=0, κ=0, discrete_diffusivity = false, isotropy::Iso = Horizontal()) where {Iso}
+function ScalarBiharmonicDiffusivity(FT=Float64; ν=0, κ=0, discrete_diffusivity = false, isotropy::Iso = XYDirections()) where {Iso}
     ν = convert_diffusivity(FT, ν, Val(discrete_diffusivity))
     κ = convert_diffusivity(FT, κ, Val(discrete_diffusivity))
     return ScalarBiharmonicDiffusivity{Iso}(ν, κ)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
@@ -13,7 +13,7 @@ end
     ScalarDiffusivity([FT=Float64;]
                          ν=0, κ=0,
                          discrete_diffusivity = false,
-                         isotropy = ThreeDimensional() 
+                         isotropy = XYZDirections() 
                          time_discretization = Explicit())
 
 Returns parameters for an isotropic diffusivity model with viscosity `ν`
@@ -29,11 +29,11 @@ single number to be a applied to all tracers.
 function ScalarDiffusivity(FT=Float64;
                               ν=0, κ=0,
                               discrete_diffusivity = false,
-                              isotropy::Iso=ThreeDimensional(),
+                              isotropy::Iso=XYZDirections(),
                               time_discretization::TD = Explicit()) where {TD, Iso}
 
-    if isotropy == Horizontal() && time_discretization == VerticallyImplicit()
-        throw(ArgumentError("VerticallyImplicitTimeDiscretization is only supported for `isotropy = Horizontal()` or `isotropy = ThreeDimensional()`"))
+    if isotropy == XYDirections() && time_discretization == VerticallyImplicit()
+        throw(ArgumentError("VerticallyImplicitTimeDiscretization is only supported for `isotropy = XYDirections()` or `isotropy = XYZDirections()`"))
     end
     κ = convert_diffusivity(FT, κ, Val(discrete_diffusivity))
     ν = convert_diffusivity(FT, ν, Val(discrete_diffusivity))

--- a/src/TurbulenceClosures/turbulence_closure_implementations/smagorinsky_lilly.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/smagorinsky_lilly.jl
@@ -3,7 +3,7 @@
 ##### We also call this 'Constant Smagorinsky'.
 #####
 
-struct SmagorinskyLilly{TD, FT, P, K} <: AbstractEddyViscosityClosure{TD, ThreeDimensional}
+struct SmagorinskyLilly{TD, FT, P, K} <: AbstractEddyViscosityClosure{TD, XYZDirections}
      C :: FT
     Cb :: FT
     Pr :: P

--- a/test/regression_tests/hydrostatic_free_turbulence_regression_test.jl
+++ b/test/regression_tests/hydrostatic_free_turbulence_regression_test.jl
@@ -5,7 +5,7 @@ using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.Coriolis: HydrostaticSphericalCoriolis, fᶠᶠᵃ
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel, VectorInvariant
 using Oceananigans.AbstractOperations: KernelFunctionOperation, volume
-using Oceananigans.TurbulenceClosures: Horizontal
+using Oceananigans.Grids: XYDirections
 
 function run_hydrostatic_free_turbulence_regression_test(grid, free_surface; regenerate_data=false)
 
@@ -17,7 +17,7 @@ function run_hydrostatic_free_turbulence_regression_test(grid, free_surface; reg
                           momentum_advection = VectorInvariant(),
                                 free_surface = free_surface,
                                     coriolis = HydrostaticSphericalCoriolis(),
-                                     closure = ScalarDiffusivity(ν=1e+5, κ=1e+4, isotropy=Horizontal()))
+                                     closure = ScalarDiffusivity(ν=1e+5, κ=1e+4, isotropy=XYDirections()))
     
     #####
     ##### Imposing initial conditions:

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -1,6 +1,7 @@
 include("dependencies_for_runtests.jl")
 
-using Oceananigans.TurbulenceClosures: Explicit, VerticallyImplicit, z_viscosity, Horizontal, Vertical, ThreeDimensional
+using Oceananigans.TurbulenceClosures: Explicit, VerticallyImplicit, z_viscosity, 
+using Oceananigans.Grids: XYZDirections, XYDirections, ZDirection
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary, GridFittedBottom
 
 function relative_error(u_num, u, time)
@@ -123,7 +124,7 @@ function test_immersed_diffusion_3D(Nz, z, time_discretization)
 
     κ = 1.0
     
-    closure = ScalarDiffusivity(ν = κ, κ = κ, isotropy = Vertical(), time_discretization = time_discretization)
+    closure = ScalarDiffusivity(ν = κ, κ = κ, isotropy = ZDirection(), time_discretization = time_discretization)
 
     b, l, m, u, t = -0.5, -0.2, 0, 0.2, 0.5
 
@@ -467,8 +468,8 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                 for time_discretization in time_discretizations
 
                     for closure in (ScalarDiffusivity(ν=1, κ=1, time_discretization=time_discretization),
-                                    ScalarDiffusivity(ν=1, κ=1, isotropy = Vertical(), time_discretization=time_discretization),
-                                    ScalarDiffusivity(ν=1, κ=1, isotropy = Horizontal()),
+                                    ScalarDiffusivity(ν=1, κ=1, isotropy = ZDirection(), time_discretization=time_discretization),
+                                    ScalarDiffusivity(ν=1, κ=1, isotropy = XYDirections()),
                                     )
 
                         fieldnames = [:c]
@@ -515,7 +516,7 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
 
                 grid = RectilinearGrid(size=(2, 2, 2), extent=(1, 1, 1), topology=topology)
 
-                for iso in (ThreeDimensional(), Horizontal(), Vertical())
+                for iso in (XYZDirections(), XYDirections(), ZDirection())
                     model = NonhydrostaticModel(timestepper = timestepper,
                                                        grid = grid,
                                                     closure = ScalarBiharmonicDiffusivity(ν=1, κ=1, isotropy=iso),

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -1,7 +1,6 @@
 include("dependencies_for_runtests.jl")
 
 using Oceananigans.TurbulenceClosures: Explicit, VerticallyImplicit, z_viscosity, 
-using Oceananigans.Grids: XYZDirections, XYDirections, ZDirection
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary, GridFittedBottom
 
 function relative_error(u_num, u, time)

--- a/test/test_hydrostatic_free_surface_immersed_boundaries.jl
+++ b/test/test_hydrostatic_free_surface_immersed_boundaries.jl
@@ -1,5 +1,6 @@
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary, GridFittedBottom
 using Oceananigans.TurbulenceClosures: VerticallyImplicit
+using Oceananigans.Grids: ZDirection
 
 @inline surface_wind_stress(λ, φ, t, p) = p.τ₀ * cos(2π * (φ - p.φ₀) / p.Lφ)
 @inline u_bottom_drag(i, j, grid, clock, fields, μ) = @inbounds - μ * fields.u[i, j, 1]
@@ -91,7 +92,7 @@ using Oceananigans.TurbulenceClosures: VerticallyImplicit
             v_bcs = FieldBoundaryConditions(bottom = v_bottom_drag_bc)
 
             νh₀ = 5e3 * (60 / grid.Nx)^2
-            constant_horizontal_diffusivity = ScalarDiffusivity(ν=νh₀, isotropy=Horizontal())
+            constant_horizontal_diffusivity = ScalarDiffusivity(ν=νh₀, isotropy=XYDirections())
 
             model = HydrostaticFreeSurfaceModel(; grid,
                                                 momentum_advection = VectorInvariant(),

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -5,7 +5,6 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels: ExplicitFreeSurface, Imp
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: SingleColumnGrid
 using Oceananigans.Coriolis: VectorInvariantEnergyConserving, VectorInvariantEnstrophyConserving
 using Oceananigans.TurbulenceClosures: VerticallyImplicit, Explicit, 
-using Oceananigans.Grids: ZDirection, XYDirections
 using Oceananigans.TurbulenceClosures: CATKEVerticalDiffusivity
 
 function time_step_hydrostatic_model_works(grid;

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -4,7 +4,8 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels: VectorInvariant, Prescri
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: ExplicitFreeSurface, ImplicitFreeSurface
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: SingleColumnGrid
 using Oceananigans.Coriolis: VectorInvariantEnergyConserving, VectorInvariantEnstrophyConserving
-using Oceananigans.TurbulenceClosures: VerticallyImplicit, Explicit, Vertical, Horizontal
+using Oceananigans.TurbulenceClosures: VerticallyImplicit, Explicit, 
+using Oceananigans.Grids: ZDirection, XYDirections
 using Oceananigans.TurbulenceClosures: CATKEVerticalDiffusivity
 
 function time_step_hydrostatic_model_works(grid;
@@ -230,9 +231,9 @@ topos_3d = ((Periodic, Periodic, Bounded),
         end
 
         for closure in (ScalarDiffusivity(),
-                        ScalarDiffusivity(isotropy = Horizontal()),
-                        ScalarDiffusivity(isotropy = Vertical()),
-                        ScalarDiffusivity(isotropy = Vertical(), time_discretization=VerticallyImplicit()),
+                        ScalarDiffusivity(isotropy = XYDirections()),
+                        ScalarDiffusivity(isotropy = ZDirection()),
+                        ScalarDiffusivity(isotropy = ZDirection(), time_discretization=VerticallyImplicit()),
                         CATKEVerticalDiffusivity(),
                         CATKEVerticalDiffusivity(time_discretization=Explicit()))
 

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -4,7 +4,7 @@ using Oceananigans.Grids: topological_tuple_length, total_size
 using Oceananigans.Fields: BackgroundField
 using Oceananigans.TimeSteppers: Clock
 using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities: CATKEVerticalDiffusivity
-using Oceananigans.TurbulenceClosures: Horizontal, Vertical
+using Oceananigans.Grids: XYZDirections, ZDirection
 
 function time_stepping_works_with_flat_dimensions(arch, topology)
     size = Tuple(1 for i = 1:topological_tuple_length(topology...))
@@ -154,8 +154,8 @@ function tracer_conserved_in_channel(arch, FT, Nt)
     topology = (Periodic, Bounded, Bounded)
     grid = RectilinearGrid(arch, size=(Nx, Ny, Nz), extent=(Lx, Ly, Lz))
     model = NonhydrostaticModel(grid = grid,
-                                closure = (ScalarDiffusivity(ν=νh, κ=κh, isotropy=Horizontal()), 
-                                           ScalarDiffusivity(ν=νz, κ=κz, isotropy=Vertical())),
+                                closure = (ScalarDiffusivity(ν=νh, κ=κh, isotropy=XYZDirections()), 
+                                           ScalarDiffusivity(ν=νz, κ=κz, isotropy=ZDirection())),
                                 buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
 
     Ty = 1e-4  # Meridional temperature gradient [K/m].

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -1,7 +1,7 @@
 include("dependencies_for_runtests.jl")
 
 using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities: CATKEVerticalDiffusivity
-using Oceananigans.TurbulenceClosures: Vertical, Horizontal
+using Oceananigans.Grids: ZDirection, XYDirections
 
 for closure in closures
     @eval begin
@@ -20,7 +20,7 @@ function constant_isotropic_diffusivity_basic(T=Float64; ν=T(0.3), κ=T(0.7))
 end
 
 function anisotropic_diffusivity_convenience_kwarg(T=Float64; νh=T(0.3), κh=T(0.7))
-    closure = ScalarDiffusivity(κ=(T=κh, S=κh), ν=νh, isotropy=Horizontal())
+    closure = ScalarDiffusivity(κ=(T=κh, S=κh), ν=νh, isotropy=XYDirections())
     return closure.ν == νh && closure.κ.T == κh && closure.κ.T == κh
 end
 
@@ -57,8 +57,8 @@ end
 
 function anisotropic_diffusivity_fluxdiv(FT=Float64; νh=FT(0.3), κh=FT(0.7), νz=FT(0.1), κz=FT(0.5))
           arch = CPU()
-      closureh = ScalarDiffusivity(FT, ν=νh, κ=(T=κh, S=κh), isotropy=Horizontal())
-      closurez = ScalarDiffusivity(FT, ν=νz, κ=(T=κz, S=κz), isotropy=Vertical())
+      closureh = ScalarDiffusivity(FT, ν=νh, κ=(T=κh, S=κh), isotropy=XYDirections())
+      closurez = ScalarDiffusivity(FT, ν=νz, κ=(T=κz, S=κz), isotropy=ZDirection())
           grid = RectilinearGrid(arch, FT, size=(3, 1, 4), extent=(3, 1, 4))
            eos = LinearEquationOfState(FT)
       buoyancy = SeawaterBuoyancy(FT, gravitational_acceleration=1, equation_of_state=eos)
@@ -111,7 +111,7 @@ end
 
 function time_step_with_variable_anisotropic_diffusivity(arch)
 
-    for dir in (Horizontal(), Vertical())
+    for dir in (XYDirections(), ZDirection())
         closure = ScalarDiffusivity(ν = (x, y, z, t) -> exp(z) * cos(x) * cos(y) * cos(t),
                                     κ = (x, y, z, t) -> exp(z) * cos(x) * cos(y) * cos(t),
                                     isotropy = dir)

--- a/validation/implicit_vertical_diffusion/hydrostatic_one_dimensional_diffusion.jl
+++ b/validation/implicit_vertical_diffusion/hydrostatic_one_dimensional_diffusion.jl
@@ -1,12 +1,12 @@
 using Plots
 using Printf
 using Oceananigans
-using Oceananigans.TurbulenceClosures: VerticallyImplicit, time_discretization, Vertical
+using Oceananigans.TurbulenceClosures: VerticallyImplicit, time_discretization
 
 grid = RectilinearGrid(size=128, z=(-0.5, 0.5), topology=(Flat, Flat, Bounded))
 
-evd_closure = ScalarDiffusivity(κ = 1.0, isotropy = Vertical())
-ivd_closure = ScalarDiffusivity(κ = 1.0, isotropy = Vertical(), time_discretization = VerticallyImplicit())
+evd_closure = ScalarDiffusivity(κ = 1.0, isotropy = ZDirection())
+ivd_closure = ScalarDiffusivity(κ = 1.0, isotropy = ZDirection(), time_discretization = VerticallyImplicit())
 
 model_kwargs = (grid=grid, tracers=:c, buoyancy=nothing, velocities=PrescribedVelocityFields())
 

--- a/validation/mesoscale_turbulence/abernathey_channel.jl
+++ b/validation/mesoscale_turbulence/abernathey_channel.jl
@@ -12,7 +12,6 @@ using Oceananigans
 using Oceananigans.Units
 using Oceananigans.OutputReaders: FieldTimeSeries
 using Oceananigans.Grids: xnode, ynode, znode
-using Oceananigans.TurbulenceClosures: Horizontal, Vertical
 
 const Lx = 1000kilometers # zonal domain length [m]
 const Ly = 2000kilometers # meridional domain length [m]
@@ -128,8 +127,8 @@ Fb = Forcing(buoyancy_relaxation, discrete_form = true, parameters = parameters)
 κz = 0.5e-5 # [m²/s] vertical diffusivity
 νz = 3e-4   # [m²/s] vertical viscocity
 
-horizontal_closure = ScalarDiffusivity(ν = νh, κ = κh, isotropy = Horizontal())
-vertical_closure = ScalarDiffusivity(ν = νz, κ = κz, isotropy = Vertical())
+horizontal_closure = ScalarDiffusivity(ν = νh, κ = κh, isotropy = XYDirections())
+vertical_closure = ScalarDiffusivity(ν = νz, κ = κz, isotropy = ZDirection())
 
 convective_adjustment = ConvectiveAdjustmentVerticalDiffusivity(convective_κz = 1.0,
     convective_νz = 0.0)

--- a/validation/mesoscale_turbulence/baroclinic_adjustment.jl
+++ b/validation/mesoscale_turbulence/baroclinic_adjustment.jl
@@ -8,7 +8,7 @@ using JLD2
 using Oceananigans
 using Oceananigans.Units
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: fields
-using Oceananigans.TurbulenceClosures: VerticallyImplicit, Vertical, Horizontal
+using Oceananigans.TurbulenceClosures: VerticallyImplicit
 
 filename = "baroclinic_adjustment"
 
@@ -50,12 +50,12 @@ coriolis = BetaPlane(latitude = -45)
 
 diffusive_closure = ScalarDiffusivity(ν = νz,
                                       κ = κz,
-                                      isotropy = Vertical(),
+                                      isotropy = ZDirection(),
                                       time_discretization = VerticallyImplicit())
 
 horizontal_closure = ScalarDiffusivity(ν = νh,
                                        κ = κh,
-                                       isotropy = Horizontal())
+                                       isotropy = XYDirections())
 
 
 

--- a/validation/mesoscale_turbulence/eddying_channel.jl
+++ b/validation/mesoscale_turbulence/eddying_channel.jl
@@ -13,7 +13,6 @@ using Oceananigans.Units
 using Oceananigans.OutputReaders: FieldTimeSeries
 using Oceananigans.Grids: xnode, ynode, znode
 using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities: CATKEVerticalDiffusivity
-using Oceananigans.TurbulenceClosures: Vertical, Horizontal
 
 filename = "eddying_channel"
 
@@ -160,11 +159,11 @@ Fb = Forcing(buoyancy_relaxation, discrete_form = true, parameters = parameters)
 
 vertical_closure = ScalarDiffusivity(ν = νv,
                                      κ = κv,
-                                     isotropy = Vertical())
+                                     isotropy = ZDirection())
 
 horizontal_closure = ScalarDiffusivity(ν = νh,
                                        κ = κh,
-                                       isotropy = Horizontal())
+                                       isotropy = XYDirections())
 
 convective_adjustment = ConvectiveAdjustmentVerticalDiffusivity(convective_κz = 1.0,
                                                                 convective_νz = 0.0)

--- a/validation/mesoscale_turbulence/eddying_channel_nonhydrostatic.jl
+++ b/validation/mesoscale_turbulence/eddying_channel_nonhydrostatic.jl
@@ -9,7 +9,6 @@ using Oceananigans.Diagnostics
 using Oceananigans.Utils
 using Oceananigans.AbstractOperations
 using Oceananigans.Advection
-using Oceananigans.TurbulenceClosures: Vertical, Horizontal
 
 const hydrostatic = false
 
@@ -69,11 +68,11 @@ buoyancy = BuoyancyTracer()
 
 vertical_closure = ScalarDiffusivity(ν = νv,
                                      κ = κv,
-                                     isotropy = Vertical())
+                                     isotropy = ZDirection())
 
 horizontal_closure = ScalarDiffusivity(ν = νh,
                                        κ = κh,
-                                       isotropy = Horizontal())
+                                       isotropy = XYDirections())
                                        
 parameters = (
     Ly = Ly,                   # y-domain length

--- a/validation/mesoscale_turbulence/zonally_averaged_abernathey_channel.jl
+++ b/validation/mesoscale_turbulence/zonally_averaged_abernathey_channel.jl
@@ -8,7 +8,6 @@ using Oceananigans
 using Oceananigans.Units
 using Oceananigans.OutputReaders: FieldTimeSeries
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary
-using Oceananigans.TurbulenceClosures: Vertical, Horizontal
 
 #####
 ##### Grid
@@ -136,11 +135,11 @@ f² = FunctionField{Center, Center, Center}(f²_func, grid)
 
 vertical_closure = ScalarDiffusivity(ν = νv,
                                      κ = κv,
-                                     isotropy = Vertical())
+                                     isotropy = ZDirection())
 
 horizontal_closure = ScalarDiffusivity(ν = νh,
                                        κ = κh,
-                                       isotropy = Horizontal())
+                                       isotropy = XYDirections())
 
 closure = (horizontal_closure, vertical_closure)
                                        

--- a/validation/mesoscale_turbulence/zonally_averaged_baroclinic_adjustment.jl
+++ b/validation/mesoscale_turbulence/zonally_averaged_baroclinic_adjustment.jl
@@ -8,7 +8,7 @@ using JLD2
 using Oceananigans
 using Oceananigans.Units
 using Oceananigans: fields
-using Oceananigans.TurbulenceClosures: VerticallyImplicit, Vertical, Horizontal
+using Oceananigans.TurbulenceClosures: VerticallyImplicit
 
 filename = "zonally_averaged_baroclinic_adjustment_withGM"
 
@@ -47,11 +47,11 @@ coriolis = BetaPlane(latitude = -45)
 
 vertical_closure = ScalarDiffusivity(ν = νv,
                                      κ = κv,
-                                     isotropy = Vertical())
+                                     isotropy = ZDirection())
 
 horizontal_closure = ScalarDiffusivity(ν = νh,
                                        κ = κh,
-                                       isotropy = Horizontal())
+                                       isotropy = XYDirections())
 
 diffusive_closures = (vertical_closure, horizontal_closure)
 

--- a/validation/mesoscale_turbulence/zonally_averaged_channel.jl
+++ b/validation/mesoscale_turbulence/zonally_averaged_channel.jl
@@ -12,7 +12,6 @@ using Oceananigans
 using Oceananigans.Units
 using Oceananigans.OutputReaders: FieldTimeSeries
 using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities: CATKEVerticalDiffusivity
-using Oceananigans.TurbulenceClosures: Vertical, Horizontal
 using Oceananigans.Grids: xnode, ynode, znode
 
 using Random
@@ -152,11 +151,11 @@ Fb = Forcing(buoyancy_relaxation, discrete_form = true, parameters = parameters)
 
 vertical_closure = ScalarDiffusivity(ν = νv,
                                      κ = κv,
-                                     isotropy = Vertical())
+                                     isotropy = ZDirection())
 
 horizontal_closure = ScalarDiffusivity(ν = νh,
                                        κ = κh,
-                                       isotropy = Horizontal())
+                                       isotropy = XYDirections())
 
 diffusive_closure = (horizontal_closure, vertical_closure)
                                        

--- a/validation/near_global_lat_lon/annual_cycle_earth_bathymetry.jl
+++ b/validation/near_global_lat_lon/annual_cycle_earth_bathymetry.jl
@@ -7,7 +7,7 @@ using Oceananigans.Units
 using Oceananigans.Coriolis: HydrostaticSphericalCoriolis
 using Oceananigans.Architectures: arch_array
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBottom, is_immersed_boundary
-using Oceananigans.TurbulenceClosures: VerticallyImplicit, Vertical, Horizontal
+using Oceananigans.TurbulenceClosures: VerticallyImplicit
 using CUDA: @allowscalar
 using Oceananigans.Operators: Δzᵃᵃᶜ
 
@@ -114,12 +114,12 @@ grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bathymetry))
 
 vertical_closure = ScalarDiffusivity(ν = νv,
                                      κ = κv,
-                                     isotropy = Vertical(),
+                                     isotropy = ZDirection(),
                                      time_discretization = VerticallyImplicit())
 
 horizontal_closure = ScalarDiffusivity(ν = νh,
                                        κ = κh,
-                                       isotropy = Horizontal())
+                                       isotropy = XYDirection())
 
 background_diffusivity = (horizontal_closure, vertical_closure)
                                        

--- a/validation/near_global_lat_lon/annual_cycle_earth_bathymetry_fine.jl
+++ b/validation/near_global_lat_lon/annual_cycle_earth_bathymetry_fine.jl
@@ -8,7 +8,7 @@ using Oceananigans.Fields: interpolate
 using Oceananigans.Coriolis: HydrostaticSphericalCoriolis
 using Oceananigans.Architectures: arch_array
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBottom
-using Oceananigans.TurbulenceClosures: VerticallyImplicit, Vertical, Horizontal
+using Oceananigans.TurbulenceClosures: VerticallyImplicit
 using CUDA: @allowscalar
 using Oceananigans.Operators: Δzᵃᵃᶜ
 


### PR DESCRIPTION
This PR is an attempt at unifying the directions used by `TurbulenceClosures` a bit, in addition to a few minor things. In summary, this PR

- Nukes the `Vertical` definition at `abstract_scalar_diffusivity_closure.jl` and uses the already-defined `ZDirection` instead. I think this decreases the amount of code but is also more accurate (since for rotated domains the `z` direction of the code isn't necessarily the "physical" vertical direction)
- Renames `ThreeDimensional`, `Horizontal` to `XYZDirections` and `XYDirections` and moves their definition to `Grids`. This was done for consistency with `ZDirection` and also follows the same argument about rotated domains.
- Exports `XYZDirections`, `XYDirections` and `ZDirection` at the top level
- Makes minor improvements to documentation

I could also change the notation from `isotropy` to `dimensions`, according to https://github.com/CliMA/Oceananigans.jl/issues/2261, depending on how people feel. I haven't done that yet because there doesn't appear to be a consensus on what to do there as of writing this.

Closes https://github.com/CliMA/Oceananigans.jl/issues/2254