### PR TITLE
Better diffusivity closure `show()`

### DIFF
--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_biharmonic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_biharmonic_diffusivity.jl
@@ -72,7 +72,14 @@ calculate_diffusivities!(diffusivities, closure::ScalarBiharmonicDiffusivity, ar
 
 function Base.summary(closure::ScalarBiharmonicDiffusivity)
     F = summary(formulation(closure))
-    return string("ScalarBiharmonicDiffusivity{$F}(ν=", prettysummary(closure.ν), ", κ=", prettysummary(closure.κ), ")")
+
+    if closure.κ == NamedTuple()
+        summary_str = string("ScalarBiharmonicDiffusivity{$F}(ν=", prettysummary(closure.ν), ")")
+    else
+        summary_str = string("ScalarBiharmonicDiffusivity{$F}(ν=", prettysummary(closure.ν), ", κ=", prettysummary(closure.κ), ")")
+    end
+
+    return summary_str
 end
 
 Base.show(io::IO, closure::ScalarBiharmonicDiffusivity) = print(io, summary(closure))

--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
@@ -106,7 +106,14 @@ function Base.summary(closure::ScalarDiffusivity)
     TD = summary(time_discretization(closure))
     prefix = replace(summary(formulation(closure)), "Formulation" => "")
     prefix === "ThreeDimensional" && (prefix = "")
-    return string(prefix, "ScalarDiffusivity{$TD}(ν=", prettysummary(closure.ν), ", κ=", prettysummary(closure.κ), ")")
+
+    if closure.κ == NamedTuple()
+        summary_str = string(prefix, "ScalarDiffusivity{$TD}(ν=", prettysummary(closure.ν), ")")
+    else
+        summary_str = string(prefix, "ScalarDiffusivity{$TD}(ν=", prettysummary(closure.ν), ", κ=", prettysummary(closure.κ), ")")
+    end
+
+    return summary_str
 end
 
 Base.show(io::IO, closure::ScalarDiffusivity) = print(io, summary(closure))


### PR DESCRIPTION
If there is no tracer then only show `ν`.

Resolves #2443.

```Julia

julia> using Oceananigans
[ Info: Oceananigans will use 10 threads

julia> grid = RectilinearGrid(size=(1, 1, 1), extent=(1, 2, 3), halo=(2, 2, 2));

julia> model = NonhydrostaticModel(closure=ScalarBiharmonicDiffusivity(); grid)
NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×2×2 halo
├── timestepper: QuasiAdamsBashforth2TimeStepper
├── tracers: ()
├── closure: ScalarBiharmonicDiffusivity{ThreeDimensionalFormulation}(ν=0.0)
├── buoyancy: Nothing
└── coriolis: Nothing
```