### PR TITLE
[WIP] Extend MultiRegion to NonhydrostaticModel

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
@@ -111,7 +111,7 @@ function implicit_free_surface_step!(free_surface::ImplicitFreeSurface, model, �
     arch   = model.architecture
  
     @apply_regionally prognostic_field_events = wait_velocity_event(arch,  prognostic_field_events)
-    fill_halo_regions!(model.velocities)
+    fill_halo_regions!(model.velocities, model.clock, fields(model))
 
     # Compute right hand side of implicit free surface equation
     @apply_regionally local_compute_integrated_volume_flux!(∫ᶻQ, model.velocities, arch)

--- a/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
+++ b/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
@@ -7,6 +7,7 @@ using DocStringExtensions
 using KernelAbstractions: @index, @kernel, Event, MultiEvent
 using KernelAbstractions.Extras.LoopInfo: @unroll
 
+using Oceananigans.Utils
 using Oceananigans.Utils: launch!
 using Oceananigans.Grids
 using Oceananigans.Solvers

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -141,15 +141,7 @@ function NonhydrostaticModel(;    grid,
     # Adjust halos when the advection scheme or turbulence closure requires it.
     # Note that halos are isotropic by default; however we respect user-input here
     # by adjusting each (x, y, z) halo individually.
-    user_halo = grid.Hx, grid.Hy, grid.Hz
-    required_halo = Hx, Hy, Hz = inflate_halo_size(user_halo..., topology(grid), advection, closure)
-    if any(user_halo .< required_halo) # Replace grid
-        @warn "Inflating model grid halo size to ($Hx, $Hy, $Hz) and recreating grid. " *
-              "The model grid will be different from the input grid. To avoid this warning, " *
-              "pass halo=($Hx, $Hy, $Hz) when constructing the grid."
-
-        grid = with_halo((Hx, Hy, Hz), grid)
-    end
+    @apply_regionally validate_model_halo(grid, advection, closure)
 
     # Collect boundary conditions for all model prognostic fields and, if specified, some model
     # auxiliary fields. Boundary conditions are "regularized" based on the _name_ of the field:
@@ -225,3 +217,15 @@ function extract_boundary_conditions(field_tuple::NamedTuple)
 end
 
 extract_boundary_conditions(field::Field) = field.boundary_conditions
+
+
+function validate_model_halo(grid, advection, closure)
+    user_halo = halo_size(grid)
+    required_halo = inflate_halo_size(user_halo..., topology(grid),
+                                      advection,
+                                      closure)
+  
+    any(user_halo .< required_halo) &&
+        throw(ArgumentError("The grid halo $user_halo must be larger than $required_halo."))
+end
+  

--- a/src/MultiRegion/multi_region_abstract_operations.jl
+++ b/src/MultiRegion/multi_region_abstract_operations.jl
@@ -12,7 +12,7 @@ Base.size(f::MultiRegionAbstractOperation) = size(getregion(f.grid, 1))
 
 @inline isregional(f::MultiRegionAbstractOperation) = true
 @inline devices(f::MultiRegionAbstractOperation)    = devices(f.grid)
-sync_all_devices!(f::MultiRegionAbstractOperation)  = sync_all_devices!(devices(f.grid))
+@inline sync_all_devices!(f::MultiRegionAbstractOperation)  = sync_all_devices!(devices(f.grid))
 
 @inline switch_device!(f::MultiRegionAbstractOperation, d) = switch_device!(f.grid, d)
 @inline getdevice(f::MultiRegionAbstractOperation, d)      = getdevice(f.grid, d)

--- a/src/MultiRegion/multi_region_models.jl
+++ b/src/MultiRegion/multi_region_models.jl
@@ -11,8 +11,9 @@ import Oceananigans.Diagnostics: accurate_cell_advection_timescale
 import Oceananigans.Advection: WENO5
 import Oceananigans.Models.HydrostaticFreeSurfaceModels: build_implicit_step_solver, validate_tracer_advection
 import Oceananigans.TurbulenceClosures: implicit_diffusion_solver
+import Oceananigans.Models.NonhydrostaticModels: PressureSolver
 
-const MultiRegionModel = HydrostaticFreeSurfaceModel{<:Any, <:Any, <:AbstractArchitecture, <:Any, <:MultiRegionGrid}
+const MultiRegionModel = Union{HydrostaticFreeSurfaceModel{<:Any, <:Any, <:AbstractArchitecture, <:Any, <:MultiRegionGrid},  NonhydrostaticModel{<:Any, <:Any, <:AbstractArchitecture, <:MultiRegionGrid}}
 
 # Utility to generate the inputs to complex `getregion`s
 function getregionalproperties(T, inner=true) 
@@ -26,6 +27,7 @@ function getregionalproperties(T, inner=true)
 end
 
 Types = (:HydrostaticFreeSurfaceModel,
+         :NonhydrostaticModel,
          :ImplicitFreeSurface,
          :ExplicitFreeSurface,
          :QuasiAdamsBashforth2TimeStepper,
@@ -44,6 +46,8 @@ end
 @inline devices(pv::PrescribedVelocityFields)    = devices(pv[findfirst(isregional, (pv.u, pv.v, pv.w))])
 
 validate_tracer_advection(tracer_advection::MultiRegionObject, grid::MultiRegionGrid) = tracer_advection, NamedTuple()
+
+PressureSolver(arch, ::MultiRegionGrid) = nothing
 
 @inline isregional(mrm::MultiRegionModel)        = true
 @inline devices(mrm::MultiRegionModel)           = devices(mrm.grid)


### PR DESCRIPTION
Now that finally `MultiRegion` is merged we can implement the single node multi GPU paradigm also in the Nonhydrostatic model

cc @tomchor 

The work can be divided in three tasks

- [x] Adapt the NonhydrostaticModel to accept a `MultiRegionGrid`. i.e., wrap local function calls in `@apply_regionally` and extend global methods in `multi_region_models.jl`. 
- [ ] Expose the parallelism in `RungeKutta3` timestepper and in the `update_state!` method. This is achieved by lumping together local function calls (all possible kernel calls such as calculate tendencies, rk substeps, etc) in outer functions and wrapping everything in `@apply_regionally`
- [ ] Implement a multi GPU pressure solver. This can be achieved in a couple of different ways. (1) transpose local memory and perform one direction FFT at the time (at we do now in the `Distributed` module through PencilArrays). (2) exploit the multi GPU capabilities of cuda through the cufftxt library that can perform single node distributed FFT to up to 16 GPUs. (3) Allocate storage and plan in Unified memory and perform the FFT in only one GPU. Ideally we would implement (3) only if we are desperate. The best solution would be to go with method (2), as (1) incurs in hefty memory transfer costs (I am not sure as to how the cufftxt implements multi GPU FFT though)

The first two tasks are quite trivial so I think the bulk of the work will be on implementing the pressure solver