### PR TITLE
Remove redundant definition of `diffusive_flux_z` for divergence damping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.75.2"
+version = "0.75.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
@@ -189,7 +189,6 @@ const AIDorAVD = Union{AID, AVD}
 
 @inline diffusive_flux_x(i, j, k, grid, ::ADD, K, ::Val, args...) = zero(eltype(grid))
 @inline diffusive_flux_y(i, j, k, grid, ::ADD, K, ::Val, args...) = zero(eltype(grid))
-@inline diffusive_flux_z(i, j, k, grid, ::ADD, K, ::Val, args...) = zero(eltype(grid))
 
 #####
 ##### Zero out not used fluxes


### PR DESCRIPTION
This emits a warning when Oceananigans is compiled:

```
WARNING: Method definition diffusive_flux_z(Any, Any, Any, Any, Oceananigans.TurbulenceClosures.AbstractScalarDiffusivity{var"#s139", var"#s138"} where var"#s138"<:Oceananigans.TurbulenceClosures.HorizontalDivergenceFormulation where var"#s139", Any, Base.Val{x} where x, Any...) in module TurbulenceClosures at /Users/gregorywagner/Projects/Oceananigans.jl/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl:192 overwritten at /Users/gregorywagner/Projects/Oceananigans.jl/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl:204.
  ** incremental compilation may be fatally broken for this module **
```