### PR TITLE
Use verbose names in `LinearEquationOfState`

### DIFF
--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -265,8 +265,8 @@ Oceananigans.FieldBoundaryConditions, with boundary conditions
 ├── south: Oceananigans.BoundaryConditions.DefaultPrognosticFieldBoundaryCondition
 ├── north: Oceananigans.BoundaryConditions.DefaultPrognosticFieldBoundaryCondition
 ├── bottom: BoundaryCondition{Oceananigans.BoundaryConditions.Gradient, Float64}
-├── top: BoundaryCondition{Oceananigans.BoundaryConditions.Value, Int64}
-└── immersed: BoundaryCondition{Oceananigans.BoundaryConditions.Flux, Nothing}
+├── top: BoundaryCondition{Value, Int64}
+└── immersed: BoundaryCondition{Flux, Nothing}
 ```
 
 If the grid is, e.g., horizontally-periodic, then each horizontal `DefaultPrognosticFieldBoundaryCondition`

--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -264,7 +264,7 @@ Oceananigans.FieldBoundaryConditions, with boundary conditions
 ├── east: Oceananigans.BoundaryConditions.DefaultPrognosticFieldBoundaryCondition
 ├── south: Oceananigans.BoundaryConditions.DefaultPrognosticFieldBoundaryCondition
 ├── north: Oceananigans.BoundaryConditions.DefaultPrognosticFieldBoundaryCondition
-├── bottom: BoundaryCondition{Oceananigans.BoundaryConditions.Gradient, Float64}
+├── bottom: BoundaryCondition{Gradient, Float64}
 ├── top: BoundaryCondition{Value, Int64}
 └── immersed: BoundaryCondition{Flux, Nothing}
 ```

--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -264,9 +264,9 @@ Oceananigans.FieldBoundaryConditions, with boundary conditions
 ├── east: Oceananigans.BoundaryConditions.DefaultPrognosticFieldBoundaryCondition
 ├── south: Oceananigans.BoundaryConditions.DefaultPrognosticFieldBoundaryCondition
 ├── north: Oceananigans.BoundaryConditions.DefaultPrognosticFieldBoundaryCondition
-├── bottom: BoundaryCondition{Gradient, Float64}
-├── top: BoundaryCondition{Value, Int64}
-└── immersed: BoundaryCondition{Flux, Nothing}
+├── bottom: BoundaryCondition{Oceananigans.BoundaryConditions.Gradient, Float64}
+├── top: BoundaryCondition{Oceananigans.BoundaryConditions.Value, Int64}
+└── immersed: BoundaryCondition{Oceananigans.BoundaryConditions.Flux, Nothing}
 ```
 
 If the grid is, e.g., horizontally-periodic, then each horizontal `DefaultPrognosticFieldBoundaryCondition`

--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -113,7 +113,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: (T, S)
 ├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(α=0.000167, β=0.00078) with -ĝ = ZDirection
+├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with -ĝ = ZDirection
 └── coriolis: Nothing
 ```
 
@@ -126,7 +126,7 @@ HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: (T, S)
 ├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(α=0.000167, β=0.00078) with -ĝ = ZDirection
+├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with -ĝ = ZDirection
 ├── free surface: ExplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 └── coriolis: Nothing
 ```
@@ -140,7 +140,7 @@ HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: (T, S)
 ├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(α=0.000167, β=0.00078) with -ĝ = ZDirection
+├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with -ĝ = ZDirection
 ├── free surface: ExplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 └── coriolis: Nothing
 ```
@@ -152,7 +152,7 @@ we might alternatively specify
 julia> buoyancy = SeawaterBuoyancy(gravitational_acceleration=1.3)
 SeawaterBuoyancy{Float64}:
 ├── gravitational_acceleration: 1.3
-└── equation of state: LinearEquationOfState(α=0.000167, β=0.00078)
+└── equation of state: LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078)
 
 julia> model = NonhydrostaticModel(grid=grid, buoyancy=buoyancy, tracers=(:T, :S))
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
@@ -160,7 +160,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: (T, S)
 ├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy with g=1.3 and LinearEquationOfState(α=0.000167, β=0.00078) with -ĝ = ZDirection
