### PR TITLE
Fixes doc references in Numerical Implementation/Elliptic Solvers section + `checkdocs = :exports`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -118,7 +118,7 @@ appendix_pages = [
     "Convergence tests" => "appendix/convergence_tests.md",
     "Performance benchmarks" => "appendix/benchmarks.md",
     "Library" => "appendix/library.md",
-    "Function index" => "appendix/function_index.md",
+    "Function index" => "appendix/function_index.md"
 ]
 
 pages = [
@@ -132,7 +132,7 @@ pages = [
     "Contributor's guide" => "contributing.md",
     "Gallery" => "gallery.md",
     "References" => "references.md",
-    "Appendix" => appendix_pages,
+    "Appendix" => appendix_pages
 ]
 
 #####
@@ -155,7 +155,7 @@ makedocs(bib,
    doctest = true,
     strict = true,
      clean = true,
- checkdocs = :none # Should fix our docstring so we can use checkdocs=:exports with strict=true.
+ checkdocs = :exports
 )
 
 deploydocs(

--- a/docs/src/appendix/fractional_step.md
+++ b/docs/src/appendix/fractional_step.md
@@ -1,4 +1,4 @@
-# Fractional step method
+# [Fractional step method](@id fractional_step_method)
 
 In some models (e.g., `NonhydrostaticModel` or `HydrostaticFreeSurfaceModel`) solving the momentum 
 coupled with the continuity equation can be cumbersome so instead we employ a fractional step 

--- a/docs/src/appendix/library.md
+++ b/docs/src/appendix/library.md
@@ -209,3 +209,10 @@ Private = false
 Modules = [Oceananigans.Utils]
 Private = false
 ```
+
+## Units
+
+```@autodocs
+Modules = [Oceananigans.Units]
+Private = false
+```

--- a/docs/src/numerical_implementation/elliptic_solvers.md
+++ b/docs/src/numerical_implementation/elliptic_solvers.md
@@ -43,7 +43,7 @@ The method can be explained easily by taking the Fourier transform of both sides
 where ``\widehat{\cdot}`` denotes the Fourier component. Here ``k_x``, ``k_y``, and ``k_z`` are the wavenumbers. However, when
 solving the equation on a staggered grid we require a solution for ``p_{NH}`` that is second-order accurate such that
 when when its Laplacian is computed, ``\nabla^2 p_{NH}`` matches ``\mathscr{F}`` to machine precision. This is crucial to
-ensure that the projection step in §\ref{sec:fractional-step} works. To do this, the wavenumbers are replaced by
+ensure that the projection step in the fractional time-step works (see [Time-stepping section](@ref time_stepping) and [Fractional step method appendix](@ref fractional_step_method)). To do this, the wavenumbers are replaced by
 eigenvalues ``\lambda^x``, ``\lambda^y``, and ``\lambda^z`` satisfying the discrete form of Poisson's equation with
 appropriate boundary conditions. Thus, Poisson's equation is diagonalized in Fourier space and the Fourier
 coefficients of the solution are easily solved for


### PR DESCRIPTION
Closes #2669.