### PR TITLE
Remove extra memory allocations of `output_construction`

### DIFF
--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -309,10 +309,12 @@ function Base.view(f::Field, i, j, k)
     # OffsetArray around a view of parent with appropriate indices:
     windowed_data = offset_windowed_data(f.data, loc, grid, window_indices)  
 
+    boundary_conditions = FieldBoundaryConditions(window_indices, f.boundary_conditions)
+
     return Field(loc,
                  grid,
                  windowed_data,
-                 f.boundary_conditions, # keep original boundary conditions
+                 boundary_conditions, # keep original boundary conditions
                  window_indices,
                  f.operand,
                  f.status)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -314,7 +314,7 @@ function Base.view(f::Field, i, j, k)
     return Field(loc,
                  grid,
                  windowed_data,
-                 boundary_conditions, # keep original boundary conditions
+                 boundary_conditions,
                  window_indices,
                  f.operand,
                  f.status)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -283,7 +283,7 @@ julia> v = view(c, :, 2:3, 1:2)
 2×2×2 Field{Center, Center, Center} on RectilinearGrid on CPU
 ├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── boundary conditions: FieldBoundaryConditions
-│   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: ZeroFlux, top: ZeroFlux, immersed: ZeroFlux
+│   └── west: Periodic, east: Periodic, south: Nothing, north: Nothing, bottom: Nothing, top: Nothing, immersed: ZeroFlux
 └── data: 8×2×2 OffsetArray(view(::Array{Float64, 3}, :, 5:6, 4:5), -2:5, 2:3, 1:2) with eltype Float64 with indices -2:5×2:3×1:2
     └── max=0.972136, min=0.0149088, mean=0.59198
 

--- a/src/OutputWriters/output_construction.jl
+++ b/src/OutputWriters/output_construction.jl
@@ -13,24 +13,6 @@ function restrict_to_interior(index::UnitRange, loc, topo, N)
 end
 
 #####
-##### Support for Sliced fields with non-trivial indices
-#####
-
-function maybe_sliced_field(user_output::ComputedField, indices)
-    boundary_conditions = FieldBoundaryConditions(indices, user_output.boundary_conditions)
-    output = Field(location(user_output), user_output.grid; 
-                   boundary_conditions, 
-                   indices, 
-                   operand = user_output.operand, 
-                   status = user_output.status)
-    return output
-end
-
-maybe_sliced_field(user_output::AbstractOperation, indices) = Field(user_output; indices)
-maybe_sliced_field(user_output::Reduction, indices) = Field(user_output; indices)
-maybe_sliced_field(user_output::Field, indices) = view(user_output, indices...)
-
-#####
 ##### Function output fallback
 #####
 
@@ -61,7 +43,7 @@ end
 
 function construct_output(user_output::Union{AbstractField, Reduction}, grid, user_indices, with_halos)
     indices = output_indices(user_output, grid, user_indices, with_halos)
-    return maybe_sliced_field(user_output, indices)
+    return Field(user_output; indices)
 end
 
 #####


### PR DESCRIPTION
https://github.com/CliMA/Oceananigans.jl/pull/2740 Introduced extra memory allocation in output construction of ComputedFields to satisfy sliced boundary conditions constraints.

This PR changes the definition of `view(f::Field, indices...)` in order to automatically satisfy sliced boundary condition constraints and avoid unnecessary memory allocation.

closes #2794 ?