### PR TITLE
Implement device-aware GPU architecture

### DIFF
--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -60,19 +60,25 @@ Abstract supertype for Distributed architectures supported by Oceananigans.
 abstract type AbstractMultiArchitecture <: AbstractArchitecture end
 
 """
-    CPU <: AbstractArchitecture
+    CPU()
 
-Run Oceananigans on one CPU node. Uses multiple threads if the environment
-variable `JULIA_NUM_THREADS` is set.
+Returns a CPU architecture for building Oceananigans models on a single CPU node.
 """
 struct CPU <: AbstractArchitecture end
 
-"""
-    GPU <: AbstractArchitecture
 
-Run Oceananigans on a single NVIDIA CUDA GPU.
+struct GPU{D} <: AbstractArchitecture
+    device :: D
+end
+
 """
-struct GPU <: AbstractArchitecture end
+    GPU(device)
+
+Returns a GPU architecture for building Oceananigans models on a GPU `device`.
+
+Currently, only Nvidia CUDA GPUs are supported.
+"""
+GPU() = GPU(CUDA.device())
 
 #####
 ##### These methods are extended in Distributed.jl

--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -66,7 +66,6 @@ Returns a CPU architecture for building Oceananigans models on a single CPU node
 """
 struct CPU <: AbstractArchitecture end
 
-
 struct GPU{D} <: AbstractArchitecture
     device :: D
 end
@@ -78,7 +77,14 @@ Returns a GPU architecture for building Oceananigans models on a GPU `device`.
 
 Currently, only Nvidia CUDA GPUs are supported.
 """
-GPU() = GPU(CUDA.device())
+function GPU()
+    if CUDA.has_cuda_gpu() 
+        return GPU(CUDA.device()) 
+    else 
+        @warn "No cuda capable device found! Reconsider running with architecture = CPU()" 
+        return GPU(nothing)
+    end
+end
 
 #####
 ##### These methods are extended in Distributed.jl


### PR DESCRIPTION
This PR associates the GPU architecture with a specific device. This helps make the device that a model / grid is located on more explicit, so we don't have to "infer" the device based on where a particular piece of memory is allocated.

cc @simone-silvestri 