### PR TITLE
Active particles with tracer interactions

### DIFF
--- a/src/LagrangianParticleTracking/LagrangianParticleTracking.jl
+++ b/src/LagrangianParticleTracking/LagrangianParticleTracking.jl
@@ -15,6 +15,7 @@ using Oceananigans.ImmersedBoundaries: immersed_cell
 using Oceananigans.Architectures: device, architecture
 using Oceananigans.Fields: interpolate, datatuple, compute!, location, fractional_indices, fractional_y_index
 using Oceananigans.Utils: prettysummary, launch!
+using Oceananigans: fields
 
 import Base: size, length, show
 
@@ -109,5 +110,5 @@ function Base.show(io::IO, lagrangian_particles::LagrangianParticles)
 end
 
 include("update_particle_properties.jl")
-
+include("tracer_interaction_utilities.jl")
 end # module

--- a/src/LagrangianParticleTracking/tracer_interaction_utilities.jl
+++ b/src/LagrangianParticleTracking/tracer_interaction_utilities.jl
@@ -1,0 +1,60 @@
+using KernelAbstractions.Extras.LoopInfo: @unroll
+using Oceananigans.Operators: volume
+using Oceananigans.Grids: AbstractGrid
+
+@inline get_node(::Bounded, i, N) = min(max(i, 1), N)
+@inline get_node(::Periodic, i, N) = ifelse(i < 1, N - i, ifelse(i > N, 1 + i, i))
+
+@inline function get_nearest_nodes(x, y, z, grid, loc)
+    i, j, k = fractional_indices(x, y, z, loc, grid)
+
+    # Convert fractional indices to unit cell coordinates 0 <= (ξ, η, ζ) <=1
+    # and integer indices (with 0-based indexing).
+    ξ, i = modf(i)
+    η, j = modf(j)
+    ζ, k = modf(k)
+
+    if (ξ, η, ζ) == (0, 0, 0) #particle on grid point special case
+        return ((Int(i+1), Int(j+1), Int(k+1), 1), ), 1.0
+    else
+        nodes = repeat([(1, 1, 1, NaN)], 8)
+        _normfactor = 0.0
+        @unroll for n=1:8
+            # Move around cube corners getting node indices (0 or 1) and distances to them
+            # Distance is d when the index is 0, or 1-d when it is 1
+            a = 0^(1+(-1)^n)
+            di = 0^abs(1-a)+ξ*(-1)^a
+
+            b = 0^(1+(-1)^floor(n/2))
+            dj = 0^abs(1-b)+η*(-1)^b
+
+            c = 0^(1+(-1)^floor(n/4))
+            dk = 0^abs(1-c)+ζ*(-1)^c
+
+            nodes[n] = (Int(i+1)+a, 
+                            Int(j+1)+b, 
+                            Int(k+1)+c, 
+                            sqrt(di^2+dj^2+dk^2))
+            _normfactor += 1 ./sqrt(di^2+dj^2+dk^2)
+        end
+        return nodes, 1/_normfactor
+    end
+end
+
+@kernel function calculate_particle_tendency_kernel!(property, tendency, particles, grid::AbstractGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
+    p = @index(Global)
+    #density = :density in keys(particles.parameters) ? particles.parameters.density : 1
+    density = 1
+
+    LX, LY, LZ = location(tendency)
+    nodes, normfactor = @inbounds get_nearest_nodes(particles.properties.x[p], particles.properties.y[p], particles.properties.z[p], grid, (LX(), LY(), LZ()))
+
+    @unroll for (i, j, k, d) in nodes 
+        # Reflect back on Bounded boundaries or wrap around for Periodic boundaries
+        i, j, k = (get_node(TX(), i, grid.Nx), get_node(TY(), j, grid.Ny), get_node(TZ(), k, grid.Nz))
+
+        node_volume = volume(i, j, k, grid, LX(), LY(), LZ())
+        value = density * @inbounds property[p] * normfactor / (d * node_volume)
+        @inbounds tendency[i, j, k] += value	
+    end
+end

--- a/src/LagrangianParticleTracking/update_particle_properties.jl
+++ b/src/LagrangianParticleTracking/update_particle_properties.jl
@@ -128,10 +128,16 @@ function update_particle_properties!(lagrangian_particles, model, Δt)
     events = []
 
     for (field_name, tracked_field) in pairs(lagrangian_particles.tracked_fields)
-        compute!(tracked_field)
-        particle_property = getproperty(lagrangian_particles.properties, field_name)
+        if isnothing(tracked_field)
+            tracked_field = fields(model)[field_name]
+         else
+             compute!(tracked_field)
+        end
+        
         LX, LY, LZ = location(tracked_field)
 
+        particle_property = getproperty(lagrangian_particles.properties, field_name)
+    
         update_field_property_kernel! = update_field_property!(device(arch), workgroup, worksize)
 
         update_event = update_field_property_kernel!(particle_property, lagrangian_particles.properties, model.grid,

--- a/validation/biogeochemistry/active_particles.jl
+++ b/validation/biogeochemistry/active_particles.jl
@@ -1,0 +1,74 @@
+using Oceananigans, StructArrays, Printf, JLD2, KernelAbstractions
+using Oceananigans.Architectures: device
+using Oceananigans.Fields: TracerFields
+using Oceananigans.LagrangianParticleTracking: calculate_particle_tendency_kernel!
+# This example will not neccesarily keep tracers above zero because two particles may/will take from the same cell in the same timestep
+
+grid = RectilinearGrid(;topology = (Bounded, Bounded, Periodic), size=(10, 10, 1), extent=(1, 1, 1))
+struct Particle{T}
+    x :: T
+    y :: T
+    z :: T
+    A :: T
+    A_sink :: T
+    B_source :: T
+end
+
+# particle randomly walks around and turns tracer a into tracer b
+function dynamics!(particles, model, Δt)
+    particles.properties.x .+= (-1).^rand(Bool, length(particles)).*rand(length(particles))*Δt
+    particles.properties.y .+= (-1).^rand(Bool, length(particles)).*rand(length(particles))*Δt
+
+    #particles go round and turns tracer a into b
+    particles.properties.A_sink .= -particles.properties.A ./ (50 .+ particles.properties.A)
+    particles.properties.B_source .= particles.properties.A ./ (50 .+ particles.properties.A)
+
+    workgroup = min(length(particles), 256)
+    worksize = length(particles)
+
+    arch = model.grid.architecture
+    
+    Gp_kernel! = calculate_particle_tendency_kernel!(device(arch), workgroup, worksize)
+
+    model.auxiliary_fields.Gₚ.A .= 0
+    model.auxiliary_fields.Gₚ.B .= 0
+
+    Gp_event_A = Gp_kernel!(particles.properties.A_sink, model.auxiliary_fields.Gₚ.A, particles, model.grid, dependencies = Event(device(arch)))
+    Gp_event_B = Gp_kernel!(particles.properties.B_source, model.auxiliary_fields.Gₚ.B, particles, model.grid, dependencies = Event(device(arch)))
+
+    events=[Gp_event_A, Gp_event_B]
+
+    wait(device(arch), MultiEvent(Tuple(events)))
+end
+
+P=2
+
+xs = 0.5*ones(P)
+ys = 0.5*ones(P)
+zs = -0.5*ones(P)
+as = zeros(P)
+a_sink_s = zeros(P)
+b_source_s = zeros(P)
+
+particles = StructArray{Particle}((xs, ys, zs, as, a_sink_s, b_source_s))
+
+Gₚ = TracerFields((:A, :B), grid)
+
+lagrangian_particles = LagrangianParticles(particles; tracked_fields=(A=nothing, ), dynamics=dynamics!)
+@info "Initialized Lagrangian particles"
+
+@inline a_sink(i, j, k, clock, grid, c) = c.Gₚ.A[i, j, k]
+@inline b_source(i, j, k, clock, grid, c) = c.Gₚ.B[i, j, k]
+
+A_forcing = Forcing(a_sink, discrete_form=true)
+B_forcing = Forcing(b_source, discrete_form=true)
+
+model = NonhydrostaticModel(grid=grid, tracers=(:A, :B), forcing = (A=A_forcing, B=B_forcing), particles=lagrangian_particles, auxiliary_fields = (; Gₚ))
+
+set!(model, A=1)
+
+@info "Constructed a model"
+
+sim = Simulation(model, Δt=1e-1, stop_time=20)
+
+#run!(sim)


### PR DESCRIPTION
Hi all, 

I am currently working on a biogeochemistry modelling environment with @johnryantaylor using Oceananigans, and as part of this have have up with a scheme to have "active" particles that interact with tracers.

How I currently have this set up: when the particle dynamics are run, the particles can increase/decrease the concentration of tracers in the cells surrounding them, but this only allows for explicit Euler integration. A better way todo this seems to be to have the particles uptake/exudation of tracers contribute to their tendencies during the time stepping as I have implemented here.

I'm unsure if this is implemented in the best way throughout but I'm fairly satisfied that I have it working as desired. 

Hope everyone is happy with this?

--------

To summaries what I have changed:

- Particle setup: particles can get a parameter called `active_properties` which is a tuple of named tuples of particle properties and tracers (e.g. `((property=:t, tracer=:x),).`) The idea being that the particle dynamics function (as already implemented) changes the particle property to set a rate of uptake/exudation of a tracer, and the below function would integrate this change to the specified tracer.

- `calculate_particle_tendency_contributions!` added after each `calculate_tendencies!` call: function goes through each particle, finds its 8 nearest cells, and adds the relevant fraction of each particle property (divided by the cell volume) to the tracer tendencies so it can be integrated by the time stepper (like tracer forcing)