### PR TITLE
Permute PencilFFT temporary array dimensions

### DIFF
--- a/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
+++ b/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
@@ -17,12 +17,7 @@ import Oceananigans: fields, prognostic_fields
 
 function PressureSolver(arch::MultiArch, local_grid::RegRectilinearGrid)
     global_grid = reconstruct_global_grid(local_grid)
-    if arch.ranks[1] == 1 # we would have to allow different settings 
-        return DistributedFFTBasedPoissonSolver(global_grid, local_grid)
-    else
-        @warn "A Distributed NonhydrostaticModel is allowed only when the x-direction is not parallelized"
-        return nothing
-    end
+    return DistributedFFTBasedPoissonSolver(global_grid, local_grid)
 end
 
 PressureSolver(arch, grid::RegRectilinearGrid)  = FFTBasedPoissonSolver(grid)

--- a/src/Models/NonhydrostaticModels/solve_for_pressure.jl
+++ b/src/Models/NonhydrostaticModels/solve_for_pressure.jl
@@ -12,6 +12,11 @@ using Oceananigans.Distributed: DistributedFFTBasedPoissonSolver
     @inbounds rhs[i, j, k] = divᶜᶜᶜ(i, j, k, grid, U★.u, U★.v, U★.w) / Δt
 end
 
+@kernel function calculate_permuted_pressure_source_term_fft_based_solver!(rhs, grid, Δt, U★)
+    i, j, k = @index(Global, NTuple)
+    @inbounds rhs[k, i, j] = divᶜᶜᶜ(i, j, k, grid, U★.u, U★.v, U★.w) / Δt
+end
+
 @kernel function calculate_pressure_source_term_fourier_tridiagonal_solver!(rhs, grid, Δt, U★)
     i, j, k = @index(Global, NTuple)
     @inbounds rhs[i, j, k] = Δzᶜᶜᶜ(i, j, k, grid) * divᶜᶜᶜ(i, j, k, grid, U★.u, U★.v, U★.w) / Δt
