### PR TITLE
Fixes `WENO5(grid=grid)` for immersed boundary grids

### DIFF
--- a/src/Advection/weno_fifth_order.jl
+++ b/src/Advection/weno_fifth_order.jl
@@ -3,7 +3,7 @@
 #####
 
 using OffsetArrays
-using Oceananigans.Grids: with_halo
+using Oceananigans.Grids: with_halo, return_metrics
 using Oceananigans.Architectures: arch_array, architecture
 using KernelAbstractions.Extras.LoopInfo: @unroll
 using Adapt
@@ -211,9 +211,6 @@ function compute_stretched_weno_coefficients(grid, stretched_smoothness, FT)
     return (coeff_xᶠᵃᵃ , coeff_xᶜᵃᵃ , coeff_yᵃᶠᵃ , coeff_yᵃᶜᵃ , coeff_zᵃᵃᶠ , coeff_zᵃᵃᶜ ,
             smooth_xᶠᵃᵃ, smooth_xᶜᵃᵃ, smooth_yᵃᶠᵃ, smooth_yᵃᶜᵃ, smooth_zᵃᵃᶠ, smooth_zᵃᵃᶜ)
 end
-
-return_metrics(::LatitudeLongitudeGrid) = (:λᶠᵃᵃ, :λᶜᵃᵃ, :φᵃᶠᵃ, :φᵃᶜᵃ, :zᵃᵃᶠ, :zᵃᵃᶜ)
-return_metrics(::RectilinearGrid)       = (:xᶠᵃᵃ, :xᶜᵃᵃ, :yᵃᶠᵃ, :yᵃᶜᵃ, :zᵃᵃᶠ, :zᵃᵃᶜ)
 
 # Flavours of WENO
 const ZWENO                   = WENO5{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, true}

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -571,6 +571,16 @@ function allocate_metrics(grid::LatitudeLongitudeGrid)
     return Δxᶠᶜ, Δxᶜᶠ, Δxᶠᶠ, Δxᶜᶜ, Δyᶠᶜ, Δyᶜᶠ, Azᶠᶜ, Azᶜᶠ, Azᶠᶠ, Azᶜᶜ
 end
 
+
+
+#####
+##### Utilities
+#####
+
+return_metrics(::LatitudeLongitudeGrid) = (:λᶠᵃᵃ, :λᶜᵃᵃ, :φᵃᶠᵃ, :φᵃᶜᵃ, :zᵃᵃᶠ, :zᵃᵃᶜ)
+
+
+
 #####
 ##### Get minima of grid
 #####

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -414,6 +414,10 @@ function on_architecture(new_arch::AbstractArchitecture, old_grid::RectilinearGr
                                        new_properties...)
 end
 
