### PR TITLE
Correct computation for buoyancy dissipation rate, `χ_diff` + demonstrate `Integral`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -158,6 +158,12 @@ makedocs(bib,
  checkdocs = :exports
 )
 
+@info "Cleaning up temporary .jld2 and .nc files created by doctests..."
+
+for file in vcat(glob("docs/*.jld2"), glob("docs/*.nc"))
+    rm(file)
+end
+
 deploydocs(
           repo = "github.com/CliMA/OceananigansDocumentation.git",
       versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
@@ -165,9 +171,3 @@ deploydocs(
   push_preview = true,
      devbranch = "main"
 )
-
-@info "Cleaning up temporary .jld2 and .nc files created by doctests..."
-
-for file in vcat(glob("docs/*.jld2"), glob("docs/*.nc"))
-    rm(file)
-end

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -134,7 +134,7 @@ u, v, w = model.velocities # unpack velocity `Field`s
 b = model.tracers.b        # unpack buoyancy `Field`
 
 ## total flow speed
-s = sqrt(u^2 + w^2)
+s = @at (Center, Center, Center) sqrt(u^2 + w^2)
 
 ## y-component of vorticity
 ζ = ∂z(u) - ∂x(w)
@@ -185,8 +185,7 @@ b_timeseries = FieldTimeSeries(saved_output_filename, "b")
 times = b_timeseries.times
 
 ## Coordinate arrays
-xs, ys, zs = nodes(s_timeseries[1])
-xb, yb, zb = nodes(b_timeseries[1])
+xc, yc, zc = nodes(b_timeseries[1])
 xζ, yζ, zζ = nodes(ζ_timeseries[1])
 nothing # hide
 
@@ -194,7 +193,7 @@ nothing # hide
 
 for i in 1:length(times)
   bᵢ = b_timeseries[i]
-  χ_timeseries[i] .= κ * (∂x(bᵢ)^2 + ∂z(bᵢ)^2)
+  χ_timeseries[i] .= @at (Center, Center, Center) κ * (∂x(bᵢ)^2 + ∂z(bᵢ)^2)
 end
 
 
@@ -225,25 +224,25 @@ axis_kwargs = (xlabel = L"x / H",
 fig = Figure(resolution = (600, 1100))
 
 ax_s = Axis(fig[2, 1];
-            title = L"speed, $(u^2+w^2)^{1/2} / (b_* H)^{1/2}", axis_kwargs...)
+            title = L"speed, $(u^2+w^2)^{1/2} / (L_x b_*) ^{1/2}", axis_kwargs...)
 
 ax_b = Axis(fig[3, 1];
             title = L"buoyancy, $b / b_*$", axis_kwargs...)
 
 ax_ζ = Axis(fig[4, 1];
-            title = L"vorticity, $(∂u/∂z - ∂w/∂x) (H/b_*)^{1/2}$", axis_kwargs...)
+            title = L"vorticity, $(∂u/∂z - ∂w/∂x) \, (L_x / b_*)^{1/2}$", axis_kwargs...)
 
 ax_χ = Axis(fig[5, 1];
-            title = L"buoyancy dissipation, $κ |\mathbf{\nabla}b|^2 (H/b_*^5)^{1/2}$", axis_kwargs...)
+            title = L"buoyancy dissipation, $κ |\mathbf{\nabla}b|^2 \, (L_x / {b_*}^5)^{1/2}$", axis_kwargs...)
 
 fig[1, :] = Label(fig, title, textsize=24, tellwidth=false)
 