@@ -26,7 +31,7 @@ function solve_for_pressure!(pressure, solver::DistributedFFTBasedPoissonSolver,
     arch = architecture(solver)
     grid = solver.local_grid
 
-    rhs_event = launch!(arch, grid, :xyz, calculate_pressure_source_term_fft_based_solver!,
+    rhs_event = launch!(arch, grid, :xyz, calculate_permuted_pressure_source_term_fft_based_solver!,
                         rhs, grid, Δt, U★, dependencies = device_event(arch))
 
     wait(device(arch), rhs_event)

--- a/src/Models/NonhydrostaticModels/solve_for_pressure.jl
+++ b/src/Models/NonhydrostaticModels/solve_for_pressure.jl
@@ -14,7 +14,7 @@ end
 
 @kernel function calculate_permuted_pressure_source_term_fft_based_solver!(rhs, grid, Δt, U★)
     i, j, k = @index(Global, NTuple)
-    @inbounds rhs[k, i, j] = divᶜᶜᶜ(i, j, k, grid, U★.u, U★.v, U★.w) / Δt
+    @inbounds rhs[k, j, i] = divᶜᶜᶜ(i, j, k, grid, U★.u, U★.v, U★.w) / Δt
 end
 
 @kernel function calculate_pressure_source_term_fourier_tridiagonal_solver!(rhs, grid, Δt, U★)

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -503,7 +503,7 @@ end
             topo = (Periodic, Periodic, Periodic)
             arch = MultiArch(; ranks)
             grid = RectilinearGrid(arch, topology=topo, size=(8, 8, 8), extent=(1, 2, 3))
-            model = NonhydrostaticModel(grid=grid)
+            model = NonhydrostaticModel(; grid)
 
             time_step!(model, 1)
             @test model isa NonhydrostaticModel
@@ -520,7 +520,7 @@ end
         topo = (Periodic, Periodic, Flat)
         arch = MultiArch(ranks=(1, 4, 1), topology = topo)
         grid = RectilinearGrid(arch, topology=topo, size=(8, 8), extent=(1, 2), halo=(3, 3))
-        model = ShallowWaterModel(advection=nothing, grid=grid, gravitational_acceleration=1)
+        model = ShallowWaterModel(; advection=nothing, grid, gravitational_acceleration=1)
 
         set!(model, h=1)
         time_step!(model, 1)

--- a/test/test_distributed_poisson_solvers.jl
+++ b/test/test_distributed_poisson_solvers.jl
@@ -21,12 +21,17 @@ using MPI
 #
 # When running the tests this way, uncomment the following line
 
-MPI.Init()
+#MPI.Init()
 
 # to initialize MPI.
 
 using Oceananigans.Distributed: reconstruct_global_grid
-using Oceananigans.Solvers: copy_real_component!
+
+@kernel function permuted_copy_123_to_321!(permuted_ϕ, ϕ)
+    i, j, k = @index(Global, NTuple)
+    # Note the index permutation
+    @inbounds permuted_ϕ[k, j, i] = ϕ[i, j, k]
+end
 
 function random_divergent_source_term(grid)
     # Generate right hand side from a random (divergent) velocity field.
@@ -59,27 +64,28 @@ function divergence_free_poisson_solution_triply_periodic(grid_points, ranks)
     topo = (Periodic, Periodic, Periodic)
     arch = MultiArch(CPU(), ranks=ranks, topology = topo)
     local_grid = RectilinearGrid(arch, topology=topo, size=grid_points, extent=(1, 2, 3))
+
+    bcs = FieldBoundaryConditions(local_grid, (Center, Center, Center))
+    bcs = inject_halo_communication_boundary_conditions(bcs, arch.local_rank, arch.connectivity)
+
+    # The test will solve for ϕ, then compare R to ∇²ϕ.
+    ϕ   = CenterField(local_grid, boundary_conditions=bcs)
+    ∇²ϕ = CenterField(local_grid, boundary_conditions=bcs)
+    R   = random_divergent_source_term(local_grid)
     
     global_grid = reconstruct_global_grid(local_grid)
     solver = DistributedFFTBasedPoissonSolver(global_grid, local_grid)
 
-    R = random_divergent_source_term(local_grid)
-    first(solver.storage) .= R
-
+    # Solve it
     ϕc = first(solver.storage)
-    solve!(ϕc, solver)
 
-    p_bcs = FieldBoundaryConditions(local_grid, (Center, Center, Center))
-    p_bcs = inject_halo_communication_boundary_conditions(p_bcs, arch.local_rank, arch.connectivity)
+    # first(solver.storage) has the permuted layout (z, y, x) compared to Oceananigans data with layout (x, y, z).
+    event = launch!(arch, local_grid, :xyz, permuted_copy_123_to_321!, ϕc, R, dependencies=device_event(arch))
+    wait(device(arch), event)
 
-    ϕ   = CenterField(local_grid, boundary_conditions=p_bcs) # "pressure"
-    ∇²ϕ = CenterField(local_grid, boundary_conditions=p_bcs)
+    solve!(ϕ, solver)
 
-    copy_event = launch!(arch, local_grid, :xyz,
-                         copy_real_component!, ϕ, first(solver.storage),
-                         dependencies=device_event(arch))
-    wait(device(arch), copy_event)
-
+    # "Recompute" ∇²ϕ
     compute_∇²!(∇²ϕ, ϕ, arch, local_grid)
 
     return R ≈ interior(∇²ϕ)
@@ -90,5 +96,7 @@ end
     @test divergence_free_poisson_solution_triply_periodic((16, 16, 1), (1, 4, 1))
     @test divergence_free_poisson_solution_triply_periodic((44, 44, 1), (1, 4, 1))
     @test divergence_free_poisson_solution_triply_periodic((44, 16, 1), (1, 4, 1))
+    @test divergence_free_poisson_solution_triply_periodic((44, 16, 1), (2, 2, 1))
     @test divergence_free_poisson_solution_triply_periodic((16, 44, 1), (1, 4, 1))
 end
+

--- a/test/test_distributed_poisson_solvers.jl
+++ b/test/test_distributed_poisson_solvers.jl
@@ -21,7 +21,7 @@ using MPI
 #
 # When running the tests this way, uncomment the following line
 
-#MPI.Init()
+MPI.Init()
 
 # to initialize MPI.
 
@@ -93,10 +93,10 @@ end
 
 @testset "Distributed FFT-based Poisson solver" begin
     @info "  Testing distributed FFT-based Poisson solver..."
-    @test divergence_free_poisson_solution_triply_periodic((16, 16, 1), (1, 4, 1))
-    @test divergence_free_poisson_solution_triply_periodic((44, 44, 1), (1, 4, 1))
-    @test divergence_free_poisson_solution_triply_periodic((44, 16, 1), (1, 4, 1))
-    @test divergence_free_poisson_solution_triply_periodic((44, 16, 1), (2, 2, 1))
-    @test divergence_free_poisson_solution_triply_periodic((16, 44, 1), (1, 4, 1))
+    @test divergence_free_poisson_solution_triply_periodic((16, 16, 8), (1, 4, 1))
+    @test divergence_free_poisson_solution_triply_periodic((44, 44, 8), (1, 4, 1))
+    @test divergence_free_poisson_solution_triply_periodic((44, 16, 8), (1, 4, 1))
+    @test divergence_free_poisson_solution_triply_periodic((44, 16, 8), (2, 2, 1))
+    @test divergence_free_poisson_solution_triply_periodic((16, 44, 8), (1, 4, 1))
 end
 


### PR DESCRIPTION
This PR permutes the dimensions of the _temporary array_ that's used by the `DistributedFFTBasedPoissonSolver` (and `PencilFFTs`) compared to Oceananigans data layout to look like (z, x, y). This permits "pencil" decompositions in x, y via PencilFFTs, which cannot partition along the first dimension.

This PR should probably expand the tests to cover these cases, which weren't tested previously because it wasn't supported.

Co-developed with @johnryantaylor.