### PR TITLE
Adds `with_halos` to `NetCDFOutputWriter`'s signature call in docstring

### DIFF
--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -138,6 +138,7 @@ end
     NetCDFOutputWriter(model, outputs; filename, schedule
                                           dir = ".",
                                    array_type = Array{Float32},
+                                   with_halos = false,
                                       indices = nothing,
                             global_attributes = Dict(),
                             output_attributes = Dict(),
@@ -166,7 +167,7 @@ Keyword arguments
 - `indices`: Tuple of indices of the output variables to include. Default is `(:, :, :)`, which
              includes the full fields.
 
-- `with_halos`: Boolean defining whether or not to include halos in the outputs.
+- `with_halos`: Boolean defining whether or not to include halos in the outputs. Default: false.
 
 - `global_attributes`: Dict of model properties to save with every file. Default: `Dict()`.
 

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -138,8 +138,8 @@ end
     NetCDFOutputWriter(model, outputs; filename, schedule
                                           dir = ".",
                                    array_type = Array{Float32},
-                                   with_halos = false,
                                       indices = nothing,
+                                   with_halos = false,
                             global_attributes = Dict(),
                             output_attributes = Dict(),
                                    dimensions = Dict(),


### PR DESCRIPTION
Minor docstring improment.