### PR TITLE
Implement the actually-Cox (aka the anti-anti-Cox) stencil for GM

### DIFF
--- a/src/TurbulenceClosures/isopycnal_rotation_tensor_components.jl
+++ b/src/TurbulenceClosures/isopycnal_rotation_tensor_components.jl
@@ -56,7 +56,6 @@ SmallSlopeIsopycnalTensor(; minimum_bz = 0) = SmallSlopeIsopycnalTensor(minimum_
 
 @inline function isopycnal_rotation_tensor_xz_fcc(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
     bx = ∂x_b(i, j, k, grid, buoyancy, tracers)
-    #bz = ∂zᶠᶜᶜ(i, j, k, grid, ℑxzᶠᵃᶠ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = ℑxzᶠᵃᶜ(i, j, k, grid, ∂zᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = max(bz, slope_model.minimum_bz)
     
@@ -66,7 +65,6 @@ SmallSlopeIsopycnalTensor(; minimum_bz = 0) = SmallSlopeIsopycnalTensor(minimum_
 end
 
 @inline function isopycnal_rotation_tensor_xz_ccf(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
-    #bx = ∂xᶜᶜᶠ(i, j, k, grid, ℑxzᶠᵃᶠ, buoyancy_perturbation, buoyancy.model, tracers)
     bx = ℑxzᶜᵃᶠ(i, j, k, grid, ∂xᶠᶜᶜ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = ∂z_b(i, j, k, grid, buoyancy, tracers)
     bz = max(bz, slope_model.minimum_bz)
@@ -78,7 +76,6 @@ end
 
 @inline function isopycnal_rotation_tensor_yz_cfc(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
     by = ∂y_b(i, j, k, grid, buoyancy, tracers)
-    #bz = ∂zᶜᶠᶜ(i, j, k, grid, ℑyzᵃᶠᶠ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = ℑyzᵃᶠᶜ(i, j, k, grid, ∂zᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = max(bz, slope_model.minimum_bz)
     

--- a/src/TurbulenceClosures/isopycnal_rotation_tensor_components.jl
+++ b/src/TurbulenceClosures/isopycnal_rotation_tensor_components.jl
@@ -57,7 +57,7 @@ SmallSlopeIsopycnalTensor(; minimum_bz = 0) = SmallSlopeIsopycnalTensor(minimum_
 @inline function isopycnal_rotation_tensor_xz_fcc(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
     bx = ∂x_b(i, j, k, grid, buoyancy, tracers)
     #bz = ∂zᶠᶜᶜ(i, j, k, grid, ℑxzᶠᵃᶠ, buoyancy_perturbation, buoyancy.model, tracers)
-    bz = ℑxzᶠᵃᶠ(i, j, k, grid, ∂zᶠᶜᶜ, buoyancy_perturbation, buoyancy.model, tracers)
+    bz = ℑxzᶠᵃᶜ(i, j, k, grid, ∂zᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = max(bz, slope_model.minimum_bz)
     
     slope_x = - bx / bz
@@ -67,7 +67,7 @@ end
 
 @inline function isopycnal_rotation_tensor_xz_ccf(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
     #bx = ∂xᶜᶜᶠ(i, j, k, grid, ℑxzᶠᵃᶠ, buoyancy_perturbation, buoyancy.model, tracers)
-    bx = ℑxzᶠᵃᶠ(i, j, k, grid, ∂xᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    bx = ℑxzᶜᵃᶠ(i, j, k, grid, ∂xᶠᶜᶜ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = ∂z_b(i, j, k, grid, buoyancy, tracers)
     bz = max(bz, slope_model.minimum_bz)
     
@@ -79,7 +79,7 @@ end
 @inline function isopycnal_rotation_tensor_yz_cfc(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
     by = ∂y_b(i, j, k, grid, buoyancy, tracers)
     #bz = ∂zᶜᶠᶜ(i, j, k, grid, ℑyzᵃᶠᶠ, buoyancy_perturbation, buoyancy.model, tracers)
-    bz = ℑyzᵃᶠᶠ(i, j, k, grid, ∂zᶜᶠᶜ, buoyancy_perturbation, buoyancy.model, tracers)
+    bz = ℑyzᵃᶠᶜ(i, j, k, grid, ∂zᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = max(bz, slope_model.minimum_bz)
     
     slope_y = - by / bz
@@ -88,7 +88,7 @@ end
 end
 
 @inline function isopycnal_rotation_tensor_yz_ccf(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
-    by = ℑyzᵃᶠᶠ(i, j, k, grid, ∂yᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    by = ℑyzᵃᶜᶠ(i, j, k, grid, ∂yᶜᶠᶜ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = ∂z_b(i, j, k, grid, buoyancy, tracers)
     bz = max(bz, slope_model.minimum_bz)
     
@@ -98,8 +98,8 @@ end
 end
 
 @inline function isopycnal_rotation_tensor_zz_ccf(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
-    bx = ℑxzᶠᵃᶠ(i, j, k, grid, ∂xᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
-    by = ℑyzᵃᶠᶠ(i, j, k, grid, ∂yᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    bx = ℑxzᶜᵃᶠ(i, j, k, grid, ∂xᶠᶜᶜ, buoyancy_perturbation, buoyancy.model, tracers)
+    by = ℑyzᵃᶜᶠ(i, j, k, grid, ∂yᶜᶠᶜ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = ∂z_b(i, j, k, grid, buoyancy, tracers)
     bz = max(bz, slope_model.minimum_bz)
 

--- a/src/TurbulenceClosures/isopycnal_rotation_tensor_components.jl
+++ b/src/TurbulenceClosures/isopycnal_rotation_tensor_components.jl
@@ -56,7 +56,8 @@ SmallSlopeIsopycnalTensor(; minimum_bz = 0) = SmallSlopeIsopycnalTensor(minimum_
 
 @inline function isopycnal_rotation_tensor_xz_fcc(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
     bx = ∂x_b(i, j, k, grid, buoyancy, tracers)
-    bz = ∂zᶠᶜᶜ(i, j, k, grid, ℑxzᶠᵃᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    #bz = ∂zᶠᶜᶜ(i, j, k, grid, ℑxzᶠᵃᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    bz = ℑxzᶠᵃᶠ(i, j, k, grid, ∂zᶠᶜᶜ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = max(bz, slope_model.minimum_bz)
     
     slope_x = - bx / bz
@@ -65,7 +66,8 @@ SmallSlopeIsopycnalTensor(; minimum_bz = 0) = SmallSlopeIsopycnalTensor(minimum_
 end
 
 @inline function isopycnal_rotation_tensor_xz_ccf(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
-    bx = ∂xᶜᶜᶠ(i, j, k, grid, ℑxzᶠᵃᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    #bx = ∂xᶜᶜᶠ(i, j, k, grid, ℑxzᶠᵃᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    bx = ℑxzᶠᵃᶠ(i, j, k, grid, ∂xᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = ∂z_b(i, j, k, grid, buoyancy, tracers)
     bz = max(bz, slope_model.minimum_bz)
     
@@ -76,7 +78,8 @@ end
 
 @inline function isopycnal_rotation_tensor_yz_cfc(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
     by = ∂y_b(i, j, k, grid, buoyancy, tracers)
-    bz = ∂zᶜᶠᶜ(i, j, k, grid, ℑyzᵃᶠᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    #bz = ∂zᶜᶠᶜ(i, j, k, grid, ℑyzᵃᶠᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    bz = ℑyzᵃᶠᶠ(i, j, k, grid, ∂zᶜᶠᶜ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = max(bz, slope_model.minimum_bz)
     
     slope_y = - by / bz
@@ -85,7 +88,7 @@ end
 end
 
 @inline function isopycnal_rotation_tensor_yz_ccf(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
-    by = ∂yᶜᶜᶠ(i, j, k, grid, ℑyzᵃᶠᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    by = ℑyzᵃᶠᶠ(i, j, k, grid, ∂yᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = ∂z_b(i, j, k, grid, buoyancy, tracers)
     bz = max(bz, slope_model.minimum_bz)
     
@@ -95,8 +98,8 @@ end
 end
 
 @inline function isopycnal_rotation_tensor_zz_ccf(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, slope_model::SmallSlopeIsopycnalTensor) where FT
-    bx = ∂xᶜᶜᶠ(i, j, k, grid, ℑxzᶠᵃᶠ, buoyancy_perturbation, buoyancy.model, tracers)
-    by = ∂yᶜᶜᶠ(i, j, k, grid, ℑyzᵃᶠᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    bx = ℑxzᶠᵃᶠ(i, j, k, grid, ∂xᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
+    by = ℑyzᵃᶠᶠ(i, j, k, grid, ∂yᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = ∂z_b(i, j, k, grid, buoyancy, tracers)
     bz = max(bz, slope_model.minimum_bz)
 
@@ -106,3 +109,4 @@ end
     
     return ifelse(bz == 0, zero(FT), slope²)
 end
+

--- a/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
@@ -77,21 +77,16 @@ R. Gerdes, C. Koberle, and J. Willebrand. (1991), "The influence of numerical ad
     on the results of ocean general circulation models", Clim. Dynamics, 5 (4), 211–226.
 """
 @inline function taper_factor_ccc(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, tapering::FluxTapering) where FT
+    # TODO: handle boundaries!
     bx = ℑxᶜᵃᵃ(i, j, k, grid, ∂x_b, buoyancy, tracers)
     by = ℑyᵃᶜᵃ(i, j, k, grid, ∂y_b, buoyancy, tracers)
     bz = ℑzᵃᵃᶜ(i, j, k, grid, ∂z_b, buoyancy, tracers)
 
-    # bz = ifelse(k == 1,       ∂z_b(i, j, 2,         grid, buoyancy, tracers),
-    #      ifelse(k == grid.Nz, ∂z_b(i, j, grid.Nz-1, grid, buoyancy, tracers),
-    #             ℑzᵃᵃᶜ(i, j, k, grid, ∂z_b, buoyancy, tracers)))
-    
     slope_x = - bx / bz
     slope_y = - by / bz
     slope² = ifelse(bz <= 0, zero(FT), slope_x^2 + slope_y^2)
 
-    ϵ = min(one(FT), tapering.max_slope^2 / slope²)
-
-    return ϵ
+    return min(one(FT), tapering.max_slope^2 / slope²)
 end
 
 """
@@ -121,11 +116,6 @@ taper_factor_ccc(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, ::Nothing) 
     κ_symmetricᶠᶜᶜ = κᶠᶜᶜ(i, j, k, grid, clock, issd_coefficient_loc, κ_symmetric)
 
     ∂x_c = ∂xᶠᶜᶜ(i, j, k, grid, c)
-
-    # These end up at fcc
-    # Gradient... of... the average
-    #∂y_c = ∂yᶠᶜᶜ(i, j, k, grid, ℑxyᶠᶠᵃ, c)
-    #∂z_c = ∂zᶠᶜᶜ(i, j, k, grid, ℑxzᶠᵃᶠ, c)
 
     # Average... of... the gradient!
     ∂y_c = ℑxyᶠᶜᵃ(i, j, k, grid, ∂yᶜᶠᶜ, c)
@@ -158,11 +148,6 @@ end
 
     ∂y_c = ∂yᶜᶠᶜ(i, j, k, grid, c)
 
-    # These end up at cfc:
-    # Gradient... of... the average
-    #∂x_c = ∂xᶜᶠᶜ(i, j, k, grid, ℑxyᶠᶠᵃ, c)
-    #∂z_c = ∂zᶜᶠᶜ(i, j, k, grid, ℑyzᵃᶠᶠ, c)
-
     # Average... of... the gradient!
     ∂x_c = ℑxyᶜᶠᵃ(i, j, k, grid, ∂xᶠᶜᶜ, c)
     ∂z_c = ℑyzᵃᶠᶜ(i, j, k, grid, ∂zᶜᶜᶠ, c)
@@ -193,11 +178,6 @@ end
     κ_symmetricᶜᶜᶠ = κᶜᶜᶠ(i, j, k, grid, clock, issd_coefficient_loc, κ_symmetric)
 
     ∂z_c = ∂zᶜᶜᶠ(i, j, k, grid, c)
-
-    # These end up at ccf
-    # Gradient... of... the average
-    #∂x_c = ∂xᶜᶜᶠ(i, j, k, grid, ℑxzᶠᵃᶠ, c)
-    #∂y_c = ∂yᶜᶜᶠ(i, j, k, grid, ℑyzᵃᶠᶠ, c)
 
     # Average... of... the gradient!
     ∂x_c = ℑxzᶜᵃᶠ(i, j, k, grid, ∂xᶠᶜᶜ, c)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
@@ -115,8 +115,14 @@ taper_factor_ccc(i, j, k, grid::AbstractGrid{FT}, buoyancy, tracers, ::Nothing) 
     κ_symmetricᶠᶜᶜ = κᶠᶜᶜ(i, j, k, grid, clock, issd_coefficient_loc, κ_symmetric)
 
     ∂x_c = ∂xᶠᶜᶜ(i, j, k, grid, c)
-    ∂y_c = ℑxyᶠᶜᵃ(i, j, k, grid, ∂yᶜᶠᶜ, c)
-    ∂z_c = ℑxzᶠᵃᶜ(i, j, k, grid, ∂zᶜᶜᶠ, c)
+
+    # End up at fcc
+    ∂y_c = ∂yᶠᶜᶜ(i, j, k, grid, ℑxyᶠᶠᵃ, c)
+    ∂z_c = ∂zᶠᶜᶜ(i, j, k, grid, ℑxzᶠᵃᶠ, c)
+
+    # Previously:
+    #∂y_c = ℑxyᶠᶜᵃ(i, j, k, grid, ∂yᶜᶠᶜ, c)
+    #∂z_c = ℑxzᶠᵃᶜ(i, j, k, grid, ∂zᶜᶜᶠ, c)
 
     R₁₁ = one(eltype(grid))
     R₁₂ = zero(eltype(grid))
@@ -143,9 +149,15 @@ end
     κ_skewᶜᶠᶜ = κᶜᶠᶜ(i, j, k, grid, clock, issd_coefficient_loc, κ_skew)
     κ_symmetricᶜᶠᶜ = κᶜᶠᶜ(i, j, k, grid, clock, issd_coefficient_loc, κ_symmetric)
 
-    ∂x_c = ℑxyᶜᶠᵃ(i, j, k, grid, ∂xᶠᶜᶜ, c)
     ∂y_c = ∂yᶜᶠᶜ(i, j, k, grid, c)
-    ∂z_c = ℑyzᵃᶠᶜ(i, j, k, grid, ∂zᶜᶜᶠ, c)
+
+    # End up at cfc
+    ∂x_c = ∂xᶜᶠᶜ(i, j, k, grid, ℑxyᶠᶠᵃ, c)
+    ∂z_c = ∂zᶜᶠᶜ(i, j, k, grid, ℑyzᵃᶠᶠ, c)
+
+    # Previously:
+    #∂x_c = ℑxyᶜᶠᵃ(i, j, k, grid, ∂xᶠᶜᶜ, c)
+    #∂z_c = ℑyzᵃᶠᶜ(i, j, k, grid, ∂zᶜᶜᶠ, c)
 
     R₂₁ = zero(eltype(grid))
     R₂₂ = one(eltype(grid))
@@ -172,9 +184,15 @@ end
     κ_skewᶜᶜᶠ = κᶜᶜᶠ(i, j, k, grid, clock, issd_coefficient_loc,κ_skew)
     κ_symmetricᶜᶜᶠ = κᶜᶜᶠ(i, j, k, grid, clock, issd_coefficient_loc, κ_symmetric)
 
-    ∂x_c = ℑxzᶜᵃᶠ(i, j, k, grid, ∂xᶠᶜᶜ, c)
-    ∂y_c = ℑyzᵃᶜᶠ(i, j, k, grid, ∂yᶜᶠᶜ, c)
     ∂z_c = ∂zᶜᶜᶠ(i, j, k, grid, c)
+
+    # End up at ccf
+    ∂x_c = ∂xᶜᶜᶠ(i, j, k, grid, ℑxzᶠᵃᶠ, c)
+    ∂y_c = ∂yᶜᶜᶠ(i, j, k, grid, ℑyzᵃᶠᶠ, c)
+
+    # Previously:
+    #∂x_c = ℑxzᶜᵃᶠ(i, j, k, grid, ∂xᶠᶜᶜ, c)
+    #∂y_c = ℑyzᵃᶜᶠ(i, j, k, grid, ∂yᶜᶠᶜ, c)
 
     R₃₁ = isopycnal_rotation_tensor_xz_ccf(i, j, k, grid, buoyancy, tracers, closure.isopycnal_tensor)
     R₃₂ = isopycnal_rotation_tensor_yz_ccf(i, j, k, grid, buoyancy, tracers, closure.isopycnal_tensor)

--- a/validation/mesoscale_turbulence/coarse_lat_lon_baroclinic_adjustment.jl
+++ b/validation/mesoscale_turbulence/coarse_lat_lon_baroclinic_adjustment.jl
@@ -1,0 +1,194 @@
+using Printf
+using Statistics
+using Random
+using Oceananigans
+using Oceananigans.Units
+using GLMakie
+
+using Oceananigans.TurbulenceClosures: FluxTapering
+
+gradient = "φ"
+filename = "coarse_baroclinic_adjustment_" * gradient
+
+# Architecture
+architecture = CPU()
+
+# Domain
+Lz = 1kilometers     # depth [m]
+Ny = 20
+Nz = 20
+save_fields_interval = 0.5day
+stop_time = 30days
+Δt = 20minutes
+
+grid = LatitudeLongitudeGrid(architecture;
+                             topology = (Bounded, Bounded, Bounded),
+                             size = (Ny, Ny, Nz), 
+                             longitude = (-5, 5),
+                             latitude = (40, 50),
+                             z = (-Lz, 0),
+                             halo = (3, 3, 3))
+
+coriolis = HydrostaticSphericalCoriolis()
+
+Δy = 1000kilometers / Ny
+@show κh = νh = Δy^4 / 10days
+vertical_closure = VerticalScalarDiffusivity(ν=1e-2, κ=1e-4)
+horizontal_closure = HorizontalScalarBiharmonicDiffusivity(ν=νh)
+
+gerdes_koberle_willebrand_tapering = FluxTapering(1e-2)
+gent_mcwilliams_diffusivity = IsopycnalSkewSymmetricDiffusivity(κ_skew = 1e3,
+                                                                κ_symmetric = (b=0, c=1e3),
+                                                                slope_limiter = gerdes_koberle_willebrand_tapering)
+
+closures = (vertical_closure, horizontal_closure, gent_mcwilliams_diffusivity)
+
+@info "Building a model..."
+
+model = HydrostaticFreeSurfaceModel(grid = grid,
+                                    coriolis = coriolis,
+                                    buoyancy = BuoyancyTracer(),
+                                    closure = closures,
+                                    tracers = (:b, :c),
+                                    momentum_advection = VectorInvariant(),
+                                    tracer_advection = WENO5(),
+                                    free_surface = ImplicitFreeSurface())
+
+@info "Built $model."
+
+"""
+Linear ramp from 0 to 1 between -Δy/2 and +Δy/2.
+
+For example:
+
+y < y₀           => ramp = 0
+y₀ < y < y₀ + Δy => ramp = y / Δy
+y > y₀ + Δy      => ramp = 1
+"""
+function ramp(λ, φ, Δ)
+    gradient == "λ" && return min(max(0, λ / Δ + 1/2), 1)
+    gradient == "φ" && return min(max(0, (φ - 45) / Δ + 1/2), 1)
+end
+
+# Parameters
+N² = 4e-6 # [s⁻²] buoyancy frequency / stratification
+M² = 8e-8 # [s⁻²] horizontal buoyancy gradient
+
+Δφ = 1 # degree
+Δz = 100
+
+Δc = 100kilometers * 2Δφ
+Δb = 100kilometers * Δφ * M²
+ϵb = 1e-2 * Δb # noise amplitude
+
+bᵢ(λ, φ, z) = N² * z + Δb * ramp(λ, φ, Δφ)
+cᵢ(λ, φ, z) = exp(-φ^2 / 2Δc^2) * exp(-(z + Lz/4)^2 / 2Δz^2)
+
+set!(model, b=bᵢ, c=cᵢ)
+
+#####
+##### Simulation building
+#####
+
+simulation = Simulation(model; Δt, stop_time)
+
+# add timestep wizard callback
+wizard = TimeStepWizard(cfl=0.1, max_change=1.1, max_Δt=Δt)
+simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(20))
+
+# add progress callback
+wall_clock = [time_ns()]
+
+function print_progress(sim)
+    @printf("[%05.2f%%] i: %d, t: %s, wall time: %s, max(u): (%6.3e, %6.3e, %6.3e) m/s, next Δt: %s\n",
+            100 * (sim.model.clock.time / sim.stop_time),
+            sim.model.clock.iteration,
+            prettytime(sim.model.clock.time),
+            prettytime(1e-9 * (time_ns() - wall_clock[1])),
+            maximum(abs, sim.model.velocities.u),
+            maximum(abs, sim.model.velocities.v),
+            maximum(abs, sim.model.velocities.w),
+            prettytime(sim.Δt))
+
+    wall_clock[1] = time_ns()
+    
+    return nothing
+end
+
+simulation.callbacks[:print_progress] = Callback(print_progress, IterationInterval(20))
+
+simulation.output_writers[:fields] = JLD2OutputWriter(model, merge(model.velocities, model.tracers),
+                                                      schedule = TimeInterval(save_fields_interval),
+                                                      filename = filename * "_fields",
+                                                      overwrite_existing = true)
+
+@info "Running the simulation..."
+
+run!(simulation)
+
+@info "Simulation completed in " * prettytime(simulation.run_wall_time)
+
+#####
+##### Visualize
+#####
+
+fig = Figure(resolution = (1400, 700))
+
+filepath = filename * "_fields.jld2"
+
+ut = FieldTimeSeries(filepath, "u")
+bt = FieldTimeSeries(filepath, "b")
+ct = FieldTimeSeries(filepath, "c")
+
+# Build coordinates, rescaling the vertical coordinate
+x, y, z = nodes((Center, Center, Center), grid)
+
+#####
+##### Plot buoyancy...
+#####
+
+times = bt.times
+Nt = length(times)
+
+if gradient == "φ" # average in x
+    un(n) = interior(mean(ut[n], dims=1), 1, :, :)
+    bn(n) = interior(mean(bt[n], dims=1), 1, :, :)
+    cn(n) = interior(mean(ct[n], dims=1), 1, :, :)
+else # average in y
+    un(n) = interior(mean(ut[n], dims=2), :, 1, :)
+    bn(n) = interior(mean(bt[n], dims=2), :, 1, :)
+    cn(n) = interior(mean(ct[n], dims=2), :, 1, :)
+end
+
+@show min_c = 0
+@show max_c = 1
+@show max_u = maximum(abs, un(Nt))
+min_u = - max_u
+
+axu = Axis(fig[2, 1], xlabel="$gradient (deg)", ylabel="z (m)", title="Zonal velocity")
+axc = Axis(fig[3, 1], xlabel="$gradient (deg)", ylabel="z (m)", title="Tracer concentration")
+slider = Slider(fig[4, 1:2], range=1:Nt, startvalue=1)
+n = slider.value
+
+u = @lift un($n)
+b = @lift bn($n)
+c = @lift cn($n)
+
+hm = heatmap!(axu, y, z, u, colorrange=(min_u, max_u), colormap=:balance)
+contour!(axu, y, z, b, levels = 25, color=:black, linewidth=2)
+cb = Colorbar(fig[2, 2], hm)
+
+hm = heatmap!(axc, y, z, c, colorrange=(0, 0.5), colormap=:speed)
+contour!(axc, y, z, b, levels = 25, color=:black, linewidth=2)
+cb = Colorbar(fig[3, 2], hm)
+
+title_str = @lift "Baroclinic adjustment with GM at t = " * prettytime(times[$n])
+ax_t = fig[1, 1:2] = Label(fig, title_str)
+
+display(fig)
+
+record(fig, filename * ".mp4", 1:Nt, framerate=8) do i
+    @info "Plotting frame $i of $Nt"
+    n[] = i
+end
+


### PR DESCRIPTION
This PR refactors the calculation of `isopycnal_rotation_components` to _actually_ use the "Cox stencil" described by [Griffies et al 1998](https://journals.ametsoc.org/view/journals/phoc/28/5/1520-0485_1998_028_0805_idiazc_2.0.co_2.xml).

~~It looks to me like MITgcm uses this so-called anti-Cox stencil.~~ It looks like MITgcm uses the Cox stencil. For example, when calculating the "Gradient of Sigma at rVel points" --- which appears in `isopycnal_rotation_tensor_xz_ccf` --- MITgcm uses

https://github.com/MITgcm/MITgcm/blob/9bcb4977016b9cc234328aa357b105d227417e43/pkg/gmredi/gmredi_calc_tensor.F#L712

which reconstructs the x-component of the density gradient by _averaging the gradient_ (with a four point average). On the other hand, we use

https://github.com/CliMA/Oceananigans.jl/blob/001ec56debf0447103d9b75c81de4036a8d6a94a/src/TurbulenceClosures/isopycnal_rotation_tensor_components.jl#L68

which instead computes the _gradient of the average_ (first by averaging with 4 points, then calculating the gradient of that).

~~But Griffies 1998 describers the Cox87 discretization as~~ EDIT: we were confused by Griffies' notation.

NOW, this PR changes all the buoyancy gradient calculations so they are similar to MITgcm (average of the gradient) --- the "actually-Cox stencil". We'll see what that does.

