### PR TITLE
Beautify examples a bit more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docs/src/generated
 
 # Plots
 *.png
+*.svg
 *.gif
 *.mp4
 

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -139,7 +139,7 @@ ax1 = Axis(fig[1, 1]; xlabel = "y (m)", ylabel = "y-spacing (m)", limits = (noth
 lines!(ax1, grid.yᵃᶜᵃ[1:Ny], grid.Δyᵃᶜᵃ[1:Ny])
 scatter!(ax1, grid.yᵃᶜᵃ[1:Ny], grid.Δyᵃᶜᵃ[1:Ny])
 
-ax2 = Axis(fig[2, 1]; xlabel = "z-spacing (m)", ylabel = "z (m)", limits = ((0, 50), nothing)))
+ax2 = Axis(fig[2, 1]; xlabel = "z-spacing (m)", ylabel = "z (m)", limits = ((0, 50), nothing))
 lines!(ax2, grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz])
 scatter!(ax2, grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz])
 

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -135,19 +135,13 @@ using CairoMakie
 
 fig = Figure(resolution=(800, 900))
 
-lines(fig[1, 1], grid.yᵃᶜᵃ[1:Ny], grid.Δyᵃᶜᵃ[1:Ny];
-                 axis = (xlabel = "y (m)",
-                         ylabel = "y-spacing (m)",
-                         limits = (nothing, (0, 250))))
+ax1 = Axis(fig[1, 1]; xlabel = "y (m)", ylabel = "y-spacing (m)", limits = (nothing, (0, 250))
+lines!(ax1, grid.yᵃᶜᵃ[1:Ny], grid.Δyᵃᶜᵃ[1:Ny])
+scatter!(ax1, grid.yᵃᶜᵃ[1:Ny], grid.Δyᵃᶜᵃ[1:Ny])
 
-scatter!(fig[1, 1], grid.yᵃᶜᵃ[1:Ny], grid.Δyᵃᶜᵃ[1:Ny])
-
-lines(fig[2, 1], grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz];
-                 axis = (xlabel = "z-spacing (m)",
-                         ylabel = "z (m)",
-                         limits = ((0, 50), nothing)))
-
-scatter!(fig[2, 1], grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz])
+ax2 = Axis(fig[2, 1]; xlabel = "z-spacing (m)", ylabel = "z (m)", limits = ((0, 50), nothing)))
+lines!(ax2, grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz])
+scatter!(ax2, grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz])
 
 save("plot_stretched_grid.svg"); nothing # hide
 ```

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -135,7 +135,7 @@ using CairoMakie
 
 fig = Figure(resolution=(800, 900))
 
-ax1 = Axis(fig[1, 1]; xlabel = "y (m)", ylabel = "y-spacing (m)", limits = (nothing, (0, 250))
+ax1 = Axis(fig[1, 1]; xlabel = "y (m)", ylabel = "y-spacing (m)", limits = (nothing, (0, 250)))
 lines!(ax1, grid.yᵃᶜᵃ[1:Ny], grid.Δyᵃᶜᵃ[1:Ny])
 scatter!(ax1, grid.yᵃᶜᵃ[1:Ny], grid.Δyᵃᶜᵃ[1:Ny])
 

--- a/examples/baroclinic_adjustment.jl
+++ b/examples/baroclinic_adjustment.jl
@@ -278,7 +278,7 @@ fig[1, 1] = Label(fig, title; textsize = 24, tellwidth = false, padding = (0, 0,
 frames = 1:length(times)
 
 record(fig, filename * ".mp4", frames, framerate=8) do i
-    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    msg = string("Plotting frame ", i, " of ", frames[end])
     print(msg * " \r")
     n[] = i
 end

--- a/examples/baroclinic_adjustment.jl
+++ b/examples/baroclinic_adjustment.jl
@@ -180,13 +180,13 @@ slicers = (west = (1, :, :),
 for side in keys(slicers)
     indices = slicers[side]
 
-    simulation.output_writers[side] = JLD2OutputWriter(model, (; b, u);
+    simulation.output_writers[side] = JLD2OutputWriter(model, (; b);
                                                        filename = filename * "_$(side)_slice",
                                                        schedule = TimeInterval(save_fields_interval),
                                                        indices)
 end
 
-simulation.output_writers[:zonal] = JLD2OutputWriter(model, (b=B, u=U);
+simulation.output_writers[:zonal] = JLD2OutputWriter(model, (b=B,);
                                                      schedule = TimeInterval(save_fields_interval),
                                                      filename = filename * "_zonal_average")
 
@@ -227,8 +227,8 @@ nothing #hide
 
 x, y, z = nodes(b_timeserieses.east)
 
-x = x .* 1e-3
-y = y .* 1e-3
+x = x .* 1e-3 # convert m -> km
+y = y .* 1e-3 # convert m -> km
 
 x_xz = repeat(x, 1, Nz)
 y_xz_north = y[end] * ones(Nx, Nz)

--- a/examples/baroclinic_adjustment.jl
+++ b/examples/baroclinic_adjustment.jl
@@ -253,7 +253,7 @@ zonal_slice_displacement = 1.2
 
 ax = Axis3(fig[2, 1], aspect=(1, 1, 1/5),
            xlabel="x (km)", ylabel="y (km)", zlabel="z (m)",
-           limits = ((x[1], zonal_slice_displacement * x[end]), (y[1], y[end]), (z[1], z[end]))
+           limits = ((x[1], zonal_slice_displacement * x[end]), (y[1], y[end]), (z[1], z[end])),
            elevation = 0.45, azimuth = 6.8,
            xspinesvisible = false, zgridvisible=false,
            protrusions=40,

--- a/examples/baroclinic_adjustment.jl
+++ b/examples/baroclinic_adjustment.jl
@@ -278,7 +278,8 @@ fig[1, 1] = Label(fig, title; textsize = 24, tellwidth = false, padding = (0, 0,
 frames = 1:length(times)
 
 record(fig, filename * ".mp4", frames, framerate=8) do i
-    @info "Plotting frame $i of $(frames[end])..."
+    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    print(msg * " \r")
     n[] = i
 end
 nothing #hide

--- a/examples/baroclinic_adjustment.jl
+++ b/examples/baroclinic_adjustment.jl
@@ -285,7 +285,7 @@ surface!(ax, x_xz, y_xz_north, z_xz;   color = b_slices.north, kwargs...)
 surface!(ax, x_xy, y_xy, z_xy_bottom ; color = b_slices.bottom, kwargs...)
 surface!(ax, x_xy, y_xy, z_xy_top;     color = b_slices.top, kwargs...)
 
-sf = surface!(ax, zonal_slice_displacement .* x_yz_east, y_yz, z_yz; color = b_avg, kwargs...)
+sf = surface!(ax, zonal_slice_displacement .* x_yz_east, y_yz, z_yz; color = avg_b, kwargs...)
 
 contour!(ax, y, z, avg_b; transformation = (:yz, zonal_slice_displacement * x[end]),
          levels = 15, linewidth = 2, color = :black)

--- a/examples/baroclinic_adjustment.jl
+++ b/examples/baroclinic_adjustment.jl
@@ -206,6 +206,22 @@ run!(simulation)
 
 using CairoMakie
 
+# We load the saved buoyancy output on the top, bottom, and east surface as `FieldTimeSeries`es.
+
+filename = "baroclinic_adjustment"
+
+sides = keys(slicers)
+
+slice_filenames = NamedTuple(side => filename * "_$(side)_slice.jld2" for side in sides)
+
+b_timeserieses = (east   = FieldTimeSeries(slice_filenames.east, "b"),
+                  north  = FieldTimeSeries(slice_filenames.north, "b"),
+                  bottom = FieldTimeSeries(slice_filenames.bottom, "b"),
+                  top    = FieldTimeSeries(slice_filenames.top, "b"))
+
+b_avg_timeseries = FieldTimeSeries(filename * "_zonal_average.jld2", "b")
+
+nothing #hide
 
 # We build the coordinates. We rescale horizontal coordinates so that they correspond to kilometers.
 
@@ -249,23 +265,6 @@ nothing #hide
 # refer to [Makie.jl's Documentation](https://makie.juliaplots.org/stable/documentation/nodes/index.html).
 
 n = Observable(1)
-
-# We load the saved buoyancy output on the top, bottom, and east surface as `FieldTimeSeries`es.
-
-filename = "baroclinic_adjustment"
-
-sides = keys(slicers)
-
-slice_filenames = NamedTuple(side => filename * "_$(side)_slice.jld2" for side in sides)
-
-b_timeserieses = (east   = FieldTimeSeries(slice_filenames.east, "b"),
-                  north  = FieldTimeSeries(slice_filenames.north, "b"),
-                  bottom = FieldTimeSeries(slice_filenames.bottom, "b"),
-                  top    = FieldTimeSeries(slice_filenames.top, "b"))
-
-b_avg_timeseries = FieldTimeSeries(filename * "_zonal_average.jld2", "b")
-
-nothing #hide
 
 # Now let's make a 3D plot of the buoyancy and in front of it we'll use the zonally-averaged output
 # to plot the instantaneous zonal-average of the buoyancy.

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -268,7 +268,7 @@ frames = 1:length(times)
 @info "Making an animation of convecting plankton..."
 
 record(fig, "convecting_plankton.mp4", frames, framerate=8) do i
-    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    msg = string("Plotting frame ", i, " of ", frames[end])
     print(msg * " \r")
     n[] = i
 end

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -66,16 +66,15 @@ buoyancy_flux_bc = FluxBoundaryCondition(buoyancy_flux, parameters = buoyancy_fl
 # buoyancy flux for the visually-oriented,
 
 using CairoMakie, Measures
+set_theme!(Theme(fontsize = 24, linewidth=2))
 
 times = range(0, 12hours, length=100)
 
 fig = Figure(resolution = (800, 300))
+ax = Axis(fig[1, 1]; xlabel = "Time (hours)", ylabel = "Surface buoyancy flux (m² s⁻³)")
 
-ax = Axis(fig[1, 1];
-          xlabel = "Time (hours)",
-          ylabel = "Surface buoyancy flux (m² s⁻³)")
-
-lines!(ax, times ./ hour, [buoyancy_flux(0, 0, t, buoyancy_flux_parameters) for t in times]; linewidth = 2)
+flux_time_series = [buoyancy_flux(0, 0, t, buoyancy_flux_parameters) for t in times]
+lines!(ax, times ./ hour, flux_time_series)
 
 # The buoyancy flux effectively shuts off after 6 hours of simulation time.
 #
@@ -125,17 +124,15 @@ plankton_dynamics = Forcing(growing_and_grazing, field_dependencies = :P,
 # advection scheme, third-order Runge-Kutta time-stepping, isotropic viscosity and diffusivities,
 # and Coriolis forces appropriate for planktonic convection at mid-latitudes on Earth.
 
-model = NonhydrostaticModel(
-                   grid = grid,
-              advection = UpwindBiasedFifthOrder(),
-            timestepper = :RungeKutta3,
-                closure = ScalarDiffusivity(ν=1e-4, κ=1e-4),
-               coriolis = FPlane(f=1e-4),
-                tracers = (:b, :P), # P for Plankton
-               buoyancy = BuoyancyTracer(),
-                forcing = (P=plankton_dynamics,),
-    boundary_conditions = (b=buoyancy_bcs,)
-)
+model = NonhydrostaticModel(; grid,
+                            advection = UpwindBiasedFifthOrder(),
+                            timestepper = :RungeKutta3,
+                            closure = ScalarDiffusivity(ν=1e-4, κ=1e-4),
+                            coriolis = FPlane(f=1e-4),
+                            tracers = (:b, :P), # P for Plankton
+                            buoyancy = BuoyancyTracer(),
+                            forcing = (; P=plankton_dynamics),
+                            boundary_conditions = (; b=buoyancy_bcs))
 
 # ## Initial condition
 #
@@ -146,9 +143,7 @@ model = NonhydrostaticModel(
 mixed_layer_depth = 32 # m
 
 stratification(z) = z < -mixed_layer_depth ? N² * z : - N² * mixed_layer_depth
-
 noise(z) = 1e-4 * N² * grid.Lz * randn() * exp(z / 4)
-
 initial_buoyancy(x, y, z) = stratification(z) + noise(z)
 
 set!(model, b=initial_buoyancy, P=1)
@@ -172,7 +167,7 @@ simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(10))
 using Printf
 
 progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
-                        iteration(sim), prettytime(time(sim)), prettytime(sim.Δt))
+                        iteration(sim), prettytime(sim), prettytime(sim.Δt))
 
 simulation.callbacks[:progress] = Callback(progress, IterationInterval(20))
 
@@ -181,7 +176,7 @@ simulation.callbacks[:progress] = Callback(progress, IterationInterval(20))
 
 outputs = (w = model.velocities.w,
            P = model.tracers.P,
-           P_avg = Average(model.tracers.P, dims=(1, 2)))
+           avg_P = Average(model.tracers.P, dims=(1, 2)))
 
 simulation.output_writers[:simple_output] =
     JLD2OutputWriter(model, outputs,
@@ -212,7 +207,7 @@ filepath = simulation.output_writers[:simple_output].filepath
 
 w_timeseries = FieldTimeSeries(filepath, "w")
 P_timeseries = FieldTimeSeries(filepath, "P")
-P_avg_timeseries = FieldTimeSeries(filepath, "P_avg")
+avg_P_timeseries = FieldTimeSeries(filepath, "avg_P")
 
 times = w_timeseries.times
 buoyancy_flux_time_series = [buoyancy_flux(0, 0, t, buoyancy_flux_parameters) for t in times]
@@ -236,7 +231,7 @@ title = @lift @sprintf("t = %s", prettytime(times[$n]))
 
 wₙ = @lift interior(w_timeseries[$n], :, 1, :)
 Pₙ = @lift interior(P_timeseries[$n], :, 1, :)
-P_avgₙ = @lift interior(P_avg_timeseries[$n], 1, 1, :)
+avg_Pₙ = @lift interior(avg_P_timeseries[$n], 1, 1, :)
 
 w_lim = maximum(abs, interior(w_timeseries))
 w_lims = (-w_lim, w_lim)
@@ -261,7 +256,7 @@ ax_b = Axis(fig[2, 3];
             xlabel = "time (hours)",
             ylabel = "buoyancy flux (m² s⁻³)")
 
-ax_P_avg = Axis(fig[3, 3];
+ax_avg_P = Axis(fig[3, 3];
                 xlabel = "plankton concentration (μM)",
                 ylabel = "z (m)",
                 limits = ((0.85, 1.3), nothing))
@@ -280,16 +275,12 @@ hm_P = heatmap!(ax_P, xp, zp, Pₙ;
 
 Colorbar(fig[3, 2], hm_P; label = "μM")
 
-lines!(ax_b, times ./ hour, buoyancy_flux_time_series;
-       linewidth = 1, color = :black, alpha = 0.4)
+lines!(ax_b, times ./ hour, buoyancy_flux_time_series; linewidth = 1, color = :black, alpha = 0.4)
 
 b_flux_point = @lift Point2f[(times[$n] / hour, buoyancy_flux_time_series[$n])]
 
-scatter!(ax_b, b_flux_point;
-         marker = :circle, markersize = 16, color = :black)
-
-lines!(ax_P_avg, P_avgₙ, zp;
-       linewidth = 2)
+scatter!(ax_b, b_flux_point; marker = :circle, markersize = 16, color = :black)
+lines!(ax_avg_P, avg_Pₙ, zp)
 
 # And, finally, we record a movie.
 

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -188,8 +188,8 @@ nothing # hide
 χ_timeseries = deepcopy(b_timeseries)
 
 for i in 1:length(times)
-  b = b_timeseries[i]
-  χ_timeseries[i] .= κ * (∂x(b)^2 + ∂z(b)^2)
+  bᵢ = b_timeseries[i]
+  χ_timeseries[i] .= κ * (∂x(bᵢ)^2 + ∂z(bᵢ)^2)
 end
 
 

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -91,12 +91,12 @@ nothing # hide
 # Runge-Kutta time-stepping scheme, and a `BuoyancyTracer`.
 
 model = NonhydrostaticModel(; grid,
-              advection = WENO5(),
-            timestepper = :RungeKutta3,
-                tracers = :b,
-               buoyancy = BuoyancyTracer(),
-                closure = ScalarDiffusivity(; ν, κ),
-    boundary_conditions = (; b=b_bcs))
+                            advection = WENO5(),
+                            timestepper = :RungeKutta3,
+                            tracers = :b,
+                            buoyancy = BuoyancyTracer(),
+                            closure = ScalarDiffusivity(; ν, κ),
+                            boundary_conditions = (; b=b_bcs))
 
 # ## Simulation set-up
 #
@@ -258,8 +258,9 @@ Colorbar(fig[5, 2], hm_χ)
 frames = 1:length(times)
 
 record(fig, "horizontal_convection.mp4", frames, framerate=8) do i
-       @info "Plotting frame $i of $(frames[end])..."
-       n[] = i
+    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    print(msg * " \r")
+    n[] = i
 end
 nothing #hide
 

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -258,7 +258,7 @@ Colorbar(fig[5, 2], hm_χ)
 frames = 1:length(times)
 
 record(fig, "horizontal_convection.mp4", frames, framerate=8) do i
-    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    msg = string("Plotting frame ", i, " of ", frames[end])
     print(msg * " \r")
     n[] = i
 end

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -176,7 +176,7 @@ frames = 1:length(w_timeseries.times)
 @info "Animating a propagating internal wave..."
 
 record(fig, filename * ".mp4", frames, framerate=8) do i
-    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    msg = string("Plotting frame ", i, " of ", frames[end])
     print(msg * " \r")
     n[] = i
 end

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -1,4 +1,3 @@
-
 # # Stratified Kelvin-Helmholtz instability
 #
 # ## Install dependencies

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -360,7 +360,7 @@ Colorbar(fig[3, 3], ax_uxz; label = "m s⁻¹")
 frames = 1:length(times)
 
 record(fig, "langmuir_turbulence.mp4", frames, framerate=8) do i
-    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    msg = string("Plotting frame ", i, " of ", frames[end])
     print(msg * " \r")
     n[] = i
 end

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -126,12 +126,11 @@ coriolis = FPlane(f=1e-4) # s⁻¹
 # model for large eddy simulation. Because our Stokes drift does not vary in ``x, y``,
 # we use `UniformStokesDrift`, which expects Stokes drift functions of ``z, t`` only.
 
-model = NonhydrostaticModel(; grid,
+model = NonhydrostaticModel(; grid, coriolis,
                             advection = WENO5(),
                             timestepper = :RungeKutta3,
                             tracers = :b,
                             buoyancy = BuoyancyTracer(),
-                            coriolis = coriolis,
                             closure = AnisotropicMinimumDissipation(),
                             stokes_drift = UniformStokesDrift(∂z_uˢ=∂z_uˢ),
                             boundary_conditions = (u=u_boundary_conditions, b=b_boundary_conditions))
@@ -180,7 +179,7 @@ simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(10))
 
 using Printf
 
-function print_progress(simulation)
+function progress(simulation)
     u, v, w = simulation.model.velocities
 
     ## Print a progress message
@@ -196,7 +195,7 @@ function print_progress(simulation)
     return nothing
 end
 
-simulation.callbacks[:progress] = Callback(print_progress, IterationInterval(10))
+simulation.callbacks[:progress] = Callback(progress, IterationInterval(20))
 
 # ## Output
 #
@@ -269,9 +268,9 @@ nothing # hide
 
 n = Observable(1)
 
-wxy_title = @lift @sprintf("w(x, y, t) at z=-8 m and t = %s ", prettytime(times[$n]))
-wxz_title = @lift @sprintf("w(x, z, t) at y=0 m and t = %s", prettytime(times[$n]))
-uxz_title = @lift @sprintf("u(x, z, t) at y=0 m and t = %s", prettytime(times[$n]))
+wxy_title = @lift string("w(x, y, t) at z=-8 m and t = ", prettytime(times[$n]))
+wxz_title = @lift string("w(x, z, t) at y=0 m and t = ", prettytime(times[$n]))
+uxz_title = @lift string("u(x, z, t) at y=0 m and t = ", prettytime(times[$n]))
 
 fig = Figure(resolution = (850, 850))
 
@@ -321,9 +320,9 @@ wuₙ = @lift time_series.wu[$n][1, 1, :]
 wvₙ = @lift time_series.wv[$n][1, 1, :]
 
 k = searchsortedfirst(grid.zᵃᵃᶠ[:], -8)
-wxyₙ = @lift collect(time_series.w[$n][:, :, k])
-wxzₙ = @lift collect(time_series.w[$n][:, 1, :])
-uxzₙ = @lift collect(time_series.u[$n][:, 1, :])
+wxyₙ = @lift interior(time_series.w[$n], :, :, k)
+wxzₙ = @lift interior(time_series.w[$n], :, 1, :)
+uxzₙ = @lift interior(time_series.u[$n], :, 1, :)
 
 wlims = (-0.03, 0.03)
 ulims = (-0.05, 0.05)
@@ -361,8 +360,9 @@ Colorbar(fig[3, 3], ax_uxz; label = "m s⁻¹")
 frames = 1:length(times)
 
 record(fig, "langmuir_turbulence.mp4", frames, framerate=8) do i
-       @info "Plotting frame $i of $(frames[end])..."
-       n[] = i
+    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    print(msg * " \r")
+    n[] = i
 end
 nothing #hide
 

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -315,7 +315,7 @@ frames = intro:length(times)
 @info "Making a motion picture of ocean wind mixing and convection..."
 
 record(fig, filename * ".mp4", frames, framerate=8) do i
-    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    msg = string("Plotting frame ", i, " of ", frames[end])
     print(msg * " \r")
     n[] = i
 end

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -60,11 +60,15 @@ grid = RectilinearGrid(size = (32, 32, Nz),
 
 # We plot vertical spacing versus depth to inspect the prescribed grid stretching:
 
-lines(grid.Δzᵃᵃᶜ[1:grid.Nz], grid.zᵃᵃᶜ[1:grid.Nz],
-      axis = (ylabel = "Depth (m)",
-              xlabel = "Vertical spacing (m)"))
+fig = Figure(resolution=(1200, 800))
+ax = Axis(fig[1, 1], ylabel = "Depth (m)", xlabel = "Vertical spacing (m)")
+lines!(ax, grid.Δzᵃᵃᶜ[1:grid.Nz], grid.zᵃᵃᶜ[1:grid.Nz])
+scatter!(ax, grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz])
 
-scatter!(grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz])
+save("ocean_wind_mixing_convection_grid_spacing.svg", fig)
+nothing #hide
+
+# ![](ocean_wind_mixing_convection_grid_spacing.svg)
 
 # ## Buoyancy that depends on temperature and salinity
 #
@@ -78,9 +82,9 @@ buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(thermal_expa
 # We calculate the surface temperature flux associated with surface heating of
 # 200 W m⁻², reference density `ρₒ`, and heat capacity `cᴾ`,
 
-Qʰ = 200  # W m⁻², surface _heat_ flux
-ρₒ = 1026 # kg m⁻³, average density at the surface of the world ocean
-cᴾ = 3991 # J K⁻¹ kg⁻¹, typical heat capacity for seawater
+Qʰ = 200.0  # W m⁻², surface _heat_ flux
+ρₒ = 1026.0 # kg m⁻³, average density at the surface of the world ocean
+cᴾ = 3991.0 # J K⁻¹ kg⁻¹, typical heat capacity for seawater
 
 Qᵀ = Qʰ / (ρₒ * cᴾ) # K m s⁻¹, surface _temperature_ flux
 
@@ -138,12 +142,11 @@ S_bcs = FieldBoundaryConditions(top=evaporation_bc)
 # for large eddy simulation to model the effect of turbulent motions at
 # scales smaller than the grid scale that we cannot explicitly resolve.
 
-model = NonhydrostaticModel(advection = UpwindBiasedFifthOrder(),
+model = NonhydrostaticModel(; grid, buoyancy,
+                            advection = UpwindBiasedFifthOrder(),
                             timestepper = :RungeKutta3,
-                            grid = grid,
                             tracers = (:T, :S),
                             coriolis = FPlane(f=1e-4),
-                            buoyancy = buoyancy,
                             closure = AnisotropicMinimumDissipation(),
                             boundary_conditions = (u=u_bcs, T=T_bcs, S=S_bcs))
 
@@ -184,20 +187,16 @@ simulation = Simulation(model, Δt=10.0, stop_time=40minutes)
 # with a Courant-Freidrichs-Lewy (CFL) number of 1.0.
 
 wizard = TimeStepWizard(cfl=1.0, max_change=1.1, max_Δt=1minute)
-
 simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(10))
 
 # Nice progress messaging is helpful:
 
 ## Print a progress message
 progress_message(sim) = @printf("Iteration: %04d, time: %s, Δt: %s, max(|w|) = %.1e ms⁻¹, wall time: %s\n",
-                                iteration(sim),
-                                prettytime(sim),
-                                prettytime(sim.Δt),
-                                maximum(abs, sim.model.velocities.w),
-                                prettytime(sim.run_wall_time))
+                                iteration(sim), prettytime(sim), prettytime(sim.Δt),
+                                maximum(abs, sim.model.velocities.w), prettytime(sim.run_wall_time))
 
-simulation.callbacks[:progress] = Callback(progress_message, IterationInterval(10))
+simulation.callbacks[:progress] = Callback(progress_message, IterationInterval(20))
 
 # We then set up the simulation:
 
@@ -283,13 +282,10 @@ axis_kwargs = (xlabel="x (m)",
                aspect = AxisAspect(grid.Lx/grid.Lz),
                limits = ((0, grid.Lx), (-grid.Lz, 0)))
 
-ax_w = Axis(fig[2, 1]; title = "vertical velocity", axis_kwargs...)
-
-ax_T = Axis(fig[2, 3]; title = "temperature", axis_kwargs...)
-
-ax_S = Axis(fig[3, 1]; title = "salinity", axis_kwargs...)
-
-ax_νₑ = Axis(fig[3, 3]; title = "eddy viscocity", axis_kwargs...)
+ax_w  = Axis(fig[2, 1]; title = "Vertical velocity", axis_kwargs...)
+ax_T  = Axis(fig[2, 3]; title = "Temperature", axis_kwargs...)
+ax_S  = Axis(fig[3, 1]; title = "Salinity", axis_kwargs...)
+ax_νₑ = Axis(fig[3, 3]; title = "Eddy viscocity", axis_kwargs...)
 
 title = @lift @sprintf("t = %s", prettytime(times[$n]))
 
@@ -310,14 +306,17 @@ Colorbar(fig[3, 2], hm_S; label = "g / kg")
 hm_νₑ = heatmap!(ax_νₑ, xT, zT, νₑₙ; colormap = :thermal, colorrange = νₑlims)
 Colorbar(fig[3, 4], hm_νₑ; label = "m s⁻²")
 
-fig[1, :] = Label(fig, title, textsize=24, tellwidth=false)
+fig[1, 1:4] = Label(fig, title, textsize=24, tellwidth=false)
 
 # And now record a movie.
 
 frames = intro:length(times)
 
+@info "Making a motion picture of ocean wind mixing and convection..."
+
 record(fig, filename * ".mp4", frames, framerate=8) do i
-    @info "Plotting frame $i of $(frames[end])..."
+    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    print(msg * " \r")
     n[] = i
 end
 nothing #hide

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -49,7 +49,7 @@ closure = ScalarDiffusivity(κ=1)
 
 # We finally pass these two ingredients to `NonhydrostaticModel`,
 
-model = NonhydrostaticModel(grid=grid, closure=closure, buoyancy=nothing, tracers=:T)
+model = NonhydrostaticModel(; grid, closure, tracers=:T)
 
 # By default, `NonhydrostaticModel` has no-flux (insulating and stress-free) boundary conditions on
 # all fields.
@@ -69,17 +69,16 @@ set!(model, T=initial_temperature)
 
 using CairoMakie
 
-linewidth = 3
-z = znodes(model.tracers.T)
-
+set_theme!(Theme(fontsize = 24, linewidth=3))
 fig = Figure()
+axis = (xlabel = "Temperature (ᵒC)", ylabel = "z")
+label = "t = 0"
 
-lines(interior(model.tracers.T, 1, 1, :), z; linewidth, label = "t = 0",
-     axis = (xlabel = "Temperature (ᵒC)",
-             ylabel = "z",
-             xlabelsize = 20,
-             ylabelsize = 20))
+z = znodes(model.tracers.T)
+T = interior(model.tracers.T, 1, 1, :)
 
+lines(T, z; label, axis)
+     
 # The function `interior` above extracts a `view` of `model.tracers.T` over the
 # physical points (excluding halos) at `(1, 1, :)`.
 #
@@ -104,15 +103,11 @@ run!(simulation)
 using Printf
 
 label = @sprintf("t = %.3f", model.clock.time)
-
-lines!(interior(model.tracers.T, 1, 1, :), z; linewidth, label)
-
+lines!(interior(model.tracers.T, 1, 1, :), z; label)
 axislegend()
 
 # Very interesting! Next, we run the simulation a bit longer and make an animation.
 # For this, we use the `JLD2OutputWriter` to write data to disk as the simulation progresses.
-
-using Oceananigans.OutputWriters: JLD2OutputWriter, IterationInterval
 
 simulation.output_writers[:temperature] =
     JLD2OutputWriter(model, model.tracers,
@@ -123,7 +118,6 @@ simulation.output_writers[:temperature] =
 # We run the simulation for 10,000 more iterations,
 
 simulation.stop_iteration += 10000
-
 run!(simulation)
 
 # Finally, we animate the results by opening the JLD2 file, extract the
@@ -133,31 +127,26 @@ run!(simulation)
 T_timeseries = FieldTimeSeries("one_dimensional_diffusion.jld2", "T")
 times = T_timeseries.times
 
+fig = Figure()
+ax = Axis(fig[2, 1]; xlabel = "Temperature (ᵒC)", ylabel = "z")
+xlims!(ax, 0, 1)
+
 n = Observable(1)
 
 T = @lift interior(T_timeseries[$n], 1, 1, :)
+lines!(T, z)
 
 label = @lift "t = " * string(round(times[$n], digits=3))
-
-fig = Figure()
-
-ax = Axis(fig[2, 1];
-          xlabel = "Temperature (ᵒC)",
-          ylabel = "z",
-          xlabelsize = 20,
-          ylabelsize = 20,
-          limits = ((0, 1), nothing))
-
-lines!(T, z; linewidth)
-
-fig[1, 1] = Label(fig, label, textsize=24, tellwidth=false)
+Label(fig[1, 1], label, tellwidth=false)
 
 # Finally, we record a movie.
 
 frames = 1:length(times)
 
-record(fig, "one_dimensional_diffusion.mp4", frames, framerate=8) do i
-    @info "Plotting frame $i of $(frames[end])..."
+print("Making an animation...")
+
+record(fig, "one_dimensional_diffusion.mp4", frames, framerate=24) do i
+    print(".")
     n[] = i
 end
 nothing #hide

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -146,7 +146,7 @@ frames = 1:length(times)
 @info "Making an animation..."
 
 record(fig, "one_dimensional_diffusion.mp4", frames, framerate=24) do i
-    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    msg = string("Plotting frame ", i, " of ", frames[end])
     print(msg * " \r")
     n[] = i
 end

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -68,8 +68,8 @@ set!(model, T=initial_temperature)
 # To see the new data in `model.tracers.T`, we plot it:
 
 using CairoMakie
-
 set_theme!(Theme(fontsize = 24, linewidth=3))
+
 fig = Figure()
 axis = (xlabel = "Temperature (ᵒC)", ylabel = "z")
 label = "t = 0"

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -143,10 +143,11 @@ Label(fig[1, 1], label, tellwidth=false)
 
 frames = 1:length(times)
 
-print("Making an animation...")
+@info "Making an animation..."
 
 record(fig, "one_dimensional_diffusion.mp4", frames, framerate=24) do i
-    print(".")
+    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    print(msg * " \r")
     n[] = i
 end
 nothing #hide

--- a/examples/shallow_water_Bickley_jet.jl
+++ b/examples/shallow_water_Bickley_jet.jl
@@ -201,7 +201,7 @@ fig[1, 1:4] = Label(fig, title, textsize=24, tellwidth=false)
 frames = 1:length(times)
 
 record(fig, "shallow_water_Bickley_jet.mp4", frames, framerate=12) do i
-    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    msg = string("Plotting frame ", i, " of ", frames[end])
     print(msg * " \r")
     n[] = i
 end

--- a/examples/shallow_water_Bickley_jet.jl
+++ b/examples/shallow_water_Bickley_jet.jl
@@ -228,7 +228,8 @@ nothing # hide
 
 using Polynomials: fit
 
-I = 6000:7000
+Nt = length(t)
+I = Nt-10:Nt
 
 degree = 1
 linear_fit_polynomial = fit(t[I], log.(norm_v[I]), degree, var = :t)

--- a/examples/shallow_water_Bickley_jet.jl
+++ b/examples/shallow_water_Bickley_jet.jl
@@ -189,7 +189,6 @@ hm_ω = heatmap!(ax_ω, x, y, ω, colorrange = (-1, 1), colormap = :balance)
 Colorbar(fig[2, 2], hm_ω)
 
 ω′ = @lift ds["ω′"][:, :, 1, $n]
-ω′_lims = @lift (-maximum(abs, ds["ω′"][:, 1, :, $n]), maximum(abs, ds["ω′"][:, 1, :, $n]))
 hm_ω′ = heatmap!(ax_ω′, x, y, ω′, colormap = :balance)
 Colorbar(fig[2, 4], hm_ω′)
 
@@ -256,7 +255,7 @@ lines!(t[I], 2 * best_fit[I]; # factor 2 offsets fit from curve for better visua
        linewidth = 4,
        label = "best fit")
 
-axislegend()
+axislegend(position = :rb)
 
 current_figure() # hide
 

--- a/examples/shallow_water_Bickley_jet.jl
+++ b/examples/shallow_water_Bickley_jet.jl
@@ -31,7 +31,7 @@ using Oceananigans.Models: ShallowWaterModel
 # The shallow water model is a two-dimensional model and thus the number of vertical
 # points `Nz` must be set to one.  Note that ``L_z`` is the mean depth of the fluid. 
 
-Lx, Ly, Lz = 2π, 20, 1
+Lx, Ly, Lz = 2π, 20, 10
 Nx, Ny = 128, 128
 
 grid = RectilinearGrid(size = (Nx, Ny),
@@ -228,8 +228,7 @@ nothing # hide
 
 using Polynomials: fit
 
-Nt = length(t)
-I = Nt-10:Nt
+I = 6000:7000
 
 degree = 1
 linear_fit_polynomial = fit(t[I], log.(norm_v[I]), degree, var = :t)

--- a/examples/shallow_water_Bickley_jet.jl
+++ b/examples/shallow_water_Bickley_jet.jl
@@ -168,7 +168,7 @@ nothing # hide
 # Read in the `output_writer` for the two-dimensional fields and then create an animation 
 # showing both the total and perturbation vorticities.
 
-fig = Figure(resolution = (800, 440))
+fig = Figure(resolution = (1200, 660))
 
 axis_kwargs = (xlabel = "x",
                ylabel = "y",

--- a/examples/shallow_water_Bickley_jet.jl
+++ b/examples/shallow_water_Bickley_jet.jl
@@ -38,27 +38,18 @@ grid = RectilinearGrid(size = (Nx, Ny),
                        x = (0, Lx), y = (-Ly/2, Ly/2),
                        topology = (Periodic, Bounded, Flat))
 
-# ## Physical parameters
-#
-# We choose non-dimensional parameters
-
-const U = 1.0         # Maximum jet velocity
-
-f = 1           # Coriolis parameter
-g = 9.8         # Gravitational acceleration
-Δη = f * U / g  # Maximum free-surface deformation as dictated by geostrophy
-
 # ## Building a `ShallowWaterModel`
 #
-# We build a `ShallowWaterModel` with the `WENO5` advection scheme and
-# 3rd-order Runge-Kutta time-stepping,
+# We build a `ShallowWaterModel` with the `WENO5` advection scheme,
+# 3rd-order Runge-Kutta time-stepping, non-dimensional Coriolis and
+# gravitational acceleration
 
-model = ShallowWaterModel(
+gravitational_acceleration = 1
+coriolis = FPlane(f=1)
+
+model = ShallowWaterModel(; grid, coriolis, gravitational_acceleration,
                           timestepper = :RungeKutta3,
-                          advection = WENO5(),
-                          grid = grid,
-                          gravitational_acceleration = g,
-                          coriolis = FPlane(f=f))
+                          advection = WENO5())
 
 # Use `architecture = GPU()` to run this problem on a GPU.
 
@@ -67,6 +58,11 @@ model = ShallowWaterModel(
 # The background velocity ``ū`` and free-surface ``η̄`` correspond to a
 # geostrophically balanced Bickely jet with maximum speed of ``U`` and maximum 
 # free-surface deformation of ``Δη``,
+
+U = 1 # Maximum jet velocity
+f = coriolis.f
+g = gravitational_acceleration
+Δη = f * U / g  # Maximum free-surface deformation as dictated by geostrophy
 
 h̄(x, y, z) = Lz - Δη * tanh(y)
 ū(x, y, z) = U * sech(y)^2
@@ -137,16 +133,18 @@ perturbation_norm(args...) = norm(v)
 # Build the `output_writer` for the two-dimensional fields to be output.
 # Output every `t = 1.0`.
 
+fields_filename = joinpath(@__DIR__, "shallow_water_Bickley_jet_fields.nc")
 simulation.output_writers[:fields] = NetCDFOutputWriter(model, (; ω, ω′),
-                                                        filename = joinpath(@__DIR__, "shallow_water_Bickley_jet_fields.nc"),
+                                                        filename = fields_filename,
                                                         schedule = TimeInterval(1),
                                                         overwrite_existing = true)
 
 # Build the `output_writer` for the growth rate, which is a scalar field.
 # Output every time step.
 
+growth_filename = joinpath(@__DIR__, "shallow_water_Bickley_jet_perturbation_norm.nc")
 simulation.output_writers[:growth] = NetCDFOutputWriter(model, (; perturbation_norm),
-                                                        filename = joinpath(@__DIR__, "shallow_water_Bickley_jet_perturbation_norm.nc"),
+                                                        filename = growth_filename,
                                                         schedule = IterationInterval(1),
                                                         dimensions = (; perturbation_norm = ()),
                                                         overwrite_existing = true)
@@ -170,19 +168,6 @@ nothing # hide
 # Read in the `output_writer` for the two-dimensional fields and then create an animation 
 # showing both the total and perturbation vorticities.
 
-ds = NCDataset(simulation.output_writers[:fields].filepath, "r")
-
-times = ds["time"][:]
-
-n = Observable(1)
-
-ω = @lift ds["ω"][:, :, 1, $n]
-ω′ = @lift ds["ω′"][:, :, 1, $n]
-
-ω′_lims = @lift (-maximum(abs, ds["ω′"][:, 1, :, $n]), maximum(abs, ds["ω′"][:, 1, :, $n]))
-
-title = @lift @sprintf("t = %.1f", times[$n])
-
 fig = Figure(resolution = (800, 440))
 
 axis_kwargs = (xlabel = "x",
@@ -190,26 +175,35 @@ axis_kwargs = (xlabel = "x",
                aspect = AxisAspect(1),
                limits = ((0, Lx), (-Ly/2, Ly/2)))
 
-ax_ω = Axis(fig[2, 1]; title = "total vorticity, ω", axis_kwargs...)
-ax_ω′ = Axis(fig[2, 3]; title = "perturbation vorticity, ω - ω̄", axis_kwargs...)
+ax_ω  = Axis(fig[2, 1]; title = "Total vorticity, ω", axis_kwargs...)
+ax_ω′ = Axis(fig[2, 3]; title = "Perturbation vorticity, ω - ω̄", axis_kwargs...)
 
+n = Observable(1)
+
+ds = NCDataset(simulation.output_writers[:fields].filepath, "r")
+
+times = ds["time"][:]
+
+ω = @lift ds["ω"][:, :, 1, $n]
 hm_ω = heatmap!(ax_ω, x, y, ω, colorrange = (-1, 1), colormap = :balance)
-
 Colorbar(fig[2, 2], hm_ω)
 
+ω′ = @lift ds["ω′"][:, :, 1, $n]
+ω′_lims = @lift (-maximum(abs, ds["ω′"][:, 1, :, $n]), maximum(abs, ds["ω′"][:, 1, :, $n]))
 hm_ω′ = heatmap!(ax_ω′, x, y, ω′, colormap = :balance)
-
 Colorbar(fig[2, 4], hm_ω′)
 
-fig[1, :] = Label(fig, title, textsize=24, tellwidth=false)
+title = @lift @sprintf("t = %.1f", times[$n])
+fig[1, 1:4] = Label(fig, title, textsize=24, tellwidth=false)
 
 # Finally, we record a movie.
 
 frames = 1:length(times)
 
 record(fig, "shallow_water_Bickley_jet.mp4", frames, framerate=12) do i
-       @info "Plotting frame $i of $(frames[end])..."
-       n[] = i
+    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    print(msg * " \r")
+    n[] = i
 end
 nothing #hide
 

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -215,13 +215,13 @@ v_max = @lift maximum(abs, ds["total_v"][:, 1, :, $n])
 
 fig = Figure(resolution = (800, 440))
 
-axis_kwargs = (xlabel = "along-slope distance",
-               ylabel = "across-slope distance",
+axis_kwargs = (xlabel = "Along-slope distance",
+               ylabel = "Across-slope distance",
                aspect = AxisAspect(Lx/Lz),
                limits = ((0, Lx), (0, Lz)))
 
 ax_ω = Axis(fig[2, 1]; title = "y-vorticity", axis_kwargs...)
-ax_v = Axis(fig[3, 1]; title = "along-slope velocity", axis_kwargs...)
+ax_v = Axis(fig[3, 1]; title = "Along-slope velocity", axis_kwargs...)
 
 hm_ω = heatmap!(ax_ω, xω, zω, ω_y, colorrange = (-0.015, +0.015), colormap = :balance)
 Colorbar(fig[2, 2], hm_ω; label = "m s⁻¹")
@@ -236,8 +236,9 @@ fig[1, :] = Label(fig, title, textsize=24, tellwidth=false)
 frames = 1:length(times)
 
 record(fig, "tilted_bottom_boundary_layer.mp4", frames, framerate=12) do i
-       @info "Plotting frame $i of $(frames[end])..."
-       n[] = i
+    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    print(msg * " \r")
+    n[] = i
 end
 nothing #hide
 

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -167,7 +167,7 @@ simulation.callbacks[:progress] = Callback(progress_message, IterationInterval(1
 #
 # We add outputs to our model using the `NetCDFOutputWriter`,
 
-u, v′, w = model.velocities
+u, v, w = model.velocities
 b = model.tracers.b
 B∞ = model.background_fields.tracers.b
 

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -65,6 +65,8 @@ lines(grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz],
 
 scatter!(grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz])
 
+current_figure() # hide
+
 # ## Tilting the domain
 #
 # We use a domain that's tilted with respect to gravity by

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -116,6 +116,7 @@ nothing # hide
 # and animate the vorticity and fluid speed.
 
 using CairoMakie
+set_theme!(Theme(fontsize = 24))
 
 @info "Making a neat movie of vorticity and speed..."
 
@@ -123,7 +124,6 @@ fig = Figure(resolution = (800, 500))
 
 axis_kwargs = (xlabel = "x",
                ylabel = "y",
-               titlesize = 24,
                limits = ((0, 2π), (0, 2π)),
                aspect = AxisAspect(1))
 
@@ -136,16 +136,15 @@ nothing #hide
 
 n = Observable(1)
 
-title = @lift "t = " * string(round(times[$n], digits=2))
+# Now let's plot the vorticity and speed.
 
 ω = @lift interior(ω_timeseries[$n], :, :, 1)
 s = @lift interior(s_timeseries[$n], :, :, 1)
 
-# Now let's plot the vorticity and speed.
-
 heatmap!(ax_ω, xω, yω, ω; colormap = :balance, colorrange = (-2, 2))
 heatmap!(ax_s, xs, ys, s; colormap = :speed, colorrange = (0, 0.2))
 
+title = @lift "t = " * string(round(times[$n], digits=2))
 Label(fig[1, 1:2], title, textsize=24, tellwidth=false)
 
 # Finally, we record a movie.

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -149,6 +149,8 @@ Label(fig[1, 1:2], title, textsize=24, tellwidth=false)
 
 # Finally, we record a movie.
 
+using Printf
+
 frames = 1:length(times)
 
 @info "Making a neat animation of vorticity and speed..."

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -149,14 +149,12 @@ Label(fig[1, 1:2], title, textsize=24, tellwidth=false)
 
 # Finally, we record a movie.
 
-using Printf
-
 frames = 1:length(times)
 
 @info "Making a neat animation of vorticity and speed..."
 
 record(fig, filename * ".mp4", frames, framerate=24) do i
-    msg = @sprintf("Plotting frame %d of %d...", i, frames[end])
+    msg = string("Plotting frame ", i, " of ", frames[end])
     print(msg * " \r")
     n[] = i
 end

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -170,6 +170,10 @@ function Base.getindex(fts::InMemoryFieldTimeSeries, n::Int)
     return Field(location(fts), fts.grid; data, boundary_conditions, indices)
 end
 
+# Making FieldTimeSeries behave like Vector
+Base.lastindex(fts::InMemoryFieldTimeSeries) = size(fts, 4)
+Base.firstindex(fts::InMemoryFieldTimeSeries) = 1
+
 #####
 ##### set!
 #####


### PR DESCRIPTION
This PR builds on @navidcy's excellent work to convert all the examples to Makie. I tried to unify the coding style in the examples as best I could. Also, there was a bit too much logging / plotting messages in the examples, which polluted the docs.

TODO:

- [x] We should use `Axis3` in the baroclinic adjustment animation.
- [x] The stretched grid is not displayed in the tilted bottom boundary layer (we could also get rid of this, because we already visualize a similar stretched grid in another example)
- [x] Remove logging noise from shallow water bickley jet, horizontal convection, and tilted bottom boundary layer examples