### PR TITLE
BC and Immersed Reductions for Sliced Fields 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.77.3"
+version = "0.77.4"
 
 [deps]
 AMGX = "c963dde9-0319-47f5-bf0c-b07d3c80ffa6"

--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -30,19 +30,16 @@ import Oceananigans.Fields: compute_at!, indices
 ##### Basic functionality
 #####
 
-abstract type AbstractOperation{LX, LY, LZ, G, I, T} <: AbstractField{LX, LY, LZ, G, T, 3} end
+abstract type AbstractOperation{LX, LY, LZ, G, T} <: AbstractField{LX, LY, LZ, G, T, 3} end
 
 const AF = AbstractField # used in unary_operations.jl, binary_operations.jl, etc
 
-const FullAbstractOperation = AbstractOperation{<:Any, <:Any, <:Any, <:Any, <:Tuple{<:Colon, <:Colon, <:Colon}}
-
-indices(a::AbstractOperation) = a.indices
-
 function Base.axes(f::AbstractOperation)
-    if f.indices === (:, : ,:)
+    idx = indices(f)
+    if idx === (:, : ,:)
         return Base.OneTo.(size(f))
     else
-        return Tuple(f.indices[i] isa Colon ? Base.OneTo(size(f, i)) : f.indices[i] for i = 1:3)
+        return Tuple(idx[i] isa Colon ? Base.OneTo(size(f, i)) : idx[i] for i = 1:3)
     end
 end
 

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -63,7 +63,6 @@ function interpolate_indices(args, loc_op)
     idxs = Any[:, :, :]
     for i in 1:3
         for arg in args
-            @show idxs
             idxs[i] = interpolate_index(indices(arg)[i], idxs[i], location(arg)[i], loc_op[i])
         end
     end
@@ -77,7 +76,6 @@ interpolate_index(::Colon, b::UnitRange, args...)  = b
 # REMEMBER! Not supported abstract operations which require an interpolation of sliced fields!
 function interpolate_index(a::UnitRange, ::Colon, loc, new_loc)  
     a = corrected_index(a, loc, new_loc)
-    @show a
     if first(a) > last(a)
         throw(ArgumentError("Cannot interpolate from $loc to $new_loc a Sliced field!"))
     end
@@ -97,5 +95,5 @@ end
 # viceverse, windowed fields interpolated from `Face`s to `Center`s lose the last index
 corrected_index(a, ::Type{Face},   ::Type{Face})   = UnitRange(first(a),   last(a))
 corrected_index(a, ::Type{Center}, ::Type{Center}) = UnitRange(first(a),   last(a))
-corrected_index(a, ::Type{Face},   ::Type{Center}) = UnitRange(first(a)+1, last(a))
-corrected_index(a, ::Type{Center}, ::Type{Face})   = UnitRange(first(a),   last(a)-1)
+corrected_index(a, ::Type{Face},   ::Type{Center}) = UnitRange(first(a),   last(a)-1)
+corrected_index(a, ::Type{Center}, ::Type{Face})   = UnitRange(first(a)+1, last(a))

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -58,6 +58,9 @@ end
 indices(f::Function) = (:, :, :)
 indices(f::Number)   = (:, :, :)
 
+# Fallback (used for KernelFunctionOperation)
+indices(f) = (:, :, :)
+
 # easy index propagation 
 function interpolate_indices(args, loc_op)
     idxs = Any[:, :, :]

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -51,10 +51,6 @@ macro at(location, abstract_operation)
     return wrapped_operation
 end
 
-"""
-    utility to propagate field indices in AbstractOperations
-"""
-
 using Oceananigans.Fields: default_indices
 
 # Numbers and functions do not have index restrictions
@@ -64,7 +60,13 @@ indices(f::Number)   = default_indices(3)
 # Fallback (used by KernelFunctionOperation)
 indices(f) = default_indices(3)
 
-# easy index propagation 
+
+"""
+    interpolate_indices(operands..., loc_operation = abstract_operation_location)
+
+Utility to propagate operands' indices in `AbstractOperations`s with multiple operands 
+(`BinaryOperation`s and `MultiaryOperation`s)
+"""
 function interpolate_indices(args...; loc_operation = (Center, Center, Center))
     idxs = Any[:, :, :]
     for i in 1:3

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -77,32 +77,23 @@ interpolate_index(::Colon, b::UnitRange, args...)  = b
 # otherwise we lose the last index
 # REMEMBER! Not supported abstract operations which require an interpolation of sliced fields!
 function interpolate_index(a::UnitRange, ::Colon, loc, new_loc)  
-    if loc == new_loc
-        return a
-    else
-        if a[1] == a[2]
-            throw(ArgumentError("Cannot interpolate from $loc to $new_loc a Sliced field!"))
-        end
-        if new_loc == Face
-            return UnitRange(a[1]+1, a[2])
-        else
-            return UnitRange(a[1], a[2]-1)    
-        end
+    a = corrected_index(a[1], loc, new_loc)
+    if a[1] > a[2]
+        throw(ArgumentError("Cannot interpolate from $loc to $new_loc a Sliced field!"))
     end
+    return a
 end
 
 # REMEMBER: issue an error when the indices are not compatible (e.g. parallel fields on different planes)
 function interpolate_index(a::UnitRange, b::UnitRange, loc, new_loc)   
-    if loc == new_loc
-        return UnitRange(max(a[1], b[1]), min(a[2], b[2]))
-    else
-        if a[1] == a[2]
-            throw(ArgumentError("Cannot interpolate from $loc to $new_loc a Sliced field!"))
-        end
-        if new_loc == Face
-            return UnitRange(max(a[1]+1, b[1]),min(a[2], b[2]))
-        else
-            return UnitRange(max(a[1], b[1]),min(a[2]-1, b[2]))
-        end
+    a = corrected_index(a[1], loc, new_loc)
+    if a[1] > a[2]
+        throw(ArgumentError("Cannot interpolate from $loc to $new_loc a Sliced field!"))
     end
+    return UnitRange(max(a[1], b[1]), min(a[2], b[2]))
 end
+
+corrected_index(a, ::Face, ::Face)     = UnitRange(a[1], a[2])
+corrected_index(a, ::Center, ::Center) = UnitRange(a[1], a[2])
+corrected_index(a, ::Face, ::Center)   = UnitRange(a[1]+1, a[2])
+corrected_index(a, ::Center, ::Face)   = UnitRange(a[1], a[2]-1)

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -66,14 +66,14 @@ indices(f) = default_indices(3)
 
 # easy index propagation 
 function interpolate_indices(args...; loc_operation = (Center, Center, Center))
-    indices = Any[:, :, :]
+    idxs = Any[:, :, :]
     for i in 1:3
         for arg in args
-            indices[i] = interpolate_index(indices(arg)[i], indices[i], location(arg)[i], loc_operation[i])
+            idxs[i] = interpolate_index(indices(arg)[i], idxs[i], location(arg)[i], loc_operation[i])
         end
     end
 
-    return Tuple(indices)
+    return Tuple(idxs)
 end
 
 interpolate_index(::Colon, ::Colon, args...)       = Colon()

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -73,8 +73,6 @@ end
 interpolate_index(::Colon, ::Colon, args...)       = Colon()
 interpolate_index(::Colon, b::UnitRange, args...)  = b
 
-# If we interpolate from a `Center` to a `Face` we lose the first index,
-# otherwise we lose the last index
 # REMEMBER! Not supported abstract operations which require an interpolation of sliced fields!
 function interpolate_index(a::UnitRange, ::Colon, loc, new_loc)  
     a = corrected_index(a[1], loc, new_loc)
@@ -93,6 +91,8 @@ function interpolate_index(a::UnitRange, b::UnitRange, loc, new_loc)
     return UnitRange(max(a[1], b[1]), min(a[2], b[2]))
 end
 
+# Windowed Fields interpolate from a `Center` to a `Face` lose the first index,
+# viceverse, windowed fields interpolated from `Face`s to `Center`s lose the last index
 corrected_index(a, ::Face, ::Face)     = UnitRange(a[1], a[2])
 corrected_index(a, ::Center, ::Center) = UnitRange(a[1], a[2])
 corrected_index(a, ::Face, ::Center)   = UnitRange(a[1]+1, a[2])

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -52,7 +52,7 @@ macro at(location, abstract_operation)
 end
 
 """
-    utility to propagate field indices in abstract operations
+    utility to propagate field indices in AbstractOperations
 """
 
 using Oceananigans.Fields: default_indices
@@ -66,14 +66,14 @@ indices(f) = default_indices(3)
 
 # easy index propagation 
 function interpolate_indices(args...; loc_operation = (Center, Center, Center))
-    idxs = Any[:, :, :]
+    indices = Any[:, :, :]
     for i in 1:3
         for arg in args
-            idxs[i] = interpolate_index(indices(arg)[i], idxs[i], location(arg)[i], loc_operation[i])
+            indices[i] = interpolate_index(indices(arg)[i], indices[i], location(arg)[i], loc_operation[i])
         end
     end
 
-    return Tuple(idxs)
+    return Tuple(indices)
 end
 
 interpolate_index(::Colon, ::Colon, args...)       = Colon()
@@ -83,7 +83,7 @@ function interpolate_index(a::UnitRange, ::Colon, loc, new_loc)
     a = corrected_index(a, loc, new_loc)
 
     # Abstract operations that require an interpolation of a sliced fields are not supported!
-    first(a) > last(a) && throw(ArgumentError("Cannot interpolate a Sliced field from $loc to $(new_loc)!"))
+    first(a) > last(a) && throw(ArgumentError("Cannot interpolate a sliced field from $loc to $(new_loc)!"))
     return a
 end
 
@@ -91,16 +91,16 @@ function interpolate_index(a::UnitRange, b::UnitRange, loc, new_loc)
     a = corrected_index(a, loc, new_loc)
 
     # Abstract operations that require an interpolation of a sliced fields are not supported!
-    first(a) > last(a) && throw(ArgumentError("Cannot interpolate a Sliced field from $loc to $(new_loc)!"))
+    first(a) > last(a) && throw(ArgumentError("Cannot interpolate a sliced field from $loc to $(new_loc)!"))
     
     indices = UnitRange(max(first(a), first(b)), min(last(a), last(b)))
     
-    # Abstract operations between parallel non-intersecating windowed fields are not 
-    first(indices) > last(indices) && throw(ArgumentError("indices $(a) and $(b) are not compatible!"))
+    # Abstract operations between parallel non-intersecating windowed fields are not supported
+    first(indices) > last(indices) && throw(ArgumentError("BinaryOperation operand indices $(a) and $(b) do not intersect!"))
     return indices
 end
 
-# Windowed Fields interpolated from `Center`s to `Face`s lose the first index.
+# Windowed fields interpolated from `Center`s to `Face`s lose the first index.
 # Viceverse, windowed fields interpolated from `Face`s to `Center`s lose the last index
 corrected_index(a, ::Type{Face},   ::Type{Face})   = UnitRange(first(a),   last(a))
 corrected_index(a, ::Type{Center}, ::Type{Center}) = UnitRange(first(a),   last(a))

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -93,7 +93,7 @@ function interpolate_index(a::UnitRange, b::UnitRange, loc, new_loc)
     # Abstract operations that require an interpolation of a sliced fields are not supported!
     first(a) > last(a) && throw(ArgumentError("Cannot interpolate a Sliced field from $loc to $(new_loc)!"))
     
-    indices = UnitRange(max(first(a), first(b)), min(first(a), last(b)))
+    indices = UnitRange(max(first(a), first(b)), min(last(a), last(b)))
     
     # Abstract operations between parallel non-intersecating windowed fields are not 
     first(indices) > last(indices) && throw(ArgumentError("indices $(a) and $(b) are not compatible!"))

--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -62,11 +62,11 @@ indices(f::Number)   = (:, :, :)
 indices(f) = (:, :, :)
 
 # easy index propagation 
-function interpolate_indices(args, loc_op)
+function interpolate_indices(args...; loc_operation = (Center, Center, Center))
     idxs = Any[:, :, :]
     for i in 1:3
         for arg in args
-            idxs[i] = interpolate_index(indices(arg)[i], idxs[i], location(arg)[i], loc_op[i])
+            idxs[i] = interpolate_index(indices(arg)[i], idxs[i], location(arg)[i], loc_operation[i])
         end
     end
 

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -1,13 +1,12 @@
 const binary_operators = Set()
 
-struct BinaryOperation{LX, LY, LZ, O, A, B, IA, IB, G, I, T} <: AbstractOperation{LX, LY, LZ, G, I, T}
+struct BinaryOperation{LX, LY, LZ, O, A, B, IA, IB, G, T} <: AbstractOperation{LX, LY, LZ, G, T}
     op :: O
     a :: A
     b :: B
     ▶a :: IA
     ▶b :: IB
     grid :: G
-    indices :: I
 
     @doc """
         BinaryOperation{LX, LY, LZ}(op, a, b, ▶a, ▶b, grid)
@@ -15,9 +14,9 @@ struct BinaryOperation{LX, LY, LZ, O, A, B, IA, IB, G, I, T} <: AbstractOperatio
     Returns an abstract representation of the binary operation `op(▶a(a), ▶b(b))`.
     on `grid`, where `▶a` and `▶b` interpolate `a` and `b` to locations `(LX, LY, LZ)`.
     """
-    function BinaryOperation{LX, LY, LZ}(op::O, a::A, b::B, ▶a::IA, ▶b::IB, grid::G, indices::I) where {LX, LY, LZ, O, A, B, IA, IB, G, I}
+    function BinaryOperation{LX, LY, LZ}(op::O, a::A, b::B, ▶a::IA, ▶b::IB, grid::G) where {LX, LY, LZ, O, A, B, IA, IB, G}
         T = eltype(grid)
-        return new{LX, LY, LZ, O, A, B, IA, IB, G, I, T}(op, a, b, ▶a, ▶b, grid, indices)
+        return new{LX, LY, LZ, O, A, B, IA, IB, G, T}(op, a, b, ▶a, ▶b, grid)
     end
 end
 
@@ -30,13 +29,14 @@ end
 # Recompute location of binary operation
 @inline at(loc, β::BinaryOperation) = β.op(loc, at(loc, β.a), at(loc, β.b))
 
+indices(β::BinaryOperation) = interpolate_indices(β.a, β.b)
+
 """Create a binary operation for `op` acting on `a` and `b` at `Lc`, where
 `a` and `b` have location `La` and `Lb`."""
 function _binary_operation(Lc, op, a, b, La, Lb, grid)
      ▶a = interpolation_operator(La, Lc)
      ▶b = interpolation_operator(Lb, Lc)
 
-     indices = interpolate_indices(a, b)
     return BinaryOperation{Lc[1], Lc[2], Lc[3]}(op, a, b, ▶a, ▶b, grid, indices)
 end
 
@@ -208,5 +208,4 @@ Adapt.adapt_structure(to, binary::BinaryOperation{LX, LY, LZ}) where {LX, LY, LZ
                                 Adapt.adapt(to, binary.b),
                                 Adapt.adapt(to, binary.▶a),
                                 Adapt.adapt(to, binary.▶b),
-                                Adapt.adapt(to, binary.grid),
-                                Adapt.adapt(to, binary.indices))
+                                Adapt.adapt(to, binary.grid))

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -29,7 +29,7 @@ end
 # Recompute location of binary operation
 @inline at(loc, β::BinaryOperation) = β.op(loc, at(loc, β.a), at(loc, β.b))
 
-indices(β::BinaryOperation) = interpolate_indices((β.a, β.b), location(β))
+indices(β::BinaryOperation) = interpolate_indices((β.a, β.b); loc_operation = location(β))
 
 """Create a binary operation for `op` acting on `a` and `b` at `Lc`, where
 `a` and `b` have location `La` and `Lb`."""

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -29,7 +29,7 @@ end
 # Recompute location of binary operation
 @inline at(loc, β::BinaryOperation) = β.op(loc, at(loc, β.a), at(loc, β.b))
 
-indices(β::BinaryOperation) = interpolate_indices(β.a, β.b)
+indices(β::BinaryOperation) = interpolate_indices((β.a, β.b), location(β))
 
 """Create a binary operation for `op` acting on `a` and `b` at `Lc`, where
 `a` and `b` have location `La` and `Lb`."""

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -37,7 +37,7 @@ function _binary_operation(Lc, op, a, b, La, Lb, grid)
      ▶a = interpolation_operator(La, Lc)
      ▶b = interpolation_operator(Lb, Lc)
 
-    return BinaryOperation{Lc[1], Lc[2], Lc[3]}(op, a, b, ▶a, ▶b, grid, indices)
+    return BinaryOperation{Lc[1], Lc[2], Lc[3]}(op, a, b, ▶a, ▶b, grid)
 end
 
 const ConcreteLocationType = Union{Type{Face}, Type{Center}}

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -29,7 +29,7 @@ end
 # Recompute location of binary operation
 @inline at(loc, β::BinaryOperation) = β.op(loc, at(loc, β.a), at(loc, β.b))
 
-indices(β::BinaryOperation) = interpolate_indices((β.a, β.b); loc_operation = location(β))
+indices(β::BinaryOperation) = interpolate_indices(β.a, β.b; loc_operation = location(β))
 
 """Create a binary operation for `op` acting on `a` and `b` at `Lc`, where
 `a` and `b` have location `La` and `Lb`."""

--- a/src/AbstractOperations/conditional_operations.jl
+++ b/src/AbstractOperations/conditional_operations.jl
@@ -108,7 +108,7 @@ end
 Adapt.adapt_structure(to, c::ConditionalOperation{LX, LY, LZ}) where {LX, LY, LZ} =
             ConditionalOperation{LX, LY, LZ}(adapt(to, c.operand),
                                      adapt(to, c.func), 
-                                     adapt(to, c.grid)
+                                     adapt(to, c.grid),
                                      adapt(to, c.condition),
                                      adapt(to, c.mask))
 

--- a/src/AbstractOperations/grid_metrics.jl
+++ b/src/AbstractOperations/grid_metrics.jl
@@ -117,24 +117,24 @@ function metric_function(loc, metric::AbstractGridMetric)
     return eval(metric_function_symbol)
 end
 
-struct GridMetricOperation{LX, LY, LZ, G, I, T, M} <: AbstractOperation{LX, LY, LZ, G, I, T}
+struct GridMetricOperation{LX, LY, LZ, G, T, M} <: AbstractOperation{LX, LY, LZ, G, T}
           metric :: M
             grid :: G
-         indices :: I
-    function GridMetricOperation{LX, LY, LZ}(metric::M, grid::G, indices::I) where {LX, LY, LZ, M, G, I}
+    function GridMetricOperation{LX, LY, LZ}(metric::M, grid::G) where {LX, LY, LZ, M, G, I}
         T = eltype(grid)
-        return new{LX, LY, LZ, G, I, T, M}(metric, grid, indices)
+        return new{LX, LY, LZ, G, I, T, M}(metric, grid)
     end
 end
 
 Adapt.adapt_structure(to, gm::GridMetricOperation{LX, LY, LZ}) where {LX, LY, LZ}=
          GridMetricOperation{LX, LY, LZ}(Adapt.adapt(to, gm.metric),
-                                         Adapt.adapt(to, gm.grid),
-                                         Adapt.adapt(to, gm.indices))
+                                         Adapt.adapt(to, gm.grid))
 
 @inline Base.getindex(gm::GridMetricOperation, i, j, k) = gm.metric(i, j, k, gm.grid)
 
+indices(gm::GridMetricOperation) = default_indices(3)
+
 # Special constructor for BinaryOperation
-GridMetricOperation(L, metric, grid) = GridMetricOperation{L[1], L[2], L[3]}(metric_function(L, metric), grid, default_indices(3))
+GridMetricOperation(L, metric, grid) = GridMetricOperation{L[1], L[2], L[3]}(metric_function(L, metric), grid)
 
 

--- a/src/AbstractOperations/grid_metrics.jl
+++ b/src/AbstractOperations/grid_metrics.jl
@@ -122,7 +122,7 @@ struct GridMetricOperation{LX, LY, LZ, G, T, M} <: AbstractOperation{LX, LY, LZ,
             grid :: G
     function GridMetricOperation{LX, LY, LZ}(metric::M, grid::G) where {LX, LY, LZ, M, G, I}
         T = eltype(grid)
-        return new{LX, LY, LZ, G, I, T, M}(metric, grid)
+        return new{LX, LY, LZ, G, T, M}(metric, grid)
     end
 end
 

--- a/src/AbstractOperations/kernel_function_operation.jl
+++ b/src/AbstractOperations/kernel_function_operation.jl
@@ -1,14 +1,13 @@
-struct KernelFunctionOperation{LX, LY, LZ, P, G, I, T, K, D} <: AbstractOperation{LX, LY, LZ, G, I, T}
+struct KernelFunctionOperation{LX, LY, LZ, P, G, T, K, D} <: AbstractOperation{LX, LY, LZ, G, T}
     kernel_function :: K
     computed_dependencies :: D
     parameters :: P
     grid :: G
-    indices :: I
 
     function KernelFunctionOperation{LX, LY, LZ}(kernel_function::K, computed_dependencies::D,
-                                                 parameters::P, grid::G, indices::I) where {LX, LY, LZ, K, G, I, D, P}
+                                                 parameters::P, grid::G) where {LX, LY, LZ, K, G, I, D, P}
         T = eltype(grid)
-        return new{LX, LY, LZ, P, G, I, T, K, D}(kernel_function, computed_dependencies, parameters, grid, indices)
+        return new{LX, LY, LZ, P, G, T, K, D}(kernel_function, computed_dependencies, parameters, grid)
     end
 
 end
@@ -60,9 +59,10 @@ function KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid;
                                             computed_dependencies = (),
                                             parameters = nothing) where {LX, LY, LZ}
 
-    indices = interpolate_indices(computed_dependencies...)
-    return KernelFunctionOperation{LX, LY, LZ}(kernel_function, computed_dependencies, parameters, grid, indices)
+    return KernelFunctionOperation{LX, LY, LZ}(kernel_function, computed_dependencies, parameters, grid)
 end
+
+indices(κ::KernelFunctionOperation) = interpolate_indices(κ.computed_dependencies...)
 
 @inline Base.getindex(κ::KernelFunctionOperation, i, j, k) = κ.kernel_function(i, j, k, κ.grid, κ.computed_dependencies..., κ.parameters)
 @inline Base.getindex(κ::KernelFunctionOperation{LX, LY, LZ, <:Nothing}, i, j, k) where {LX, LY, LZ} = κ.kernel_function(i, j, k, κ.grid, κ.computed_dependencies...)
