### PR TITLE
Updates `distributed_nonhydrostatic_model_mpi.jl`

### DIFF
--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -515,7 +515,7 @@ uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
 version = "2.36.0+0"
 
 [[LinearAlgebra]]
-deps = ["Libdl", "libblastrampoline_jll"]
+deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LogExpFunctions]]
@@ -601,10 +601,6 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "887579a3eb005446d514ab7aeac5d1d027658b8f"
 uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
 version = "1.3.5+1"
-
-[[OpenBLAS_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
-uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 
 [[OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -740,7 +736,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["SHA", "Serialization"]
+deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[Random123]]
@@ -1092,10 +1088,6 @@ deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll"
 git-tree-sha1 = "5982a94fcba20f02f42ace44b9894ee2b140fe47"
 uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
 version = "0.15.1+0"
-
-[[libblastrampoline_jll]]
-deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
-uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [[libfdk_aac_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/benchmark/distributed_nonhydrostatic_model_mpi.jl
+++ b/benchmark/distributed_nonhydrostatic_model_mpi.jl
@@ -7,7 +7,6 @@ using BenchmarkTools
 
 using Oceananigans
 using Oceananigans.Distributed
-using Benchmarks
 
 Logging.global_logger(OceananigansLogger())
 
@@ -16,9 +15,6 @@ MPI.Init()
       comm = MPI.COMM_WORLD
 local_rank = MPI.Comm_rank(comm)
          R = MPI.Comm_size(comm)
-
- # Assigns one GPU per rank, could increase efficiency but must have enough GPUs
- # CUDA.device!(local_rank)
 
  Nx = parse(Int, ARGS[1])
  Ny = parse(Int, ARGS[2])
@@ -45,7 +41,7 @@ time_step!(model, 1) # warmup
 MPI.Barrier(comm)
 
 trial = @benchmark begin
-    @sync_gpu time_step!($model, 1)
+    time_step!($model, 1)
 end samples=10 evals=1
 
 MPI.Barrier(comm)


### PR DESCRIPTION
This PR tries to make the script a bit easier to run based on my experiences with it. For example `Benchmark` and `@gpu_sync` aren't needed in this case and we can delete it.

So far I've only been able to run this with one core (see https://github.com/CliMA/Oceananigans.jl/issues/2433).

Closes https://github.com/CliMA/Oceananigans.jl/issues/2433