### PR TITLE
Implement lastindex for FieldTimeSeries

### DIFF
--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -170,6 +170,10 @@ function Base.getindex(fts::InMemoryFieldTimeSeries, n::Int)
     return Field(location(fts), fts.grid; data, boundary_conditions, indices)
 end
 
+# Making FieldTimeSeries behave like Vector
+Base.lastindex(fts::InMemoryFieldTimeSeries) = size(fts, 4)
+Base.firstindex(fts::InMemoryFieldTimeSeries) = 1
+
 #####
 ##### set!
 #####


### PR DESCRIPTION
This makes it so

```julia
bt = FieldTimeSeries(filename, "b")
b = bt[end]
```

returns the last element in the `FieldTimeSeries`.