### PR TITLE
Update `ImplicitFreeSurface` & `HeptadiagonalIterativeSolver` docstrings

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
@@ -45,7 +45,7 @@ where ``η^n`` is the free-surface elevation at the ``n``-th time step, ``H`` is
 the gravitational acceleration, ``Δt`` is the time step, ``𝐐_⋆`` is the barotropic volume flux
 associated with the predictor velocity field, and ``𝛁_h`` is the horizontal gradient operator.
 
-This equation can be solved in general using the [`PreconditionedConjugateGradientSolver`](@ref) but 
+This equation can be solved, in general, using the [`PreconditionedConjugateGradientSolver`](@ref) but 
 other solvers can be invoked in special cases.
 
 In the case that ``H`` is constant, we divide through to obtain
@@ -57,13 +57,13 @@ In the case that ``H`` is constant, we divide through to obtain
 Thus, for constant ``H`` and on grids with regular spacing in ``x`` and ``y`` directions, the free
 surface can be obtained using the [`FFTBasedPoissonSolver`](@ref).
 
-Keyword Arguments
-=================
+`solver_method` can be either of:
+* `:FastFourierTransform` (for [`FFTBasedPoissonSolver`](@ref))
+* `:HeptadiagonalIterativeSolver`  (for [`HeptadiagonalIterativeSolver`](@ref))
+* `:PreconditionedConjugateGradient` (for [`PreconditionedConjugateGradientSolver`](@ref))
 
-* `solver_method`: Options are: `:FastFourierTransform` (for [`FFTBasedPoissonSolver`](@ref)), `:HeptadiagonalIterativeSolver`
-  (for [`HeptadiagonalIterativeSolver`](@ref)), and `:PreconditionedConjugateGradient` (for [`PreconditionedConjugateGradientSolver`](@ref)).
-  By default, if the grid is has regular spacing in horizontal directions then the `:FastFourierTransform` is chosen, otherwise
-  the `:HeptadiagonalIterativeSolver`.
+By default, if the grid has regular spacing in the horizontal directions then the `:FastFourierTransform` is chosen,
+otherwise the `:HeptadiagonalIterativeSolver`.
 """
 ImplicitFreeSurface(; solver_method=:Default, gravitational_acceleration=g_Earth, solver_settings...) =
     ImplicitFreeSurface(nothing, gravitational_acceleration, nothing, nothing, solver_method, solver_settings)

--- a/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
@@ -35,7 +35,7 @@ Base.show(io::IO, fs::ImplicitFreeSurface) =
 """
     ImplicitFreeSurface(; solver_method=:Default, gravitational_acceleration=g_Earth, solver_settings...)
 
-The implicit free-surface equation is
+Return an implicit free-surface solver. The implicit free-surface equation is
 
 ```math
 \\left [ 𝛁_h ⋅ (H 𝛁_h) - \\frac{1}{g Δt^2} \\right ] η^{n+1} = \\frac{𝛁_h ⋅ 𝐐_⋆}{g Δt} - \\frac{η^{n}}{g Δt^2} ,
@@ -45,7 +45,8 @@ where ``η^n`` is the free-surface elevation at the ``n``-th time step, ``H`` is
 the gravitational acceleration, ``Δt`` is the time step, ``𝐐_⋆`` is the barotropic volume flux
 associated with the predictor velocity field, and ``𝛁_h`` is the horizontal gradient operator.
 
-This equation can be solved in general using the [`PreconditionedConjugateGradientSolver`](@ref).
+This equation can be solved in general using the [`PreconditionedConjugateGradientSolver`](@ref) but 
+other solvers can be invoked in special cases.
 
 In the case that ``H`` is constant, we divide through to obtain
 
@@ -54,7 +55,15 @@ In the case that ``H`` is constant, we divide through to obtain
 ```
 
 Thus, for constant ``H`` and on grids with regular spacing in ``x`` and ``y`` directions, the free