-hm_s = heatmap!(ax_s, xs, zs, sₙ;
+hm_s = heatmap!(ax_s, xc, zc, sₙ;
                 colorrange = (0, slim),
                 colormap = :speed)
 Colorbar(fig[2, 2], hm_s)
 
-hm_b = heatmap!(ax_b, xb, zb, bₙ;
+hm_b = heatmap!(ax_b, xc, zc, bₙ;
                 colorrange = (-blim, blim),
                 colormap = :thermal)
 Colorbar(fig[3, 2], hm_b)
@@ -253,7 +252,7 @@ hm_ζ = heatmap!(ax_ζ, xζ, zζ, ζₙ;
                 colormap = :balance)
 Colorbar(fig[4, 2], hm_ζ)
 
-hm_χ = heatmap!(ax_χ, xs, zs, χₙ;
+hm_χ = heatmap!(ax_χ, xc, zc, χₙ;
                 colorrange = (0, χlim),
                 colormap = :dense)
 Colorbar(fig[5, 2], hm_χ)
@@ -334,10 +333,11 @@ end
 
 fig = Figure(resolution = (850, 450))
  
-ax_KE = Axis(fig[1, 1], xlabel = "time", ylabel = L"KE $ / (b_* H)$")
+ax_KE = Axis(fig[1, 1], xlabel = L"t \, (b_* / L_x)^{1/2}", ylabel = L"KE $ / (L_x b_*)$")
 lines!(ax_KE, t, kinetic_energy; linewidth = 3)
 
-ax_Nu = Axis(fig[2, 1], xlabel = "time", ylabel = L"Nu")
+ax_Nu = Axis(fig[2, 1], xlabel = L"t \, (b_* / L_x)^{1/2}", ylabel = L"Nu")
 lines!(ax_Nu, t, Nu; linewidth = 3)
 
 current_figure() # hide
+fig

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -280,7 +280,7 @@ nothing #hide
 # Nu = \frac{\langle \chi \rangle}{\langle \chi_{\rm diff} \rangle} \, ,
 # ```
 #
-# where angle brackets above denote both a volume and time average and  ``\chi_{\rm diff}`` is
+# where angle brackets above denote both a volume and time average and ``\chi_{\rm diff}`` is
 # the buoyancy dissipation that we get without any flow, i.e., the buoyancy dissipation associated
 # with the buoyancy distribution that satisfies
 #
@@ -288,12 +288,12 @@ nothing #hide
 # \kappa \nabla^2 b_{\rm diff} = 0 \, ,
 # ```
 #
-# with the same boundary conditions same as our setup. In this case we can readily find that
+# with the same boundary conditions same as our setup. In this case, we can readily find that
 #
 # ```math
 # b_{\rm diff}(x, z) = b_s(x) \frac{\cosh \left [2 \pi (H + z) / L_x \right ]}{\cosh(2 \pi H / L_x)} \, ,
 # ```
-# which implies ``\langle \chi_{\rm diff} \rangle = \kappa b_*^2 \pi \tanh(2 \pi Η /Lx)``.
+# which implies ``\langle \chi_{\rm diff} \rangle = \kappa b_*^2 \pi \tanh(2 \pi Η /Lx) / (L_x H)``.
 #
 # We use the loaded `FieldTimeSeries` to compute the Nusselt number from buoyancy and the volume
 # average kinetic energy of the fluid.
@@ -301,7 +301,7 @@ nothing #hide
 # First we compute the diffusive buoyancy dissipation, ``\chi_{\rm diff}`` (which is just a
 # scalar):
 
-χ_diff = κ * b★^2 * π * tanh(2π * H / Lx)
+χ_diff = κ * b★^2 * π * tanh(2π * H / Lx) / (Lx * H)
 nothing # hide
 
 # We then create two `ReducedField`s to store the volume integrals of the kinetic energy density
@@ -331,7 +331,7 @@ for i = 1:length(t)
     
     b = b_timeseries[i]
     sum!(∫ⱽ_mod²_∇b, (∂x(b)^2 + ∂z(b)^2) * volume)
-    Nu[i] = (κ *  ∫ⱽ_mod²_∇b[1, 1, 1]) / χ_diff
+    Nu[i] = (κ *  ∫ⱽ_mod²_∇b[1, 1, 1] / (Lx * H)) / χ_diff
 end
 
 fig = Figure(resolution = (850, 450))

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -331,7 +331,8 @@ for i = 1:length(t)
     
     b = b_timeseries[i]
     sum!(∫ⱽ_mod²_∇b, (∂x(b)^2 + ∂z(b)^2) * volume)
-    Nu[i] = (κ *  ∫ⱽ_mod²_∇b[1, 1, 1] / (Lx * H)) / χ_diff
+    χ = κ *  ∫ⱽ_mod²_∇b[1, 1, 1] / (Lx * H)
+    Nu[i] = χ / χ_diff
 end
 
 fig = Figure(resolution = (850, 450))

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -9,11 +9,6 @@ default_included_properties(::NonhydrostaticModel) = [:grid, :coriolis, :buoyanc
 default_included_properties(::ShallowWaterModel) = [:grid, :coriolis, :closure]
 default_included_properties(::HydrostaticFreeSurfaceModel) = [:grid, :coriolis, :buoyancy, :closure]
 
-"""
-    JLD2OutputWriter{I, T, O, IF, IN, KW} <: AbstractOutputWriter
-
-An output writer for writing to JLD2 files.
-"""
 mutable struct JLD2OutputWriter{O, T, D, IF, IN, KW} <: AbstractOutputWriter
     filepath :: String
     outputs :: O
@@ -76,6 +71,9 @@ Keyword arguments
                will save xy-slices of the bottom-most index.
 
   - `with_halos` (Bool): Whether or not to slice halo regions from fields before writing output.
+                         Note, that to postprocess saved output (e.g., compute derivatives, etc)
+                         information about the boundary conditions is often crucial. In that case
+                         you might need to set `with_halos = true`.
 
   - `array_type`: The array type to which output arrays are converted to prior to saving.
                   Default: `Array{Float32}`.

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -167,7 +167,10 @@ Keyword arguments
 - `indices`: Tuple of indices of the output variables to include. Default is `(:, :, :)`, which
              includes the full fields.
 
-- `with_halos`: Boolean defining whether or not to include halos in the outputs. Default: false.
+- `with_halos`: Boolean defining whether or not to include halos in the outputs. Default: `false`.
+                Note, that to postprocess saved output (e.g., compute derivatives, etc)
+                information about the boundary conditions is often crucial. In that case
+                you might need to set `with_halos = true`.
 
 - `global_attributes`: Dict of model properties to save with every file. Default: `Dict()`.
 


### PR DESCRIPTION
In the horizontal convection example `χ_diff` is defined as a volume average of the buoyancy dissipation but when computing it were not dividing by the total volume. Now fixed. To compute the buoyancy dissipation the halos were crucial so as to take into account correct boundary conditions for `b` -- the example now remarks on this and saves output using `with_halos = true`.

Closes #2735.