### PR TITLE
Denote which coordinate is lat and which is lon in `show(io, ::LatitudeLongitudeGrid)`

### DIFF
--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -403,9 +403,9 @@ function domain_summary(topo, name, left, right)
     topo_string = topo isa Periodic ? "Periodic " :
                                       "Bounded  "
 
-    prefix = string(topo_string, name, " ∈ [",
-                    scalar_summary(left), ", ",
-                    scalar_summary(right), interval)
+    return string(topo_string, name, " ∈ [",
+                  scalar_summary(left), ", ",
+                  scalar_summary(right), interval)
 end
 
 function dimension_summary(topo, name, left, right, spacing, pad_domain=0)
@@ -418,4 +418,3 @@ coordinate_summary(Δ::Number, name) = @sprintf("regularly spaced with Δ%s=%s",
 coordinate_summary(Δ::AbstractVector, name) = @sprintf("variably spaced with min(Δ%s)=%s, max(Δ%s)=%s",
                                                        name, scalar_summary(minimum(parent(Δ))),
                                                        name, scalar_summary(maximum(parent(Δ))))
-

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -245,9 +245,9 @@ function Base.show(io::IO, grid::LatitudeLongitudeGrid)
 
     longest = max(length(x_summary), length(y_summary), length(z_summary)) 
 
-    x_summary = dimension_summary(TX(), "lon", λ₁, λ₂, grid.Δλᶜᵃᵃ, longest - length(x_summary) -2)
-    y_summary = dimension_summary(TY(), "lat", φ₁, φ₂, grid.Δφᵃᶜᵃ, longest - length(y_summary) -2)
-    z_summary = dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary))
+    x_summary = dimension_summary(TX(), "lon", λ₁, λ₂, grid.Δλᶜᵃᵃ, longest - length(x_summary))
+    y_summary = dimension_summary(TY(), "lat", φ₁, φ₂, grid.Δφᵃᶜᵃ, longest - length(y_summary))
+    z_summary = dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary) + 2)
 
     print(io, summary(grid), '\n',
           "├── ", x_summary, '\n',

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -83,21 +83,24 @@ regular_dimensions(::ZRegLatLonGrid) = tuple(3)
 
 """
     LatitudeLongitudeGrid([architecture = CPU(), FT = Float64];
+                          precompute_metrics = true,
                           size,
-                          latitude,
                           longitude,
+                          latitude,
                           z,
                           radius = R_Earth,
-                          precompute_metrics = false,
+                          topology = nothing,
                           halo = (1, 1, 1))
 
 Creates a `LatitudeLongitudeGrid` with `size = (Nx, Ny, Nz)` grid points.
+
+Note: the latitude-longitude coordinates are expected in degrees.
 
 Positional arguments
 =================
 
 - `architecture`: Specifies whether arrays of coordinates and spacings are stored
-                  on the CPU or GPU. Default: `architecture = CPU()`.
+                  on the CPU or GPU. Default: `CPU()`.
 
 - `FT` : Floating point data type. Default: `FT = Float64`.
 
@@ -106,21 +109,19 @@ Keyword arguments
 
 - `size` (required): A 3-tuple prescribing the number of grid points each direction.
 
-- `latitude`, `longitude`, `z`: Each is either a
+- `longitude`, `latitude`, `z`: Each is either a
                                 (i) 2-tuple that specify the end points of the domain,
                                 (ii) one-dimensional array specifying the cell interface locations or
                                 (iii) a single-argument function that takes an index and returns
                                       cell interface location.
 
 - `precompute_metrics`: Boolean specifying whether to precompute horizontal spacings and areas.
-                        If `!precompute_metrics` (the default), horizontal spacings and areas
-                        are computed on-the-fly during a simulation.
+                        Default: `true`. When `precompute_metrics = false`, horizontal spacings
+                        and areas are computed on-the-fly during a simulation.
 
 - `topology`: Tuple of topologies (`Flat`, `Bounded`, Periodic`) for each direction. The vertical
               `topology[3]` must be `Bounded`, while the latitude-longitude topology can be
-              `Bounded`, `Periodic`, or `Flat`. The default latitudinal `topology[2]` is `Bounded`.
-              The default longitudinal `topology[1]` is `Periodic`
-              if `diff(longitude) == 360` and `Bounded` otherwise.
+              `Bounded`, `Periodic`, or `Flat`.
 
 - `halo`: A 3-tuple of integers specifying the size of the halo region of cells surrounding
           the physical interior.
@@ -129,8 +130,8 @@ function LatitudeLongitudeGrid(architecture::AbstractArchitecture = CPU(),
                                FT::DataType = Float64;
                                precompute_metrics = true,
                                size,
-                               latitude,
                                longitude,
+                               latitude,
                                z,
                                radius = R_Earth,
                                topology = nothing,
@@ -244,8 +245,8 @@ function Base.show(io::IO, grid::LatitudeLongitudeGrid)
 
     longest = max(length(x_summary), length(y_summary), length(z_summary)) 
 
-    x_summary = dimension_summary(TX(), "λ", λ₁, λ₂, grid.Δλᶜᵃᵃ, longest - length(x_summary))
-    y_summary = dimension_summary(TY(), "φ", φ₁, φ₂, grid.Δφᵃᶜᵃ, longest - length(y_summary))
+    x_summary = dimension_summary(TX(), "lon", λ₁, λ₂, grid.Δλᶜᵃᵃ, longest - length(x_summary) -2)
+    y_summary = dimension_summary(TY(), "lat", φ₁, φ₂, grid.Δφᵃᶜᵃ, longest - length(y_summary) -2)
     z_summary = dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary))
 
     print(io, summary(grid), '\n',

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -248,7 +248,7 @@ function Base.show(io::IO, grid::LatitudeLongitudeGrid)
 
     x_summary = "longitude: " * dimension_summary(TX(), "λ", λ₁, λ₂, grid.Δλᶜᵃᵃ, longest - length(x_summary))
     y_summary = "latitude:  " * dimension_summary(TY(), "φ", φ₁, φ₂, grid.Δφᵃᶜᵃ, longest - length(y_summary))
-    z_summary = "vertical:  " * dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary))
+    z_summary = "z:         " * dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary))
 
     print(io, summary(grid), '\n',
           "├── ", x_summary, '\n',

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -83,58 +83,60 @@ regular_dimensions(::ZRegLatLonGrid) = tuple(3)
 
 """
     LatitudeLongitudeGrid([architecture = CPU(), FT = Float64];
-                          precompute_metrics = true,
                           size,
                           longitude,
                           latitude,
                           z,
                           radius = R_Earth,
                           topology = nothing,
+                          precompute_metrics = true,
                           halo = (1, 1, 1))
 
-Creates a `LatitudeLongitudeGrid` with `size = (Nx, Ny, Nz)` grid points.
-
-Note: the latitude-longitude coordinates are expected in degrees.
+Creates a `LatitudeLongitudeGrid` with coordinates `(λ, φ, z)` denoting longitude, latitude,
+and vertical coordinate respectively.
 
 Positional arguments
-=================
+====================
 
 - `architecture`: Specifies whether arrays of coordinates and spacings are stored
                   on the CPU or GPU. Default: `CPU()`.
 
-- `FT` : Floating point data type. Default: `FT = Float64`.
+- `FT` : Floating point data type. Default: `Float64`.
 
 Keyword arguments
 =================
 
 - `size` (required): A 3-tuple prescribing the number of grid points each direction.
 
-- `longitude`, `latitude`, `z`: Each is either a
-                                (i) 2-tuple that specify the end points of the domain,
-                                (ii) one-dimensional array specifying the cell interface locations or
-                                (iii) a single-argument function that takes an index and returns
-                                      cell interface location.
+- `longitude`, `latitude`, `z` (required): Each is either a
+                                           (i) 2-tuple that specify the end points of the domain,
+                                           (ii) one-dimensional array specifying the cell interface locations or
+                                           (iii) a single-argument function that takes an index and returns
+                                                 cell interface location.
+  **Note**: the latitude and longitude coordinates extents are expected in degrees.
+
+- `radius`: The radius of the sphere the grid lives on. By default is equal to the radius of Earth.
+
+- `topology`: Tuple of topologies (`Flat`, `Bounded`, `Periodic`) for each direction. The vertical 
+              `topology[3]` must be `Bounded`, while the latitude-longitude topologies can be
+              `Bounded`, `Periodic`, or `Flat`.
 
 - `precompute_metrics`: Boolean specifying whether to precompute horizontal spacings and areas.
-                        Default: `true`. When `precompute_metrics = false`, horizontal spacings
-                        and areas are computed on-the-fly during a simulation.
-
-- `topology`: Tuple of topologies (`Flat`, `Bounded`, Periodic`) for each direction. The vertical
-              `topology[3]` must be `Bounded`, while the latitude-longitude topology can be
-              `Bounded`, `Periodic`, or `Flat`.
+                        Default: `true`. When `false`, horizontal spacings and areas are computed
+                        on-the-fly during a simulation.
 
 - `halo`: A 3-tuple of integers specifying the size of the halo region of cells surrounding
           the physical interior.
 """
 function LatitudeLongitudeGrid(architecture::AbstractArchitecture = CPU(),
                                FT::DataType = Float64;
-                               precompute_metrics = true,
                                size,
                                longitude,
                                latitude,
                                z,
                                radius = R_Earth,
                                topology = nothing,
+                               precompute_metrics = true,
                                halo = (1, 1, 1))
 
     Nλ, Nφ, Nz, Hλ, Hφ, Hz, latitude, longitude, topology =
@@ -204,7 +206,6 @@ function validate_lat_lon_grid_args(latitude, longitude, size, halo, topology)
         @warn "Are you sure you want to use a latitude-longitude grid with a grid point at the pole?"
 
     Lλ = λ₂ - λ₁
-    Lφ = φ₂ - φ₁
 
     if !isnothing(topology)
         TX, TY, TZ = topology
@@ -245,9 +246,9 @@ function Base.show(io::IO, grid::LatitudeLongitudeGrid)
 
     longest = max(length(x_summary), length(y_summary), length(z_summary)) 
 
-    x_summary = dimension_summary(TX(), "lon", λ₁, λ₂, grid.Δλᶜᵃᵃ, longest - length(x_summary))
-    y_summary = dimension_summary(TY(), "lat", φ₁, φ₂, grid.Δφᵃᶜᵃ, longest - length(y_summary))
-    z_summary = dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary) + 2)
+    x_summary = dimension_summary(TX(), "λ", λ₁, λ₂, grid.Δλᶜᵃᵃ, longest - length(x_summary))
+    y_summary = dimension_summary(TY(), "φ", φ₁, φ₂, grid.Δφᵃᶜᵃ, longest - length(y_summary))
+    z_summary = dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary))
 
     print(io, summary(grid), '\n',
           "├── ", x_summary, '\n',

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -246,9 +246,9 @@ function Base.show(io::IO, grid::LatitudeLongitudeGrid)
 
     longest = max(length(x_summary), length(y_summary), length(z_summary)) 
 
-    x_summary = dimension_summary(TX(), "λ", λ₁, λ₂, grid.Δλᶜᵃᵃ, longest - length(x_summary))
-    y_summary = dimension_summary(TY(), "φ", φ₁, φ₂, grid.Δφᵃᶜᵃ, longest - length(y_summary))
-    z_summary = dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary))
+    x_summary = "longitude: " * dimension_summary(TX(), "λ", λ₁, λ₂, grid.Δλᶜᵃᵃ, longest - length(x_summary))
+    y_summary = "latitude:  " * dimension_summary(TY(), "φ", φ₁, φ₂, grid.Δφᵃᶜᵃ, longest - length(y_summary))
+    z_summary = "vertical:  " * dimension_summary(TZ(), "z", z₁, z₂, grid.Δzᵃᵃᶜ, longest - length(z_summary))
 
     print(io, summary(grid), '\n',
           "├── ", x_summary, '\n',


### PR DESCRIPTION
This PR updates the `show()` method for `LatitudeLongitudeGrid` to denote which of the directions is latitude and which is longitude. It also updates the docstring to match the latest syntax.

### Before this PR

```julia
julia> using Oceananigans

julia> LatitudeLongitudeGrid(size = (10, 4, 5),
                             latitude = (-40, 40),
                             longitude = (-20, 20),
                             z = (-2000, 0),
                             topology = (Periodic, Bounded, Bounded),
                             halo = (2, 2, 2))
10×4×5 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 2×2×2 halo and with precomputed metrics
├── Periodic λ ∈ [-20.0, 20.0)  regularly spaced with Δλ=4.0
├── Bounded  φ ∈ [-40.0, 40.0]  regularly spaced with Δφ=20.0
└── Bounded  z ∈ [-2000.0, 0.0] regularly spaced with Δz=400.0
```


### After this PR

```Julia
julia> using Oceananigans

julia> LatitudeLongitudeGrid(size = (10, 4, 5),
                             latitude = (-40, 40),
                             longitude = (-20, 20),
                             z = (-2000, 0),
                             topology = (Periodic, Bounded, Bounded),
                             halo = (2, 2, 2))
10×4×5 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 2×2×2 halo and with precomputed metrics
├── longitude: Periodic λ ∈ [-20.0, 20.0)  regularly spaced with Δλ=4.0
├── latitude:  Bounded  φ ∈ [-40.0, 40.0]  regularly spaced with Δφ=20.0
└── z:         Bounded  z ∈ [-2000.0, 0.0] regularly spaced with Δz=400.0
```