### PR TITLE
Throws error when size of dimension is mismatched when constructing RectilinearGrid

### DIFF
--- a/src/Distributed/distributed_grids.jl
+++ b/src/Distributed/distributed_grids.jl
@@ -1,6 +1,5 @@
 using MPI
 using Oceananigans.Grids: topology, size, halo_size, architecture, pop_flat_elements
-using Oceananigans.Grids: validate_rectilinear_domain, validate_topology
 using Oceananigans.Grids: validate_rectilinear_grid_args, validate_lat_lon_grid_args
 using Oceananigans.Grids: generate_coordinate, with_precomputed_metrics
 using Oceananigans.Grids: cpu_face_constructor_x, cpu_face_constructor_y, cpu_face_constructor_z

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -281,7 +281,7 @@ function validate_rectilinear_grid_args(topology, size, halo, FT, extent, x, y, 
     halo = validate_halo(TX, TY, TZ, halo)
 
     # Validate the rectilinear domain
-    x, y, z = validate_rectilinear_domain(TX, TY, TZ, FT, extent, x, y, z)
+    x, y, z = validate_rectilinear_domain(TX, TY, TZ, FT, size, extent, x, y, z)
 
     return TX, TY, TZ, size, halo, x, y, z
 end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -719,7 +719,7 @@ end
 
             # Testing show function
             Nz = 20
-            grid = RectilinearGrid(arch, size=(1, 1, Nz-1), x=(0, 1), y=(0, 1), z=collect(0:Nz).^2)
+            grid = RectilinearGrid(arch, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=collect(0:Nz).^2)
             
             @test try
             CUDA.allowscalar(false)           


### PR DESCRIPTION
Closes https://github.com/CliMA/Oceananigans.jl/issues/2548

Before this PR:

```julia
julia> using Oceananigans

julia> grid = RectilinearGrid(size=(4, 4, 4),
                              x = (0,1), y=(0,1),
                              z = LinRange(0,1,20), 
                              halo=(3,3,3),
                              )
4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
├── Periodic x ∈ [0.0, 1.0)      regularly spaced with Δx=0.25
├── Periodic y ∈ [0.0, 1.0)      regularly spaced with Δy=0.25
└── Bounded  z ∈ [0.0, 0.210526] variably spaced with min(Δz)=0.0526316, max(Δz)=0.0526316

julia> grid.zᵃᵃᶜ
10-element OffsetArray(::Vector{Float64}, -2:7) with eltype Float64 with indices -2:7:
 -0.13157894736842105
 -0.07894736842105263
 -0.02631578947368421
  0.02631578947368421
  0.07894736842105263
  0.13157894736842105
  0.18421052631578946
  0.23684210526315788
  0.2894736842105263
  0.3421052631578947

julia> collect(grid.xᶜᵃᵃ)
10-element Vector{Float64}:
 -0.625
 -0.375
 -0.125
  0.125
  0.375
  0.625
  0.875
  1.125
  1.375
  1.625
```

After this PR:

```julia
julia> using Oceananigans
[ Info: Precompiling Oceananigans [9e8cae18-63c1-5223-a75c-80ca9d6e9a09]
[ Info: Oceananigans will use 6 threads

julia> grid = RectilinearGrid(size=(4, 4, 4),
                              x = (0,1), y=(0,1),
                              z = LinRange(0,1,20), 
                              halo=(3,3,3),
                              )
ERROR: ArgumentError: `length(z)` must be equal to size passed to `size` argument.
Stacktrace:
 [1] validate_dimension_specification(T::Type, ξ::LinRange{Float64}, dir::Symbol, size_dir::Int64, FT::Type)
   @ Oceananigans.Grids ~/repos/Oceananigans.jl/src/Grids/input_validation.jl:108
 [2] validate_rectilinear_domain(TX::Type, TY::Type, TZ::Type, FT::Type, size::Tuple{Int64, Int64, Int64}, extent::Nothing, x::Tuple{Int64, Int64}, y::Tuple{Int64, Int64}, z::LinRange{Float64})
   @ Oceananigans.Grids ~/repos/Oceananigans.jl/src/Grids/input_validation.jl:100
 [3] validate_rectilinear_grid_args(topology::Tuple{DataType, DataType, DataType}, size::Tuple{Int64, Int64, Int64}, halo::Tuple{Int64, Int64, Int64}, FT::Type, extent::Nothing, x::Tuple{Int64, Int64}, y::Tuple{Int64, Int64}, z::LinRange{Float64})
   @ Oceananigans.Grids ~/repos/Oceananigans.jl/src/Grids/rectilinear_grid.jl:284
 [4] RectilinearGrid(architecture::CPU, FT::Type; size::Tuple{Int64, Int64, Int64}, x::Tuple{Int64, Int64}, y::Tuple{Int64, Int64}, z::LinRange{Float64}, halo::Tuple{Int64, Int64, Int64}, extent::Nothing, topology::Tuple{DataType, DataType, DataType})
   @ Oceananigans.Grids ~/repos/Oceananigans.jl/src/Grids/rectilinear_grid.jl:259
 [5] top-level scope
   @ REPL[2]:1
 [6] top-level scope
   @ ~/.julia/packages/CUDA/Uurn4/src/initialization.jl:52
```

I decided to throw an error instead of a warning because I don't think we want the user be able to proceed in a situation like this.