+├── buoyancy: SeawaterBuoyancy with g=1.3 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with -ĝ = ZDirection
 └── coriolis: Nothing
 ```
 
@@ -172,10 +172,10 @@ To specify the thermal expansion and haline contraction coefficients
 ``\alpha = 2 \times 10^{-3} \; \text{K}^{-1}`` and ``\beta = 5 \times 10^{-4} \text{psu}^{-1}``,
 
 ```jldoctest
-julia> buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=2e-3, β=5e-4))
+julia> buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(thermal_expansion=2e-3, haline_contraction=5e-4))
 SeawaterBuoyancy{Float64}:
 ├── gravitational_acceleration: 9.80665
-└── equation of state: LinearEquationOfState(α=0.002, β=0.0005)
+└── equation of state: LinearEquationOfState(thermal_expansion=0.002, haline_contraction=0.0005)
 ```
 
 ### Idealized nonlinear equations of state

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -71,11 +71,9 @@ plot(grid.Δzᵃᵃᶜ[1:grid.Nz], grid.zᵃᵃᶜ[1:grid.Nz],
 #
 # We use the `SeawaterBuoyancy` model with a linear equation of state,
 
-buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=2e-4, β=8e-4))
+buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(thermal_expansion = 2e-4,
+                                                                    haline_contraction = 8e-4))
 
-# where ``\alpha`` and ``\beta`` are the thermal expansion and haline contraction
-# coefficients for temperature and salinity.
-#
 # ## Boundary conditions
 #
 # We calculate the surface temperature flux associated with surface heating of

--- a/src/BuoyancyModels/linear_equation_of_state.jl
+++ b/src/BuoyancyModels/linear_equation_of_state.jl
@@ -4,48 +4,55 @@
 Linear equation of state for seawater.
 """
 struct LinearEquationOfState{FT} <: AbstractEquationOfState
-    α :: FT
-    β :: FT
+    thermal_expansion :: FT
+    haline_contraction :: FT
 end
 
-Base.summary(eos::LinearEquationOfState) = string("LinearEquationOfState(α=", scalar_summary(eos.α),
-                                                                      ", β=", scalar_summary(eos.β), ")")
+Base.summary(eos::LinearEquationOfState) =
+    string("LinearEquationOfState(thermal_expansion=", scalar_summary(eos.thermal_expansion),
+                               ", haline_contraction=", scalar_summary(eos.haline_contraction), ")")
 
 Base.show(io, eos::LinearEquationOfState) = print(io, summary(eos))
 
 """
-    LinearEquationOfState([FT=Float64;] α=1.67e-4, β=7.80e-4)
+    LinearEquationOfState([FT=Float64;] thermal_expansion=1.67e-4, haline_contraction=7.80e-4)
 
-Returns parameters for a linear equation of state for seawater with
-thermal expansion coefficient ``α`` [K⁻¹] and haline contraction coefficient
-``β`` [psu⁻¹]. The buoyancy perturbation associated with a linear equation of state is
+Return `LinearEquationOfState` for `SeawaterBuoyancy` with
+`thermal_expansion` coefficient and `haline_contraction` coefficient.
+The buoyancy perturbation ``b`` for `LinearEquationOfState` is
 
 ```math
