### PR TITLE
Biharmonic divergence damping

### DIFF
--- a/src/TurbulenceClosures/abstract_scalar_biharmonic_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_scalar_biharmonic_diffusivity_closure.jl
@@ -31,6 +31,7 @@ const ccc = (Center(), Center(), Center())
 
 const AIBD = AbstractScalarBiharmonicDiffusivity{<:ThreeDimensionalFormulation}
 const AHBD = AbstractScalarBiharmonicDiffusivity{<:HorizontalFormulation}
+const ADBD = AbstractScalarBiharmonicDiffusivity{<:HorizontalDivergenceFormulation}
 const AVBD = AbstractScalarBiharmonicDiffusivity{<:VerticalFormulation}
 
 @inline viscous_flux_ux(i, j, k, grid, clo::AIBD, K, U, C, clk, b) = + ν_σᶜᶜᶜ(i, j, k, grid, clo, K, clk, ∂xᶜᶜᶜ, biharmonic_mask_x, ∇²ᶠᶜᶜ, U.u)
@@ -52,6 +53,9 @@ const AVBD = AbstractScalarBiharmonicDiffusivity{<:VerticalFormulation}
 @inline viscous_flux_vz(i, j, k, grid, clo::AVBD, K, U, C, clk, b) = + ν_σᶜᶠᶠ(i, j, k, grid, clo, K, clk, biharmonic_mask_z, ∂zᶜᶠᶠ, ∂²zᶜᶠᶜ, U.v)
 @inline viscous_flux_wz(i, j, k, grid, clo::AVBD, K, U, C, clk, b) = + ν_σᶜᶜᶜ(i, j, k, grid, clo, K, clk, ∂zᶜᶜᶜ, biharmonic_mask_z, ∂²zᶜᶜᶠ, U.w)
 
+@inline viscous_flux_ux(i, j, k, grid, clo::ADBD, K, U, C, clk, b) = + ν_σᶜᶜᶜ(i, j, k, grid, clo, K, clk, δ★ᶜᶜᶜ, U.u, U.v)   
+@inline viscous_flux_vy(i, j, k, grid, clo::ADBD, K, U, C, clk, b) = + ν_σᶜᶜᶜ(i, j, k, grid, clo, K, clk, δ★ᶜᶜᶜ, U.u, U.v)
+
 #####
 ##### Diffusive fluxes
 #####
@@ -62,23 +66,6 @@ const AVBD = AbstractScalarBiharmonicDiffusivity{<:VerticalFormulation}
 @inline diffusive_flux_x(i, j, k, grid, clo::AHBD, K, ::Val{id}, U, C, clk, b) where id = κ_σᶠᶜᶜ(i, j, k, grid, clo, K, Val(id), clk, biharmonic_mask_x, ∂x_∇²h_cᶠᶜᶜ, C[id])
 @inline diffusive_flux_y(i, j, k, grid, clo::AHBD, K, ::Val{id}, U, C, clk, b) where id = κ_σᶜᶠᶜ(i, j, k, grid, clo, K, Val(id), clk, biharmonic_mask_y, ∂y_∇²h_cᶜᶠᶜ, C[id])
 @inline diffusive_flux_z(i, j, k, grid, clo::AVBD, K, ::Val{id}, U, C, clk, b) where id = κ_σᶜᶜᶠ(i, j, k, grid, clo, K, Val(id), clk, biharmonic_mask_z, ∂³zᶜᶜᶠ, C[id])
-
-#####
-##### Zero out not used fluxes
-#####
-
-for (dir, closure) in zip((:x, :y, :z), (:AVBD, :AVBD, :AHBD))
-    diffusive_flux = Symbol(:diffusive_flux_, dir)
-    viscous_flux_u = Symbol(:viscous_flux_u, dir)
-    viscous_flux_v = Symbol(:viscous_flux_v, dir)
-    viscous_flux_w = Symbol(:viscous_flux_w, dir)
-    @eval begin
-        @inline $diffusive_flux(i, j, k, grid, closure::$closure, args...) = zero(eltype(grid))
-        @inline $viscous_flux_u(i, j, k, grid, closure::$closure, args...) = zero(eltype(grid))
-        @inline $viscous_flux_v(i, j, k, grid, closure::$closure, args...) = zero(eltype(grid))
-        @inline $viscous_flux_w(i, j, k, grid, closure::$closure, args...) = zero(eltype(grid))
-    end
-end
 
 #####
 ##### Biharmonic-specific viscous operators

--- a/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
@@ -139,6 +139,23 @@ const C = Center
 #####
 ##### Stress divergences
 #####
