### PR TITLE
Adds HorizontalDivergenceFormulation for scalar diffusions

### DIFF
--- a/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
@@ -5,33 +5,35 @@ Abstract type for closures with *isotropic* diffusivities.
 """
 abstract type AbstractScalarDiffusivity{TD, F} <: AbstractTurbulenceClosure{TD} end
 
+abstract type AbstractDiffusivityFormulation end
+
 """
     struct ThreeDimensionalFormulation end
 
 Specifies a three-dimensionally-isotropic `ScalarDiffusivity`.
 """
-struct ThreeDimensionalFormulation end
+struct ThreeDimensionalFormulation <: AbstractDiffusivityFormulation end
 
 """
     struct HorizontalFormulation end
 
 Specifies a horizontally-isotropic, `VectorInvariant`, `ScalarDiffusivity`.
 """
-struct HorizontalFormulation end
+struct HorizontalFormulation <: AbstractDiffusivityFormulation end
 
 """
     struct HorizontalDivergenceFormulation end
 
 Specifies viscosity for "divergence damping". Has no effect on tracers.
 """
-struct HorizontalDivergenceFormulation end
+struct HorizontalDivergenceFormulation <: AbstractDiffusivityFormulation end
 
 """
     struct VerticalFormulation end
 
 Specifies a `ScalarDiffusivity` acting only in the vertical direction.
 """
-struct VerticalFormulation end
+struct VerticalFormulation <: AbstractDiffusivityFormulation end
 
 """
     viscosity(closure, diffusivities)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
@@ -55,6 +55,10 @@ function ScalarDiffusivity(time_discretization=ExplicitTimeDiscretization(),
     return ScalarDiffusivity{typeof(time_discretization), typeof(formulation)}(ν, κ)
 end
 
+# Explicit default
+ScalarDiffusivity(formulation::AbstractDiffusivityFormulation, FT=Float64; kw...) =
+    ScalarDiffusivity(ExplicitTimeDiscretization(), formulation, FT; kw...)
+
 const VerticalScalarDiffusivity{TD} = ScalarDiffusivity{TD, VerticalFormulation} where TD
 const HorizontalScalarDiffusivity{TD} = ScalarDiffusivity{TD, HorizontalFormulation} where TD
 


### PR DESCRIPTION
This allows us to implement "divergence damping" for large scale ocean models via `ScalarDiffusivity`:

```julia
using Oceananigans.TurbulenceClosures: HorizontalDivergenceFormulation
divergence_damping = ScalarDiffusivity(HorizontalDivergenceFormulation(), ν=1)
```

We probably also want vorticity damping. There also might be other names, for vorticity damping the coefficient is often referred to as the "rotational viscosity".

A few other things:

* Possibly one should throw an error if users specify kappa, since this closure has no tracer diffusion.
* I added an abstract type for the formulations
* Should we use flux=0 fallbacks? We have a substantial amount of code devoted to emitting zero fluxes for many cases (eg zero tracer flux in this case).