-    b = g (α T - β S).
+    b = g (α T - β S),
 ```
 
-Default constants are taken from Table 1.2 (page 33) of Vallis, "Atmospheric and Oceanic Fluid
+where ``g`` is gravitational acceleration, ``α`` is `thermal_expansion`, ``β`` is
+`haline_contraction`, ``T`` is temperature, and ``S`` is practical salinity units.
+
+Default constants in units inverse Kelvin and practical salinity units
+for `thermal_expansion` and `haline_contraction`, respectively,
+are taken from Table 1.2 (page 33) of Vallis, "Atmospheric and Oceanic Fluid
 Dynamics: Fundamentals and Large-Scale Circulation" (2nd ed, 2017).
 """
-LinearEquationOfState(FT=Float64; α=1.67e-4, β=7.80e-4) = LinearEquationOfState{FT}(α, β)
+LinearEquationOfState(FT=Float64; thermal_expansion=1.67e-4, haline_contraction=7.80e-4) =
+    LinearEquationOfState{FT}(thermal_expansion, haline_contraction)
 
 #####
 ##### Thermal expansion and haline contraction coefficients
 #####
 
-@inline  thermal_expansion(Θ, sᴬ, D, eos::LinearEquationOfState) = eos.α
-@inline haline_contraction(Θ, sᴬ, D, eos::LinearEquationOfState) = eos.β
+@inline  thermal_expansion(Θ, sᴬ, D, eos::LinearEquationOfState) = eos.thermal_expansion
+@inline haline_contraction(Θ, sᴬ, D, eos::LinearEquationOfState) = eos.haline_contraction
 
 # Shortcuts
-@inline  thermal_expansionᶜᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.α
-@inline  thermal_expansionᶠᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.α
-@inline  thermal_expansionᶜᶠᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.α
-@inline  thermal_expansionᶜᶜᶠ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.α
+@inline  thermal_expansionᶜᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.thermal_expansion
+@inline  thermal_expansionᶠᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.thermal_expansion
+@inline  thermal_expansionᶜᶠᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.thermal_expansion
+@inline  thermal_expansionᶜᶜᶠ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.thermal_expansion
 
-@inline haline_contractionᶜᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.β
-@inline haline_contractionᶠᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.β
-@inline haline_contractionᶜᶠᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.β
-@inline haline_contractionᶜᶜᶠ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.β
+@inline haline_contractionᶜᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.haline_contraction
+@inline haline_contractionᶠᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.haline_contraction
+@inline haline_contractionᶜᶠᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.haline_contraction
+@inline haline_contractionᶜᶜᶠ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.haline_contraction
 
 #####
 ##### Convinient aliases to dispatch on
@@ -60,11 +67,12 @@ const LinearSalinitySeawaterBuoyancy = SeawaterBuoyancy{FT, <:LinearEquationOfSt
 #####
 
 @inline buoyancy_perturbation(i, j, k, grid, b::LinearSeawaterBuoyancy, C) =
-    @inbounds b.gravitational_acceleration * (b.equation_of_state.α * C.T[i, j, k] - b.equation_of_state.β * C.S[i, j, k])
+    @inbounds b.gravitational_acceleration * (b.equation_of_state.thermal_expansion * C.T[i, j, k] -
+                                              b.equation_of_state.haline_contraction * C.S[i, j, k])
 
 @inline buoyancy_perturbation(i, j, k, grid, b::LinearTemperatureSeawaterBuoyancy, C) =
-    @inbounds b.gravitational_acceleration * b.equation_of_state.α * C.T[i, j, k]
+    @inbounds b.gravitational_acceleration * b.equation_of_state.thermal_expansion * C.T[i, j, k]
 
 @inline buoyancy_perturbation(i, j, k, grid, b::LinearSalinitySeawaterBuoyancy, C) =
-    @inbounds - b.gravitational_acceleration * b.equation_of_state.β * C.S[i, j, k]
+    @inbounds - b.gravitational_acceleration * b.equation_of_state.haline_contraction * C.S[i, j, k]
 

--- a/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
+++ b/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
@@ -27,17 +27,15 @@ function run_ocean_large_eddy_simulation_regression_test(arch, grid_type, closur
     T_bcs = FieldBoundaryConditions(top = BoundaryCondition(Flux, Qᵀ), bottom = BoundaryCondition(Gradient, ∂T∂z))
     S_bcs = FieldBoundaryConditions(top = BoundaryCondition(Flux, 5e-8))
 
-    # Model instantiation
-    model = NonhydrostaticModel(
-                     grid = grid,
-                 coriolis = FPlane(f=1e-4),
-                 buoyancy = Buoyancy(model=SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=2e-4, β=8e-4))),
-                  tracers = (:T, :S),
-                  closure = closure,
-      boundary_conditions = (u=u_bcs, T=T_bcs, S=S_bcs)
-    )
+    equation_of_state = LinearEquationOfState(thermal_expansion=2e-4, haline_contraction=8e-4)
 
-    @show model.diffusivity_fields
+    # Model instantiation
+    model = NonhydrostaticModel(; grid, 
+                                coriolis = FPlane(f=1e-4),
+                                buoyancy = SeawaterBuoyancy(; equation_of_state),
+                                tracers = (:T, :S),
+                                closure = closure,
+                                boundary_conditions = (u=u_bcs, T=T_bcs, S=S_bcs))
 
     # We will manually change the stop_iteration as needed.
     simulation = Simulation(model, Δt=Δt, stop_iteration=0)

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -218,7 +218,7 @@ for arch in archs
                                       topology=(Periodic, Periodic, Bounded))
 
         buoyancy = SeawaterBuoyancy(gravitational_acceleration = 1,
-                                             equation_of_state = LinearEquationOfState(α=1, β=1))
+                                    equation_of_state = LinearEquationOfState(thermal_expansion=1, haline_contraction=1))
 
         model = NonhydrostaticModel(grid = grid,
                                 buoyancy = buoyancy,

--- a/test/test_buoyancy.jl
+++ b/test/test_buoyancy.jl
@@ -8,8 +8,8 @@ using Oceananigans.BuoyancyModels:
     haline_contractionᶜᶜᶜ, haline_contractionᶠᶜᶜ, haline_contractionᶜᶠᶜ, haline_contractionᶜᶜᶠ
 
 function instantiate_linear_equation_of_state(FT, α, β)
-    eos = LinearEquationOfState(FT, α=α, β=β)
-    return eos.α == FT(α) && eos.β == FT(β)
+    eos = LinearEquationOfState(FT, thermal_expansion=α, haline_contraction=β)
+    return eos.thermal_expansion == FT(α) && eos.haline_contraction == FT(β)
 end
 
 function instantiate_seawater_buoyancy(FT, EquationOfState; kwargs...)

--- a/test/test_computed_field.jl
+++ b/test/test_computed_field.jl
@@ -332,7 +332,7 @@ for arch in archs
                                topology=(Periodic, Periodic, Bounded))
 
         buoyancy = SeawaterBuoyancy(gravitational_acceleration = 1,
-                                    equation_of_state = LinearEquationOfState(α=1, β=1))
+                                    equation_of_state = LinearEquationOfState(thermal_expansion=1, haline_contraction=1))
 
         model = NonhydrostaticModel(; grid, buoyancy, tracers = (:T, :S))
 
@@ -528,7 +528,7 @@ for arch in archs
 
             uT = Field(u * T)
 
-            α = model.buoyancy.model.equation_of_state.α
+            α = model.buoyancy.model.equation_of_state.thermal_expansion
             g = model.buoyancy.model.gravitational_acceleration
             b = BuoyancyField(model)
 

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -352,7 +352,7 @@ function stratified_fluid_remains_at_rest_with_tilted_gravity_temperature_tracer
     g̃ = (0, sind(θ), cosd(θ))
     buoyancy = Buoyancy(model=SeawaterBuoyancy(), gravity_unit_vector=g̃)
 
-    α  = buoyancy.model.equation_of_state.α
+    α  = buoyancy.model.equation_of_state.thermal_expansion
     g₀ = buoyancy.model.gravitational_acceleration
     ∂T∂z = N² / (g₀ * α)
 

--- a/validation/mesoscale_turbulence/eddying_channel_nonhydrostatic.jl
+++ b/validation/mesoscale_turbulence/eddying_channel_nonhydrostatic.jl
@@ -58,7 +58,7 @@ cᵖ = 3994.0   # [J/K]  heat capacity
 ρ  = 999.8    # [kg/m³] density
 const h = 1000.0     # [m] e-folding length scale for northern sponge
 const ΔB = 8 * α * g # [m/s²] total change in buoyancy from surface to bottom
-eos = LinearEquationOfState(FT, α=α, β=0)
+eos = LinearEquationOfState(FT, thermal_expansion=α, haline_contraction=0)
 buoyancy = BuoyancyTracer()
 
 κh = 0.5e-5 # [m²/s] horizontal diffusivity

--- a/validation/near_global_lat_lon/annual_cycle_earth_bathymetry.jl
+++ b/validation/near_global_lat_lon/annual_cycle_earth_bathymetry.jl
@@ -199,13 +199,15 @@ T_bcs = FieldBoundaryConditions(top = T_surface_relaxation_bc)
 free_surface = ImplicitFreeSurface(solver_method=:HeptadiagonalIterativeSolver, preconditioner_method=:SparseInverse,
                                    preconditioner_settings = (ε = 0.01, nzrel = 6))
 
+equation_of_state=LinearEquationOfState(thermal_expansion=2e-4)
+
 model = HydrostaticFreeSurfaceModel(grid = grid,
                                     free_surface = free_surface,
                                     momentum_advection = VectorInvariant(),
                                     tracer_advection = WENO5(),
                                     coriolis = HydrostaticSphericalCoriolis(),
                                     boundary_conditions = (u=u_bcs, v=v_bcs, T=T_bcs),
-                                    buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=2e-4, β=0.0)),
+                                    buoyancy = SeawaterBuoyancy(; equation_of_state, constant_salinity=30),
                                     tracers = (:T, :S),
                                     closure = (background_diffusivity..., convective_adjustment)) #,
                                     # forcing = (u=Fu, v=Fv))

--- a/validation/near_global_lat_lon/annual_cycle_earth_bathymetry_fine.jl
+++ b/validation/near_global_lat_lon/annual_cycle_earth_bathymetry_fine.jl
@@ -198,7 +198,7 @@ datadep"near_global_lat_lon"
 
 # free_surface = ImplicitFreeSurface(solver_method=:HeptadiagonalIterativeSolver)
 
-# buoyancy     = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=2e-4, β=0.0), constant_salinity = true)
+# buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(thermal_expansion=2e-4), constant_salinity=true)
 
 # model = HydrostaticFreeSurfaceModel(grid = grid,
 #                                     free_surface = free_surface,

--- a/validation/near_global_lat_lon/constant_forcing_earth_bathymetry.jl
+++ b/validation/near_global_lat_lon/constant_forcing_earth_bathymetry.jl
@@ -109,14 +109,14 @@ u_bcs = FieldBoundaryConditions(top = u_wind_stress_bc, bottom = u_bottom_drag_b
 v_bcs = FieldBoundaryConditions(top = v_wind_stress_bc, bottom = v_bottom_drag_bc)
 T_bcs = FieldBoundaryConditions(top = T_surface_relaxation_bc)
 
+equation_of_state = LinearEquationOfState(thermal_expansion=2e-4)
+
 model = HydrostaticFreeSurfaceModel(grid = grid,
-                                    #free_surface = ImplicitFreeSurface(maximum_iterations=10),
-                                    #free_surface = ImplicitFreeSurface(),
                                     momentum_advection = VectorInvariant(),
                                     tracer_advection = WENO5(),
                                     coriolis = HydrostaticSphericalCoriolis(),
                                     boundary_conditions = (u=u_bcs, v=v_bcs, T=T_bcs),
-                                    buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=2e-4, β=0.0)),
+                                    buoyancy = SeawaterBuoyancy(; equation_of_state, constant_salinity=true),
                                     tracers = (:T, :S),
                                     closure = (background_diffusivity, convective_adjustment))
 

--- a/validation/stratified_couette_flow/stratified_couette_flow.jl
+++ b/validation/stratified_couette_flow/stratified_couette_flow.jl
@@ -112,14 +112,12 @@ function simulate_stratified_couette_flow(; Nxy, Nz, arch=GPU(), h=1, U_wall=1,
     #####
     ##### Non-dimensional model setup
     #####
-
-    model = NonhydrostaticModel(
-                       grid = grid,
-                   buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=1.0, β=0.0)),
-                    tracers = (:T, :S),
-                    closure = AnisotropicMinimumDissipation(ν=ν, κ=κ),
-        boundary_conditions = (u=ubcs, v=vbcs, T=Tbcs)
-    )
+    equation_of_state = LinearEquationOfState(thermal_expansion=1.0, haline_contraction=0.0)
+    buoyancy = SeawaterBuoyancy(; equation_of_state)
+    model = NonhydrostaticModel(; grid, buoyancy,
+                                tracers = (:T, :S),
+                                closure = AnisotropicMinimumDissipation(ν=ν, κ=κ),
+                                boundary_conditions = (u=ubcs, v=vbcs, T=Tbcs))
 
     #####
     ##### Set initial conditions


### PR DESCRIPTION
This PR changes `α` and `β` in `LinearEquationOfState` to `thermal_expansion` and `haline_contraction`.

Closes #453 