### PR TITLE
Make JLD2 look before leaping

### DIFF
--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -255,7 +255,7 @@ function write_output!(writer::JLD2OutputWriter, model)
 
     # Look before you leap, as they say
     jldopen(path, "r+"; writer.jld2_kw...) do file
-        iteration_exists = string(current_iteration) ∈ keys(file["timeseries/t"])
+        iteration_exists = "t" ∈ keys(file["timeseries"]) && string(current_iteration) ∈ keys(file["timeseries/t"])
     end
 
     if iteration_exists

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -254,7 +254,7 @@ function write_output!(writer::JLD2OutputWriter, model)
     iteration_exists = false
 
     # Look before you leap, as they say
-    jldopen(path, "r+"; kwargs...) do file
+    jldopen(path, "r+"; writers.jld2_kw...) do file
         iteration_exists = string(current_iteration) ∈ keys(file["timeseries/t"])
     end
 

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -254,7 +254,7 @@ function write_output!(writer::JLD2OutputWriter, model)
     iteration_exists = false
 
     # Look before you leap, as they say
-    jldopen(path, "r+"; writers.jld2_kw...) do file
+    jldopen(path, "r+"; writer.jld2_kw...) do file
         iteration_exists = string(current_iteration) ∈ keys(file["timeseries/t"])
     end
 


### PR DESCRIPTION
This PR "enhances" `JLD2OutputWriter` so it first _checks_ whether an iteration number exists in the file it's about to save to. If the iteration number does exist, it emits warning, but does not fail. Previously, it would fail. This helps when restoring a simulation from a checkpoint when output is saved at higher frequency than the simulation is checkpointed.

TODO: probably test makes sense.