### PR TITLE
Some backward compatibility for `FieldTimeSeries`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.73.6"
+version = "0.73.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -105,15 +105,6 @@ function FieldTimeSeries(path, name, backend::InMemory;
     isnothing(times)        && (times      = [file["timeseries/t/$i"] for i in iterations])
     isnothing(location)     && (location   = file["timeseries/$name/serialized/location"])
 
-    # These lines ensure that Oceananigans files generated prior to vXXX can still
-    # be loaded
-    try # to deserialize the grid
-        if isnothing(grid)
-            grid = file["serialized/grid"]
-        end
-    catch err # probably won't work if the grid was on GPU
-    end
-
     if boundary_conditions isa UnspecifiedBoundaryConditions
         boundary_conditions = file["timeseries/$name/serialized/boundary_conditions"]
     end
@@ -124,14 +115,42 @@ function FieldTimeSeries(path, name, backend::InMemory;
         (:, :, :)
     end
 
-    close(file)
+    isnothing(grid) && (grid = file["serialized/grid"])
 
     # Default to CPU if neither architecture nor grid is specified
-    architecture = isnothing(architecture) ?
-        (isnothing(grid) ? CPU() : Architectures.architecture(grid)) :
-        architecture
+    architecture = isnothing(architecture) ? (isnothing(grid) ? CPU() : Architectures.architecture(grid)) : architecture
 
-    grid = on_architecture(architecture, grid)
+    # This should be removed in a month or two (4/5/2022).
+    grid = try
+        on_architecture(architecture, grid)
+    catch err # Likely, the grid has CuArrays in it...
+        if grid isa RectilinearGrid # we can try...
+            Nx = file["grid/Nx"]
+            Ny = file["grid/Ny"]
+            Nz = file["grid/Nz"]
+            Hx = file["grid/Hx"]
+            Hy = file["grid/Hy"]
+            Hz = file["grid/Hz"]
+            xᶠᵃᵃ = file["grid/xᶠᵃᵃ"]
+            yᵃᶠᵃ = file["grid/yᵃᶠᵃ"]
+            zᵃᵃᶠ = file["grid/zᵃᵃᶠ"]
+            x = file["grid/Δxᶠᵃᵃ"] isa Number ? (xᶠᵃᵃ[1], xᶠᵃᵃ[Nx+1]) : xᶠᵃᵃ
+            y = file["grid/Δyᵃᶠᵃ"] isa Number ? (yᵃᶠᵃ[1], yᵃᶠᵃ[Ny+1]) : yᵃᶠᵃ
+            z = file["grid/Δzᵃᵃᶠ"] isa Number ? (zᵃᵃᶠ[1], zᵃᵃᶠ[Nz+1]) : zᵃᵃᶠ
+            topo = topology(grid)
+
+            # Reduce for Flat dimensions
+            domain = NamedTuple((:x, :y, :z)[i] => (x, y, z)[i] for i=1:3 if topo[i] !== Flat)
+            size = Tuple((Nx, Ny, Nz)[i] for i=1:3 if topo[i] !== Flat)
+            halo = Tuple((Hx, Hy, Hz)[i] for i=1:3 if topo[i] !== Flat)
+
+            RectilinearGrid(architecture; size, halo, topology=topo, domain...)
+        else
+            throw(err)
+        end
+    end
+
+    close(file)
 
     LX, LY, LZ = location
     time_series = FieldTimeSeries{LX, LY, LZ}(grid, times; indices, boundary_conditions)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/ri_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/ri_based_vertical_diffusivity.jl
@@ -13,6 +13,9 @@ struct RiBasedVerticalDiffusivity{TD, FT, LZ} <: AbstractScalarDiffusivity{TD, V
     coefficient_z_location :: LZ
 end
 
+RiBasedVerticalDiffusivity{TD}(ν₀::FT, Ri₀ν::FT, Riᵟν::FT, κ₀::FT, Ri₀κ::FT, Riᵟκ::FT, coefficient_z_location::LZ) where {TD, FT, LZ} =
+    RiBasedVerticalDiffusivity{TD, FT, LZ}(ν₀, Ri₀ν, Riᵟν, κ₀, Ri₀κ, Riᵟκ, coefficient_z_location)
+
 """
     RiBasedVerticalDiffusivity([td=VerticallyImplicitTimeDiscretization(), FT=Float64] kwargs...)
 
@@ -43,12 +46,11 @@ function RiBasedVerticalDiffusivity(time_discretization = VerticallyImplicitTime
                                     Riᵟκ = 1.0)
 
     TD = typeof(time_discretization)
-    LZ = typeof(coefficient_z_location)
+
     coefficient_z_location isa Face || coefficient_z_location isa Center ||
         error("coefficient_z_location is $LZ but must be `Face()` or `Center()`!")
 
-    return RiBasedVerticalDiffusivity{TD, FT, LZ}(ν₀, Ri₀ν, Riᵟν, κ₀, Ri₀κ, Riᵟκ,
-                                                  coefficient_z_location)
+    return RiBasedVerticalDiffusivity{TD}(ν₀, Ri₀ν, Riᵟν, κ₀, Ri₀κ, Riᵟκ, coefficient_z_location)
 end
 
 RiBasedVerticalDiffusivity(FT::DataType; kw...) =

--- a/src/TurbulenceClosures/turbulence_closure_implementations/ri_based_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/ri_based_vertical_diffusivity.jl
@@ -14,7 +14,23 @@ struct RiBasedVerticalDiffusivity{TD, FT, LZ} <: AbstractScalarDiffusivity{TD, V
 end
 
 """
-    RiBasedVerticalDiffusivity
+    RiBasedVerticalDiffusivity([td=VerticallyImplicitTimeDiscretization(), FT=Float64] kwargs...)
+
+Returns a closure that estimates the vertical viscosity and diffusivity
+from "convective adjustment" coefficients `ν₀` and `κ₀` multiplied by
+a decreasing function of the Richardson number.
+
+Keyword Arguments
+=========
+
+* ν₀ (Float64 parameter): Convective adjustment viscosity. Default: 0.01
+* Ri₀ν (Float64 parameter): Ri threshold for decreasing viscosity. Default: -0.5
+* Riᵟν (Float64 parameter): Width over which Ri decreases to 0. Default: 1.0
+* κ₀ (Float64 parameter): Convective adjustment diffusivity for tracers. Default: 0.1
+* Ri₀κ (Float64 parameter): Ri threshold for decreasing viscosity. Default: -0.5
+* Riᵟκ (Float64 parameter): Width over which Ri decreases to 0. Default: 1.0
+* coefficient_z_location (Face() or Center()): The vertical location of the diffusivity and viscosity.
+                                               Default: Face().
 """
 function RiBasedVerticalDiffusivity(time_discretization = VerticallyImplicitTimeDiscretization(),
                                     FT = Float64;
@@ -48,6 +64,8 @@ const FlavorOfRBVD{LZ} = Union{RBVD{LZ}, RBVDArray{LZ}} where LZ
 
 @inline viscosity_location(::FlavorOfRBVD{LZ}) where LZ = (Center(), Center(), LZ())
 @inline diffusivity_location(::FlavorOfRBVD{LZ}) where LZ = (Center(), Center(), LZ())
+@inline viscosity(::FlavorOfRBVD, diffusivities) = diffusivities.ν
+@inline diffusivity(::FlavorOfRBVD, diffusivities, id) = diffusivities.κ
 
 with_tracers(tracers, closure::FlavorOfRBVD) = closure
 
@@ -57,9 +75,6 @@ function DiffusivityFields(grid, tracer_names, bcs, closure::FlavorOfRBVD{LZ}) w
     ν = Field{Center, Center, LZ}(grid)
     return (; κ, ν)
 end
-
-@inline viscosity(::FlavorOfRBVD, diffusivities) = diffusivities.ν
-@inline diffusivity(::FlavorOfRBVD, diffusivities, id) = diffusivities.κ
 
 function calculate_diffusivities!(diffusivities, closure::FlavorOfRBVD, model)
 


### PR DESCRIPTION
This PR updates `FieldTimeSeries` to be slightly "backward compatible" and capable of loading data from Oceananigans versions that did not have `Field.indices`, or which serialized stretched GPU grids with `CuArray`s.

We might have to constantly maintain this... but hopefully eventually structures will be more stable, and eventually we can just delete the stuff added here.