@@ -75,6 +75,5 @@ Adapt.adapt_structure(to, κ::KernelFunctionOperation{LX, LY, LZ}) where {LX, LY
     KernelFunctionOperation{LX, LY, LZ}(Adapt.adapt(to, κ.kernel_function),
                                         Adapt.adapt(to, κ.computed_dependencies),
                                         Adapt.adapt(to, κ.parameters),
-                                        Adapt.adapt(to, κ.grid),
-                                        Adapt.adapt(to, κ.indices))
+                                        Adapt.adapt(to, κ.grid))
 

--- a/src/AbstractOperations/kernel_function_operation.jl
+++ b/src/AbstractOperations/kernel_function_operation.jl
@@ -62,7 +62,7 @@ function KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid;
     return KernelFunctionOperation{LX, LY, LZ}(kernel_function, computed_dependencies, parameters, grid)
 end
 
-indices(κ::KernelFunctionOperation) = interpolate_indices(κ.computed_dependencies...)
+indices(κ::KernelFunctionOperation) = interpolate_indices(κ.computed_dependencies, location(κ))
 
 @inline Base.getindex(κ::KernelFunctionOperation, i, j, k) = κ.kernel_function(i, j, k, κ.grid, κ.computed_dependencies..., κ.parameters)
 @inline Base.getindex(κ::KernelFunctionOperation{LX, LY, LZ, <:Nothing}, i, j, k) where {LX, LY, LZ} = κ.kernel_function(i, j, k, κ.grid, κ.computed_dependencies...)

--- a/src/AbstractOperations/kernel_function_operation.jl
+++ b/src/AbstractOperations/kernel_function_operation.jl
@@ -62,7 +62,7 @@ function KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid;
     return KernelFunctionOperation{LX, LY, LZ}(kernel_function, computed_dependencies, parameters, grid)
 end
 
-indices(κ::KernelFunctionOperation) = interpolate_indices(κ.computed_dependencies, location(κ))
+indices(κ::KernelFunctionOperation) = interpolate_indices(κ.computed_dependencies; loc_operation = location(κ))
 
 @inline Base.getindex(κ::KernelFunctionOperation, i, j, k) = κ.kernel_function(i, j, k, κ.grid, κ.computed_dependencies..., κ.parameters)
 @inline Base.getindex(κ::KernelFunctionOperation{LX, LY, LZ, <:Nothing}, i, j, k) where {LX, LY, LZ} = κ.kernel_function(i, j, k, κ.grid, κ.computed_dependencies...)

--- a/src/AbstractOperations/kernel_function_operation.jl
+++ b/src/AbstractOperations/kernel_function_operation.jl
@@ -62,7 +62,7 @@ function KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid;
     return KernelFunctionOperation{LX, LY, LZ}(kernel_function, computed_dependencies, parameters, grid)
 end
 
-indices(κ::KernelFunctionOperation) = interpolate_indices(κ.computed_dependencies; loc_operation = location(κ))
+indices(κ::KernelFunctionOperation) = interpolate_indices(κ.computed_dependencies...; loc_operation = location(κ))
 
 @inline Base.getindex(κ::KernelFunctionOperation, i, j, k) = κ.kernel_function(i, j, k, κ.grid, κ.computed_dependencies..., κ.parameters)
 @inline Base.getindex(κ::KernelFunctionOperation{LX, LY, LZ, <:Nothing}, i, j, k) where {LX, LY, LZ} = κ.kernel_function(i, j, k, κ.grid, κ.computed_dependencies...)

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -1,13 +1,12 @@
 const multiary_operators = Set()
 
-struct MultiaryOperation{LX, LY, LZ, N, O, A, IN, G, I, T} <: AbstractOperation{LX, LY, LZ, G, I, T}
+struct MultiaryOperation{LX, LY, LZ, N, O, A, IN, G, T} <: AbstractOperation{LX, LY, LZ, G, T}
     op :: O
     args :: A
     ▶ :: IN
     grid :: G
-    indices :: I
 
-    function MultiaryOperation{LX, LY, LZ}(op::O, args::A, ▶::IN, grid::G, indices::I) where {LX, LY, LZ, O, A, IN, G, I}
+    function MultiaryOperation{LX, LY, LZ}(op::O, args::A, ▶::IN, grid::G) where {LX, LY, LZ, O, A, IN, G}
         T = eltype(grid)
         N = length(args)
         return new{LX, LY, LZ, N, O, A, IN, G, I, T}(op, args, ▶, grid, indices)
@@ -21,10 +20,11 @@ end
 ##### MultiaryOperation construction
 #####
 
+indices(Π::MultiaryOperation) = interpolate_indices(Π.args...)
+
 function _multiary_operation(L, op, args, Largs, grid) where {LX, LY, LZ}
     ▶ = Tuple(interpolation_operator(La, L) for La in Largs)
-    indices = interpolate_indices(args...)
-    return MultiaryOperation{L[1], L[2], L[3]}(op, Tuple(a for a in args), ▶, grid, indices)
+    return MultiaryOperation{L[1], L[2], L[3]}(op, Tuple(a for a in args), ▶, grid)
 end
 
 # Recompute location of multiary operation
@@ -149,6 +149,5 @@ Adapt.adapt_structure(to, multiary::MultiaryOperation{LX, LY, LZ}) where {LX, LY
     MultiaryOperation{LX, LY, LZ}(Adapt.adapt(to, multiary.op),
                                   Adapt.adapt(to, multiary.args),
                                   Adapt.adapt(to, multiary.▶),
-                                  Adapt.adapt(to, multiary.grid),
-                                  Adapt.adapt(to, multiary.indices))
+                                  Adapt.adapt(to, multiary.grid))
 

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -20,7 +20,7 @@ end
 ##### MultiaryOperation construction
 #####
 
