### PR TITLE
small bugfix in multi-region

### DIFF
--- a/src/Utils/multi_region_transformation.jl
+++ b/src/Utils/multi_region_transformation.jl
@@ -186,7 +186,7 @@ macro apply_regionally(expr)
                 func = exp.args[1]
                 args = exp.args[2:end]
                 new_expr.args[idx] = quote
-                    $ret = construct_regionally!($func, $(args...))
+                    $ret = construct_regionally($func, $(args...))
                 end
             end
         end


### PR DESCRIPTION
never really used in the code but solves a bug which appeared if  `@apply_regionally` was used with a `begin ... end` 
as

```
@apply_regionally begin
    fill!(u, 0.0)
    r = data(u)
end
```