### PR TITLE
Bugfix for `DiscreteDiffusionFunction` + passes prognostic + auxiliary fields to forcing functions

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
@@ -82,7 +82,7 @@ implicitly during time-stepping.
              - ∂yᶜᶠᶜ(i, j, k, grid, hydrostatic_pressure_anomaly)
              - ∂ⱼ_τ₂ⱼ(i, j, k, grid, closure, diffusivities, clock, model_fields, buoyancy)
              - immersed_∂ⱼ_τ₂ⱼ(i, j, k, grid, velocities, v_immersed_bc, closure, diffusivities, clock, model_fields)
-             + forcings.v(i, j, k, grid, clock, hydrostatic_prognostic_fields(velocities, free_surface, tracers)))
+             + forcings.v(i, j, k, grid, clock, model_fields))
 end
 
 """
@@ -116,7 +116,7 @@ where `c = C[tracer_index]`.
     return ( - div_Uc(i, j, k, grid, advection, velocities, c)
              - ∇_dot_qᶜ(i, j, k, grid, closure, diffusivities, val_tracer_index, c, clock, model_fields, buoyancy)
              - immersed_∇_dot_qᶜ(i, j, k, grid, c, c_immersed_bc, closure, diffusivities, val_tracer_index, clock, model_fields)
-             + forcing(i, j, k, grid, clock, hydrostatic_prognostic_fields(velocities, free_surface, tracers)))
+             + forcing(i, j, k, grid, clock, model_fields))
 end
 
 """
@@ -165,6 +165,6 @@ end
              + shear_production(i, j, k, grid, closure, velocities, diffusivities)
              + buoyancy_flux(i, j, k, grid, closure, velocities, tracers, buoyancy, diffusivities)
              - dissipation(i, j, k, grid, closure, velocities, tracers, buoyancy, clock, top_tracer_bcs)
-             + forcing(i, j, k, grid, clock, hydrostatic_prognostic_fields(velocities, free_surface, tracers)))
+             + forcing(i, j, k, grid, clock, model_fields))
 end
 

--- a/src/TurbulenceClosures/turbulence_closure_utils.jl
+++ b/src/TurbulenceClosures/turbulence_closure_utils.jl
@@ -1,6 +1,6 @@
 using Oceananigans.Operators
 
-tracer_diffusivities(tracers, κ::Union{Number, Function}) = with_tracers(tracers, NamedTuple(), (tracers, init) -> κ)
+tracer_diffusivities(tracers, κ::Union{Number, Function, DiscreteDiffusionFunction}) = with_tracers(tracers, NamedTuple(), (tracers, init) -> κ)
 tracer_diffusivities(tracers, ::Nothing) = nothing
 
 function tracer_diffusivities(tracers, κ::NamedTuple)

--- a/src/TurbulenceClosures/turbulence_closure_utils.jl
+++ b/src/TurbulenceClosures/turbulence_closure_utils.jl
@@ -1,6 +1,8 @@
 using Oceananigans.Operators
 
-tracer_diffusivities(tracers, κ::Union{Number, Function, DiscreteDiffusionFunction}) = with_tracers(tracers, NamedTuple(), (tracers, init) -> κ)
+const PossibleDiffusivity = Union{Number, Function, DiscreteDiffusionFunction, AbstractArray}
+
+tracer_diffusivities(tracers, κ::PossibleDiffusivity) = with_tracers(tracers, NamedTuple(), (tracers, init) -> κ)
 tracer_diffusivities(tracers, ::Nothing) = nothing
 
 function tracer_diffusivities(tracers, κ::NamedTuple)

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -130,7 +130,7 @@ function time_step_with_variable_discrete_diffusivity(arch)
     closure_ν = ScalarDiffusivity(ν = νd, discrete_form=true, loc = (Face, Center, Center))
     closure_κ = ScalarDiffusivity(κ = κd, discrete_form=true, loc = (Center, Face, Center))
 
-    model = NonhydrostaticModel(grid=RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 2, 3)), closure=(closure_ν, closure_κ))
+    model = NonhydrostaticModel(grid=RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 2, 3)), tracers = (:T, :S), closure=(closure_ν, closure_κ))
     time_step!(model, 1, euler=true)
 
     return true

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -123,6 +123,19 @@ function time_step_with_variable_anisotropic_diffusivity(arch)
     return true
 end
 
+function time_step_with_variable_discrete_diffusivity(arch)
+    @inline νd(i, j, k, grid, clock, fields) = 1 + fields.u[i, j, k] * 5
+    @inline κd(i, j, k, grid, clock, fields) = 1 + fields.v[i, j, k] * 5
+
+    closure_ν = ScalarDiffusivity(ν = νd, discrete_form=true, loc = (Face, Center, Center))
+    closure_κ = ScalarDiffusivity(κ = κd, discrete_form=true, loc = (Center, Face, Center))
+
+    model = NonhydrostaticModel(grid=RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 2, 3)), closure=(closure_ν, closure_κ))
+    time_step!(model, 1, euler=true)
+
+    return true
+end
+
 function time_step_with_tupled_closure(FT, arch)
     closure_tuple = (AnisotropicMinimumDissipation(FT), ScalarDiffusivity(FT))
 
@@ -207,6 +220,7 @@ end
         for arch in archs
             @test time_step_with_variable_isotropic_diffusivity(arch)
             @test time_step_with_variable_anisotropic_diffusivity(arch)
+            @test time_step_with_variable_discrete_diffusivity(arch)
         end
     end
 


### PR DESCRIPTION
small bugfix for which `discrete_form=form` and `Fields` were not working for tracers.

Also passing all the fields to the forcing function instead of only the prognostic ones