+
+#####
+##### Fallback: flux = 0
+#####
+
+for dir in (:x, :y, :z)
+    diffusive_flux = Symbol(:diffusive_flux_, dir)
+    viscous_flux_u = Symbol(:viscous_flux_u, dir)
+    viscous_flux_v = Symbol(:viscous_flux_v, dir)
+    viscous_flux_w = Symbol(:viscous_flux_w, dir)
+    @eval begin
+        @inline $diffusive_flux(i, j, k, grid, args...) = zero(grid)
+        @inline $viscous_flux_u(i, j, k, grid, args...) = zero(grid)
+        @inline $viscous_flux_v(i, j, k, grid, args...) = zero(grid)
+        @inline $viscous_flux_w(i, j, k, grid, args...) = zero(grid)
+    end
+end
     
 const AID = AbstractScalarDiffusivity{<:Any, <:ThreeDimensionalFormulation}
 const AHD = AbstractScalarDiffusivity{<:Any, <:HorizontalFormulation}
@@ -171,11 +188,6 @@ const AVD = AbstractScalarDiffusivity{<:Any, <:VerticalFormulation}
 @inline viscous_flux_ux(i, j, k, grid, closure::ADD, K, U, C, clock, b) = - ν_δᶜᶜᶜ(i, j, k, grid, closure, K, clock, U.u, U.v)
 @inline viscous_flux_vy(i, j, k, grid, closure::ADD, K, U, C, clock, b) = - ν_δᶜᶜᶜ(i, j, k, grid, closure, K, clock, U.u, U.v)
 
-@inline viscous_flux_uy(i, j, k, grid, closure::ADD, args...) = zero(eltype(grid))
-@inline viscous_flux_vx(i, j, k, grid, closure::ADD, args...) = zero(eltype(grid))
-@inline viscous_flux_wx(i, j, k, grid, closure::ADD, args...) = zero(eltype(grid))
-@inline viscous_flux_wy(i, j, k, grid, closure::ADD, args...) = zero(eltype(grid))
-
 #####
 ##### Diffusive fluxes
 #####
@@ -186,26 +198,6 @@ const AIDorAVD = Union{AID, AVD}
 @inline diffusive_flux_x(i, j, k, grid, cl::AIDorAHD, K, ::Val{id}, U, C, clk, b) where id = - κᶠᶜᶜ(i, j, k, grid, cl, K, Val(id), clk) * ∂xᶠᶜᶜ(i, j, k, grid, C[id])
 @inline diffusive_flux_y(i, j, k, grid, cl::AIDorAHD, K, ::Val{id}, U, C, clk, b) where id = - κᶜᶠᶜ(i, j, k, grid, cl, K, Val(id), clk) * ∂yᶜᶠᶜ(i, j, k, grid, C[id])
 @inline diffusive_flux_z(i, j, k, grid, cl::AIDorAVD, K, ::Val{id}, U, C, clk, b) where id = - κᶜᶜᶠ(i, j, k, grid, cl, K, Val(id), clk) * ∂zᶜᶜᶠ(i, j, k, grid, C[id])
-
-@inline diffusive_flux_x(i, j, k, grid, ::ADD, K, ::Val, args...) = zero(eltype(grid))
-@inline diffusive_flux_y(i, j, k, grid, ::ADD, K, ::Val, args...) = zero(eltype(grid))
-
-#####
-##### Zero out not used fluxes
-#####
-
-for (dir, Clo) in zip((:x, :y, :z, :z), (:AVD, :AVD, :AHD, :ADD))
-    diffusive_flux = Symbol(:diffusive_flux_, dir)
-    viscous_flux_u = Symbol(:viscous_flux_u, dir)
-    viscous_flux_v = Symbol(:viscous_flux_v, dir)
-    viscous_flux_w = Symbol(:viscous_flux_w, dir)
-    @eval begin
-        @inline $diffusive_flux(i, j, k, grid, closure::$Clo, K, ::Val, args...) = zero(eltype(grid))
-        @inline $viscous_flux_u(i, j, k, grid, closure::$Clo, args...) = zero(eltype(grid))
-        @inline $viscous_flux_v(i, j, k, grid, closure::$Clo, args...) = zero(eltype(grid))
-        @inline $viscous_flux_w(i, j, k, grid, closure::$Clo, args...) = zero(eltype(grid))
-    end
-end
 
 #####
 ##### Support for VerticallyImplicit


### PR DESCRIPTION
This PR introduces a "Biharmonic" divergence damping.

In line with #2440, `ScalarBiharmonicDiffusivity(HorizontalDivergenceFormulation(), ν = 1)`, is a biharmonic diffusion that acts only on the divergent component of the horizontal velocity field.

This allows us to diffuse the remaining horizontally rotational component through the use of a WENO scheme (which does not act on vertical motions, hence does not dissipate noise generated through divergent motions)