### PR TITLE
Initialize schedules at iteration 0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.71.1"
+version = "0.71.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.71.2"
+version = "0.71.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -179,9 +179,22 @@ function initialize_simulation!(sim)
     # Reset! the model time-stepper, evaluate all diagnostics, and write all output at first iteration
     if clock.iteration == 0
         reset!(sim.model.timestepper)
-        [run_diagnostic!(diag, model) for diag in values(sim.diagnostics)]
-        [callback(sim)                for callback in values(sim.callbacks)]
-        [write_output!(writer, model) for writer in values(sim.output_writers)]
+
+        # Initialize schedules and run diagnostics, callbacks, and output writers
+        for diag in values(sim.diagnostics)
+            diag.schedule(sim.model)
+            run_diagnostic!(diag, model)
+        end
+
+        for callback in values(sim.callbacks)
+            callback.schedule(model)
+            callback(sim)
+        end
+
+        for writer in values(sim.output_writers)
+            writer.schedule(sim.model)
+            write_output!(writer, model)
+        end
     end
 
     sim.initialized = true


### PR DESCRIPTION
This PR tweaks `initialize_simulation!` so that the schedules get called when `iteration == 0` --- in addition to running diagnostics, executing callbacks, and writing output.

This is a tiny step in the direction of having a robust initialization procedure. I think we still need to work on the abstractions a bit though, since it'd be nice to initialize schedules / callbacks more explicitly rather than implicitly relying on `iteration == 0`. This change will affect `SpecifiedTimes` and `WallTimeInterval` the most, I think.

TODO:

- [ ] Test for initialization of `SpecifiedTimes`?