### PR TITLE
Adds back a fig in Docs/Model/Grids + example with `Flat` topology

### DIFF
--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -26,7 +26,7 @@ end
 ```
 
 ```jldoctest
-julia> grid = RectilinearGrid(size=(32, 64, 256), extent=(128, 256, 512))
+julia> grid = RectilinearGrid(size = (32, 64, 256), extent = (128, 256, 512))
 32×64×256 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── Periodic x ∈ [0.0, 128.0)  regularly spaced with Δx=4.0
 ├── Periodic y ∈ [0.0, 256.0)  regularly spaced with Δy=4.0
@@ -44,7 +44,7 @@ architecture. By default `architecture = CPU()`. By providing `GPU()` as the `ar
 we can construct the grid on GPU:
 
 ```julia
-julia> grid = RectilinearGrid(GPU(), size=(32, 64, 256), extent=(128, 256, 512))
+julia> grid = RectilinearGrid(GPU(), size = (32, 64, 256), extent = (128, 256, 512))
 32×64×256 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on GPU with 3×3×3 halo
 ├── Periodic x ∈ [0.0, 128.0)  regularly spaced with Δx=4.0
 ├── Periodic y ∈ [0.0, 256.0)  regularly spaced with Δy=4.0
@@ -63,7 +63,7 @@ A "channel" model that is periodic in the ``x``-direction and wall-bounded
 in the ``y``- and ``z``-dimensions is build with,
 
 ```jldoctest
-julia> grid = RectilinearGrid(topology=(Periodic, Bounded, Bounded), size=(64, 64, 32), extent=(1e4, 1e4, 1e3))
+julia> grid = RectilinearGrid(topology = (Periodic, Bounded, Bounded), size = (64, 64, 32), extent = (1e4, 1e4, 1e3))
 64×64×32 RectilinearGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
 ├── Periodic x ∈ [0.0, 10000.0) regularly spaced with Δx=156.25
 ├── Bounded  y ∈ [0.0, 10000.0] regularly spaced with Δy=156.25
@@ -75,7 +75,7 @@ to use a two-dimensional horizontal, doubly periodic domain the topology is `(Pe
 In that case, the `size` and `extent` are 2-tuples, e.g.,
 
 ```jldoctest
-julia> grid = RectilinearGrid(topology=(Periodic, Periodic, Flat), size=(32, 32), extent=(10, 20))
+julia> grid = RectilinearGrid(topology = (Periodic, Periodic, Flat), size = (32, 32), extent = (10, 20))
 32×32×1 RectilinearGrid{Float64, Periodic, Periodic, Flat} on CPU with 3×3×0 halo
 ├── Periodic x ∈ [0.0, 10.0)      regularly spaced with Δx=0.3125
 ├── Periodic y ∈ [0.0, 20.0)      regularly spaced with Δy=0.625
@@ -89,7 +89,7 @@ For example, a grid with ``x \in [-100, 100]`` meters, ``y \in [0, 12.5]`` meter
 is constructed via
 
 ```jldoctest
-julia> grid = RectilinearGrid(size=(32, 16, 256), x=(-100, 100), y=(0, 12.5), z=(-π, π))
+julia> grid = RectilinearGrid(size = (32, 16, 256), x = (-100, 100), y = (0, 12.5), z = (-π, π))
 32×16×256 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── Periodic x ∈ [-100.0, 100.0)     regularly spaced with Δx=6.25
 ├── Periodic y ∈ [0.0, 12.5)         regularly spaced with Δy=0.78125
@@ -100,7 +100,7 @@ julia> grid = RectilinearGrid(size=(32, 16, 256), x=(-100, 100), y=(0, 12.5), z=
 
 For a "channel" model, as the one we constructed above, one would probably like to have finer resolution near
 the channel walls. We construct a grid that has non-regular spacing in the bounded dimensions, here ``y`` and ``z``
-by by prescribing functions for `y` and `z` keyword arguments. 
+by prescribing functions for `y` and `z` keyword arguments.
 
 For example, we can use the Chebychev nodes, which are more closely stacked near boundaries, to prescribe the
 ``y``- and ``z``-faces.
@@ -115,7 +115,7 @@ julia> chebychev_spaced_y_faces(j) = - Ly/2 * cos(π * (j - 1) / Ny);
 julia> chebychev_spaced_z_faces(k) = - Lz/2 - Lz/2 * cos(π * (k - 1) / Nz);
 
 julia> grid = RectilinearGrid(size = (Nx, Ny, Nz),
-                              topology=(Periodic, Bounded, Bounded),
+                              topology = (Periodic, Bounded, Bounded),
                               x = (0, Lx),
                               y = chebychev_spaced_y_faces,
                               z = chebychev_spaced_z_faces)
@@ -134,7 +134,7 @@ Lx, Ly, Lz = 1e4, 1e4, 1e3
 chebychev_spaced_y_faces(j) = - Ly/2 * cos(π * (j - 1) / Ny);
 chebychev_spaced_z_faces(k) = - Lz/2 - Lz/2 * cos(π * (k - 1) / Nz);
 grid = RectilinearGrid(size = (Nx, Ny, Nz),
-                              topology=(Periodic, Bounded, Bounded),
+                              topology = (Periodic, Bounded, Bounded),
                               x = (0, Lx),
                               y = chebychev_spaced_y_faces,
                               z = chebychev_spaced_z_faces)
@@ -165,7 +165,7 @@ save("plot_stretched_grid.svg", fig); nothing # hide
 A simple latitude-longitude grid with `Float64` type can be constructed by
 
 ```jldoctest
-julia> grid = LatitudeLongitudeGrid(size=(36, 34, 25),
+julia> grid = LatitudeLongitudeGrid(size = (36, 34, 25),
                                     longitude = (-180, 180),
                                     latitude = (-85, 85),
                                     z = (-1000, 0))

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -165,8 +165,6 @@ save("plot_stretched_grid.svg", fig); nothing # hide
 A simple latitude-longitude grid with `Float64` type can be constructed by
 
 ```jldoctest
-julia> using Oceananigans
-
 julia> grid = LatitudeLongitudeGrid(size=(36, 34, 25),
                                     longitude = (-180, 180),
                                     latitude = (-85, 85),

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -143,7 +143,7 @@ ax2 = Axis(fig[2, 1]; xlabel = "z-spacing (m)", ylabel = "z (m)", limits = ((0, 
 lines!(ax2, grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz])
 scatter!(ax2, grid.Δzᵃᵃᶜ[1:Nz], grid.zᵃᵃᶜ[1:Nz])
 
-save("plot_stretched_grid.svg"); nothing # hide
+save("plot_stretched_grid.svg", fig); nothing # hide
 ```
 
 ![](plot_stretched_grid.svg)

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -4,7 +4,6 @@ The grids currently supported are:
 - `RectilinearGrid`s with either constant or variable grid spacings and
 - `LatitudeLongitudeGrid` on the sphere.
 
-Each dimension can have different spacings.
 
 ## `RectilinearGrid`
 

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -1,9 +1,12 @@
 # Grids
 
-We currently `RectilinearGrid`s with either constant or variable grid spacings and also
-`LatitudeLongitudeGrid` on the sphere.
+The grids currently supported are:
+- `RectilinearGrid`s with either constant or variable grid spacings and
+- `LatitudeLongitudeGrid` on the sphere.
 
-The spacings can be different for each dimension.
+Each dimension can have different spacings.
+
+## `RectilinearGrid`
 
 A `RectilinearGrid` is constructed by specifying the `size` of the grid (a `Tuple` specifying
 the number of grid points in each direction) and either the `extent` (a `Tuple` specifying the
@@ -34,7 +37,7 @@ julia> grid = RectilinearGrid(size=(32, 64, 256), extent=(128, 256, 512))
     When using the `extent` keyword, e.g., `extent = (Lx, Ly, Lz)`, then the ``x \in [0, L_x]``,
     ``y \in [0, L_y]``, and ``z \in [-L_z, 0]`` -- a sensible choice for oceanographic applications.
 
-## Specifying the grid's architecture
+### Specifying the grid's architecture
 
 The first positional argument in either `RectilinearGrid` or `LatitudeLongitudeGrid` is the grid's
 architecture. By default `architecture = CPU()`. By providing `GPU()` as the `architecture` argument
@@ -48,7 +51,7 @@ julia> grid = RectilinearGrid(GPU(), size=(32, 64, 256), extent=(128, 256, 512))
 └── Bounded  z ∈ [-512.0, 0.0] regularly spaced with Δz=2.0
 ```
 
-## Specifying the grid's topology
+### Specifying the grid's topology
 
 Another crucial keyword is a 3-`Tuple` that specifies the grid's `topology`.
 In each direction the grid may be `Periodic`, `Bounded` or `Flat`.
@@ -67,10 +70,19 @@ julia> grid = RectilinearGrid(topology=(Periodic, Bounded, Bounded), size=(64, 6
 └── Bounded  z ∈ [-1000.0, 0.0] regularly spaced with Δz=31.25
 ```
 
-The `Flat` topology is useful when running problems with fewer than 3 dimensions. As an example,
+The `Flat` topology comes handy when running problems with less than 3 dimensions. As an example,
 to use a two-dimensional horizontal, doubly periodic domain the topology is `(Periodic, Periodic, Flat)`.
+In that case, the `size` and `extent` are 2-tuples, e.g.,
 
-## Specifying domain end points
+```jldoctest
+julia> grid = RectilinearGrid(topology=(Periodic, Periodic, Flat), size=(32, 32), extent=(10, 20))
+32×32×1 RectilinearGrid{Float64, Periodic, Periodic, Flat} on CPU with 3×3×0 halo
+├── Periodic x ∈ [0.0, 10.0)      regularly spaced with Δx=0.3125
+├── Periodic y ∈ [0.0, 20.0)      regularly spaced with Δy=0.625
+└── Flat z
+```
+
+### Specifying domain end points
 
 To specify a domain with a different origin than the default, the `x`, `y`, and `z` keyword arguments must be used.
 For example, a grid with ``x \in [-100, 100]`` meters, ``y \in [0, 12.5]`` meters, and ``z \in [-\pi, \pi]`` meters
@@ -84,7 +96,7 @@ julia> grid = RectilinearGrid(size=(32, 16, 256), x=(-100, 100), y=(0, 12.5), z=
 └── Bounded  z ∈ [-3.14159, 3.14159] regularly spaced with Δz=0.0245437
 ```
 
-## Grids with non-regular spacing in some of the directions
+### Grids with non-regular spacing in some of the directions
 
 For a "channel" model, as the one we constructed above, one would probably like to have finer resolution near
 the channel walls. We construct a grid that has non-regular spacing in the bounded dimensions, here ``y`` and ``z``
@@ -148,6 +160,7 @@ save("plot_stretched_grid.svg", fig); nothing # hide
 
 ![](plot_stretched_grid.svg)
 
+## `LatitudeLongitudeGrid`
 
 A simple latitude-longitude grid with `Float64` type can be constructed by
 

--- a/docs/src/model_setup/grids.md
+++ b/docs/src/model_setup/grids.md
@@ -69,7 +69,7 @@ julia> grid = RectilinearGrid(topology = (Periodic, Bounded, Bounded), size = (6
 └── Bounded  z ∈ [-1000.0, 0.0] regularly spaced with Δz=31.25
 ```
 
-The `Flat` topology comes handy when running problems with less than 3 dimensions. As an example,
+The `Flat` topology comes in handy when running problems with fewer than 3 dimensions. As an example,
 to use a two-dimensional horizontal, doubly periodic domain the topology is `(Periodic, Periodic, Flat)`.
 In that case, the `size` and `extent` are 2-tuples, e.g.,
 


### PR DESCRIPTION
This PR adds back a figure that somehow is not shown in the Docs/Model/Grids section and also adds an example of grid construction that has a `Flat` topology in the same docs.