-surface can be obtained using the `FFTImplicitFreeSurfaceSolver`.
+surface can be obtained using the [`FFTBasedPoissonSolver`](@ref).
+
+Keyword Arguments
+=================
+
+* `solver_method`: Options are: `:FastFourierTransform` (for [`FFTBasedPoissonSolver`](@ref)), `:HeptadiagonalIterativeSolver`
+  (for [`HeptadiagonalIterativeSolver`](@ref)), and `:PreconditionedConjugateGradient` (for [`PreconditionedConjugateGradientSolver`](@ref)).
+  By default, if the grid is has regular spacing in horizontal directions then the `:FastFourierTransform` is chosen, otherwise
+  the `:HeptadiagonalIterativeSolver`.
 """
 ImplicitFreeSurface(; solver_method=:Default, gravitational_acceleration=g_Earth, solver_settings...) =
     ImplicitFreeSurface(nothing, gravitational_acceleration, nothing, nothing, solver_method, solver_settings)

--- a/src/Solvers/fft_based_poisson_solver.jl
+++ b/src/Solvers/fft_based_poisson_solver.jl
@@ -30,6 +30,23 @@ print(io, "FFTBasedPoissonSolver on ", string(typeof(architecture(solver))), ": 
           "    ├── forward: ", transform_list_str(solver.transforms.forward), "\n",
           "    └── backward: ", transform_list_str(solver.transforms.backward))
 
+"""
+    FFTBasedPoissonSolver(grid, planner_flag=FFTW.PATIENT)
+
+Return an `FFTBasedPoissonSolver` that solves the "generalized" Poisson equation,
+
+```math
+(∇² + m) ϕ = b,
+```
+
+where ``m`` is a number, using a eigenfunction expansion of the discrete Poisson operator
+on a staggered grid and for periodic or Neumann boundary conditions.
+
+In-place transforms are applied to ``b``, which means ``b`` must have complex-valued
+elements (typically the same type as `solver.storage`).
+
+See [`solve!`](@ref) for more information about the FFT-based Poisson solver algorithm.
+"""
 function FFTBasedPoissonSolver(grid, planner_flag=FFTW.PATIENT)
     topo = (TX, TY, TZ) =  topology(grid)
 

--- a/src/Solvers/heptadiagonal_iterative_solver.jl
+++ b/src/Solvers/heptadiagonal_iterative_solver.jl
@@ -73,12 +73,7 @@ to [`matrix_from_coefficients`](@ref).
 To allow for variable time step, the diagonal term `- Az / (g * Δt²)` is only added later on
 and it is updated only when the previous time step changes (`previous_Δt != Δt`).
 
-Preconditioning is done through the various methods implemented in `sparse_preconditioners.jl`. 
-
-`HeptadiagonalIterativeSolver` works for GPU, but it relies on serial backward and forward substitution which are very
-heavy and destroy all the computational advantage, therefore it is switched off until a
-parallel backward/forward substitution is implemented. It is also updated based on the
-matrix when `previous_Δt != Δt`.
+Preconditioning is done through the various methods implemented in `Solvers/sparse_preconditioners.jl`.
     
 The `iterative_solver` used can is to be chosen from the IterativeSolvers.jl package. 
 The default solver is a Conjugate Gradient (`cg`):

--- a/src/Solvers/heptadiagonal_iterative_solver.jl
+++ b/src/Solvers/heptadiagonal_iterative_solver.jl
@@ -68,7 +68,7 @@ The sparse matrix `A` can be constructed with:
 - `CuSparseMatrixCSC(constructors...)` for GPU
 
 The constructors are calculated based on the pentadiagonal coeffients passed as an input
-to [`matrix_from_coefficients`](@ref).
+to `matrix_from_coefficients` function.
 
 To allow for variable time step, the diagonal term `- Az / (g * Δt²)` is only added later on
 and it is updated only when the previous time step changes (`previous_Δt != Δt`).

--- a/src/Solvers/heptadiagonal_iterative_solver.jl
+++ b/src/Solvers/heptadiagonal_iterative_solver.jl
@@ -73,7 +73,7 @@ to [`matrix_from_coefficients`](@ref).
 To allow for variable time step, the diagonal term `- Az / (g * Δt²)` is only added later on
 and it is updated only when the previous time step changes (`previous_Δt != Δt`).
 
-Preconditioning is done through the incomplete LU factorization. 
+Preconditioning is done through the various methods implemented in `sparse_preconditioners.jl`. 
 
 `HeptadiagonalIterativeSolver` works for GPU, but it relies on serial backward and forward substitution which are very
 heavy and destroy all the computational advantage, therefore it is switched off until a


### PR DESCRIPTION
Enhances docstring for the `ImplicitFreeSurface` constructor to include the available solver methods.

Closes #2620