-indices(Π::MultiaryOperation) = interpolate_indices(Π.args; loc_operation = location(Π))
+indices(Π::MultiaryOperation) = interpolate_indices(Π.args...; loc_operation = location(Π))
 
 function _multiary_operation(L, op, args, Largs, grid) where {LX, LY, LZ}
     ▶ = Tuple(interpolation_operator(La, L) for La in Largs)

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -9,7 +9,7 @@ struct MultiaryOperation{LX, LY, LZ, N, O, A, IN, G, T} <: AbstractOperation{LX,
     function MultiaryOperation{LX, LY, LZ}(op::O, args::A, ▶::IN, grid::G) where {LX, LY, LZ, O, A, IN, G}
         T = eltype(grid)
         N = length(args)
-        return new{LX, LY, LZ, N, O, A, IN, G, I, T}(op, args, ▶, grid, indices)
+        return new{LX, LY, LZ, N, O, A, IN, G, T}(op, args, ▶, grid, indices)
     end
 end
 

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -9,7 +9,7 @@ struct MultiaryOperation{LX, LY, LZ, N, O, A, IN, G, T} <: AbstractOperation{LX,
     function MultiaryOperation{LX, LY, LZ}(op::O, args::A, ▶::IN, grid::G) where {LX, LY, LZ, O, A, IN, G}
         T = eltype(grid)
         N = length(args)
-        return new{LX, LY, LZ, N, O, A, IN, G, T}(op, args, ▶, grid, indices)
+        return new{LX, LY, LZ, N, O, A, IN, G, T}(op, args, ▶, grid)
     end
 end
 

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -20,7 +20,7 @@ end
 ##### MultiaryOperation construction
 #####
 
-indices(Π::MultiaryOperation) = interpolate_indices(Π.args...)
+indices(Π::MultiaryOperation) = interpolate_indices(Π.args, location(Π))
 
 function _multiary_operation(L, op, args, Largs, grid) where {LX, LY, LZ}
     ▶ = Tuple(interpolation_operator(La, L) for La in Largs)

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -20,7 +20,7 @@ end
 ##### MultiaryOperation construction
 #####
 
-indices(Π::MultiaryOperation) = interpolate_indices(Π.args, location(Π))
+indices(Π::MultiaryOperation) = interpolate_indices(Π.args; loc_operation = location(Π))
 
 function _multiary_operation(L, op, args, Largs, grid) where {LX, LY, LZ}
     ▶ = Tuple(interpolation_operator(La, L) for La in Largs)

--- a/src/AbstractOperations/unary_operations.jl
+++ b/src/AbstractOperations/unary_operations.jl
@@ -24,7 +24,7 @@ end
 ##### UnaryOperation construction
 #####
 
-indices(υ::UnaryOperation) = indices(υ.operator)
+indices(υ::UnaryOperation) = indices(υ.arg)
 
 """Create a unary operation for `operator` acting on `arg` which interpolates the
 result from `Larg` to `L`."""

--- a/src/AbstractOperations/unary_operations.jl
+++ b/src/AbstractOperations/unary_operations.jl
@@ -1,11 +1,10 @@
 const unary_operators = Set()
 
-struct UnaryOperation{LX, LY, LZ, O, A, IN, G, I, T} <: AbstractOperation{LX, LY, LZ, G, I, T}
+struct UnaryOperation{LX, LY, LZ, O, A, IN, G, T} <: AbstractOperation{LX, LY, LZ, G, T}
     op :: O
     arg :: A
     ▶ :: IN
     grid :: G
-    indices :: I
 
     @doc """
         UnaryOperation{LX, LY, LZ}(op, arg, ▶, grid)
@@ -13,9 +12,9 @@ struct UnaryOperation{LX, LY, LZ, O, A, IN, G, I, T} <: AbstractOperation{LX, LY
     Returns an abstract `UnaryOperation` representing the action of `op` on `arg`,
     and subsequent interpolation by `▶` on `grid`.
     """
-    function UnaryOperation{LX, LY, LZ}(op::O, arg::A, ▶::IN, grid::G, indices::I) where {LX, LY, LZ, O, A, IN, G, I}
+    function UnaryOperation{LX, LY, LZ}(op::O, arg::A, ▶::IN, grid::G) where {LX, LY, LZ, O, A, IN, G}
         T = eltype(grid)
-        return new{LX, LY, LZ, O, A, IN, G, I, T}(op, arg, ▶, grid, indices)
+        return new{LX, LY, LZ, O, A, IN, G, I, T}(op, arg, ▶, grid)
     end
 end
 
@@ -25,11 +24,13 @@ end
 ##### UnaryOperation construction
 #####
 
+indices(υ::UnaryOperation) = indices(υ.operator)
+
 """Create a unary operation for `operator` acting on `arg` which interpolates the
 result from `Larg` to `L`."""
 function _unary_operation(L, operator, arg, Larg, grid)
     ▶ = interpolation_operator(Larg, L)
-    return UnaryOperation{L[1], L[2], L[3]}(operator, arg, ▶, grid, indices(operator))
+    return UnaryOperation{L[1], L[2], L[3]}(operator, arg, ▶, grid)
 end
 
 # Recompute location of unary operation
@@ -127,6 +128,5 @@ Adapt.adapt_structure(to, unary::UnaryOperation{LX, LY, LZ}) where {LX, LY, LZ} 
     UnaryOperation{LX, LY, LZ}(Adapt.adapt(to, unary.op),
                                Adapt.adapt(to, unary.arg),
                                Adapt.adapt(to, unary.▶),
-                               Adapt.adapt(to, unary.grid),
-                               Adapt.adapt(to, unary.indices))
+                               Adapt.adapt(to, unary.grid))
 

--- a/src/AbstractOperations/unary_operations.jl
+++ b/src/AbstractOperations/unary_operations.jl
@@ -14,7 +14,7 @@ struct UnaryOperation{LX, LY, LZ, O, A, IN, G, T} <: AbstractOperation{LX, LY, L
     """
     function UnaryOperation{LX, LY, LZ}(op::O, arg::A, ▶::IN, grid::G) where {LX, LY, LZ, O, A, IN, G}
         T = eltype(grid)
-        return new{LX, LY, LZ, O, A, IN, G, I, T}(op, arg, ▶, grid)
+        return new{LX, LY, LZ, O, A, IN, G, T}(op, arg, ▶, grid)
     end
 end
 

--- a/src/BoundaryConditions/fill_halo_regions.jl
+++ b/src/BoundaryConditions/fill_halo_regions.jl
@@ -51,6 +51,7 @@ function fill_halo_event!(task, halo_tuple, c, indices, loc, arch, barrier, grid
     bc_left     = halo_tuple[2][task]
     bc_right    = halo_tuple[3][task]
 
+    # Calculate size and offset of the fill_halo kernel
     size   = fill_halo_size(c, fill_halo!, indices, bc_left, loc, grid)
     offset = fill_halo_offset(size, fill_halo!, indices)
 
@@ -181,40 +182,39 @@ fill_bottom_and_top_halo!(c, bottom_bc, top_bc, size, offset, loc, arch, dep, gr
     launch!(arch, grid, size, _fill_bottom_and_top_halo!, c, bottom_bc, top_bc, offset, loc, grid, args...; dependencies=dep, kwargs...)
 
 #####
-##### Pass kernel size and offset for Windowed and Sliced Fields
+##### Calculate kernel size and offset for Windowed and Sliced Fields
 #####
 
 const WEB = typeof(fill_west_and_east_halo!)
 const SNB = typeof(fill_south_and_north_halo!)
 const TBB = typeof(fill_bottom_and_top_halo!)
 
-# In case of a tuple we are _always_ dealing with full fields!
+# Tupled halo filling _only_ deals with full fields!
 @inline fill_halo_size(::Tuple, ::WEB, args...) = :yz
 @inline fill_halo_size(::Tuple, ::SNB, args...) = :xz
 @inline fill_halo_size(::Tuple, ::TBB, args...) = :xy
 
-# If indices are colon, just fill the whole boundary!
+# If indices are colon, fill the whole boundary plane!
 @inline fill_halo_size(::OffsetArray, ::WEB, ::Tuple{<:Any, <:Colon, <:Colon}, args...) = :yz
 @inline fill_halo_size(::OffsetArray, ::SNB, ::Tuple{<:Colon, <:Any, <:Colon}, args...) = :xz
 @inline fill_halo_size(::OffsetArray, ::TBB, ::Tuple{<:Colon, <:Colon, <:Any}, args...) = :xy
 
-# If the index is a Colon and the location is _NOT_ a `Nothing` (meaning not a reduced field), 
-# then we take the size of the grid, otherwise the size of the array 
+# If the index is a Colon and the location is _NOT_ a `Nothing` (i.e. not a `ReducedField`), 
+# then fill the whole boundary, otherwise fill the size of the corresponding array
 @inline whole_halo(idx, loc)           = false
 @inline whole_halo(idx,     ::Nothing) = false
 @inline whole_halo(::Colon, ::Nothing) = false
 @inline whole_halo(::Colon,       loc) = true
 
-# If they are not... we have to calculate the size!
+# Calculate kernel size
 @inline fill_halo_size(c::OffsetArray, ::WEB, idx, bc, loc, grid) = @inbounds (ifelse(whole_halo(idx[2], loc[2]), size(grid, 2), size(c, 2)), ifelse(whole_halo(idx[3], loc[3]), size(grid, 3), size(c, 3)))
 @inline fill_halo_size(c::OffsetArray, ::SNB, idx, bc, loc, grid) = @inbounds (ifelse(whole_halo(idx[1], loc[1]), size(grid, 1), size(c, 1)), ifelse(whole_halo(idx[3], loc[3]), size(grid, 3), size(c, 3)))
 @inline fill_halo_size(c::OffsetArray, ::TBB, idx, bc, loc, grid) = @inbounds (ifelse(whole_halo(idx[1], loc[1]), size(grid, 1), size(c, 1)), ifelse(whole_halo(idx[2], loc[2]), size(grid, 2), size(c, 2)))
 
-# Remember that Periodic BC have to fill also the halo points always!
+# Remember that Periodic BCs also fill halo points!
 @inline fill_halo_size(c::OffsetArray, ::WEB, idx, ::PBC, args...) = @inbounds size(c)[[2, 3]]
 @inline fill_halo_size(c::OffsetArray, ::SNB, idx, ::PBC, args...) = @inbounds size(c)[[1, 3]]
 @inline fill_halo_size(c::OffsetArray, ::TBB, idx, ::PBC, args...) = @inbounds size(c)[[1, 2]]
-
 @inline fill_halo_size(c::OffsetArray, ::WEB, ::Tuple{<:Any, <:Colon, <:Colon}, ::PBC, args...) = @inbounds size(c)[[2, 3]]
 @inline fill_halo_size(c::OffsetArray, ::SNB, ::Tuple{<:Colon, <:Any, <:Colon}, ::PBC, args...) = @inbounds size(c)[[1, 3]]
 @inline fill_halo_size(c::OffsetArray, ::TBB, ::Tuple{<:Colon, <:Colon, <:Any}, ::PBC, args...) = @inbounds size(c)[[1, 2]]

--- a/src/BoundaryConditions/fill_halo_regions.jl
+++ b/src/BoundaryConditions/fill_halo_regions.jl
@@ -221,6 +221,6 @@ const TBB = typeof(fill_bottom_and_top_halo!)
 
 # The offsets are non-zero only if the indices are not Colon
 @inline fill_halo_offset(::Symbol, args...)    = (0, 0)
-@inline fill_halo_offset(::Tuple, ::WEB, idx)  = (ifelse(idx[2] == Colon(), 0, first(idx[2])-1), ifelse(idx[3] == Colon(), 0, first(idx[3])-1))
-@inline fill_halo_offset(::Tuple, ::SNB, idx)  = (ifelse(idx[1] == Colon(), 0, first(idx[1])-1), ifelse(idx[3] == Colon(), 0, first(idx[3])-1))
-@inline fill_halo_offset(::Tuple, ::TBB, idx)  = (ifelse(idx[1] == Colon(), 0, first(idx[1])-1), ifelse(idx[2] == Colon(), 0, first(idx[2])-1))
+@inline fill_halo_offset(::Tuple, ::WEB, idx)  = (idx[2] == Colon() ? 0 : first(idx[2])-1, idx[3] == Colon() ? 0 : first(idx[3])-1)
+@inline fill_halo_offset(::Tuple, ::SNB, idx)  = (idx[1] == Colon() ? 0 : first(idx[1])-1, idx[3] == Colon() ? 0 : first(idx[3])-1)
+@inline fill_halo_offset(::Tuple, ::TBB, idx)  = (idx[1] == Colon() ? 0 : first(idx[1])-1, idx[2] == Colon() ? 0 : first(idx[2])-1)

--- a/src/BoundaryConditions/fill_halo_regions.jl
+++ b/src/BoundaryConditions/fill_halo_regions.jl
@@ -206,9 +206,9 @@ const TBB = typeof(fill_bottom_and_top_halo!)
 @inline whole_halo(::Colon,       loc) = true
 
 # If they are not... we have to calculate the size!
-@inline fill_halo_size(c::OffsetArray, ::WEB, idx, bc, loc, grid) = @inbounds (whole_halo(idx[2], loc[2]) ? size(grid, 2) : size(c, 2), whole_halo(idx[3], loc[3]) ? size(grid, 3) : size(c, 3))
-@inline fill_halo_size(c::OffsetArray, ::SNB, idx, bc, loc, grid) = @inbounds (whole_halo(idx[1], loc[1]) ? size(grid, 1) : size(c, 1), whole_halo(idx[3], loc[3]) ? size(grid, 3) : size(c, 3))
-@inline fill_halo_size(c::OffsetArray, ::TBB, idx, bc, loc, grid) = @inbounds (whole_halo(idx[1], loc[1]) ? size(grid, 1) : size(c, 1), whole_halo(idx[2], loc[2]) ? size(grid, 2) : size(c, 2))
+@inline fill_halo_size(c::OffsetArray, ::WEB, idx, bc, loc, grid) = @inbounds (ifelse(whole_halo(idx[2], loc[2]), size(grid, 2), size(c, 2)), ifelse(whole_halo(idx[3], loc[3]), size(grid, 3), size(c, 3)))
+@inline fill_halo_size(c::OffsetArray, ::SNB, idx, bc, loc, grid) = @inbounds (ifelse(whole_halo(idx[1], loc[1]), size(grid, 1), size(c, 1)), ifelse(whole_halo(idx[3], loc[3]), size(grid, 3), size(c, 3)))
+@inline fill_halo_size(c::OffsetArray, ::TBB, idx, bc, loc, grid) = @inbounds (ifelse(whole_halo(idx[1], loc[1]), size(grid, 1), size(c, 1)), ifelse(whole_halo(idx[2], loc[2]), size(grid, 2), size(c, 2)))
 
 # Remember that Periodic BC have to fill also the halo points always!
 @inline fill_halo_size(c::OffsetArray, ::WEB, idx, ::PBC, args...) = @inbounds size(c)[[2, 3]]
@@ -221,6 +221,6 @@ const TBB = typeof(fill_bottom_and_top_halo!)
 
 # The offsets are non-zero only if the indices are not Colon
 @inline fill_halo_offset(::Symbol, args...)    = (0, 0)
-@inline fill_halo_offset(::Tuple, ::WEB, idx)  = (idx[2] == Colon() ? 0 : first(idx[2])-1, idx[3] == Colon() ? 0 : first(idx[3])-1)
-@inline fill_halo_offset(::Tuple, ::SNB, idx)  = (idx[1] == Colon() ? 0 : first(idx[1])-1, idx[3] == Colon() ? 0 : first(idx[3])-1)
-@inline fill_halo_offset(::Tuple, ::TBB, idx)  = (idx[1] == Colon() ? 0 : first(idx[1])-1, idx[2] == Colon() ? 0 : first(idx[2])-1)
+@inline fill_halo_offset(::Tuple, ::WEB, idx)  = (ifelse(idx[2] == Colon(), 0, first(idx[2])-1), ifelse(idx[3] == Colon(), 0, first(idx[3])-1))
+@inline fill_halo_offset(::Tuple, ::SNB, idx)  = (ifelse(idx[1] == Colon(), 0, first(idx[1])-1), ifelse(idx[3] == Colon(), 0, first(idx[3])-1))
+@inline fill_halo_offset(::Tuple, ::TBB, idx)  = (ifelse(idx[1] == Colon(), 0, first(idx[1])-1), ifelse(idx[2] == Colon(), 0, first(idx[2])-1))

--- a/src/BoundaryConditions/fill_halo_regions_flux.jl
+++ b/src/BoundaryConditions/fill_halo_regions_flux.jl
@@ -38,50 +38,62 @@ using KernelAbstractions.Extras.LoopInfo: @unroll
 ##### Single halo filling kernels
 #####
 
-@kernel function fill_flux_west_halo!(c, grid)
+@kernel function fill_flux_west_halo!(c, offset, grid)
     j, k = @index(Global, NTuple)
-    _fill_flux_west_halo!(1, j, k, grid, c)
+    j′ = j + offset[1]
+    k′ = k + offset[2]
+    _fill_flux_west_halo!(1, j′, k′, grid, c)
 end
 
-@kernel function fill_flux_south_halo!(c, grid)
+@kernel function fill_flux_south_halo!(c, offset, grid)
     i, k = @index(Global, NTuple)
-    _fill_flux_south_halo!(i, 1, k, grid, c)
+    i′ = i + offset[1]
+    k′ = k + offset[2]
+    _fill_flux_south_halo!(i′, 1, k′, grid, c)
 end
 
-@kernel function fill_flux_bottom_halo!(c, grid)
+@kernel function fill_flux_bottom_halo!(c, offset, grid)
     i, j = @index(Global, NTuple)
-    _fill_flux_bottom_halo!(i, j, 1, grid, c)
+    i′ = i + offset[1]
+    j′ = j + offset[2]
+    _fill_flux_bottom_halo!(i′, j′, 1, grid, c)
 end
 
-@kernel function fill_flux_east_halo!(c, grid)
+@kernel function fill_flux_east_halo!(c, offset, grid)
     j, k = @index(Global, NTuple)
-    _fill_flux_east_halo!(1, j, k, grid, c)
+    j′ = j + offset[1]
+    k′ = k + offset[2]
+    _fill_flux_east_halo!(1, j′, k′, grid, c)
 end
 
-@kernel function fill_flux_north_halo!(c, grid)
+@kernel function fill_flux_north_halo!(c, offset, grid)
     i, k = @index(Global, NTuple)
-    _fill_flux_north_halo!(i, 1, k, grid, c)
+    i′ = i + offset[1]
+    k′ = k + offset[2]
+    _fill_flux_north_halo!(i′, 1, k′, grid, c)
 end
 
-@kernel function fill_flux_top_halo!(c, grid)
+@kernel function fill_flux_top_halo!(c, offset, grid)
     i, j = @index(Global, NTuple)
-    _fill_flux_top_halo!(i, j, 1, grid, c)
+    j′ = j + offset[1]
+    k′ = k + offset[2]
+    _fill_flux_top_halo!(i′, j′, 1, grid, c)
 end
 
 #####
 ##### Kernel launchers for flux boundary conditions
 #####
 
-fill_west_halo!(c, bc::FBC, arch, dep, grid, args...; kwargs...) = 
-            launch!(arch, grid, :yz, fill_flux_west_halo!, c, grid; dependencies=dep, kwargs...)
-fill_east_halo!(c, bc::FBC, arch, dep, grid, args...; kwargs...) = 
-            launch!(arch, grid, :yz, fill_flux_east_halo!, c, grid; dependencies=dep, kwargs...)
-fill_south_halo!(c, bc::FBC, arch, dep, grid, args...; kwargs...) = 
-            launch!(arch, grid, :xz, fill_flux_south_halo!, c, grid; dependencies=dep, kwargs...)
-fill_north_halo!(c, bc::FBC, arch, dep, grid, args...; kwargs...) = 
-            launch!(arch, grid, :xz, fill_flux_north_halo!, c, grid; dependencies=dep, kwargs...)
-fill_bottom_halo!(c, bc::FBC, arch, dep, grid, args...; kwargs...) = 
-            launch!(arch, grid, :xy, fill_flux_bottom_halo!, c, grid; dependencies=dep, kwargs...)
-fill_top_halo!(c, bc::FBC, arch, dep, grid, args...; kwargs...) = 
-            launch!(arch, grid, :xy, fill_flux_top_halo!, c, grid; dependencies=dep, kwargs...)
+fill_west_halo!(c, bc::FBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = 
+            launch!(arch, grid, kernel_size, fill_flux_west_halo!, c, offset,grid; dependencies=dep, kwargs...)
+fill_east_halo!(c, bc::FBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = 
+            launch!(arch, grid, kernel_size, fill_flux_east_halo!, c, offset,grid; dependencies=dep, kwargs...)
+fill_south_halo!(c, bc::FBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = 
+            launch!(arch, grid, kernel_size, fill_flux_south_halo!, c, offset,grid; dependencies=dep, kwargs...)
+fill_north_halo!(c, bc::FBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = 
+            launch!(arch, grid, kernel_size, fill_flux_north_halo!, c, offset,grid; dependencies=dep, kwargs...)
+fill_bottom_halo!(c, bc::FBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = 
+            launch!(arch, grid, kernel_size, fill_flux_bottom_halo!, c, offset,grid; dependencies=dep, kwargs...)
+fill_top_halo!(c, bc::FBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = 
+            launch!(arch, grid, kernel_size, fill_flux_top_halo!, c, offset, grid; dependencies=dep, kwargs...)
 

--- a/src/BoundaryConditions/fill_halo_regions_open.jl
+++ b/src/BoundaryConditions/fill_halo_regions_open.jl
@@ -9,27 +9,33 @@
 # because the boundary-normal index can vary (and array boundary conditions need to be
 # 3D in general).
 
-@kernel function set_west_or_east_u!(u, i_boundary, bc, grid, args...)
+@kernel function set_west_or_east_u!(u, offset, i_boundary, bc, grid, args...)
     j, k = @index(Global, NTuple)
-    @inbounds u[i_boundary, j, k] = getbc(bc, j, k, grid, args...)
+    j′ = j + offset[1]
+    k′ = k + offset[2]
+@inbounds u[i_boundary, j′, k′] = getbc(bc, j′, k′, grid, args...)
 end
 
-@kernel function set_south_or_north_v!(v, j_boundary, bc, grid, args...)
+@kernel function set_south_or_north_v!(v, offset, j_boundary, bc, grid, args...)
     i, k = @index(Global, NTuple)
-    @inbounds v[i, j_boundary, k] = getbc(bc, i, k, grid, args...)
+    i′ = i + offset[1]
+    k′ = k + offset[2]
+@inbounds v[i′, j_boundary, k′] = getbc(bc, i′, k′, grid, args...)
 end
 
-@kernel function set_bottom_or_top_w!(w, k_boundary, bc, grid, args...)
+@kernel function set_bottom_or_top_w!(w, offset, k_boundary, bc, grid, args...)
     i, j = @index(Global, NTuple)
-    @inbounds w[i, j, k_boundary] = getbc(bc, i, j, grid, args...)
+    i′ = i + offset[1]
+    j′ = j + offset[2]
+@inbounds w[i′, j′, k_boundary] = getbc(bc, i′, j′, grid, args...)
 end
 
-@inline   fill_west_halo!(u, bc::OBC, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, :yz, set_west_or_east_u!,   u,           1, bc, grid, args...; dependencies=dep, kwargs...)
-@inline   fill_east_halo!(u, bc::OBC, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, :yz, set_west_or_east_u!,   u, grid.Nx + 1, bc, grid, args...; dependencies=dep, kwargs...)
-@inline  fill_south_halo!(v, bc::OBC, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, :xz, set_south_or_north_v!, v,           1, bc, grid, args...; dependencies=dep, kwargs...)
-@inline  fill_north_halo!(v, bc::OBC, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, :xz, set_south_or_north_v!, v, grid.Ny + 1, bc, grid, args...; dependencies=dep, kwargs...)
-@inline fill_bottom_halo!(w, bc::OBC, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, :xy, set_bottom_or_top_w!,  w,           1, bc, grid, args...; dependencies=dep, kwargs...)
-@inline    fill_top_halo!(w, bc::OBC, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, :xy, set_bottom_or_top_w!,  w, grid.Nz + 1, bc, grid, args...; dependencies=dep, kwargs...)
+@inline   fill_west_halo!(u, bc::OBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, kernel_size, set_west_or_east_u!,   u, offset,           1, bc, grid, args...; dependencies=dep, kwargs...)
+@inline   fill_east_halo!(u, bc::OBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, kernel_size, set_west_or_east_u!,   u, offset, grid.Nx + 1, bc, grid, args...; dependencies=dep, kwargs...)
+@inline  fill_south_halo!(v, bc::OBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, kernel_size, set_south_or_north_v!, v, offset,           1, bc, grid, args...; dependencies=dep, kwargs...)
+@inline  fill_north_halo!(v, bc::OBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, kernel_size, set_south_or_north_v!, v, offset, grid.Ny + 1, bc, grid, args...; dependencies=dep, kwargs...)
+@inline fill_bottom_halo!(w, bc::OBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, kernel_size, set_bottom_or_top_w!,  w, offset,           1, bc, grid, args...; dependencies=dep, kwargs...)
+@inline    fill_top_halo!(w, bc::OBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) = launch!(arch, grid, kernel_size, set_bottom_or_top_w!,  w, offset, grid.Nz + 1, bc, grid, args...; dependencies=dep, kwargs...)
 
 @inline   _fill_west_halo!(j, k, grid, c, bc::OBC, loc, args...) = @inbounds c[1, j, k]           = getbc(bc, j, k, grid, args...)
 @inline   _fill_east_halo!(j, k, grid, c, bc::OBC, loc, args...) = @inbounds c[grid.Nx + 1, j, k] = getbc(bc, j, k, grid, args...)

--- a/src/Coriolis/Coriolis.jl
+++ b/src/Coriolis/Coriolis.jl
@@ -2,10 +2,11 @@ module Coriolis
 
 export
     FPlane, ConstantCartesianCoriolis, BetaPlane, NonTraditionalBetaPlane,
-    HydrostaticSphericalCoriolis, 
+    HydrostaticSphericalCoriolis, WetCellEnstrophyConservingScheme,
     x_f_cross_U, y_f_cross_U, z_f_cross_U
 
 using Printf
+using Adapt
 using Oceananigans.Grids
 using Oceananigans.Operators
 

--- a/src/Coriolis/hydrostatic_spherical_coriolis.jl
+++ b/src/Coriolis/hydrostatic_spherical_coriolis.jl
@@ -1,11 +1,15 @@
-using Oceananigans.Grids: LatitudeLongitudeGrid, ConformalCubedSphereFaceGrid
+using Oceananigans.Grids: LatitudeLongitudeGrid, ConformalCubedSphereFaceGrid, peripheral_node
 using Oceananigans.Operators: Δx_qᶜᶠᶜ, Δy_qᶠᶜᶜ, Δxᶠᶜᶜ, Δyᶜᶠᶜ, hack_sind
 using Oceananigans.Advection: EnergyConservingScheme, EnstrophyConservingScheme
 
-# Our two Coriolis schemes are energy-conserving or enstrophy-conserving
-# with a "vector invariant" momentum advection scheme, but not with a "flux form"
-# or "conservation form" advection scheme (which does not currently exist for
-# curvilinear grids).
+
+"""
+    struct WetCellEnstrophyConservingScheme
+
+A parameter object for an enstrophy-conserving Coriolis scheme that excludes dry edges (indices for which `peripheral_node == true`)
+from the velocity interpolation.
+"""
+struct WetCellEnstrophyConservingScheme end
 
 """
     struct HydrostaticSphericalCoriolis{S, FT} <: AbstractRotation
@@ -28,18 +32,48 @@ By default, `rotation_rate` is assumed to be Earth's.
 Keyword arguments
 =================
 
-- `scheme`: Either `EnergyConservingScheme()` (default) or `EnstrophyConservingScheme()`.
+- `scheme`: Either `EnergyConservingScheme()` (default), `EnstrophyConservingScheme()`, or `WetCellEnstrophyConservingScheme()`.
 """
 HydrostaticSphericalCoriolis(FT::DataType=Float64; rotation_rate=Ω_Earth, scheme::S=EnergyConservingScheme()) where S =
     HydrostaticSphericalCoriolis{S, FT}(rotation_rate, scheme)
 
-@inline φᶠᶠᵃ(i, j, k, grid::LatitudeLongitudeGrid) = @inbounds grid.φᵃᶠᵃ[j]
+@inline φᶠᶠᵃ(i, j, k, grid::LatitudeLongitudeGrid)        = @inbounds grid.φᵃᶠᵃ[j]
 @inline φᶠᶠᵃ(i, j, k, grid::ConformalCubedSphereFaceGrid) = @inbounds grid.φᶠᶠᵃ[i, j]
 
 @inline fᶠᶠᵃ(i, j, k, grid, coriolis::HydrostaticSphericalCoriolis) =
     2 * coriolis.rotation_rate * hack_sind(φᶠᶠᵃ(i, j, k, grid))
 
 @inline z_f_cross_U(i, j, k, grid::AbstractGrid{FT}, coriolis::HydrostaticSphericalCoriolis, U) where FT = zero(FT)
+
+#####
+##### Wet Point Enstrophy-conserving scheme
+#####
+
+# It might happen that a cell is wet but all the neighbouring staggered nodes are dry,
+# (an example is a 1-cell large channel)
+# In that case the Coriolis force is equal to zero
+
+const CoriolisWetCellEnstrophyConserving = HydrostaticSphericalCoriolis{<:WetCellEnstrophyConservingScheme}
+
+@inline revert_peripheral_node(i, j, k, grid, f::Function, args...) = @inbounds 1.0 - f(i, j, k, grid, args...)
+
+@inline function mask_dry_points_ℑxyᶠᶜᵃ(i, j, k, grid, f::Function, args...) 
+    neighbouring_wet_nodes = @inbounds ℑxyᶠᶜᵃ(i, j, k, grid, revert_peripheral_node, peripheral_node, Center(), Face(), Center())
+    return ifelse(neighbouring_wet_nodes == 0, zero(grid),
+           @inbounds ℑxyᶠᶜᵃ(i, j, k, grid, f, args...) / neighbouring_wet_nodes)
+end
+
+@inline function mask_dry_points_ℑxyᶜᶠᵃ(i, j, k, grid, f::Function, args...) 
+    neighbouring_wet_nodes = @inbounds ℑxyᶜᶠᵃ(i, j, k, grid, revert_peripheral_node, peripheral_node, Face(), Center(), Center())
+    return ifelse(neighbouring_wet_nodes == 0, zero(grid),
+           @inbounds ℑxyᶜᶠᵃ(i, j, k, grid, f, args...) / neighbouring_wet_nodes)
+end
+
+@inline x_f_cross_U(i, j, k, grid, coriolis::CoriolisWetCellEnstrophyConserving, U) =
+    @inbounds - ℑyᵃᶜᵃ(i, j, k, grid, fᶠᶠᵃ, coriolis) * mask_dry_points_ℑxyᶠᶜᵃ(i, j, k, grid, Δx_qᶜᶠᶜ, U[2]) / Δxᶠᶜᶜ(i, j, k, grid)
+
+@inline y_f_cross_U(i, j, k, grid, coriolis::CoriolisWetCellEnstrophyConserving, U) =
+    @inbounds + ℑxᶜᵃᵃ(i, j, k, grid, fᶠᶠᵃ, coriolis) * mask_dry_points_ℑxyᶜᶠᵃ(i, j, k, grid, Δy_qᶠᶜᶜ, U[1]) / Δyᶜᶠᶜ(i, j, k, grid)
 
 #####
 ##### Enstrophy-conserving scheme
@@ -72,12 +106,13 @@ const CoriolisEnergyConserving = HydrostaticSphericalCoriolis{<:EnergyConserving
 ##### Show
 #####
 
-function Base.show(io::IO, hydrostatic_spherical_coriolis::HydrostaticSphericalCoriolis{S}) where S
+function Base.show(io::IO, hydrostatic_spherical_coriolis::HydrostaticSphericalCoriolis) 
 
     rotation_rate = hydrostatic_spherical_coriolis.rotation_rate
+    coriolis_scheme = hydrostatic_spherical_coriolis.scheme
     rotation_rate_Earth = rotation_rate / Ω_Earth
 
     return print(io, "HydrostaticSphericalCoriolis", '\n',
                  "├─ rotation rate: " * @sprintf("%.2e", rotation_rate) * " s⁻¹ = " * @sprintf("%.2e", rotation_rate_Earth) * " Ω_Earth", '\n',
-                 "└─ scheme: $S")
+                 "└─ scheme: $(summary(coriolis_scheme))")
 end

--- a/src/CubedSpheres/cubed_sphere_kernel_launching.jl
+++ b/src/CubedSpheres/cubed_sphere_kernel_launching.jl
@@ -27,12 +27,10 @@ function get_face(op::KernelFunctionOperation, face_index)
     computed_dependencies = get_face(op.computed_dependencies, face_index)
     parameters = get_face(op.parameters, face_index)
     face_grid = get_face(op.grid, face_index)
-    face_indices = get_face(op.indices, face_index)
     return KernelFunctionOperation{LX, LY, LZ}(op.kernel_function,
                                                computed_dependencies,
                                                parameters,
-                                               face_grid,
-                                               face_indices)
+                                               face_grid)
 end
 
 function launch!(arch, grid::ConformalCubedSphereGrid, dims, kernel!, args...; kwargs...)

--- a/src/CubedSpheres/cubed_sphere_kernel_launching.jl
+++ b/src/CubedSpheres/cubed_sphere_kernel_launching.jl
@@ -27,10 +27,12 @@ function get_face(op::KernelFunctionOperation, face_index)
     computed_dependencies = get_face(op.computed_dependencies, face_index)
     parameters = get_face(op.parameters, face_index)
     face_grid = get_face(op.grid, face_index)
+    face_indices = get_face(op.indices, face_index)
     return KernelFunctionOperation{LX, LY, LZ}(op.kernel_function,
                                                computed_dependencies,
                                                parameters,
-                                               face_grid)
+                                               face_grid,
+                                               face_indices)
 end
 
 function launch!(arch, grid::ConformalCubedSphereGrid, dims, kernel!, args...; kwargs...)

--- a/src/Distributed/halo_communication.jl
+++ b/src/Distributed/halo_communication.jl
@@ -65,13 +65,16 @@ function tupled_fill_halo_regions!(full_fields, grid::DistributedGrid, args...; 
     end
 end
 
+# TODO: distributed halo filling does not support windowed fields at the moment
+# TODO: combination of communicating and other boundary conditions in one direction are not implemented yet!
 function fill_halo_regions!(c::OffsetArray, bcs, loc, grid::DistributedGrid, args...; kwargs...)
     arch    = architecture(grid)
     barrier = Event(device(child_architecture(arch)))
 
-    x_events_requests = fill_west_and_east_halos!(c, bcs.west, bcs.east, loc, arch, barrier, grid, args...; kwargs...)
-    y_events_requests = fill_south_and_north_halos!(c, bcs.south, bcs.north, loc, arch, barrier, grid, args...; kwargs...)
-    z_events_requests = fill_bottom_and_top_halos!(c, bcs.bottom, bcs.top, loc, arch, barrier, grid, args...; kwargs...)
+    offset = (0, 0)
+    x_events_requests = fill_west_and_east_halos!(c, bcs.west, bcs.east, :yz, offset, loc, arch, barrier, grid, args...; kwargs...)
+    y_events_requests = fill_south_and_north_halos!(c, bcs.south, bcs.north, :xz, offset, loc, arch, barrier, grid, args...; kwargs...)
+    z_events_requests = fill_bottom_and_top_halos!(c, bcs.bottom, bcs.top, :xy, offset, loc, arch, barrier, grid, args...; kwargs...)
 
     events_and_requests = [x_events_requests..., y_events_requests..., z_events_requests...]
 
@@ -96,8 +99,8 @@ for (side, opposite_side) in zip([:west, :south, :bottom], [:east, :north, :top]
     fill_both_halo!  = Symbol("fill_$(side)_and_$(opposite_side)_halo!")
 
     @eval begin
-        function $fill_both_halos!(c, bc_side, bc_opposite_side, loc, arch, barrier, grid, args...; kwargs...)
-                event = $fill_both_halo!(c, bc_side, bc_opposite_side, loc, child_architecture(arch), barrier, grid, args...; kwargs...)
+        function $fill_both_halos!(c, bc_side, bc_opposite_side, size, offset, loc, arch, barrier, grid, args...; kwargs...)
+                event = $fill_both_halo!(c, bc_side, bc_opposite_side, size, offset, loc, child_architecture(arch), barrier, grid, args...; kwargs...)
             return [event]
         end
     end
@@ -119,7 +122,7 @@ for (side, opposite_side, dir) in zip([:west, :south, :bottom], [:east, :north, 
     recv_and_fill_opposite_side_halo! = Symbol("recv_and_fill_$(opposite_side)_halo!")
 
     @eval begin
-        function $fill_both_halos!(c, bc_side::CBCT, bc_opposite_side::CBCT, loc, arch, 
+        function $fill_both_halos!(c, bc_side::CBCT, bc_opposite_side::CBCT, size, offset, loc, arch, 
                                    barrier, grid, args...; kwargs...)
 
             @assert bc_side.condition.from == bc_opposite_side.condition.from  # Extra protection in case of bugs

--- a/src/Distributed/halo_communication.jl
+++ b/src/Distributed/halo_communication.jl
@@ -67,7 +67,7 @@ end
 
 # TODO: distributed halo filling does not support windowed fields at the moment
 # TODO: combination of communicating and other boundary conditions in one direction are not implemented yet!
-function fill_halo_regions!(c::OffsetArray, bcs, loc, grid::DistributedGrid, args...; kwargs...)
+function fill_halo_regions!(c::OffsetArray, bcs, indices, loc, grid::DistributedGrid, args...; kwargs...)
     arch    = architecture(grid)
     barrier = Event(device(child_architecture(arch)))
 

--- a/src/Distributed/halo_communication.jl
+++ b/src/Distributed/halo_communication.jl
@@ -65,6 +65,7 @@ function tupled_fill_halo_regions!(full_fields, grid::DistributedGrid, args...; 
     end
 end
 
+# REMEMBER! indices, kernel_size (:yz, :xz and :xy) and offset are not used in distributed halo filling because sliced fields are not supported yet
 # TODO: distributed halo filling does not support windowed fields at the moment
 # TODO: combination of communicating and other boundary conditions in one direction are not implemented yet!
 function fill_halo_regions!(c::OffsetArray, bcs, indices, loc, grid::DistributedGrid, args...; kwargs...)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -145,7 +145,7 @@ Field(f::Field; indices=f.indices) = view(f, indices...) # hmm...
 """
     CenterField(grid; kw...)
 
-Returns `Field{Center, Center, Center}` on `arch`itecture and `grid`.
+Return a `Field{Center, Center, Center}` on `grid`.
 Additional keyword arguments are passed to the `Field` constructor.
 """
 CenterField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Center, Center, Center), grid, T; kw...)
@@ -153,7 +153,7 @@ CenterField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Center
 """
     XFaceField(grid; kw...)
 
-Returns `Field{Face, Center, Center}` on `grid`.
+Return a `Field{Face, Center, Center}` on `grid`.
 Additional keyword arguments are passed to the `Field` constructor.
 """
 XFaceField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Face, Center, Center), grid, T; kw...)
@@ -161,7 +161,7 @@ XFaceField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Face, C
 """
     YFaceField(grid; kw...)
 
-Returns `Field{Center, Face, Center}` on `grid`.
+Return a `Field{Center, Face, Center}` on `grid`.
 Additional keyword arguments are passed to the `Field` constructor.
 """
 YFaceField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Center, Face, Center), grid, T; kw...)
@@ -169,7 +169,7 @@ YFaceField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Center,
 """
     ZFaceField(grid; kw...)
 
-Returns `Field{Center, Center, Face}` on `grid`.
+Return a `Field{Center, Center, Face}` on `grid`.
 Additional keyword arguments are passed to the `Field` constructor.
 """
 ZFaceField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Center, Center, Face), grid, T; kw...)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -134,9 +134,11 @@ function Field(loc::Tuple,
                T::DataType = eltype(grid);
                indices = default_indices(3),
                data = new_data(T, grid, loc, validate_indices(indices, loc, grid)),
-               boundary_conditions = FieldBoundaryConditions(grid, loc, validate_indices(indices, loc, grid)))
+               boundary_conditions = FieldBoundaryConditions(grid, loc, validate_indices(indices, loc, grid)),
+               operand = nothing,
+               status = nothing)
 
-    return Field(loc, grid, data, boundary_conditions, indices, nothing, nothing)
+    return Field(loc, grid, data, boundary_conditions, indices, operand, status)
 end
     
 Field(z::ZeroField; kw...) = z

--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -60,8 +60,7 @@ function fill_halo_regions!(maybe_nested_tuple::Union{NamedTuple, Tuple}, args..
     
     # MultiRegion fields are considered windowed_fields (indices isa MultiRegionObject))
     windowed_fields = filter(f -> !(f isa FullField), fields_with_bcs)
-
-    ordinary_fields = filter(f -> f isa FullField, fields_with_bcs)
+    ordinary_fields = filter(f -> (f isa FullField) && !(f isa ReducedField), fields_with_bcs)
 
     # Fill halo regions for reduced and windowed fields
     for field in (reduced_fields..., windowed_fields...)

--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -20,7 +20,7 @@ set!(u::Field, v) = u .= v # fallback
 function set!(u::Field, f::Function)
     if architecture(u) isa GPU
         cpu_grid = on_architecture(CPU(), u.grid)
-        u_cpu = Field(location(u), cpu_grid)
+        u_cpu = Field(location(u), cpu_grid; indices = indices(u))
         f_field = field(location(u), f, cpu_grid)
         set!(u_cpu, f_field)
         set!(u, u_cpu)

--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -57,7 +57,7 @@ function set!(u::Field, v::Field)
             copyto!(u_parent, v_parent)
         catch # just copy interior points
             v_data = arch_array(architecture(u), v.data)
-            interior(u) .= interior(v_data, location(v), v.grid)
+            interior(u) .= interior(v_data, location(v), v.grid, v.indices)
         end
     end
 

--- a/src/Grids/inactive_node.jl
+++ b/src/Grids/inactive_node.jl
@@ -80,7 +80,7 @@ for PrimaryTopo in Topos
 end
 
 """
-    inactive_node(LX, LY, LZ, i, j, k, grid)
+    inactive_node(i, j, k, grid, LX, LY, LZ)
 
 Return `true` when the location `(LX, LY, LZ)` is "inactive" and thus not directly
 associated with an "active" cell.
@@ -92,40 +92,40 @@ For `Center` locations, this means the direction is `Bounded` and that the
 cell or interface centered on the location is completely outside the active
 region of the grid.
 """
-@inline inactive_node(LX, LY, LZ, i, j, k, grid) = inactive_cell(i, j, k, grid)
+@inline inactive_node(i, j, k, grid, LX, LY, LZ) = inactive_cell(i, j, k, grid)
 
-@inline inactive_node(::Face, LY, LZ, i, j, k, grid) = inactive_cell(i, j, k, grid) & inactive_cell(i-1, j, k, grid)
-@inline inactive_node(LX, ::Face, LZ, i, j, k, grid) = inactive_cell(i, j, k, grid) & inactive_cell(i, j-1, k, grid)
-@inline inactive_node(LX, LY, ::Face, i, j, k, grid) = inactive_cell(i, j, k, grid) & inactive_cell(i, j, k-1, grid)
+@inline inactive_node(i, j, k, grid, ::Face, LY, LZ) = inactive_cell(i, j, k, grid) & inactive_cell(i-1, j, k, grid)
+@inline inactive_node(i, j, k, grid, LX, ::Face, LZ) = inactive_cell(i, j, k, grid) & inactive_cell(i, j-1, k, grid)
+@inline inactive_node(i, j, k, grid, LX, LY, ::Face) = inactive_cell(i, j, k, grid) & inactive_cell(i, j, k-1, grid)
 
-@inline inactive_node(::Face, ::Face, LZ, i, j, k, grid) = inactive_node(c, f, c, i, j, k, grid) & inactive_node(c, f, c, i-1, j, k, grid)
-@inline inactive_node(::Face, LY, ::Face, i, j, k, grid) = inactive_node(c, c, f, i, j, k, grid) & inactive_node(c, c, f, i-1, j, k, grid)
-@inline inactive_node(LX, ::Face, ::Face, i, j, k, grid) = inactive_node(c, f, c, i, j, k, grid) & inactive_node(c, f, c, i, j, k-1, grid)
+@inline inactive_node(i, j, k, grid, ::Face, ::Face, LZ) = inactive_node(i, j, k, grid, c, f, c) & inactive_node(i-1, j, k, grid, c, f, c)
+@inline inactive_node(i, j, k, grid, ::Face, LY, ::Face) = inactive_node(i, j, k, grid, c, c, f) & inactive_node(i-1, j, k, grid, c, c, f)
+@inline inactive_node(i, j, k, grid, LX, ::Face, ::Face) = inactive_node(i, j, k, grid, c, f, c) & inactive_node(i, j, k-1, grid, c, f, c)
 
-@inline inactive_node(::Face, ::Face, ::Face, i, j, k, grid) = inactive_node(c, f, f, i, j, k, grid) & inactive_node(c, f, f, i-1, j, k, grid)
+@inline inactive_node(i, j, k, grid, ::Face, ::Face, ::Face) = inactive_node(i, j, k, grid, c, f, f) & inactive_node(i-1, j, k, grid, c, f, f)
 
 """
-    peripheral_node(LX, LY, LZ, i, j, k, grid)
+    peripheral_node(i, j, k, grid, LX, LY, LZ)
 
 Return `true` when the location `(LX, LY, LZ)`, is _either_ inactive or
 lies on the boundary between inactive and active cells in a `Bounded` direction.
 """
-@inline peripheral_node(LX, LY, LZ, i, j, k, grid) = inactive_cell(i, j, k, grid)
+@inline peripheral_node(i, j, k, grid, LX, LY, LZ) = inactive_cell(i, j, k, grid)
 
-@inline peripheral_node(::Face, LY, LZ, i, j, k, grid) = inactive_cell(i, j, k, grid) | inactive_cell(i-1, j, k, grid)
-@inline peripheral_node(LX, ::Face, LZ, i, j, k, grid) = inactive_cell(i, j, k, grid) | inactive_cell(i, j-1, k, grid)
-@inline peripheral_node(LX, LY, ::Face, i, j, k, grid) = inactive_cell(i, j, k, grid) | inactive_cell(i, j, k-1, grid)
+@inline peripheral_node(i, j, k, grid, ::Face, LY, LZ) = inactive_cell(i, j, k, grid) | inactive_cell(i-1, j, k, grid)
+@inline peripheral_node(i, j, k, grid, LX, ::Face, LZ) = inactive_cell(i, j, k, grid) | inactive_cell(i, j-1, k, grid)
+@inline peripheral_node(i, j, k, grid, LX, LY, ::Face) = inactive_cell(i, j, k, grid) | inactive_cell(i, j, k-1, grid)
 
-@inline peripheral_node(::Face, ::Face, LZ, i, j, k, grid) = peripheral_node(c, f, c, i, j, k, grid) | peripheral_node(c, f, c, i-1, j, k, grid)
-@inline peripheral_node(::Face, LY, ::Face, i, j, k, grid) = peripheral_node(c, c, f, i, j, k, grid) | peripheral_node(c, c, f, i-1, j, k, grid)
-@inline peripheral_node(LX, ::Face, ::Face, i, j, k, grid) = peripheral_node(c, f, c, i, j, k, grid) | peripheral_node(c, f, c, i, j, k-1, grid)
+@inline peripheral_node(i, j, k, grid, ::Face, ::Face, LZ) = peripheral_node(i, j, k, grid, c, f, c) | peripheral_node(i-1, j, k, grid, c, f, c)
+@inline peripheral_node(i, j, k, grid, ::Face, LY, ::Face) = peripheral_node(i, j, k, grid, c, c, f) | peripheral_node(i-1, j, k, grid, c, c, f)
+@inline peripheral_node(i, j, k, grid, LX, ::Face, ::Face) = peripheral_node(i, j, k, grid, c, f, c) | peripheral_node(i, j, k-1, grid, c, f, c)
 
-@inline peripheral_node(::Face, ::Face, ::Face, i, j, k, grid) = peripheral_node(c, f, f, i, j, k, grid) | peripheral_node(c, f, f, i-1, j, k, grid)
+@inline peripheral_node(i, j, k, grid, ::Face, ::Face, ::Face) = peripheral_node(i, j, k, grid, c, f, f) | peripheral_node(i-1, j, k, grid, c, f, f)
 
 """
-    boundary_node(LX, LY, LZ, i, j, k, grid)
+    boundary_node(i, j, k, grid, LX, LY, LZ)
 
 Return `true` when the location `(LX, LY, LZ)` lies on a boundary.
 """
-@inline boundary_node(LX, LY, LZ, i, j, k, grid) = peripheral_node(LX, LY, LZ, i, j, k, grid) & !inactive_node(LX, LY, LZ, i, j, k, grid)
+@inline boundary_node(i, j, k, grid, LX, LY, LZ) = peripheral_node(i, j, k, grid, LX, LY, LZ) & !inactive_node(i, j, k, grid, LX, LY, LZ)
 

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -194,19 +194,19 @@ i-1          i
 
 We then have
 
-    * `inactive_node(f, c, c, i, 1, 1, grid) = false`
+    * `inactive_node(i, 1, 1, grid, f, c, c) = false`
 
 As well as
 
-    * `inactive_node(c, c, c, i,   1, 1, grid) = false`
-    * `inactive_node(c, c, c, i-1, 1, 1, grid) = true`
-    * `inactive_node(f, c, c, i-1, 1, 1, grid) = true`
+    * `inactive_node(i,   1, 1, grid, c, c, c) = false`
+    * `inactive_node(i-1, 1, 1, grid, c, c, c) = true`
+    * `inactive_node(i-1, 1, 1, grid, f, c, c) = true`
 """
 @inline inactive_cell(i, j, k, ibg::IBG) = immersed_cell(i, j, k, ibg) | inactive_cell(i, j, k, ibg.underlying_grid)
 
 # Isolate periphery of the immersed boundary
-@inline immersed_peripheral_node(LX, LY, LZ, i, j, k, ibg::IBG) =  peripheral_node(LX, LY, LZ, i, j, k, ibg) &
-                                                                  !peripheral_node(LX, LY, LZ, i, j, k, ibg.underlying_grid)
+@inline immersed_peripheral_node(i, j, k, ibg::IBG, LX, LY, LZ) =  peripheral_node(i, j, k, ibg, LX, LY, LZ) &
+                                                                  !peripheral_node(i, j, k, ibg.underlying_grid, LX, LY, LZ)
 
 #####
 ##### Utilities
@@ -259,7 +259,7 @@ for (locate_coeff, loc) in ((:κᶠᶜᶜ, (f, c, c)),
 
     @eval begin
         @inline $locate_coeff(i, j, k, ibg::IBG{FT}, coeff) where FT =
-            ifelse(inactive_node(loc..., i, j, k, ibg), $locate_coeff(i, j, k, ibg.underlying_grid, coeff), zero(FT))
+            ifelse(inactive_node(i, j, k, ibg, loc...), $locate_coeff(i, j, k, ibg.underlying_grid, coeff), zero(FT))
     end
 end
 

--- a/src/ImmersedBoundaries/conditional_derivatives.jl
+++ b/src/ImmersedBoundaries/conditional_derivatives.jl
@@ -8,12 +8,12 @@ import Oceananigans.Operators:
 
 # Defining all the First order derivatives for the immersed boundaries
 
-@inline conditional_x_derivative_f(LY, LZ, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(c, LY, LZ, i, j, k, ibg) | inactive_node(c, LY, LZ, i-1, j, k, ibg), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
-@inline conditional_x_derivative_c(LY, LZ, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(f, LY, LZ, i, j, k, ibg) | inactive_node(f, LY, LZ, i+1, j, k, ibg), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
-@inline conditional_y_derivative_f(LX, LZ, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(LX, c, LZ, i, j, k, ibg) | inactive_node(LX, c, LZ, i, j-1, k, ibg), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
-@inline conditional_y_derivative_c(LX, LZ, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(LX, f, LZ, i, j, k, ibg) | inactive_node(LX, f, LZ, i, j+1, k, ibg), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
-@inline conditional_z_derivative_f(LX, LY, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(LX, LY, c, i, j, k, ibg) | inactive_node(LX, LY, c, i, j, k-1, ibg), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
-@inline conditional_z_derivative_c(LX, LY, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(LX, LY, f, i, j, k, ibg) | inactive_node(LX, LY, f, i, j, k+1, ibg), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
+@inline conditional_x_derivative_f(LY, LZ, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(i, j, k, ibg, c, LY, LZ) | inactive_node(i-1, j, k, ibg, c, LY, LZ), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
+@inline conditional_x_derivative_c(LY, LZ, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(i, j, k, ibg, f, LY, LZ) | inactive_node(i+1, j, k, ibg, f, LY, LZ), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
+@inline conditional_y_derivative_f(LX, LZ, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(i, j, k, ibg, LX, c, LZ) | inactive_node(i, j-1, k, ibg, LX, c, LZ), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
+@inline conditional_y_derivative_c(LX, LZ, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(i, j, k, ibg, LX, f, LZ) | inactive_node(i, j+1, k, ibg, LX, f, LZ), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
+@inline conditional_z_derivative_f(LX, LY, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(i, j, k, ibg, LX, LY, c) | inactive_node(i, j, k-1, ibg, LX, LY, c), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
+@inline conditional_z_derivative_c(LX, LY, i, j, k, ibg::IBG{FT}, deriv, args...) where FT = ifelse(inactive_node(i, j, k, ibg, LX, LY, f) | inactive_node(i, j, k+1, ibg, LX, LY, f), zero(FT), deriv(i, j, k, ibg.underlying_grid, args...))
 
 @inline translate_loc(a) = a == :ᶠ ? :f : :c
 

--- a/src/ImmersedBoundaries/conditional_derivatives.jl
+++ b/src/ImmersedBoundaries/conditional_derivatives.jl
@@ -38,7 +38,7 @@ for (d, ξ) in enumerate((:x, :y, :z))
 end
 
 using  Oceananigans.Operators
-import Oceananigans.Operators: Γᶠᶠᶜ, div_xyᶜᶜᶜ
+import Oceananigans.Operators: Γᶠᶠᶜ, div_xyᶜᶜᶜ, div_xyᶜᶜᶠ
 
 # Circulation equal to zero on a solid nodes
 @inline Γᶠᶠᶜ(i, j, k, ibg::IBG, u, v) =  
@@ -47,5 +47,10 @@ import Oceananigans.Operators: Γᶠᶠᶜ, div_xyᶜᶜᶜ
 @inline function div_xyᶜᶜᶜ(i, j, k, ibg::IBG, u, v)  
     return 1 / Azᶜᶜᶜ(i, j, k, ibg) * (conditional_x_derivative_c(c, c, i, j, k, ibg, δxᶜᵃᵃ, Δy_qᶠᶜᶜ, u) +
                                       conditional_y_derivative_c(c, c, i, j, k, ibg, δyᵃᶜᵃ, Δx_qᶜᶠᶜ, v))
+end
+
+@inline function div_xyᶜᶜᶠ(i, j, k, ibg::IBG, u, v)  
+    return 1 / Azᶜᶜᶠ(i, j, k, ibg) * (conditional_x_derivative_c(c, f, i, j, k, ibg, δxᶜᵃᵃ, Δy_qᶠᶜᶠ, u) +
+                                      conditional_y_derivative_c(c, f, i, j, k, ibg, δyᵃᶜᵃ, Δx_qᶜᶠᶠ, v))
 end
 

--- a/src/ImmersedBoundaries/conditional_fluxes.jl
+++ b/src/ImmersedBoundaries/conditional_fluxes.jl
@@ -16,7 +16,7 @@ Return either
 This can be used either to condition intrinsic flux functions, or immersed boundary flux functions.
 """
 @inline conditional_flux(i, j, k, ibg, ℓx, ℓy, ℓz, qᴮ, qᴵ) =
-    ifelse(immersed_peripheral_node(ℓx, ℓy, ℓz, i, j, k, ibg), qᴮ, qᴵ)
+    ifelse(immersed_peripheral_node(i, j, k, ibg, ℓx, ℓy, ℓz), qᴮ, qᴵ)
 
 # Conveniences
 @inline conditional_flux_ccc(i, j, k, ibg::IBG, qᴮ, qᴵ) = conditional_flux(i, j, k, ibg, c, c, c, qᴮ, qᴵ)
@@ -92,18 +92,18 @@ example
 
 julia> calc_inactive_cells(2, :none, :z, :ᶜ)
 4-element Vector{Any}:
- :(inactive_node(c, c, f, i, j, k + -1, ibg))
- :(inactive_node(c, c, f, i, j, k + 0, ibg))
- :(inactive_node(c, c, f, i, j, k + 1, ibg))
- :(inactive_node(c, c, f, i, j, k + 2, ibg))
+ :(inactive_node(i, j, k + -1, ibg, c, c, f))
+ :(inactive_node(i, j, k + 0,  ibg, c, c, f))
+ :(inactive_node(i, j, k + 1,  ibg, c, c, f))
+ :(inactive_node(i, j, k + 2,  ibg, c, c, f))
 
 julia> calc_inactive_cells(3, :left, :x, :ᶠ)
 5-element Vector{Any}:
- :(inactive_node(c, c, c, i + -3, j, k, ibg))
- :(inactive_node(c, c, c, i + -2, j, k, ibg))
- :(inactive_node(c, c, c, i + -1, j, k, ibg))
- :(inactive_node(c, c, c, i + 0, j, k, ibg))
- :(inactive_node(c, c, c, i + 1, j, k, ibg))
+ :(inactive_node(i + -3, j, k, ibg, c, c, c))
+ :(inactive_node(i + -2, j, k, ibg, c, c, c))
+ :(inactive_node(i + -1, j, k, ibg, c, c, c))
+ :(inactive_node(i + 0,  j, k, ibg, c, c, c))
+ :(inactive_node(i + 1,  j, k, ibg, c, c, c))
 
 """
 @inline function calc_inactive_stencil(buffer, shift, dir, side; xside = :ᶠ, yside = :ᶠ, zside = :ᶠ, xshift = 0, yshift = 0, zshift = 0) 
@@ -125,10 +125,10 @@ julia> calc_inactive_cells(3, :left, :x, :ᶠ)
         yflipside = yside == :ᶠ ? :c : :f
         zflipside = zside == :ᶠ ? :c : :f
         inactive_cells[idx] =  dir == :x ? 
-                               :(inactive_node($xflipside, $yflipside, $zflipside, i + $(c + xshift), j + $yshift, k + $zshift, ibg)) :
+                               :(inactive_node(i + $(c + xshift), j + $yshift, k + $zshift, ibg, $xflipside, $yflipside, $zflipside)) :
                                dir == :y ?
-                               :(inactive_node($xflipside, $yflipside, $zflipside, i + $xshift, j + $(c + yshift), k + $zshift, ibg)) :
-                               :(inactive_node($xflipside, $yflipside, $zflipside, i + $xshift, j + $yshift, k + $(c + zshift), ibg))                    
+                               :(inactive_node(i + $xshift, j + $(c + yshift), k + $zshift, ibg, $xflipside, $yflipside, $zflipside)) :
+                               :(inactive_node(i + $xshift, j + $yshift, k + $(c + zshift), ibg, $xflipside, $yflipside, $zflipside))                    
     end
 
     return inactive_cells

--- a/src/ImmersedBoundaries/grid_fitted_immersed_boundaries.jl
+++ b/src/ImmersedBoundaries/grid_fitted_immersed_boundaries.jl
@@ -110,8 +110,8 @@ Adapt.adapt_structure(to, ib::GridFittedBottom) = GridFittedBottom(adapt(to, ib.
 #### Same goes for the face solver, where we check at centers k in both Upper and lower diagonal
 ####
 
-@inline immersed_ivd_peripheral_node(LX, LY, ::Center, i, j, k, ibg) = immersed_peripheral_node(LX, LY, Face(), i, j, k+1, ibg)
-@inline immersed_ivd_peripheral_node(LX, LY, ::Face, i, j, k, ibg)   = immersed_peripheral_node(LX, LY, Center(), i, j, k, ibg)
+@inline immersed_ivd_peripheral_node(i, j, k, ibg, LX, LY, ::Center) = immersed_peripheral_node(i, j, k+1, ibg, LX, LY, Face())
+@inline immersed_ivd_peripheral_node(i, j, k, ibg, LX, LY, ::Face)   = immersed_peripheral_node(i, j, k,   ibg, LX, LY, Center())
 
 # Extend the upper and lower diagonal functions of the batched tridiagonal solver
 
@@ -127,7 +127,7 @@ for location in (:upper_, :lower_)
                 $immersed_func(i, j, k, ibg::GFIBG, closure, K, id, ℓx, ℓy, ℓz, clock, Δt, κz)
 
         @inline function $immersed_func(i, j, k, ibg::GFIBG, closure, K, id, ℓx, ℓy, ℓz, clock, Δt, κz)
-            return ifelse(immersed_ivd_peripheral_node(ℓx, ℓy, ℓz, i, j, k, ibg),
+            return ifelse(immersed_ivd_peripheral_node(i, j, k, ibg, ℓx, ℓy, ℓz),
                           zero(eltype(ibg.underlying_grid)),
                           $ordinary_func(i, j, k, ibg.underlying_grid, closure, K, id, ℓx, ℓy, ℓz, clock, Δt, κz))
         end

--- a/src/ImmersedBoundaries/immersed_reductions.jl
+++ b/src/ImmersedBoundaries/immersed_reductions.jl
@@ -27,3 +27,27 @@ const IF = AbstractField{<:Any, <:Any, <:Any, <:ImmersedBoundaryGrid}
     return get_condition(condition.func, i, j, k, ibg, args...) & !(immersed_peripheral_node(i, j, k, ibg, LX(), LY(), LZ()))
 end 
 
+#####
+##### Reduction operations on Reduced Fields have to test if entirety of the immersed direction is immersed to exclude it
+#####
+
+# struct NotImmersedReduced{F, D} <: Function
+#     func :: F
+#     immersed_dimensions :: D
+# end
+
+# function NotImmersedReduced(func; location = ())
+
+# # ImmersedReducedFields
+# const IRF = ReducedField{<:Any, <:Any, <:Any, <:ImmersedBoundaryGrid}
+
+# @inline condition_operand(func::Function,         op::IRF, cond,      mask) = ConditionalOperation(op; func, condition=NotImmersedReduced(cond),     mask)
+# @inline condition_operand(func::Function,         op::IRF, ::Nothing, mask) = ConditionalOperation(op; func, condition=NotImmersedReduced(truefunc), mask)
+# @inline condition_operand(func::typeof(identity), op::IRF, ::Nothing, mask) = ConditionalOperation(op; func, condition=NotImmersedReduced(truefunc), mask)
+
+# @inline function get_condition(condition::NotImmersedReduced, i, j, k, ibg, co::ConditionalOperation, args...)
+#     LX, LY, LZ = location(co)
+#     return get_condition(condition.func, i, j, k, ibg, args...) & !immersed_column(i, j, k, ibg, LX(), LY(), LZ(), condition))
+# end 
+
+# @inline function immersed_column(i, j, k, ibg, reduced_dims, )

--- a/src/ImmersedBoundaries/immersed_reductions.jl
+++ b/src/ImmersedBoundaries/immersed_reductions.jl
@@ -57,11 +57,16 @@ const IRF = Union{XIRF, YIRF, ZIRF, YZIRF, XZIRF, XYIRF, XYZIRF}
 @inline condition_operand(func::typeof(identity), op::IRF, ::Nothing, mask) = ConditionalOperation(op; func, condition=NotImmersedColumn(immersed_column(op), truefunc), mask)
 
 @inline function immersed_column(field::IRF)
-    reduced_dims = reduced_dimensions(field)
-    one_field    = ConditionalOperation{location(field)...}(OneField(Int), identity, field.grid, NotImmersed(truefunc), 0.0)
+    reduced_dims  = reduced_dimensions(field)
+    full_location = fill_location.(location(field)) 
+    one_field    = ConditionalOperation{full_location...}(OneField(Int), identity, field.grid, NotImmersed(truefunc), 0.0)
 
     return sum(one_field, dims = reduced_dims)
 end
+
+@inline fill_location(::Type{Face})    = Face
+@inline fill_location(::Type{Center})  = Center
+@inline fill_location(::Type{Nothing}) = Center
 
 @inline function get_condition(condition::NotImmersedColumn, i, j, k, ibg, co::ConditionalOperation, args...)
     LX, LY, LZ = location(co)

--- a/src/ImmersedBoundaries/immersed_reductions.jl
+++ b/src/ImmersedBoundaries/immersed_reductions.jl
@@ -23,7 +23,7 @@ const IF = AbstractField{<:Any, <:Any, <:Any, <:ImmersedBoundaryGrid}
 @inline conditional_length(c::IF, dims) = conditional_length(condition_operand(identity, c, nothing, 0), dims)
 
 @inline function get_condition(condition::NotImmersed, i, j, k, ibg, co::ConditionalOperation, args...)
-    LX, LY, LZ = location(co)    
-    return get_condition(condition.func, i, j, k, ibg, args...) & !(immersed_peripheral_node(LX(), LY(), LZ(), i, j, k, ibg))
+    LX, LY, LZ = location(co)
+    return get_condition(condition.func, i, j, k, ibg, args...) & !(immersed_peripheral_node(i, j, k, ibg, LX(), LY(), LZ()))
 end 
 

--- a/src/ImmersedBoundaries/mask_immersed_field.jl
+++ b/src/ImmersedBoundaries/mask_immersed_field.jl
@@ -48,7 +48,7 @@ mask_immersed_velocities!(U, arch, grid) = tuple(NoneEvent())
 #####
 
 @inline function scalar_mask(i, j, k, grid, ::AbstractGridFittedBoundary, LX, LY, LZ, value, field)
-    return @inbounds ifelse(peripheral_node(LX, LY, LZ, i, j, k, grid),
+    return @inbounds ifelse(peripheral_node(i, j, k, grid, LX, LY, LZ),
                             value,
                             field[i, j, k])
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl
@@ -25,7 +25,7 @@ fill_horizontal_velocity_halos!(args...) = nothing
 ##### HydrostaticFreeSurfaceModel definition
 #####
 
-FreeSurfaceDisplacementField(velocities, free_surface, grid) = CenterField(grid, indices = (:, :, size(grid, 3)))
+FreeSurfaceDisplacementField(velocities, free_surface, grid) = ZFaceField(grid, indices = (:, :, size(grid, 3)+1))
 FreeSurfaceDisplacementField(velocities, ::Nothing, grid) = nothing
 
 include("compute_w_from_continuity.jl")

--- a/src/Models/HydrostaticFreeSurfaceModels/barotropic_pressure_correction.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/barotropic_pressure_correction.jl
@@ -46,7 +46,7 @@ end
     i, j, k = @index(Global, NTuple)
 
     @inbounds begin
-        U.u[i, j, k] -= g * Δt * ∂xᶠᶜᶜ(i, j, grid.Nz, grid, η)
-        U.v[i, j, k] -= g * Δt * ∂yᶜᶠᶜ(i, j, grid.Nz, grid, η)
+        U.u[i, j, k] -= g * Δt * ∂xᶠᶜᶜ(i, j, grid.Nz+1, grid, η)
+        U.v[i, j, k] -= g * Δt * ∂yᶜᶠᶜ(i, j, grid.Nz+1, grid, η)
     end
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/barotropic_pressure_correction.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/barotropic_pressure_correction.jl
@@ -34,6 +34,8 @@ function pressure_correct_velocities!(model::ImplicitFreeSurfaceHFSM, Δt;
     return nothing
 end
 
+calculate_free_surface_tendency!(grid, model::ImplicitFreeSurfaceHFSM, dependencies) = NoneEvent()
+
 function pressure_correct_velocities!(model::SplitExplicitFreeSurfaceHFSM, Δt; dependecies = nothing)
     u, v, _ = model.velocities
     grid = model.grid 

--- a/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
@@ -195,7 +195,7 @@ end
 """ Calculate the right-hand-side of the free surface displacement (η) equation. """
 @kernel function calculate_hydrostatic_free_surface_Gη!(Gη, grid, args...)
     i, j = @index(Global, NTuple)
-    @inbounds Gη[i, j, grid.Nz] = free_surface_tendency(i, j, grid, args...)
+    @inbounds Gη[i, j, grid.Nz+1] = free_surface_tendency(i, j, grid, args...)
 end
 
 #####

--- a/src/Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl
@@ -41,10 +41,10 @@ end
 #####
 
 @inline explicit_barotropic_pressure_x_gradient(i, j, k, grid, free_surface::ExplicitFreeSurface) =
-    free_surface.gravitational_acceleration * ∂xᶠᶜᶜ(i, j, grid.Nz, grid, free_surface.η)
+    free_surface.gravitational_acceleration * ∂xᶠᶜᶜ(i, j, grid.Nz+1, grid, free_surface.η)
 
 @inline explicit_barotropic_pressure_y_gradient(i, j, k, grid, free_surface::ExplicitFreeSurface) =
-    free_surface.gravitational_acceleration * ∂yᶜᶠᶜ(i, j, grid.Nz, grid, free_surface.η)
+    free_surface.gravitational_acceleration * ∂yᶜᶠᶜ(i, j, grid.Nz+1, grid, free_surface.η)
 
 #####
 ##### Time stepping
@@ -79,6 +79,6 @@ end
     i, j = @index(Global, NTuple)
 
     @inbounds begin
-        η[i, j, Nz] += Δt * ((FT(1.5) + χ) * Gηⁿ[i, j, Nz] - (FT(0.5) + χ) * Gη⁻[i, j, Nz])
+        η[i, j, Nz+1] += Δt * ((FT(1.5) + χ) * Gηⁿ[i, j, Nz+1] - (FT(0.5) + χ) * Gη⁻[i, j, Nz+1])
     end
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl
@@ -62,7 +62,7 @@ function explicit_ab2_step_free_surface!(free_surface, model, Δt, χ, prognosti
     
     free_surface_event = launch!(model.architecture, model.grid, :xy,
                                 _explicit_ab2_step_free_surface!, free_surface.η, Δt, χ,
-                                model.timestepper.Gⁿ.η, model.timestepper.G⁻.η, model.grid.Nz,
+                                model.timestepper.Gⁿ.η, model.timestepper.G⁻.η, size(model.grid, 3),
                                 dependencies = device_event(model.architecture))
     
     return MultiEvent(tuple(prognostic_field_events[1]..., prognostic_field_events[2]..., free_surface_event))

--- a/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
@@ -110,9 +110,9 @@ end
 
 @kernel function fft_implicit_free_surface_right_hand_side!(rhs, grid, g, Lz, Δt, ∫ᶻQ, η)
     i, j = @index(Global, NTuple)
-    k_surface = grid.Nz+1
-    Az = Azᶜᶜᶠ(i, j, k_surface, grid)
-    δ_Q = flux_div_xyᶜᶜᶠ(i, j, k_surface, grid, ∫ᶻQ.u, ∫ᶻQ.v)
-    @inbounds rhs[i, j, 1] = (δ_Q - Az * η[i, j, k_surface] / Δt) / (g * Lz * Δt * Az)
+    k_top = grid.Nz+1
+    Az = Azᶜᶜᶠ(i, j, k_top, grid)
+    δ_Q = flux_div_xyᶜᶜᶠ(i, j, k_top, grid, ∫ᶻQ.u, ∫ᶻQ.v)
+    @inbounds rhs[i, j, 1] = (δ_Q - Az * η[i, j, k_top] / Δt) / (g * Lz * Δt * Az)
 end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
@@ -112,6 +112,6 @@ end
     i, j = @index(Global, NTuple)
     Az = Azᶜᶜᶜ(i, j, grid.Nz, grid)
     δ_Q = flux_div_xyᶜᶜᶜ(i, j, 1, grid, ∫ᶻQ.u, ∫ᶻQ.v)
-    @inbounds rhs[i, j, grid.Nz] = (δ_Q - Az * η[i, j, grid.Nz] / Δt) / (g * Lz * Δt * Az)
+    @inbounds rhs[i, j, 1] = (δ_Q - Az * η[i, j, grid.Nz] / Δt) / (g * Lz * Δt * Az)
 end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
@@ -112,6 +112,6 @@ end
     i, j = @index(Global, NTuple)
     Az = Azᶜᶜᶜ(i, j, grid.Nz, grid)
     δ_Q = flux_div_xyᶜᶜᶜ(i, j, 1, grid, ∫ᶻQ.u, ∫ᶻQ.v)
-    @inbounds rhs[i, j, 1] = (δ_Q - Az * η[i, j, grid.Nz] / Δt) / (g * Lz * Δt * Az)
+    @inbounds rhs[i, j, 1] = (δ_Q - Az * η[i, j, grid.Nz+1] / Δt) / (g * Lz * Δt * Az)
 end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
@@ -110,8 +110,9 @@ end
 
 @kernel function fft_implicit_free_surface_right_hand_side!(rhs, grid, g, Lz, Δt, ∫ᶻQ, η)
     i, j = @index(Global, NTuple)
-    Az = Azᶜᶜᶜ(i, j, grid.Nz, grid)
-    δ_Q = flux_div_xyᶜᶜᶜ(i, j, 1, grid, ∫ᶻQ.u, ∫ᶻQ.v)
-    @inbounds rhs[i, j, 1] = (δ_Q - Az * η[i, j, grid.Nz+1] / Δt) / (g * Lz * Δt * Az)
+    k_surface = grid.Nz+1
+    Az = Azᶜᶜᶠ(i, j, k_surface, grid)
+    δ_Q = flux_div_xyᶜᶜᶠ(i, j, k_surface, grid, ∫ᶻQ.u, ∫ᶻQ.v)
+    @inbounds rhs[i, j, 1] = (δ_Q - Az * η[i, j, k_surface] / Δt) / (g * Lz * Δt * Az)
 end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
@@ -134,11 +134,11 @@ The tendency is called ``G_η`` and defined via
                                        forcings,
                                        clock)
 
-    k_surface = grid.Nz + 1
+    k_top = grid.Nz + 1
     model_fields = merge(hydrostatic_fields(velocities, free_surface, tracers), auxiliary_fields)
 
-    return @inbounds (   velocities.w[i, j, k_surface]
-                       + forcings.η(i, j, k_surface, grid, clock, model_fields))
+    return @inbounds (   velocities.w[i, j, k_top]
+                       + forcings.η(i, j, k_top, grid, clock, model_fields))
 end
 
 @inline function hydrostatic_turbulent_kinetic_energy_tendency(i, j, k, grid,

--- a/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface_utils.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface_utils.jl
@@ -1,5 +1,3 @@
-using Oceananigans.Fields: Field, ZReducedField
-
 """
 Compute the horizontal divergence of vertically-uniform quantity using
 vertically-integrated face areas `∫ᶻ_Axᶠᶜᶜ` and `∫ᶻ_Ayᶜᶠᶜ`.

--- a/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
@@ -104,7 +104,7 @@ end
     Az   = Azᶜᶜᶜ(i, j, 1, grid)
     δ_Q  = flux_div_xyᶜᶜᶜ(i, j, 1, grid, ∫ᶻQ.u, ∫ᶻQ.v)
     t = i + grid.Nx * (j - 1)
-    @inbounds rhs[t] = (δ_Q - Az * η[i, j, grid.Nz] / Δt) / (g * Δt)
+    @inbounds rhs[t] = (δ_Q - Az * η[i, j, grid.Nz+1] / Δt) / (g * Δt)
 end
 
 function compute_matrix_coefficients(vertically_integrated_areas, grid, gravitational_acceleration)

--- a/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
@@ -101,10 +101,10 @@ end
 # linearized right hand side
 @kernel function implicit_linearized_free_surface_right_hand_side!(rhs, grid, g, Δt, ∫ᶻQ, η)
     i, j = @index(Global, NTuple)
-    Az   = Azᶜᶜᶜ(i, j, 1, grid)
+    Az   = Azᶜᶜᶜ(i, j, grid.Nz, grid)
     δ_Q  = flux_div_xyᶜᶜᶜ(i, j, 1, grid, ∫ᶻQ.u, ∫ᶻQ.v)
     t = i + grid.Nx * (j - 1)
-    @inbounds rhs[t] = (δ_Q - Az * η[i, j, grid.Nz+1] / Δt) / (g * Δt)
+    @inbounds rhs[t] = (δ_Q - Az * η[i, j, grid.Nz + 1] / Δt) / (g * Δt)
 end
 
 function compute_matrix_coefficients(vertically_integrated_areas, grid, gravitational_acceleration)

--- a/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
@@ -40,8 +40,8 @@ step `Δt`, gravitational acceleration `g`, and free surface at time-step `n` `�
 function MatrixImplicitFreeSurfaceSolver(grid::AbstractGrid, settings, gravitational_acceleration::Number)
     
     # Initialize vertically integrated lateral face areas
-    ∫ᶻ_Axᶠᶜᶜ = Field{Face, Center, Nothing}(grid)
-    ∫ᶻ_Ayᶜᶠᶜ = Field{Center, Face, Nothing}(grid)
+    ∫ᶻ_Axᶠᶜᶜ = Field((Face, Center, Nothing), grid)
+    ∫ᶻ_Ayᶜᶠᶜ = Field((Center, Face, Nothing), grid)
 
     vertically_integrated_lateral_areas = (xᶠᶜᶜ = ∫ᶻ_Axᶠᶜᶜ, yᶜᶠᶜ = ∫ᶻ_Ayᶜᶠᶜ)
 
@@ -134,8 +134,8 @@ end
 @kernel function _compute_coefficients!(diag, Ax, Ay, ∫Ax, ∫Ay, grid, g)
     i, j = @index(Global, NTuple)
     @inbounds begin
-        Ay[i, j, 1]    = ∫Ay[i, j, 1] / Δyᶜᶠᶜ(i, j, 1, grid)  
-        Ax[i, j, 1]    = ∫Ax[i, j, 1] / Δxᶠᶜᶜ(i, j, 1, grid)  
-        diag[i, j, 1]  = - Azᶜᶜᶜ(i, j, 1, grid) / g
+        Ay[i, j, 1]    = ∫Ay[i, j, 1] / Δyᶜᶠᶜ(i, j, grid.Nz+1, grid)  
+        Ax[i, j, 1]    = ∫Ax[i, j, 1] / Δxᶠᶜᶜ(i, j, grid.Nz+1, grid)  
+        diag[i, j, 1]  = - Azᶜᶜᶠ(i, j, grid.Nz+1, grid) / g
     end
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
@@ -101,11 +101,11 @@ end
 # linearized right hand side
 @kernel function implicit_linearized_free_surface_right_hand_side!(rhs, grid, g, Δt, ∫ᶻQ, η)
     i, j = @index(Global, NTuple)
-    k_surface = grid.Nz + 1
-    Az   = Azᶜᶜᶠ(i, j, k_surface, grid)
-    δ_Q  = flux_div_xyᶜᶜᶠ(i, j, k_surface, grid, ∫ᶻQ.u, ∫ᶻQ.v)
+    k_top = grid.Nz + 1
+    Az   = Azᶜᶜᶠ(i, j, k_top, grid)
+    δ_Q  = flux_div_xyᶜᶜᶠ(i, j, k_top, grid, ∫ᶻQ.u, ∫ᶻQ.v)
     t = i + grid.Nx * (j - 1)
-    @inbounds rhs[t] = (δ_Q - Az * η[i, j, k_surface] / Δt) / (g * Δt)
+    @inbounds rhs[t] = (δ_Q - Az * η[i, j, k_top] / Δt) / (g * Δt)
 end
 
 function compute_matrix_coefficients(vertically_integrated_areas, grid, gravitational_acceleration)

--- a/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
@@ -101,10 +101,11 @@ end
 # linearized right hand side
 @kernel function implicit_linearized_free_surface_right_hand_side!(rhs, grid, g, Δt, ∫ᶻQ, η)
     i, j = @index(Global, NTuple)
-    Az   = Azᶜᶜᶜ(i, j, grid.Nz, grid)
-    δ_Q  = flux_div_xyᶜᶜᶜ(i, j, 1, grid, ∫ᶻQ.u, ∫ᶻQ.v)
+    k_surface = grid.Nz + 1
+    Az   = Azᶜᶜᶠ(i, j, k_surface, grid)
+    δ_Q  = flux_div_xyᶜᶜᶠ(i, j, k_surface, grid, ∫ᶻQ.u, ∫ᶻQ.v)
     t = i + grid.Nx * (j - 1)
-    @inbounds rhs[t] = (δ_Q - Az * η[i, j, grid.Nz + 1] / Δt) / (g * Δt)
+    @inbounds rhs[t] = (δ_Q - Az * η[i, j, k_surface] / Δt) / (g * Δt)
 end
 
 function compute_matrix_coefficients(vertically_integrated_areas, grid, gravitational_acceleration)

--- a/src/Models/HydrostaticFreeSurfaceModels/mg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/mg_implicit_free_surface_solver.jl
@@ -63,7 +63,7 @@ function MGImplicitFreeSurfaceSolver(grid::AbstractGrid,
                                      placeholder_timestep = -1.0)
     arch = architecture(grid)
 
-    right_hand_side = ZFaceField(grid, indices = (:, :, size(grid, 3)+1))
+    right_hand_side = Field((Center, Center, Nothing), grid)
     
     # Initialize vertically integrated lateral face areas
     ∫ᶻ_Axᶠᶜᶜ = Field{Face, Center, Nothing}(with_halo((3, 3, 1), grid))

--- a/src/Models/HydrostaticFreeSurfaceModels/mg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/mg_implicit_free_surface_solver.jl
@@ -132,8 +132,8 @@ end
 
 @kernel function _Az_∇h²ᶜᶜᶜ_linear_operation!(L_ηⁿ⁺¹, grid, ηⁿ⁺¹, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ)
     i, j = @index(Global, NTuple)
-    k_surface = grid.Nz + 1
-    @inbounds L_ηⁿ⁺¹[i, j, k_surface] = Az_∇h²ᶜᶜᶜ(i, j, k_surface, grid, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, ηⁿ⁺¹)
+    k_top = grid.Nz + 1
+    @inbounds L_ηⁿ⁺¹[i, j, k_top] = Az_∇h²ᶜᶜᶜ(i, j, k_top, grid, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, ηⁿ⁺¹)
 end
 
 build_implicit_step_solver(::Val{:Multigrid}, grid, settings, gravitational_acceleration) =

--- a/src/Models/HydrostaticFreeSurfaceModels/mg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/mg_implicit_free_surface_solver.jl
@@ -132,7 +132,7 @@ end
 
 @kernel function _Az_∇h²ᶜᶜᶜ_linear_operation!(L_ηⁿ⁺¹, grid, ηⁿ⁺¹, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ)
     i, j = @index(Global, NTuple)
-    @inbounds L_ηⁿ⁺¹[i, j, grid.Nz] = Az_∇h²ᶜᶜᶜ(i, j, grid.Nz, grid, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, ηⁿ⁺¹)
+    @inbounds L_ηⁿ⁺¹[i, j, grid.Nz+1] = Az_∇h²ᶜᶜᶜ(i, j, grid.Nz+1, grid, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, ηⁿ⁺¹)
 end
 
 build_implicit_step_solver(::Val{:Multigrid}, grid, settings, gravitational_acceleration) =

--- a/src/Models/HydrostaticFreeSurfaceModels/mg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/mg_implicit_free_surface_solver.jl
@@ -63,8 +63,8 @@ function MGImplicitFreeSurfaceSolver(grid::AbstractGrid,
                                      placeholder_timestep = -1.0)
     arch = architecture(grid)
 
-    right_hand_side = Field((Center, Center, Center), grid, indices = (:, :, grid.Nz))
-
+    right_hand_side = ZFaceField(grid, indices = (:, :, size(grid, 3)+1))
+    
     # Initialize vertically integrated lateral face areas
     ∫ᶻ_Axᶠᶜᶜ = Field{Face, Center, Nothing}(with_halo((3, 3, 1), grid))
     ∫ᶻ_Ayᶜᶠᶜ = Field{Center, Face, Nothing}(with_halo((3, 3, 1), grid))

--- a/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
@@ -114,9 +114,9 @@ end
 
 @kernel function implicit_free_surface_right_hand_side!(rhs, grid, g, Δt, ∫ᶻQ, η)
     i, j = @index(Global, NTuple)
-    Az = Azᶜᶜᶜ(i, j, grid.Nz, grid)
-    δ_Q = flux_div_xyᶜᶜᶜ(i, j, grid.Nz, grid, ∫ᶻQ.u, ∫ᶻQ.v)
     k_surface = grid.Nz + 1
+    Az = Azᶜᶜᶠ(i, j, k_surface, grid)
+    δ_Q = flux_div_xyᶜᶜᶜ(i, j, k_surface, grid, ∫ᶻQ.u, ∫ᶻQ.v)
     @inbounds rhs[i, j, k_surface] = (δ_Q - Az * η[i, j, k_surface] / Δt) / (g * Δt)
 end
 
@@ -282,10 +282,10 @@ function diagonally_dominant_precondition!(P_r, r, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ay
 end
 
 # Kernels that calculate coefficients for the preconditioner
-@inline Ax⁻(i, j, grid, ax) = @inbounds   ax[i, j, 1] / Δxᶠᶜᶜ(i, j, grid.Nz, grid)
-@inline Ay⁻(i, j, grid, ay) = @inbounds   ay[i, j, 1] / Δyᶜᶠᶜ(i, j, grid.Nz, grid)
-@inline Ax⁺(i, j, grid, ax) = @inbounds ax[i+1, j, 1] / Δxᶠᶜᶜ(i+1, j, grid.Nz, grid)
-@inline Ay⁺(i, j, grid, ay) = @inbounds ay[i, j+1, 1] / Δyᶜᶠᶜ(i, j+1, grid.Nz, grid)
+@inline Ax⁻(i, j, grid, ax) = @inbounds   ax[i, j, 1] / Δxᶠᶜᶠ(i, j, grid.Nz+1, grid)
+@inline Ay⁻(i, j, grid, ay) = @inbounds   ay[i, j, 1] / Δyᶜᶠᶠ(i, j, grid.Nz+1, grid)
+@inline Ax⁺(i, j, grid, ax) = @inbounds ax[i+1, j, 1] / Δxᶠᶜᶠ(i+1, j, grid.Nz+1, grid)
+@inline Ay⁺(i, j, grid, ay) = @inbounds ay[i, j+1, 1] / Δyᶜᶠᶠ(i, j+1, grid.Nz+1, grid)
 
 @inline Ac(i, j, grid, g, Δt, ax, ay) = - Ax⁻(i, j, grid, ax) -
                                           Ax⁺(i, j, grid, ax) -

--- a/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
@@ -62,7 +62,7 @@ function PCGImplicitFreeSurfaceSolver(grid::AbstractGrid, settings, gravitationa
         get(settings, :preconditioner, nothing)
 
     # TODO: reuse solver.storage for rhs when preconditioner isa FFTImplicitFreeSurfaceSolver?
-    right_hand_side = ZFaceField(grid, indices = (:, :, size(grid, 3)+1))
+    right_hand_side = ZFaceField(grid, indices = (:, :, size(grid, 3) + 1))
 
     solver = PreconditionedConjugateGradientSolver(implicit_free_surface_linear_operation!;
                                                    template_field = right_hand_side,
@@ -116,7 +116,8 @@ end
     i, j = @index(Global, NTuple)
     Az = Azᶜᶜᶜ(i, j, grid.Nz, grid)
     δ_Q = flux_div_xyᶜᶜᶜ(i, j, grid.Nz, grid, ∫ᶻQ.u, ∫ᶻQ.v)
-    @inbounds rhs[i, j, grid.Nz+1] = (δ_Q - Az * η[i, j, grid.Nz+1] / Δt) / (g * Δt)
+    k_surface = grid.Nz + 1
+    @inbounds rhs[i, j, k_surface] = (δ_Q - Az * η[i, j, k_surface] / Δt) / (g * Δt)
 end
 
 """
@@ -167,7 +168,7 @@ where  ̂ indicates a vertical integral, and
 """
 @kernel function _implicit_free_surface_linear_operation!(L_ηⁿ⁺¹, grid, ηⁿ⁺¹, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, g, Δt)
     i, j = @index(Global, NTuple)
-    k_surface = grid.Nz+1
+    k_surface = grid.Nz + 1
     Az = Azᶜᶜᶜ(i, j, grid.Nz, grid)
     @inbounds L_ηⁿ⁺¹[i, j, k_surface] = Az_∇h²ᶜᶜᶜ(i, j, k_surface, grid, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, ηⁿ⁺¹) - Az * ηⁿ⁺¹[i, j, k_surface] / (g * Δt^2)
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
@@ -197,7 +197,7 @@ end
 
 @kernel function fft_preconditioner_right_hand_side!(fft_rhs, pcg_rhs, η, grid, Az, Lz)
     i, j = @index(Global, NTuple)
-    @inbounds fft_rhs[i, j, grid.Nz] = pcg_rhs[i, j, grid.Nz] / (Lz * Az)
+    @inbounds fft_rhs[i, j, 1] = pcg_rhs[i, j, grid.Nz] / (Lz * Az)
 end
 
 # TODO: make it so adding this term:

--- a/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
@@ -110,13 +110,13 @@ function compute_implicit_free_surface_right_hand_side!(rhs, implicit_solver::PC
 end
 
 """ Compute the divergence of fluxes Qu and Qv. """
-@inline flux_div_xyᶜᶜᶜ(i, j, k, grid, Qu, Qv) = δxᶜᵃᵃ(i, j, k, grid, Qu) + δyᵃᶜᵃ(i, j, k, grid, Qv)
+@inline flux_div_xyᶜᶜᶠ(i, j, k, grid, Qu, Qv) = δxᶜᵃᵃ(i, j, k, grid, Qu) + δyᵃᶜᵃ(i, j, k, grid, Qv)
 
 @kernel function implicit_free_surface_right_hand_side!(rhs, grid, g, Δt, ∫ᶻQ, η)
     i, j = @index(Global, NTuple)
     k_surface = grid.Nz + 1
     Az = Azᶜᶜᶠ(i, j, k_surface, grid)
-    δ_Q = flux_div_xyᶜᶜᶜ(i, j, k_surface, grid, ∫ᶻQ.u, ∫ᶻQ.v)
+    δ_Q = flux_div_xyᶜᶜᶠ(i, j, k_surface, grid, ∫ᶻQ.u, ∫ᶻQ.v)
     @inbounds rhs[i, j, k_surface] = (δ_Q - Az * η[i, j, k_surface] / Δt) / (g * Δt)
 end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
@@ -114,10 +114,10 @@ end
 
 @kernel function implicit_free_surface_right_hand_side!(rhs, grid, g, Δt, ∫ᶻQ, η)
     i, j = @index(Global, NTuple)
-    k_surface = grid.Nz + 1
-    Az = Azᶜᶜᶠ(i, j, k_surface, grid)
-    δ_Q = flux_div_xyᶜᶜᶠ(i, j, k_surface, grid, ∫ᶻQ.u, ∫ᶻQ.v)
-    @inbounds rhs[i, j, k_surface] = (δ_Q - Az * η[i, j, k_surface] / Δt) / (g * Δt)
+    k_top = grid.Nz + 1
+    Az = Azᶜᶜᶠ(i, j, k_top, grid)
+    δ_Q = flux_div_xyᶜᶜᶠ(i, j, k_top, grid, ∫ᶻQ.u, ∫ᶻQ.v)
+    @inbounds rhs[i, j, k_top] = (δ_Q - Az * η[i, j, k_top] / Δt) / (g * Δt)
 end
 
 """
@@ -168,9 +168,9 @@ where  ̂ indicates a vertical integral, and
 """
 @kernel function _implicit_free_surface_linear_operation!(L_ηⁿ⁺¹, grid, ηⁿ⁺¹, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, g, Δt)
     i, j = @index(Global, NTuple)
-    k_surface = grid.Nz + 1
+    k_top = grid.Nz + 1
     Az = Azᶜᶜᶜ(i, j, grid.Nz, grid)
-    @inbounds L_ηⁿ⁺¹[i, j, k_surface] = Az_∇h²ᶜᶜᶜ(i, j, k_surface, grid, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, ηⁿ⁺¹) - Az * ηⁿ⁺¹[i, j, k_surface] / (g * Δt^2)
+    @inbounds L_ηⁿ⁺¹[i, j, k_top] = Az_∇h²ᶜᶜᶜ(i, j, k_top, grid, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, ηⁿ⁺¹) - Az * ηⁿ⁺¹[i, j, k_top] / (g * Δt^2)
 end
 
 #####

--- a/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
@@ -142,8 +142,8 @@ function implicit_free_surface_linear_operation!(L_ηⁿ⁺¹, ηⁿ⁺¹, ∫�
 end
 
 # Kernels that act on vertically integrated / surface quantities
-@inline ∫ᶻ_Ax_∂x_ηᶠᶜᶜ(i, j, k, grid, ∫ᶻ_Axᶠᶜᶜ, η) = @inbounds ∫ᶻ_Axᶠᶜᶜ[i, j, k] * ∂xᶠᶜᶜ(i, j, k, grid, η)
-@inline ∫ᶻ_Ay_∂y_ηᶜᶠᶜ(i, j, k, grid, ∫ᶻ_Ayᶜᶠᶜ, η) = @inbounds ∫ᶻ_Ayᶜᶠᶜ[i, j, k] * ∂yᶜᶠᶜ(i, j, k, grid, η)
+@inline ∫ᶻ_Ax_∂x_ηᶠᶜᶜ(i, j, k, grid, ∫ᶻ_Axᶠᶜᶜ, η) = @inbounds ∫ᶻ_Axᶠᶜᶜ[i, j, k] * ∂xᶠᶜᶠ(i, j, k, grid, η)
+@inline ∫ᶻ_Ay_∂y_ηᶜᶠᶜ(i, j, k, grid, ∫ᶻ_Ayᶜᶠᶜ, η) = @inbounds ∫ᶻ_Ayᶜᶠᶜ[i, j, k] * ∂yᶜᶠᶠ(i, j, k, grid, η)
 
 """
     _implicit_free_surface_linear_operation!(L_ηⁿ⁺¹, grid, ηⁿ⁺¹, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, g, Δt)

--- a/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
@@ -62,7 +62,7 @@ function PCGImplicitFreeSurfaceSolver(grid::AbstractGrid, settings, gravitationa
         get(settings, :preconditioner, nothing)
 
     # TODO: reuse solver.storage for rhs when preconditioner isa FFTImplicitFreeSurfaceSolver?
-    right_hand_side = Field((Center, Center, Center), grid, indices = (:, :, grid.Nz))
+    right_hand_side = ZFaceField(grid, indices = (:, :, size(grid, 3)+1))
 
     solver = PreconditionedConjugateGradientSolver(implicit_free_surface_linear_operation!;
                                                    template_field = right_hand_side,

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
@@ -35,7 +35,7 @@ SplitExplicitFreeSurface(; gravitational_acceleration = g_Earth, substeps = 200)
 
 # The new constructor is defined later on after the state, settings, auxiliary have been defined
 function FreeSurface(free_surface::SplitExplicitFreeSurface, velocities, grid)
-    η =  Field{Center, Center, Nothing}(grid)
+    η =  FreeSurfaceDisplacementField(velocities, free_surface, grid)
 
     return SplitExplicitFreeSurface(η, SplitExplicitState(grid),
                                     SplitExplicitAuxiliary(grid),
@@ -46,7 +46,7 @@ end
 function SplitExplicitFreeSurface(grid; gravitational_acceleration = g_Earth,
                                         settings = SplitExplicitSettings(200))
 
-    η =  Field{Center, Center, Nothing}(grid)
+    η =  FreeSurfaceDisplacementField(velocities, free_surface, grid)
 
     sefs = SplitExplicitFreeSurface(η,
                                     SplitExplicitState(grid),

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
@@ -46,16 +46,14 @@ end
 function SplitExplicitFreeSurface(grid; gravitational_acceleration = g_Earth,
                                         settings = SplitExplicitSettings(200))
 
-    η = ZFaceField(grid, indices = (:, :, size(grid, 3)+1))
+η = ZFaceField(grid, indices = (:, :, size(grid, 3)+1))
 
-    sefs = SplitExplicitFreeSurface(η,
+    return SplitExplicitFreeSurface(η,
                                     SplitExplicitState(grid),
                                     SplitExplicitAuxiliary(grid),
                                     gravitational_acceleration,
                                     settings
                                     )
-
-    return sefs
 end
 
 """
@@ -118,12 +116,12 @@ end
 
 function SplitExplicitAuxiliary(grid::AbstractGrid)
 
-    Gᵁ = Field{Face,Center,Nothing}(grid)
-    Gⱽ = Field{Center,Face,Nothing}(grid)
+    Gᵁ = Field{Face,   Center, Nothing}(grid)
+    Gⱽ = Field{Center, Face,   Nothing}(grid)
 
-    Hᶠᶜ = Field{Face,Center,Nothing}(grid)
-    Hᶜᶠ = Field{Center,Face,Nothing}(grid)
-    Hᶜᶜ = Field{Center,Center,Nothing}(grid)
+    Hᶠᶜ = Field{Face,   Center, Nothing}(grid)
+    Hᶜᶠ = Field{Center, Face,   Nothing}(grid)
+    Hᶜᶜ = Field{Center, Center, Nothing}(grid)
 
     dz = GridMetricOperation((Face, Center, Center), Δz, grid)
     sum!(Hᶠᶜ, dz)

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
@@ -46,7 +46,7 @@ end
 function SplitExplicitFreeSurface(grid; gravitational_acceleration = g_Earth,
                                         settings = SplitExplicitSettings(200))
 
-    η =  FreeSurfaceDisplacementField(velocities, free_surface, grid)
+    η = ZFaceField(grid, indices = (:, :, size(grid, 3)+1))
 
     sefs = SplitExplicitFreeSurface(η,
                                     SplitExplicitState(grid),

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
@@ -25,7 +25,7 @@ end
     k_surface = grid.Nz+1
     
     # ∂τ(η) = - ∇⋅U
-    @inbounds η[i, j, k_surface] -=  Δτ * div_xyᶜᶜᶠ(i, j, k_surface, grid, U, V)
+    @inbounds η[i, j, k_surface] -=  Δτ * div_xyᶜᶜᶠ(i, j, 1, grid, U, V)
     # time-averaging
     @inbounds U̅[i, j, 1]         +=  velocity_weight * U[i, j, 1]
     @inbounds V̅[i, j, 1]         +=  velocity_weight * V[i, j, 1]

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
@@ -14,18 +14,18 @@ using Oceananigans.Operators
 @kernel function split_explicit_free_surface_substep_kernel_1!(grid, Δτ, η, U, V, Gᵁ, Gⱽ, g, Hᶠᶜ, Hᶜᶠ)
     i, j = @index(Global, NTuple)
     # ∂τ(U) = - ∇η + G
-    @inbounds U[i, j, 1] +=  Δτ * (-g * Hᶠᶜ[i, j] * ∂xᶠᶜᶜ(i, j, grid.Nz, grid, η) + Gᵁ[i, j, 1])
-    @inbounds V[i, j, 1] +=  Δτ * (-g * Hᶜᶠ[i, j] * ∂yᶜᶠᶜ(i, j, grid.Nz, grid, η) + Gⱽ[i, j, 1])
+    @inbounds U[i, j, 1] +=  Δτ * (-g * Hᶠᶜ[i, j] * ∂xᶠᶜᶠ(i, j, grid.Nz+1, grid, η) + Gᵁ[i, j, 1])
+    @inbounds V[i, j, 1] +=  Δτ * (-g * Hᶜᶠ[i, j] * ∂yᶜᶠᶠ(i, j, grid.Nz+1, grid, η) + Gⱽ[i, j, 1])
 end
 
 @kernel function split_explicit_free_surface_substep_kernel_2!(grid, Δτ, η, U, V, η̅, U̅, V̅, velocity_weight, free_surface_weight)
     i, j = @index(Global, NTuple)
     # ∂τ(η) = - ∇⋅U
-    @inbounds η[i, j, 1] -=  Δτ * div_xyᶜᶜᶜ(i, j, 1, grid, U, V)
+    @inbounds η[i, j, grid.Nz+1] -=  Δτ * div_xyᶜᶜᶜ(i, j, 1, grid, U, V)
     # time-averaging
-    @inbounds U̅[i, j, 1] +=  velocity_weight * U[i, j, 1]
-    @inbounds V̅[i, j, 1] +=  velocity_weight * V[i, j, 1]
-    @inbounds η̅[i, j, 1] +=  free_surface_weight * η[i, j, grid.Nz]
+    @inbounds U̅[i, j, 1]         +=  velocity_weight * U[i, j, 1]
+    @inbounds V̅[i, j, 1]         +=  velocity_weight * V[i, j, 1]
+    @inbounds η̅[i, j, 1]         +=  free_surface_weight * η[i, j, grid.Nz+1]
 end
 
 function split_explicit_free_surface_substep!(η, state, auxiliary, settings, arch, grid, g, Δτ, substep_index)

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
@@ -34,8 +34,8 @@ end
 
 function split_explicit_free_surface_substep!(η, state, auxiliary, settings, arch, grid, g, Δτ, substep_index)
     # unpack state quantities, parameters and forcing terms 
-    U, V, η̅, U̅, V̅     = state.U, state.V, state.η̅, state.U̅, state.V̅
-    Gᵁ, Gⱽ, Hᶠᶜ, Hᶜᶠ  = auxiliary.Gᵁ, auxiliary.Gⱽ, auxiliary.Hᶠᶜ, auxiliary.Hᶜᶠ
+    U, V, η̅, U̅, V̅    = state.U, state.V, state.η̅, state.U̅, state.V̅
+    Gᵁ, Gⱽ, Hᶠᶜ, Hᶜᶠ = auxiliary.Gᵁ, auxiliary.Gⱽ, auxiliary.Hᶠᶜ, auxiliary.Hᶜᶠ
 
     vel_weight = settings.velocity_weights[substep_index]
     η_weight   = settings.free_surface_weights[substep_index]

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
@@ -11,6 +11,9 @@ using Oceananigans.Operators
 ∂t(U) = - gH∇η + f
 =#
 
+# the free surface η and its average η̄ are located on `Face`s at the surface (grid.Nz +1). All other intermediate variables
+# (U, V, , Ū, V̄) are barotropic fields (`ReducedField`) for which a k index is not defined
+
 @kernel function split_explicit_free_surface_substep_kernel_1!(grid, Δτ, η, U, V, Gᵁ, Gⱽ, g, Hᶠᶜ, Hᶜᶠ)
     i, j = @index(Global, NTuple)
     k_surface = grid.Nz+1
@@ -29,7 +32,7 @@ end
     # time-averaging
     @inbounds U̅[i, j, 1]         +=  velocity_weight * U[i, j, 1]
     @inbounds V̅[i, j, 1]         +=  velocity_weight * V[i, j, 1]
-    @inbounds η̅[i, j, 1]         +=  free_surface_weight * η[i, j, k_surface]
+    @inbounds η̅[i, j, k_surface] +=  free_surface_weight * η[i, j, k_surface]
 end
 
 function split_explicit_free_surface_substep!(η, state, auxiliary, settings, arch, grid, g, Δτ, substep_index)

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
@@ -13,19 +13,23 @@ using Oceananigans.Operators
 
 @kernel function split_explicit_free_surface_substep_kernel_1!(grid, Δτ, η, U, V, Gᵁ, Gⱽ, g, Hᶠᶜ, Hᶜᶠ)
     i, j = @index(Global, NTuple)
+    k_surface = grid.Nz+1
+
     # ∂τ(U) = - ∇η + G
-    @inbounds U[i, j, 1] +=  Δτ * (-g * Hᶠᶜ[i, j] * ∂xᶠᶜᶠ(i, j, grid.Nz+1, grid, η) + Gᵁ[i, j, 1])
-    @inbounds V[i, j, 1] +=  Δτ * (-g * Hᶜᶠ[i, j] * ∂yᶜᶠᶠ(i, j, grid.Nz+1, grid, η) + Gⱽ[i, j, 1])
+    @inbounds U[i, j, 1] +=  Δτ * (-g * Hᶠᶜ[i, j] * ∂xᶠᶜᶠ(i, j, k_surface, grid, η) + Gᵁ[i, j, 1])
+    @inbounds V[i, j, 1] +=  Δτ * (-g * Hᶜᶠ[i, j] * ∂yᶜᶠᶠ(i, j, k_surface, grid, η) + Gⱽ[i, j, 1])
 end
 
 @kernel function split_explicit_free_surface_substep_kernel_2!(grid, Δτ, η, U, V, η̅, U̅, V̅, velocity_weight, free_surface_weight)
     i, j = @index(Global, NTuple)
+    k_surface = grid.Nz+1
+    
     # ∂τ(η) = - ∇⋅U
-    @inbounds η[i, j, grid.Nz+1] -=  Δτ * div_xyᶜᶜᶜ(i, j, 1, grid, U, V)
+    @inbounds η[i, j, k_surface] -=  Δτ * div_xyᶜᶜᶠ(i, j, k_surface, grid, U, V)
     # time-averaging
     @inbounds U̅[i, j, 1]         +=  velocity_weight * U[i, j, 1]
     @inbounds V̅[i, j, 1]         +=  velocity_weight * V[i, j, 1]
-    @inbounds η̅[i, j, 1]         +=  free_surface_weight * η[i, j, grid.Nz+1]
+    @inbounds η̅[i, j, 1]         +=  free_surface_weight * η[i, j, k_surface]
 end
 
 function split_explicit_free_surface_substep!(η, state, auxiliary, settings, arch, grid, g, Δτ, substep_index)

--- a/src/Models/HydrostaticFreeSurfaceModels/store_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/store_hydrostatic_free_surface_tendencies.jl
@@ -13,7 +13,7 @@ import Oceananigans.TimeSteppers: store_tendencies!
 """ Store source terms for `η`. """
 @kernel function _store_free_surface_tendency!(Gη⁻, grid, Gη⁰)
     i, j = @index(Global, NTuple)
-    @inbounds Gη⁻[i, j, grid.Nz] = Gη⁰[i, j, grid.Nz]
+    @inbounds Gη⁻[i, j, grid.Nz+1] = Gη⁰[i, j, grid.Nz+1]
 end
 
 store_free_surface_tendency!(free_surface, model, barrier) = NoneEvent()

--- a/src/MultiRegion/multi_region_boundary_conditions.jl
+++ b/src/MultiRegion/multi_region_boundary_conditions.jl
@@ -65,7 +65,7 @@ function fill_halo_regions!(c::MultiRegionObject, bcs, indices, loc, mrg::MultiR
     arch = architecture(mrg)
 
     halo_tuple = construct_regionally(permute_boundary_conditions, bcs)
-    
+
     for task = 1:3
         barrier = device_event(arch)
         apply_regionally!(fill_halo_event!, task, halo_tuple, 
@@ -88,13 +88,13 @@ for (lside, rside) in zip([:west, :south, :bottom], [:east, :north, :bottom])
 
     @eval begin
         function $fill_both_halo!(c, left_bc::CBC, right_bc, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) 
-            event = $fill_right_halo!(c, right_bc, arch, dep, grid, args...; kwargs...)
-            $fill_left_halo!(c, left_bc, arch, event, grid, args...; kwargs...)
+            event = $fill_right_halo!(c, right_bc, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...)
+            $fill_left_halo!(c, left_bc, kernel_size, offset, loc, arch, event, grid, args...; kwargs...)
             return NoneEvent()
         end   
         function $fill_both_halo!(c, left_bc, right_bc::CBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) 
-            event = $fill_left_halo!(c, left_bc, arch, dep, grid, args...; kwargs...)
-            $fill_right_halo!(c, right_bc, arch, event, grid, args...; kwargs...)
+            event = $fill_left_halo!(c, left_bc, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...)
+            $fill_right_halo!(c, right_bc, kernel_size, offset, loc, arch, event, grid, args...; kwargs...)
             return NoneEvent()
         end   
     end
@@ -164,7 +164,7 @@ end
 ##### Single fill_halo! for Communicating boundary condition 
 #####
     
-function fill_west_halo!(c, bc::CBC, arch, dep, grid, neighbors, buffers, args...; kwargs...)
+function fill_west_halo!(c, bc::CBC, kernel_size, offset, loc, arch, dep, grid, neighbors, buffers, args...; kwargs...)
     
     H = halo_size(grid)[1]
     N = size(grid)[1]
@@ -187,7 +187,7 @@ function fill_west_halo!(c, bc::CBC, arch, dep, grid, neighbors, buffers, args..
     return nothing
 end
 
-function fill_east_halo!(c, bc::CBC, arch, dep, grid, neighbors, buffers, args...; kwargs...)
+function fill_east_halo!(c, bc::CBC, kernel_size, offset, loc, arch, dep, grid, neighbors, buffers, args...; kwargs...)
 
     H = halo_size(grid)[1]
     N = size(grid)[1]
@@ -210,7 +210,7 @@ function fill_east_halo!(c, bc::CBC, arch, dep, grid, neighbors, buffers, args..
     return nothing
 end
 
-function fill_south_halo!(c, bc::CBC, arch, dep, grid, neighbors, buffers, args...; kwargs...)
+function fill_south_halo!(c, bc::CBC, kernel_size, offset, loc, arch, dep, grid, neighbors, buffers, args...; kwargs...)
         
     H = halo_size(grid)[2]
     N = size(grid)[2]
@@ -233,7 +233,7 @@ function fill_south_halo!(c, bc::CBC, arch, dep, grid, neighbors, buffers, args.
     return nothing
 end
 
-function fill_north_halo!(c, bc::CBC, arch, dep, grid, neighbors, buffers, args...; kwargs...)
+function fill_north_halo!(c, bc::CBC, kernel_size, offset, loc, arch, dep, grid, neighbors, buffers, args...; kwargs...)
     
     H = halo_size(grid)[2]
     N = size(grid)[2]

--- a/src/MultiRegion/multi_region_boundary_conditions.jl
+++ b/src/MultiRegion/multi_region_boundary_conditions.jl
@@ -40,7 +40,7 @@ function fill_halo_regions!(field::MultiRegionField, args...; kwargs...)
 
     return fill_halo_regions!(field.data,
                               field.boundary_conditions,
-                              (:, :, :),
+                              field.indices,
                               instantiated_location(field),
                               field.grid,
                               field.boundary_buffers,

--- a/src/MultiRegion/multi_region_boundary_conditions.jl
+++ b/src/MultiRegion/multi_region_boundary_conditions.jl
@@ -89,7 +89,7 @@ for (lside, rside) in zip([:west, :south, :bottom], [:east, :north, :bottom])
     @eval begin
         function $fill_both_halo!(c, left_bc::CBC, right_bc, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) 
             event = $fill_right_halo!(c, right_bc, arch, dep, grid, args...; kwargs...)
-            $fill_left_halo!(c,  left_bc, arch, event, grid, args...; kwargs...)
+            $fill_left_halo!(c, left_bc, arch, event, grid, args...; kwargs...)
             return NoneEvent()
         end   
         function $fill_both_halo!(c, left_bc, right_bc::CBC, kernel_size, offset, loc, arch, dep, grid, args...; kwargs...) 

--- a/src/MultiRegion/multi_region_output_writers.jl
+++ b/src/MultiRegion/multi_region_output_writers.jl
@@ -10,13 +10,11 @@ import Oceananigans.OutputWriters:
 # a performant operation
 function fetch_output(mrf::MultiRegionField, model)
     field = reconstruct_global_field(mrf)
-    compute_at!(field, time(model))
+    compute_at!(field, model.clock.time)
     return parent(field)
 end
   
 function construct_output(mrf::MultiRegionField, grid, user_indices, with_halos)
-    grid = user_output.grid
-  
     # TODO: support non-default indices I guess
     # for that we have to figure out how to partition indices, eg user_indices is "global"
     # indices = output_indices(user_output, grid, user_indices, with_halos)

--- a/src/MultiRegion/unified_implicit_free_surface_solver.jl
+++ b/src/MultiRegion/unified_implicit_free_surface_solver.jl
@@ -92,7 +92,7 @@ end
     Az   = Azᶜᶜᶜ(i, j, 1, grid)
     δ_Q  = flux_div_xyᶜᶜᶜ(i, j, 1, grid, ∫ᶻQ.u, ∫ᶻQ.v)
     t    = displaced_xy_index(i, j, grid, region, partition)
-    @inbounds rhs[t] = (δ_Q - Az * η[i, j, 1] / Δt) / (g * Δt)
+    @inbounds rhs[t] = (δ_Q - Az * η[i, j, grid.Nz+1] / Δt) / (g * Δt)
 end
 
 function solve!(η, implicit_free_surface_solver::UnifiedImplicitFreeSurfaceSolver, rhs, g, Δt)
@@ -127,5 +127,5 @@ end
 @kernel function _redistribute_lhs!(η, sol, region, grid, partition)
     i, j = @index(Global, NTuple)
     t = displaced_xy_index(i, j, grid, region, partition)
-    @inbounds η[i, j, 1] = sol[t]
+    @inbounds η[i, j, grid.Nz+1] = sol[t]
 end

--- a/src/MultiRegion/unified_implicit_free_surface_solver.jl
+++ b/src/MultiRegion/unified_implicit_free_surface_solver.jl
@@ -7,7 +7,7 @@ using Oceananigans.Fields: Field
 using Oceananigans.Models.HydrostaticFreeSurfaceModels:
              compute_vertically_integrated_lateral_areas!,
              compute_matrix_coefficients,
-             flux_div_xyᶜᶜᶜ
+             flux_div_xyᶜᶜᶠ  
 
 import Oceananigans.Models.HydrostaticFreeSurfaceModels:
              build_implicit_step_solver,
@@ -90,7 +90,7 @@ end
 @kernel function implicit_linearized_unified_free_surface_right_hand_side!(rhs, grid, g, Δt, ∫ᶻQ, η, region, partition)
     i, j = @index(Global, NTuple)
     Az   = Azᶜᶜᶜ(i, j, 1, grid)
-    δ_Q  = flux_div_xyᶜᶜᶜ(i, j, 1, grid, ∫ᶻQ.u, ∫ᶻQ.v)
+    δ_Q  = flux_div_xyᶜᶜᶠ(i, j, 1, grid, ∫ᶻQ.u, ∫ᶻQ.v)
     t    = displaced_xy_index(i, j, grid, region, partition)
     @inbounds rhs[t] = (δ_Q - Az * η[i, j, grid.Nz+1] / Δt) / (g * Δt)
 end

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -49,7 +49,7 @@ export Ay_∂yᶠᶠᶠ, Ay_∂yᶠᶠᶜ, Ay_∂yᶠᶜᶠ, Ay_∂yᶠᶜᶜ, A
 export Az_∂zᶠᶠᶠ, Az_∂zᶠᶠᶜ, Az_∂zᶠᶜᶠ, Az_∂zᶠᶜᶜ, Az_∂zᶜᶠᶠ, Az_∂zᶜᶠᶜ, Az_∂zᶜᶜᶠ, Az_∂zᶜᶜᶜ
 
 # Divergences
-export divᶜᶜᶜ, div_xyᶜᶜᶜ, ζ₃ᶠᶠᶜ
+export divᶜᶜᶜ, div_xyᶜᶜᶜ, div_xyᶜᶜᶠ, ζ₃ᶠᶠᶜ
 export ∇²ᶜᶜᶜ, ∇²ᶠᶜᶜ, ∇²ᶜᶠᶜ, ∇²ᶜᶜᶠ, ∇²hᶜᶜᶜ, ∇²hᶠᶜᶜ, ∇²hᶜᶠᶜ
 
 # Interpolations

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -54,9 +54,8 @@ export ∇²ᶜᶜᶜ, ∇²ᶠᶜᶜ, ∇²ᶜᶠᶜ, ∇²ᶜᶜᶠ, ∇²hᶜ
 
 # Interpolations
 export ℑxᶜᵃᵃ, ℑxᶠᵃᵃ, ℑyᵃᶜᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶜ, ℑzᵃᵃᶠ
-export ℑᴶxᶜᵃᵃ, ℑᴶxᶠᵃᵃ, ℑᴶyᵃᶜᵃ, ℑᴶyᵃᶠᵃ, ℑᴶzᵃᵃᶜ, ℑᴶzᵃᵃᶠ
 export ℑxyᶜᶜᵃ, ℑxyᶠᶜᵃ, ℑxyᶠᶠᵃ, ℑxyᶜᶠᵃ, ℑxzᶜᵃᶜ, ℑxzᶠᵃᶜ, ℑxzᶠᵃᶠ, ℑxzᶜᵃᶠ, ℑyzᵃᶜᶜ, ℑyzᵃᶠᶜ, ℑyzᵃᶠᶠ, ℑyzᵃᶜᶠ
-export ℑxyzᶜᶜᶠ, ℑxyzᶜᶠᶜ, ℑxyzᶠᶜᶜ, ℑxyzᶜᶠᶠ, ℑxyzᶠᶜᶠ, ℑxyzᶠᶠᶜ
+export ℑxyzᶜᶜᶠ, ℑxyzᶜᶠᶜ, ℑxyzᶠᶜᶜ, ℑxyzᶜᶠᶠ, ℑxyzᶠᶜᶠ, ℑxyzᶠᶠᶜ, ℑxyzᶜᶜᶜ, ℑxyzᶠᶠᶠ
 
 using Oceananigans.Grids
 

--- a/src/Operators/divergence_operators.jl
+++ b/src/Operators/divergence_operators.jl
@@ -36,6 +36,10 @@ and `Δx` is the length of the cell centered on (Center, Face, Any) in `x` (a `v
     1 / Azᶜᶜᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Δy_qᶠᶜᶜ, u) +
                                 δyᵃᶜᵃ(i, j, k, grid, Δx_qᶜᶠᶜ, v))
 
+@inline div_xyᶜᶜᶠ(i, j, k, grid, u, v) = 
+    1 / Azᶜᶜᶠ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, Δy_qᶠᶜᶠ, u) +
+                                δyᵃᶜᵃ(i, j, k, grid, Δx_qᶜᶠᶠ, v))
+
 # Convention
  index_left(i, ::Center) = i
  index_left(i, ::Face)   = i - 1

--- a/src/Operators/interpolation_operators.jl
+++ b/src/Operators/interpolation_operators.jl
@@ -71,6 +71,9 @@ using Oceananigans.Grids: Flat
 ##### Triple interpolation
 #####
 
+@inline ℑxyzᶜᶜᶜ(i, j, k, grid, f, args...) = ℑxᶜᵃᵃ(i, j, k, grid, ℑyᵃᶜᵃ, ℑzᵃᵃᶜ, f, args...)
+@inline ℑxyzᶠᶠᶠ(i, j, k, grid, f, args...) = ℑxᶠᵃᵃ(i, j, k, grid, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ, f, args...)
+
 @inline ℑxyzᶜᶜᶠ(i, j, k, grid, f, args...) = ℑxᶜᵃᵃ(i, j, k, grid, ℑyᵃᶜᵃ, ℑzᵃᵃᶠ, f, args...)
 @inline ℑxyzᶜᶠᶜ(i, j, k, grid, f, args...) = ℑxᶜᵃᵃ(i, j, k, grid, ℑyᵃᶠᵃ, ℑzᵃᵃᶜ, f, args...)
 @inline ℑxyzᶠᶜᶜ(i, j, k, grid, f, args...) = ℑxᶠᵃᵃ(i, j, k, grid, ℑyᵃᶜᵃ, ℑzᵃᵃᶜ, f, args...)

--- a/src/Operators/interpolation_utils.jl
+++ b/src/Operators/interpolation_utils.jl
@@ -109,10 +109,10 @@ function index_and_interp_dependencies(X, Y, Z, dependencies, model_field_names)
 end
 
 # Adds a interpolate function which takes i, j, k, grid, from, and to as an argument
-for LX in (:Center, :Face), LY in (:Center, Face), LZ in (:Center, :Face)
+for LX in (:Center, :Face), LY in (:Center, :Face), LZ in (:Center, :Face)
     for IX in (:Center, :Face), IY in (:Center, :Face), IZ in (:Center, :Face)
         from = (eval(LX), eval(LY), eval(LZ))
-        to   = (eval(IX), eval(IY), eval(LZ))
+        to   = (eval(IX), eval(IY), eval(IZ))
         interp_func = Symbol(interpolation_operator(from, to))
         @eval begin
             ℑxyz(i, j, k, grid, from::F, to::T, c) where {F<:Tuple{<:$LX, <:$LY, <:$LZ}, T<:Tuple{<:$IX, <:$IY, <:$IZ}} = 

--- a/src/OutputWriters/output_construction.jl
+++ b/src/OutputWriters/output_construction.jl
@@ -13,7 +13,7 @@ function restrict_to_interior(index::UnitRange, loc, topo, N)
 end
 
 #####
-##### Support for written Sliced computed fields (correct boundary conditions and data)
+##### Support for Sliced fields with non-trivial indices
 #####
 
 function maybe_sliced_field(user_output::ComputedField, indices)
@@ -26,8 +26,8 @@ function maybe_sliced_field(user_output::ComputedField, indices)
     return output
 end
 
-maybe_sliced_field(user_output::AbstractOperation, indices) = user_output
-maybe_sliced_field(user_output::Reduction, indices) = user_output
+maybe_sliced_field(user_output::AbstractOperation, indices) = Field(user_output; indices)
+maybe_sliced_field(user_output::Reduction, indices) = Field(user_output; indices)
 maybe_sliced_field(user_output::Field, indices) = view(user_output, indices...)
 
 #####
@@ -61,14 +61,8 @@ end
 
 function construct_output(user_output::Union{AbstractField, Reduction}, grid, user_indices, with_halos)
     indices = output_indices(user_output, grid, user_indices, with_halos)
-    user_output = maybe_sliced_field(user_output, indices)
-
-    return construct_output(user_output, indices)
+    return maybe_sliced_field(user_output, indices)
 end
-
-construct_output(user_output::Field, indices) = user_output
-construct_output(user_output::Reduction, indices) = Field(user_output; indices)
-construct_output(user_output::AbstractOperation, indices) = Field(user_output; indices)
 
 #####
 ##### Time-averaging

--- a/src/OutputWriters/output_construction.jl
+++ b/src/OutputWriters/output_construction.jl
@@ -13,19 +13,6 @@ function restrict_to_interior(index::UnitRange, loc, topo, N)
 end
 
 #####
-##### Function output fallback
-#####
-
-function construct_output(output, grid, indices, with_halos)
-    if !(indices isa typeof(default_indices(3)))
-        output_type = output isa Function ? "Function" : ""
-        @warn "Cannot slice $output_type $output with $indices: output will be unsliced."
-    end
-
-    return output
-end
-
-#####
 ##### Support for written Sliced computed fields (correct boundary conditions and data)
 #####
 
@@ -42,6 +29,19 @@ end
 maybe_sliced_field(user_output::AbstractOperation, indices) = user_output
 maybe_sliced_field(user_output::Reduction, indices) = user_output
 maybe_sliced_field(user_output::Field, indices) = user_output
+
+#####
+##### Function output fallback
+#####
+
+function construct_output(output, grid, indices, with_halos)
+    if !(indices isa typeof(default_indices(3)))
+        output_type = output isa Function ? "Function" : ""
+        @warn "Cannot slice $output_type $output with $indices: output will be unsliced."
+    end
+
+    return output
+end
 
 #####
 ##### Support for Field, Reduction, and AbstractOperation outputs

--- a/src/OutputWriters/output_construction.jl
+++ b/src/OutputWriters/output_construction.jl
@@ -66,7 +66,7 @@ function construct_output(user_output::Union{AbstractField, Reduction}, grid, us
     return construct_output(user_output, indices)
 end
 
-construct_output(user_output::Field, indices) = user_output
+construct_output(user_output, indices) = view(user_output, indices...)
 construct_output(user_output::Reduction, indices) = Field(user_output; indices)
 construct_output(user_output::AbstractOperation, indices) = Field(user_output; indices)
 

--- a/src/OutputWriters/output_construction.jl
+++ b/src/OutputWriters/output_construction.jl
@@ -1,5 +1,5 @@
 using Oceananigans.Fields: validate_indices, Reduction
-using Oceananigans.AbstractOperations: AbstractOperation
+using Oceananigans.AbstractOperations: AbstractOperation, ComputedField
 using Oceananigans.Grids: default_indices
 
 restrict_to_interior(::Colon, loc, topo, N) = interior_indices(loc, topo, N)
@@ -29,7 +29,7 @@ end
 ##### Support for written Sliced computed fields (correct boundary conditions and data)
 #####
 
-function maybe_sliced_field(user_output::Field, indices)
+function maybe_sliced_field(user_output::ComputedField, indices)
     boundary_conditions = FieldBoundaryConditions(indices, user_output.boundary_conditions)
     output = Field(location(user_output), user_output.grid; 
                    boundary_conditions, 
@@ -41,6 +41,7 @@ end
 
 maybe_sliced_field(user_output::AbstractOperation, indices) = user_output
 maybe_sliced_field(user_output::Reduction, indices) = user_output
+maybe_sliced_field(user_output::Field, indices) = user_output
 
 #####
 ##### Support for Field, Reduction, and AbstractOperation outputs

--- a/src/OutputWriters/output_construction.jl
+++ b/src/OutputWriters/output_construction.jl
@@ -28,7 +28,7 @@ end
 
 maybe_sliced_field(user_output::AbstractOperation, indices) = user_output
 maybe_sliced_field(user_output::Reduction, indices) = user_output
-maybe_sliced_field(user_output::Field, indices) = user_output
+maybe_sliced_field(user_output::Field, indices) = view(user_output, indices...)
 
 #####
 ##### Function output fallback
@@ -66,7 +66,7 @@ function construct_output(user_output::Union{AbstractField, Reduction}, grid, us
     return construct_output(user_output, indices)
 end
 
-construct_output(user_output, indices) = view(user_output, indices...)
+construct_output(user_output::Field, indices) = user_output
 construct_output(user_output::Reduction, indices) = Field(user_output; indices)
 construct_output(user_output::AbstractOperation, indices) = Field(user_output; indices)
 

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -94,7 +94,7 @@ function solve!(x, solver::FourierTridiagonalPoissonSolver, b=nothing)
     # so that the solution has zero-mean.
     ϕ .= ϕ .- mean(ϕ)
 
-    copy_event = launch!(arch, solver.grid, :xyz, copy_real_component!, x, ϕ, dependencies=device_event(arch))
+    copy_event = launch!(arch, solver.grid, :xyz, copy_real_component!, x, ϕ, indices(x), dependencies=device_event(arch))
     wait(device(arch), copy_event)
 
     return nothing

--- a/src/Solvers/preconditioned_conjugate_gradient_solver.jl
+++ b/src/Solvers/preconditioned_conjugate_gradient_solver.jl
@@ -159,18 +159,18 @@ function solve!(x, solver::PreconditionedConjugateGradientSolver, b, args...)
     # Initialize
     solver.iteration = 0
 
-    # q = A*x
+    # q = A * x
     q = solver.linear_operator_product
     solver.linear_operation!(q, x, args...)
 
-    # r = b - A*x
+    # r = b - A * x
     parent(solver.residual) .= parent(b) .- parent(q)
 
     residual_norm = norm(solver.residual)
     tolerance = max(solver.reltol * residual_norm, solver.abstol)
 
     @debug "PreconditionedConjugateGradientSolver, |b|: $(norm(b))"
-    @debug "PreconditionedConjugateGradientSolver, |A(x)|: $(norm(q))"
+    @debug "PreconditionedConjugateGradientSolver, |A * x|: $(norm(q))"
 
     while iterating(solver, tolerance)
         iterate!(x, solver, b, args...)

--- a/src/TurbulenceClosures/abstract_scalar_biharmonic_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_scalar_biharmonic_diffusivity_closure.jl
@@ -111,6 +111,6 @@ end
 @inline biharmonic_mask_y(i, j, k, grid, f, args...) = ifelse(y_peripheral_node(i, j, k, grid), zero(eltype(grid)), f(i, j, k, grid, args...))
 @inline biharmonic_mask_z(i, j, k, grid, f, args...) = ifelse(z_peripheral_node(i, j, k, grid), zero(eltype(grid)), f(i, j, k, grid, args...))
 
-@inline x_peripheral_node(i, j, k, grid) = peripheral_node(Face(), Center(), Center(), i, j, k, grid)
-@inline y_peripheral_node(i, j, k, grid) = peripheral_node(Center(), Face(), Center(), i, j, k, grid)
-@inline z_peripheral_node(i, j, k, grid) = peripheral_node(Center(), Center(), Face(), i, j, k, grid)
+@inline x_peripheral_node(i, j, k, grid) = peripheral_node(i, j, k, grid, Face(), Center(), Center())
+@inline y_peripheral_node(i, j, k, grid) = peripheral_node(i, j, k, grid, Center(), Face(), Center())
+@inline z_peripheral_node(i, j, k, grid) = peripheral_node(i, j, k, grid, Center(), Center(), Face())

--- a/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
@@ -151,7 +151,7 @@ end
     bx = ℑxyᶜᶠᵃ(i, j, k, grid, ∂xᶠᶜᶜ, buoyancy_perturbation, buoyancy.model, tracers)
     bz = ℑyzᵃᶠᶜ(i, j, k, grid, ∂zᶜᶜᶠ, buoyancy_perturbation, buoyancy.model, tracers)
 
-    by = ∂y_b(i, j, k,   grid, buoyancy, tracers)
+    by = ∂y_b(i, j, k, grid, buoyancy, tracers)
 
     return calc_tapering(bx, by, bz, grid, closure.isopycnal_tensor, closure.slope_limiter)
 end
@@ -172,7 +172,9 @@ end
     
     slope_x = - bx / bz
     slope_y = - by / bz
-    slope² = ifelse(bz < 0, zero(grid), slope_x^2 + slope_y^2)
+   
+    # in case of a stable buoyancy gradient (bz > 0), the slope is set to zero
+    slope² = ifelse(bz <= 0, zero(grid), slope_x^2 + slope_y^2) 
 
     return min(one(grid), slope_limiter.max_slope^2 / slope²)
 end

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -1,7 +1,7 @@
 include("dependencies_for_runtests.jl")
 
 using Oceananigans.Operators: ℑxyᶜᶠᵃ, ℑxyᶠᶜᵃ
-using Oceananigans.Fields: compute_at!
+using Oceananigans.Fields: compute_at!, indices
 using Oceananigans.BuoyancyModels: BuoyancyField
 
 function simple_binary_operation(op, a, b, num1, num2)

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -305,5 +305,42 @@ for arch in archs
                 end
             end
         end
+
+        @testset "Indexing of AbstractOperations [$(typeof(arch))]" begin
+            
+            grid = RectilinearGrid(arch, size=(3, 3, 3), extent=(1, 1, 1))
+
+            test_indices   = [(2:3, :, :), (:, 2:3, :), (:, :, 2:3)]
+            face_indices   = [(2:2, :, :), (:, 2:2, :), (:, :, 2:2)]
+            center_indices = [(3:3, :, :), (:, 3:3, :), (:, :, 3:3)]
+
+            FaceFields = (XFaceField, YFaceField, ZFaceField)
+            
+            for (ti, fi, ci, FaceField) in zip(test_indices, face_indices, center_indices, FaceFields)
+                a = CenterField(grid)
+                b = CenterField(grid, indices = ti)
+                @test indices(a * b)  == ti
+                @test indices(sin(b)) == ti
+                            
+                c = CenterField(grid, indices=ti)
+                d = FaceField(grid, indices=ti)
+                @test indices(c * d) == fi
+                @test indices(d * c) == ci
+            end
+
+            a = CenterField(grid, indices = test_indices[1])
+            b = XFaceField(grid,  indices = test_indices[2])
+            c = YFaceField(grid,  indices = test_indices[3])
+
+            d = Field((Face, Face, Center), grid, indices = (:, 2:3, 1:2))
+
+            @test indices(a * b * c) == (2:3, 2:3, 2:3)
+            @test indices(b * a * c) == (3:3, 2:3, 2:3)
+            @test indices(c * a * b) == (2:3, 3:3, 2:3)
+            @test indices(a * b * c * d) == (2:3, 2:2, 2:2)
+            @test indices(b * c * d * a) == (3:3, 2:2, 2:2)
+            @test indices(c * d * a * b) == (2:3, 3:3, 2:2)
+            @test indices(d * a * b * c) == (3:3, 3:3, 2:2)
+        end
     end
 end

--- a/test/test_field_reductions.jl
+++ b/test/test_field_reductions.jl
@@ -216,5 +216,21 @@ trilinear(x, y, z) = x + y + z
                 end
             end
         end
+        @testset "Immersed Fields reduction [$(typeof(arch))]" begin
+            @info "  Testing reductions of immersed Fields [$(typeof(arch))]"
+            underlying_grid = RectilinearGrid(arch, size=(3, 3, 3), extent=(1, 1, 1))
+            
+            grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom((x, y) -> y < 0.5 ? - 0.6 : 0))
+            c = Field((Center, Center, Nothing), grid)
+
+            set!(c, (x, y) -> y)
+            @test maximum(c) == CUDA.@allowscalar grid.yᵃᶜᵃ[1]
+
+            grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom((x, y) -> y < 0.5 ? - 0.6 : -0.4))
+            c = Field((Center, Center, Nothing), grid)
+
+            set!(c, (x, y) -> y)
+            @test maximum(c) == CUDA.@allowscalar grid.yᵃᶜᵃ[3]
+        end
     end
 end

--- a/test/test_implicit_free_surface_solver.jl
+++ b/test/test_implicit_free_surface_solver.jl
@@ -113,14 +113,20 @@ end
 
         bump(x, y) = - Lz * (1 - 0.2 * exp(-x^2 / 2width^2))
         
-        bumpy_rectilinear_grid = ImmersedBoundaryGrid(rectilinear_grid, GridFittedBottom(bump))
+        underlying_grid = RectilinearGrid(arch, size = (128, 1, 5),
+                                          x = (-5000kilometers, 5000kilometers),
+                                          y = (0, 100kilometers),
+                                          z = [-500, -300, -220, -170, -60, 0],
+                                          topology = (Bounded, Periodic, Bounded))
+
+        bumpy_vertically_stretched_rectilinear_grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bump))
 
         lat_lon_grid = LatitudeLongitudeGrid(arch, size = (50, 50, 5),
                                              longitude = (-20, 30),
                                              latitude = (-10, 40),
                                              z = (-4000, 0))
 
-        for grid in (rectilinear_grid, bumpy_rectilinear_grid, lat_lon_grid)
+        for grid in (rectilinear_grid, bumpy_vertically_stretched_rectilinear_grid, lat_lon_grid)
             G = string(nameof(typeof(grid)))
 
             @info "Testing PreconditionedConjugateGradient implicit free surface solver [$A, $G]..."

--- a/test/test_implicit_free_surface_solver.jl
+++ b/test/test_implicit_free_surface_solver.jl
@@ -38,7 +38,7 @@ function set_simple_divergent_velocity!(model)
     Δz = CUDA.@allowscalar Δzᶜᶠᶜ(i, j, k, grid)
 
     # We prescribe the value of the zonal transport in a cell, i.e., `u * Δy * Δz`. This
-    # way `norm(rhs)` of the free-surface solver does not depend on the grid extensd/resolution.
+    # way `norm(rhs)` of the free-surface solver does not depend on the grid extent/resolution.
     transport = 1e5 # m³ s⁻¹
     CUDA.@allowscalar u[i, j, k] = transport / (Δy * Δz)
 

--- a/test/test_implicit_free_surface_solver.jl
+++ b/test/test_implicit_free_surface_solver.jl
@@ -34,8 +34,8 @@ function set_simple_divergent_velocity!(model)
     i, j, k = Int(floor(grid.Nx / 2)) + 1, Int(floor(grid.Ny / 2)) + 1, grid.Nz
     inactive_cell(i, j, k, grid) && error("The nudged cell at ($i, $j, $k) is inactive.")
 
-    Δy = Δyᶜᶠᶜ(i, j, k, grid)
-    Δz = Δzᶜᶠᶜ(i, j, k, grid)
+    Δy = CUDA.@allowscalar Δyᶜᶠᶜ(i, j, k, grid)
+    Δz = CUDA.@allowscalar Δzᶜᶠᶜ(i, j, k, grid)
 
     # We prescribe the value of the zonal transport in a cell, i.e., `u * Δy * Δz`. This
     # way `norm(rhs)` of the free-surface solver does not depend on the grid extensd/resolution.

--- a/test/test_implicit_free_surface_solver.jl
+++ b/test/test_implicit_free_surface_solver.jl
@@ -72,15 +72,15 @@ function run_implicit_free_surface_solver_tests(arch, grid, free_surface)
     g = g_Earth
     η = model.free_surface.η
 
-    ∫ᶻ_Axᶠᶜᶜ = Field{Face, Center, Nothing}(with_halo((3, 3, 1), grid), indices = (:, :, grid.Nz))
-    ∫ᶻ_Ayᶜᶠᶜ = Field{Center, Face, Nothing}(with_halo((3, 3, 1), grid), indices = (:, :, grid.Nz))
+    ∫ᶻ_Axᶠᶜᶜ = Field{Face, Center, Nothing}(with_halo((3, 3, 1), grid))
+    ∫ᶻ_Ayᶜᶠᶜ = Field{Center, Face, Nothing}(with_halo((3, 3, 1), grid))
 
     vertically_integrated_lateral_areas = (xᶠᶜᶜ = ∫ᶻ_Axᶠᶜᶜ, yᶜᶠᶜ = ∫ᶻ_Ayᶜᶠᶜ)
 
     compute_vertically_integrated_lateral_areas!(vertically_integrated_lateral_areas)
     fill_halo_regions!(vertically_integrated_lateral_areas)
 
-    left_hand_side = Field{Center, Center, Nothing}(grid, indices = (:, :, grid.Nz))
+    left_hand_side = ZFaceField(grid, indices = (:, :, grid.Nz + 1))
     implicit_free_surface_linear_operation!(left_hand_side, η, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, g, Δt)
 
     # Compare
@@ -121,7 +121,6 @@ end
                                              z = (-4000, 0))
 
         for grid in (rectilinear_grid, bumpy_rectilinear_grid, lat_lon_grid)
-
             G = string(nameof(typeof(grid)))
 
             @info "Testing PreconditionedConjugateGradient implicit free surface solver [$A, $G]..."

--- a/test/test_split_explicit_free_surface_solver.jl
+++ b/test/test_split_explicit_free_surface_solver.jl
@@ -32,7 +32,7 @@ import Oceananigans.Models.HydrostaticFreeSurfaceModels: SplitExplicitState, Spl
             free_surface_weight = 0.0
             Δτ = 1.0
 
-            η₀(x, y) = sin(x)
+            η₀(x, y, z) = sin(x)
             set!(η, η₀)
             U₀(x, y) = 0.0
             set!(U, U₀)
@@ -70,7 +70,7 @@ import Oceananigans.Models.HydrostaticFreeSurfaceModels: SplitExplicitState, Spl
             Δτ_end = T - Nt * Δτ
 
             # set!(η, f(x,y))
-            η₀(x, y) = sin(x)
+            η₀(x, y, z) = sin(x)
             set!(η, η₀)
             U₀(x, y) = 0.0
             set!(U, U₀)
@@ -119,7 +119,7 @@ import Oceananigans.Models.HydrostaticFreeSurfaceModels: SplitExplicitState, Spl
             η_avg = 1.0
             U_avg = 2.0
             V_avg = 3.0
-            η₀(x, y) = η_avg
+            η₀(x, y, z) = η_avg
             set!(η, η₀)
             U₀(x, y) = U_avg
             set!(U, U₀)
@@ -182,7 +182,7 @@ import Oceananigans.Models.HydrostaticFreeSurfaceModels: SplitExplicitState, Spl
             # set!(η, f(x,y)) k^2 = ω^2
             gu_c = 1.0
             gv_c = 2.0
-            η₀(x, y) = sin(kx * x) * sin(ky * y) + 1
+            η₀(x, y, z) = sin(kx * x) * sin(ky * y) + 1
             set!(η, η₀)
 
             η_mean_before = mean(Array(interior(η)))

--- a/validation/multi_region/multi_region_near_global_quarter_degree.jl
+++ b/validation/multi_region/multi_region_near_global_quarter_degree.jl
@@ -171,8 +171,8 @@ v_wind_stress_bc = FluxBoundaryCondition(surface_wind_stress, discrete_form = tr
 # Linear bottom drag:
 μ = 0.001 # ms⁻¹
 
-@inline is_immersed_drag_u(i, j, k, grid) = Int(peripheral_node(Face(), Center(), Center(), i, j, k-1, grid) & !inactive_node(Face(), Center(), Center(), i, j, k, grid))
-@inline is_immersed_drag_v(i, j, k, grid) = Int(peripheral_node(Center(), Face(), Center(), i, j, k-1, grid) & !inactive_node(Center(), Face(), Center(), i, j, k, grid))                                
+@inline is_immersed_drag_u(i, j, k, grid) = Int(peripheral_node(i, j, k-1, grid, Face(), Center(), Center()) & !inactive_node(i, j, k, grid, Face(), Center(), Center()))
+@inline is_immersed_drag_v(i, j, k, grid) = Int(peripheral_node(i, j, k-1, grid, Center(), Face(), Center()) & !inactive_node(i, j, k, grid, Center(), Face(), Center()))                                
 
 # Keep a constant linear drag parameter independent on vertical level
 @inline u_immersed_bottom_drag(i, j, k, grid, clock, fields, μ) = @inbounds - μ * is_immersed_drag_u(i, j, k, grid) * fields.u[i, j, k] / Δzᵃᵃᶜ(i, j, k, grid)

--- a/validation/near_global_lat_lon/near_global_quarter_degree.jl
+++ b/validation/near_global_lat_lon/near_global_quarter_degree.jl
@@ -1,7 +1,6 @@
 using Statistics
 using JLD2
 using Printf
-using Plots
 using Oceananigans
 using Oceananigans.Units
 
@@ -10,13 +9,11 @@ using Oceananigans.Advection: VelocityStencil
 using Oceananigans.Architectures: arch_array
 using Oceananigans.Coriolis: HydrostaticSphericalCoriolis
 using Oceananigans.BoundaryConditions
-using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBottom, inactive_node, peripheral_node
-using CUDA: @allowscalar, device!
+using Oceananigans.ImmersedBoundaries: inactive_node, peripheral_node
+using CUDA: @allowscalar
 using Oceananigans.Operators
 using Oceananigans.Operators: Δzᵃᵃᶜ
 using Oceananigans: prognostic_fields
-
-device!(3)
 
 @inline function visualize(field, lev, dims) 
     (dims == 1) && (idx = (lev, :, :))
@@ -24,7 +21,7 @@ device!(3)
     (dims == 3) && (idx = (:, :, lev))
 
     r = deepcopy(Array(interior(field)))[idx...]
-    r[ r.==0 ] .= NaN
+    r[r.==0] .= NaN
     return r
 end
 
@@ -128,7 +125,8 @@ target_sea_surface_salinity    = S★ = arch_array(arch, S★)
 using Oceananigans.Operators: Δx, Δy
 using Oceananigans.TurbulenceClosures
 
-@inline νhb(i, j, k, grid, lx, ly, lz) = (1 / (1 / Δx(i, j, k, grid, lx, ly, lz)^2 + 1 / Δy(i, j, k, grid, lx, ly, lz)^2 ))^2 / 5days
+@inline νhb(i, j, k, grid, lx, ly, lz, clock, fields) =
+                (1 / (1 / Δx(i, j, k, grid, lx, ly, lz)^2 + 1 / Δy(i, j, k, grid, lx, ly, lz)^2))^2 / 5days
 
 vertical_diffusivity   = VerticalScalarDiffusivity(VerticallyImplicitTimeDiscretization(), ν=νz, κ=κz)
 convective_adjustment  = ConvectiveAdjustmentVerticalDiffusivity(VerticallyImplicitTimeDiscretization(), convective_κz = 1.0)
@@ -164,7 +162,7 @@ u_wind_stress_bc = FluxBoundaryCondition(surface_wind_stress, discrete_form = tr
 v_wind_stress_bc = FluxBoundaryCondition(surface_wind_stress, discrete_form = true, parameters = τʸ)
 
 # Linear bottom drag:
-μ = 0.001 # ms⁻¹
+μ = 0.001 # m s⁻¹
 
 @inline u_bottom_drag(i, j, grid, clock, fields, μ) = @inbounds - μ * fields.u[i, j, 1]
 @inline v_bottom_drag(i, j, grid, clock, fields, μ) = @inbounds - μ * fields.v[i, j, 1]
@@ -213,11 +211,11 @@ end
 
 T_surface_relaxation_bc = FluxBoundaryCondition(surface_temperature_relaxation,
                                                 discrete_form = true,
-                                                parameters = (λ = Δz_top/7days, T★ = target_sea_surface_temperature))
+                                                parameters = (λ = Δz_top / 7days, T★ = target_sea_surface_temperature))
 
 S_surface_relaxation_bc = FluxBoundaryCondition(surface_salinity_relaxation,
                                                 discrete_form = true,
-                                                parameters = (λ = Δz_top/7days, S★ = target_sea_surface_salinity))
+                                                parameters = (λ = Δz_top / 7days, S★ = target_sea_surface_salinity))
 
 u_bcs = FieldBoundaryConditions(top = u_wind_stress_bc, bottom = u_bottom_drag_bc, immersed = u_immersed_bc)
 v_bcs = FieldBoundaryConditions(top = v_wind_stress_bc, bottom = v_bottom_drag_bc, immersed = v_immersed_bc)
@@ -228,15 +226,15 @@ free_surface = ImplicitFreeSurface(solver_method=:HeptadiagonalIterativeSolver)
 
 buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState())
 
-model = HydrostaticFreeSurfaceModel(grid = grid,
-                                    free_surface = free_surface,
-                                    momentum_advection = WENO(vector_invariant = VelocityStencil()),
-                                    coriolis = HydrostaticSphericalCoriolis(),
-                                    buoyancy = buoyancy,
-                                    tracers = (:T, :S),
-                                    closure = (vertical_diffusivity, convective_adjustment, biharmonic_viscosity),
-                                    boundary_conditions = (u=u_bcs, v=v_bcs, T=T_bcs, S=S_bcs),
-                                    tracer_advection = WENO(underlying_grid))
+model = HydrostaticFreeSurfaceModel(; grid,
+                                      free_surface,
+                                      momentum_advection = WENO(vector_invariant = VelocityStencil()),
+                                      coriolis = HydrostaticSphericalCoriolis(),
+                                      buoyancy,
+                                      tracers = (:T, :S),
+                                      closure = (vertical_diffusivity, convective_adjustment, biharmonic_viscosity),
+                                      boundary_conditions = (u=u_bcs, v=v_bcs, T=T_bcs, S=S_bcs),
+                                      tracer_advection = WENO(underlying_grid))
 
 #####
 ##### Initial condition:
@@ -261,7 +259,7 @@ fill_halo_regions!(S)
 ##### Simulation setup
 #####
 
-Δt = 6minutes  # for initialization, then we can go up to 6 minutes?
+Δt = 6minutes  # probably we can go to 10min or 15min?
 
 simulation = Simulation(model, Δt = Δt, stop_time = Nyears*years)
 
@@ -316,5 +314,3 @@ run!(simulation, pickup = pickup_file)
     Free surface: $(typeof(model.free_surface).name.wrapper)
     Time step: $(prettytime(Δt))
 """
-
-

--- a/validation/near_global_lat_lon/near_global_quarter_degree_one_level.jl
+++ b/validation/near_global_lat_lon/near_global_quarter_degree_one_level.jl
@@ -142,16 +142,6 @@ v_wind_stress_bc = FluxBoundaryCondition(surface_wind_stress, discrete_form = tr
 # Linear bottom drag:
 μ = 0.001 # ms⁻¹
 
-@inline is_immersed_drag_u(i, j, k, grid) = Int(peripheral_node(Face(), Center(), Center(), i, j, k-1, grid) & !inactive_node(Face(), Center(), Center(), i, j, k, grid))
-@inline is_immersed_drag_v(i, j, k, grid) = Int(peripheral_node(Center(), Face(), Center(), i, j, k-1, grid) & !inactive_node(Center(), Face(), Center(), i, j, k, grid))
-
-# Keep a constant linear drag parameter independent on vertical level
-@inline u_immersed_bottom_drag(i, j, k, grid, clock, fields, μ) = @inbounds - μ * is_immersed_drag_u(i, j, k, grid) * fields.u[i, j, k] / Δzᵃᵃᶜ(i, j, k, grid)
-@inline v_immersed_bottom_drag(i, j, k, grid, clock, fields, μ) = @inbounds - μ * is_immersed_drag_v(i, j, k, grid) * fields.v[i, j, k] / Δzᵃᵃᶜ(i, j, k, grid)
-
-Fu = Forcing(u_immersed_bottom_drag, discrete_form = true, parameters = μ)
-Fv = Forcing(v_immersed_bottom_drag, discrete_form = true, parameters = μ)
-
 u_bottom_drag_bc = FluxBoundaryCondition(u_bottom_drag, discrete_form = true, parameters = μ)
 v_bottom_drag_bc = FluxBoundaryCondition(v_bottom_drag, discrete_form = true, parameters = μ)
 
@@ -159,7 +149,6 @@ u_bcs = FieldBoundaryConditions(top = u_wind_stress_bc, bottom = u_bottom_drag_b
 v_bcs = FieldBoundaryConditions(top = v_wind_stress_bc, bottom = v_bottom_drag_bc)
 
 free_surface = ImplicitFreeSurface(solver_method=:HeptadiagonalIterativeSolver)
-# free_surface = ExplicitFreeSurface()
 
 buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState())
 


### PR DESCRIPTION
This PR is the successor of #2723

The overall objective is to improve the support of `Sliced` and `Windowed` fields such that we can represent the Free surface as a Sliced field (a regular field which lives at indices `(:, :, grid.Nz+1)`)

To do so we must
- implement halo filling support
- implement conditional reductions for windowed field

bonus
- allow interaction of windowed fields and regular fields through propagation of indices in abstract operations 

cc @glwagner @navidcy 