### PR TITLE
Update dissipation and surface TKE flux parameters for CATKE

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.73.1"
+version = "0.73.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
@@ -91,7 +91,7 @@ end
 
 """
     CATKEVerticalDiffusivity(time_discretization = VerticallyImplicitTimeDiscretization, FT=Float64;
-                             Cᴰ = 2.91,
+                             Cᴰ = 0.215,
                              mixing_length = MixingLength{FT}(),
                              surface_TKE_flux = SurfaceTKEFlux{FT}(),
                              warning = true)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/surface_TKE_flux.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/surface_TKE_flux.jl
@@ -23,8 +23,8 @@ The calibration was performed using a combination of Markov Chain Monte Carlo (M
 annealing and noisy Ensemble Kalman Inversion methods.
 """
 Base.@kwdef struct SurfaceTKEFlux{FT}
-    Cᵂu★ :: FT = 3.62
-    CᵂwΔ :: FT = 1.31
+    Cᵂu★ :: FT = 4.56
+    CᵂwΔ :: FT = 4.46
 end
 
 #####


### PR DESCRIPTION
This PR updates the dissipation and surface TKE flux parameter for CATKE. These were _not_ updated in #2273, but they should have been.

cc @adelinehillier