### PR TITLE
Minor changes in Langmuir and Ocean wind mixing examples

### DIFF
--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -47,7 +47,7 @@ grid = RectilinearGrid(size=(32, 32, 32), extent=(128, 128, 64))
 using Oceananigans.BuoyancyModels: g_Earth
 
  amplitude = 0.8 # m
-wavelength = 60 # m
+wavelength = 60  # m
 wavenumber = 2π / wavelength # m⁻¹
  frequency = sqrt(g_Earth * wavenumber) # s⁻¹
 

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -100,7 +100,7 @@ u_boundary_conditions = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ
 # along with a weak, destabilizing flux of buoyancy at the surface to faciliate
 # spin-up from rest.
 
-Qᵇ = 2.307e-9 # m² s⁻³, surface buoyancy flux
+Qᵇ = 2.307e-8 # m² s⁻³, surface buoyancy flux
 N² = 1.936e-5 # s⁻², initial and bottom buoyancy gradient
 
 b_boundary_conditions = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ),

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -53,7 +53,8 @@ h(k) = (k - 1) / Nz
 ## Generating function
 z_faces(k) = Lz * (ζ₀(k) * Σ(k) - 1)
 
-grid = RectilinearGrid(size = (32, 32, Nz), 
+grid = RectilinearGrid(CPU();
+                       size = (32, 32, Nz), 
                           x = (0, 64),
                           y = (0, 64),
                           z = z_faces)
@@ -155,8 +156,8 @@ model = NonhydrostaticModel(; grid, buoyancy,
 # * To use the Smagorinsky-Lilly turbulence closure (with a constant model coefficient) rather than
 #   `AnisotropicMinimumDissipation`, use `closure = SmagorinskyLilly()` in the model constructor.
 #
-# * To change the `architecture` to `GPU`, replace `architecture = CPU()` with
-#   `architecture = GPU()`.
+# * To change the architecture to `GPU`, replace `CPU()` with `GPU()` inside the
+#   `grid` constructor.
 
 # ## Initial conditions
 #
@@ -239,25 +240,6 @@ time_series = (w = FieldTimeSeries(filepath, "w"),
 ## Coordinate arrays
 xw, yw, zw = nodes(time_series.w)
 xT, yT, zT = nodes(time_series.T)
-
-""" Return colorbar levels equispaced between `(-clim, clim)` and encompassing the extrema of `c`. """
-function divergent_levels(c, clim, nlevels=21)
-    cmax = maximum(abs, c)
-    levels = clim > cmax ? range(-clim, stop=clim, length=nlevels) : range(-cmax, stop=cmax, length=nlevels)
-
-    return (levels[1], levels[end]), levels
-end
-
-""" Return colorbar levels equispaced between `clims` and encompassing the extrema of `c`."""
-function sequential_levels(c, clims, nlevels=20)
-    levels = range(clims[1], stop=clims[2], length=nlevels)
-    cmin, cmax = minimum(c), maximum(c)
-    cmin < clims[1] && (levels = vcat([cmin], levels))
-    cmax > clims[2] && (levels = vcat(levels, [cmax]))
-
-    return clims, levels
-end
-nothing # hide
 
 # We start the animation at ``t = 10minutes`` since things are pretty boring till then:
 


### PR DESCRIPTION
This PR:
- The Langmuir example currently claims that the buoyancy flux in the 2021 paper is `2.307e-9 # m² s⁻³, surface buoyancy flux` and sets up the buoyancy flux accordingly. But the paper actually sets up a flux of `2.307e-8` so I changed that (I think it was a typo). @glwagner can you please confirm that I'm not missing anything?

- Updates the CPU -> GPU functionality done via grid constructor instead via model in the Ocean wind mixing example.

Docs should render here: It should render here: https://clima.github.io/OceananigansDocumentation/previews/PR2646