### PR TITLE
Return `field` from `compute!(field::ReducedComputedField)`

### DIFF
--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -366,7 +366,7 @@ Base.size(f::Field)  = length_indices.(      size(location(f), f.grid), f.indice
 
 Computes `field.data` from `field.operand`.
 """
-compute!(field, time=nothing) = nothing # fallback
+compute!(field, time=nothing) = field # fallback
 
 """
     @compute(exprs...)

--- a/src/Fields/field_reductions.jl
+++ b/src/Fields/field_reductions.jl
@@ -75,7 +75,7 @@ function compute!(field::ReducedComputedField, time=nothing)
     reduction = field.operand
     compute_at!(reduction.operand, time)
     reduction.reduce!(field, reduction.operand)
-    return nothing
+    return field
 end
 
 #####


### PR DESCRIPTION
Just a little sugary convenience so we can write one-liners like

```Julia
U = compute!(Field(Average(u, dims=1)))
```

(Note that other `compute!` already do this, we just have a few lingering inconsistencies.)