### PR TITLE
[WIP] Model allocation interface and model-wise buffer communication

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/materialize_prognostic_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/materialize_prognostic_fields.jl
@@ -1,0 +1,2 @@
+
+materialize_prognostic_fields(model::HydrostaticFreeSurfaceModel, tracer_names) = nothing


### PR DESCRIPTION
This PR introduces the idea expressed in issue #2509 as well as introducing two unique buffers for _prognostic_ and _diagnostic_ fields which allow the parallelization of memory transfer