### PR TITLE
Cleanup unused type variables

### DIFF
--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -57,10 +57,6 @@ using Oceananigans.Fields: default_indices
 indices(f::Function) = default_indices(3)
 indices(f::Number)   = default_indices(3)
 
-# Fallback (used by KernelFunctionOperation)
-indices(f) = default_indices(3)
-
-
 """
     interpolate_indices(operands..., loc_operation = abstract_operation_location)
 

--- a/src/AbstractOperations/derivatives.jl
+++ b/src/AbstractOperations/derivatives.jl
@@ -28,7 +28,7 @@ end
 
 """Create a derivative operator `∂` acting on `arg` at `L∂`, followed by
 interpolation to `L` on `grid`."""
-function _derivative(L, ∂, arg, L∂, abstract_∂, grid) where {LX, LY, LZ}
+function _derivative(L, ∂, arg, L∂, abstract_∂, grid) 
     ▶ = interpolation_operator(L∂, L)
     return Derivative{L[1], L[2], L[3]}(∂, arg, ▶, abstract_∂, grid)
 end

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -20,7 +20,7 @@ end
 ##### MultiaryOperation construction
 #####
 
-function _multiary_operation(L, op, args, Largs, grid) where {LX, LY, LZ}
+function _multiary_operation(L, op, args, Largs, grid)
     ▶ = Tuple(interpolation_operator(La, L) for La in Largs)
     return MultiaryOperation{L[1], L[2], L[3]}(op, Tuple(a for a in args), ▶, grid)
 end

--- a/src/OutputReaders/field_dataset.jl
+++ b/src/OutputReaders/field_dataset.jl
@@ -49,5 +49,5 @@ end
 
 Base.getindex(fds::FieldDataset, inds...) = Base.getindex(fds.fields, inds...)
 
-Base.show(io::IO, fds::FieldDataset) where {X, Y, Z, K, A} =
+Base.show(io::IO, fds::FieldDataset) =
   print(io, "FieldDataset with $(length(fds.fields)) fields and $(length(fds.metadata)) metadata entries.")


### PR DESCRIPTION
Following the warnings issued by julia `v1.8.2`
```

WARNING: method definition for _multiary_operation at /home/ssilvest/Oceananigans.jl/src/AbstractOperations/multiary_operations.jl:23 declares type variable LZ but does not use it.
WARNING: method definition for _multiary_operation at /home/ssilvest/Oceananigans.jl/src/AbstractOperations/multiary_operations.jl:23 declares type variable LY but does not use it.
WARNING: method definition for _multiary_operation at /home/ssilvest/Oceananigans.jl/src/AbstractOperations/multiary_operations.jl:23 declares type variable LX but does not use it.
WARNING: method definition for _derivative at /home/ssilvest/Oceananigans.jl/src/AbstractOperations/derivatives.jl:31 declares type variable LZ but does not use it.
WARNING: method definition for _derivative at /home/ssilvest/Oceananigans.jl/src/AbstractOperations/derivatives.jl:31 declares type variable LY but does not use it.
WARNING: method definition for _derivative at /home/ssilvest/Oceananigans.jl/src/AbstractOperations/derivatives.jl:31 declares type variable LX but does not use it.
WARNING: method definition for show at /home/ssilvest/Oceananigans.jl/src/OutputReaders/field_dataset.jl:52 declares type variable A but does not use it.
WARNING: method definition for show at /home/ssilvest/Oceananigans.jl/src/OutputReaders/field_dataset.jl:52 declares type variable K but does not use it.
WARNING: method definition for show at /home/ssilvest/Oceananigans.jl/src/OutputReaders/field_dataset.jl:52 declares type variable Z but does not use it.
WARNING: method definition for show at /home/ssilvest/Oceananigans.jl/src/OutputReaders/field_dataset.jl:52 declares type variable Y but does not use it.
WARNING: method definition for show at /home/ssilvest/Oceananigans.jl/src/OutputReaders/field_dataset.jl:52 declares type variable X but does not use it.
```