### PR TITLE
Bugfix in implicit free surface

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/barotropic_pressure_correction.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/barotropic_pressure_correction.jl
@@ -48,7 +48,7 @@ end
     i, j, k = @index(Global, NTuple)
 
     @inbounds begin
-        U.u[i, j, k] -= g * Δt * ∂xᶠᶜᶜ(i, j, grid.Nz+1, grid, η)
-        U.v[i, j, k] -= g * Δt * ∂yᶜᶠᶜ(i, j, grid.Nz+1, grid, η)
+        U.u[i, j, k] -= g * Δt * ∂xᶠᶜᶠ(i, j, grid.Nz+1, grid, η)
+        U.v[i, j, k] -= g * Δt * ∂yᶜᶠᶠ(i, j, grid.Nz+1, grid, η)
     end
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/matrix_implicit_free_surface_solver.jl
@@ -135,8 +135,8 @@ end
 @kernel function _compute_coefficients!(diag, Ax, Ay, ∫Ax, ∫Ay, grid, g)
     i, j = @index(Global, NTuple)
     @inbounds begin
-        Ay[i, j, 1]    = ∫Ay[i, j, 1] / Δyᶜᶠᶜ(i, j, grid.Nz+1, grid)  
-        Ax[i, j, 1]    = ∫Ax[i, j, 1] / Δxᶠᶜᶜ(i, j, grid.Nz+1, grid)  
+        Ay[i, j, 1]    = ∫Ay[i, j, 1] / Δyᶜᶠᶠ(i, j, grid.Nz+1, grid)  
+        Ax[i, j, 1]    = ∫Ax[i, j, 1] / Δxᶠᶜᶠ(i, j, grid.Nz+1, grid)  
         diag[i, j, 1]  = - Azᶜᶜᶠ(i, j, grid.Nz+1, grid) / g
     end
 end


### PR DESCRIPTION
A leftover bug from the sliced fields PR that was neglecting the free surface contribution on immersed grids (and crashing our global simulations)