+
+return_metrics(::RectilinearGrid) = (:xᶠᵃᵃ, :xᶜᵃᵃ, :yᵃᶠᵃ, :yᵃᶜᵃ, :zᵃᵃᶠ, :zᵃᵃᶜ)
+
+
 #####
 ##### Get minima of grid
 #####

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -259,8 +259,6 @@ for (locate_coeff, loc) in ((:κᶠᶜᶜ, (f, c, c)),
     end
 end
 
-
-
 include("immersed_grid_metrics.jl")
 include("grid_fitted_immersed_boundaries.jl")
 include("conditional_fluxes.jl")

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -66,7 +66,8 @@ import Oceananigans.Advection:
     _advective_momentum_flux_Ww,
     _advective_tracer_flux_x,
     _advective_tracer_flux_y,
-    _advective_tracer_flux_z
+    _advective_tracer_flux_z,
+    return_metrics
 
 import Oceananigans.TurbulenceClosures:
     _viscous_flux_ux,
@@ -258,6 +259,10 @@ for (locate_coeff, loc) in ((:κᶠᶜᶜ, (f, c, c)),
             ifelse(inactive_node(loc..., i, j, k, ibg), $locate_coeff(i, j, k, ibg.underlying_grid, coeff), zero(FT))
     end
 end
+
+
+return_metrics(grid::ImmersedBoundaryGrid) = return_metrics(grid.underlying_grid)
+
 
 include("immersed_grid_metrics.jl")
 include("grid_fitted_immersed_boundaries.jl")

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -51,7 +51,7 @@ import Oceananigans.Grids:
         
 import Oceananigans.Grids: architecture, on_architecture, with_halo
 import Oceananigans.Grids: xnode, ynode, znode, all_x_nodes, all_y_nodes, all_z_nodes
-import Oceananigans.Grids: inactive_cell
+import Oceananigans.Grids: inactive_cell, return_metrics
 import Oceananigans.Coriolis: φᶠᶠᵃ
 
 import Oceananigans.Advection:
@@ -66,8 +66,7 @@ import Oceananigans.Advection:
     _advective_momentum_flux_Ww,
     _advective_tracer_flux_x,
     _advective_tracer_flux_y,
-    _advective_tracer_flux_z,
-    return_metrics
+    _advective_tracer_flux_z
 
 import Oceananigans.TurbulenceClosures:
     _viscous_flux_ux,

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -51,7 +51,7 @@ import Oceananigans.Grids:
         
 import Oceananigans.Grids: architecture, on_architecture, with_halo
 import Oceananigans.Grids: xnode, ynode, znode, all_x_nodes, all_y_nodes, all_z_nodes
-import Oceananigans.Grids: inactive_cell, return_metrics
+import Oceananigans.Grids: inactive_cell
 import Oceananigans.Coriolis: φᶠᶠᵃ
 
 import Oceananigans.Advection:
@@ -259,8 +259,6 @@ for (locate_coeff, loc) in ((:κᶠᶜᶜ, (f, c, c)),
     end
 end
 
-
-return_metrics(grid::ImmersedBoundaryGrid) = return_metrics(grid.underlying_grid)
 
 
 include("immersed_grid_metrics.jl")

--- a/src/ImmersedBoundaries/immersed_grid_metrics.jl
+++ b/src/ImmersedBoundaries/immersed_grid_metrics.jl
@@ -1,4 +1,5 @@
 using Oceananigans.AbstractOperations: GridMetricOperation
+using Oceananigans.Advection: compute_stretched_weno_coefficients
 
 const c = Center()
 const f = Face()
@@ -31,3 +32,5 @@ end
 @inline Δzᵃᵃᶜ(i, j, k, ibg::IBG) = Δzᵃᵃᶜ(i, j, k, ibg.underlying_grid)
 @inline Δzᵃᵃᶠ(i, j, k, ibg::IBG) = Δzᵃᵃᶠ(i, j, k, ibg.underlying_grid)
 
+
+compute_stretched_weno_coefficients(grid::ImmersedBoundaryGrid; kwargs...) = compute_stretched_weno_coefficients(grid.underlying_grid, kwargs...)

--- a/src/ImmersedBoundaries/immersed_grid_metrics.jl
+++ b/src/ImmersedBoundaries/immersed_grid_metrics.jl
@@ -1,5 +1,7 @@
 using Oceananigans.AbstractOperations: GridMetricOperation
 
+import Oceananigans.Grids: return_metrics, min_Δx, min_Δy, min_Δz
+
 const c = Center()
 const f = Face()
 const IBG = ImmersedBoundaryGrid
@@ -31,3 +33,8 @@ end
 @inline Δzᵃᵃᶜ(i, j, k, ibg::IBG) = Δzᵃᵃᶜ(i, j, k, ibg.underlying_grid)
 @inline Δzᵃᵃᶠ(i, j, k, ibg::IBG) = Δzᵃᵃᶠ(i, j, k, ibg.underlying_grid)
 
+
+return_metrics(grid::ImmersedBoundaryGrid) = return_metrics(grid.underlying_grid)
+min_Δx(grid::ImmersedBoundaryGrid) = min_Δx(grid.underlying_grid)
+min_Δy(grid::ImmersedBoundaryGrid) = min_Δy(grid.underlying_grid)
+min_Δz(grid::ImmersedBoundaryGrid) = min_Δz(grid.underlying_grid)

--- a/src/ImmersedBoundaries/immersed_grid_metrics.jl
+++ b/src/ImmersedBoundaries/immersed_grid_metrics.jl
@@ -1,5 +1,4 @@
 using Oceananigans.AbstractOperations: GridMetricOperation
-using Oceananigans.Advection: compute_stretched_weno_coefficients
 
 const c = Center()
 const f = Face()
@@ -32,5 +31,3 @@ end
 @inline Δzᵃᵃᶜ(i, j, k, ibg::IBG) = Δzᵃᵃᶜ(i, j, k, ibg.underlying_grid)
 @inline Δzᵃᵃᶠ(i, j, k, ibg::IBG) = Δzᵃᵃᶠ(i, j, k, ibg.underlying_grid)
 
-
-compute_stretched_weno_coefficients(grid::ImmersedBoundaryGrid; kwargs...) = compute_stretched_weno_coefficients(grid.underlying_grid, kwargs...)


### PR DESCRIPTION
This PR fixes the following problem:

```julia
julia> using Oceananigans

julia> grid_base = RectilinearGrid(size=(4, 4, 4),
                              x = (0, 1), y=(0, 1),
                              z = (0, 1),
                              halo=(3,3,3),
                              )
4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
├── Periodic x ∈ [0.0, 1.0) regularly spaced with Δx=0.25
├── Periodic y ∈ [0.0, 1.0) regularly spaced with Δy=0.25
└── Bounded  z ∈ [0.0, 1.0] regularly spaced with Δz=0.25

julia> grid = ImmersedBoundaryGrid(grid_base, GridFittedBottom(bathymetry))
4×4×4 ImmersedBoundaryGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo:
├── immersed_boundary: GridFittedBottom{OffsetArrays.OffsetMatrix{Float64, Matrix{Float64}}}
├── underlying_grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
├── Periodic x ∈ [0.0, 1.0) regularly spaced with Δx=0.25
├── Periodic y ∈ [0.0, 1.0) regularly spaced with Δy=0.25
└── Bounded  z ∈ [0.0, 1.0] regularly spaced with Δz=0.25

julia> model = NonhydrostaticModel(grid = grid,
                                   advection = WENO5(grid=grid),
                                  )
┌ Warning: WENO on a curvilinear stretched coordinate is not validated, use at your own risk!!
└ @ Oceananigans.Advection ~/repos/Oceananigans.jl/src/Advection/weno_fifth_order.jl:197
ERROR: MethodError: no method matching return_metrics(::ImmersedBoundaryGrid{Float64, Periodic, Periodic, Bounded, RectilinearGrid{Float64, Periodic, Periodic, Bounded, Float64, Float64, Float64, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}, CPU}, GridFittedBottom{OffsetArrays.OffsetMatrix{Float64, Matrix{Float64}}}, CPU})
Closest candidates are:
  return_metrics(::LatitudeLongitudeGrid) at /home/tomas/repos/Oceananigans.jl/src/Advection/weno_fifth_order.jl:215
  return_metrics(::RectilinearGrid) at /home/tomas/repos/Oceananigans.jl/src/Advection/weno_fifth_order.jl:216
Stacktrace:
 [1] compute_stretched_weno_coefficients(grid::ImmersedBoundaryGrid{Float64, Periodic, Periodic, Bounded, RectilinearGrid{Float64, Periodic, Periodic, Bounded, Float64, Float64, Float64, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}, CPU}, GridFittedBottom{OffsetArrays.OffsetMatrix{Float64, Matrix{Float64}}}, CPU}, stretched_smoothness::Bool, FT::Type)
   @ Oceananigans.Advection ~/repos/Oceananigans.jl/src/Advection/weno_fifth_order.jl:199
 [2] WENO5(FT::DataType; grid::ImmersedBoundaryGrid{Float64, Periodic, Periodic, Bounded, RectilinearGrid{Float64, Periodic, Periodic, Bounded, Float64, Float64, Float64, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}, CPU}, GridFittedBottom{OffsetArrays.OffsetMatrix{Float64, Matrix{Float64}}}, CPU}, coeffs::Nothing, stretched_smoothness::Bool, zweno::Bool, vector_invariant::Nothing)
   @ Oceananigans.Advection ~/repos/Oceananigans.jl/src/Advection/weno_fifth_order.jl:173
 [3] top-level scope
   @ REPL[18]:1
 [4] top-level scope
   @ ~/.julia/packages/CUDA/Uurn4/src/initialization.jl:52
```

Although I'm facing a bit of chicken and egg problem, since ideally I'd fix this in the `Advection/weno_fifth_order.jl` file, but at that point the IBM stuff hasn't been defined. So I'm trying to do it inside `ImmersedBoundaries/immersed_grid_metrics.jl`.