### PR TITLE
Refactor vector invariant advection

### DIFF
--- a/benchmark/benchmark_implicit_surface_solvers.jl
+++ b/benchmark/benchmark_implicit_surface_solvers.jl
@@ -82,8 +82,8 @@ for N in 10:10:250
         tracer_advection = WENO()
     else
         coriolis = HydrostaticSphericalCoriolis()
-        momentum_advection = WENO(vector_invariant = VelocityStencil())
-        tracer_advection = WENO(vector_invariant = VelocityStencil())
+        momentum_advection = VectionInvariant(scheme = WENO(), stencil = VelocityStencil())
+        tracer_advection = WENO()
     end
 
     for implicit_free_surface_solver in implicit_free_surface_solvers

--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -55,10 +55,10 @@ include("reconstruction_coefficients.jl")
 include("centered_reconstruction.jl")
 include("upwind_biased_reconstruction.jl")
 include("weno_reconstruction.jl")
+include("vector_invariant_advection.jl")
 include("weno_interpolants.jl")
 include("stretched_weno_smoothness.jl")
 
-include("vector_invariant_advection.jl")
 include("topologically_conditional_interpolation.jl")
 
 include("momentum_advection_operators.jl")

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -22,7 +22,6 @@ VectorInvariant(grid; scheme::S = EnstrophyConservingScheme(), stencil = nothing
 const VectorInvariantEnergyConserving    = VectorInvariant{<:EnergyConservingScheme}
 const VectorInvariantEnstrophyConserving = VectorInvariant{<:EnstrophyConservingScheme}
 
-
 const WENOVectorInvariantVel{N, FT, XT, YT, ZT, VI, WF, PP}  = 
       VectorInvariant{WENO{N, FT, XT, YT, ZT, WF, PP}, VI} where {N, FT, XT, YT, ZT, VI<:VelocityStencil, WF, PP}
 const WENOVectorInvariantVort{N, FT, XT, YT, ZT, VI, WF, PP} = 
@@ -85,6 +84,19 @@ end
     return + upwind_biased_product(û, ζᴸ, ζᴿ) 
 end
 
+@inline function vertical_vorticity_U(i, j, k, grid, advection::VectorInvariant{<:UpwindBiased}, u, v) 
+    v̂  =  ℑxᶠᵃᵃ(i, j, k, grid, ℑyᵃᶜᵃ, Δx_qᶜᶠᶜ, v) / Δxᶠᶜᶜ(i, j, k, grid) 
+    ζᴸ =  _left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, advection.scheme, ζ₃ᶠᶠᶜ, u, v)
+    ζᴿ = _right_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, advection.scheme, ζ₃ᶠᶠᶜ, u, v)
+    return - upwind_biased_product(v̂, ζᴸ, ζᴿ) 
+end
+
+@inline function vertical_vorticity_V(i, j, k, grid, advection::VectorInvariant{<:UpwindBiased}, u, v) 
+    û  =  ℑyᵃᶠᵃ(i, j, k, grid, ℑxᶜᵃᵃ, Δy_qᶠᶜᶜ, u) / Δyᶜᶠᶜ(i, j, k, grid)
+    ζᴸ =  _left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, advection.scheme, ζ₃ᶠᶠᶜ, u, v)
+    ζᴿ = _right_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, advection.scheme, ζ₃ᶠᶠᶜ, u, v)
+    return + upwind_biased_product(û, ζᴸ, ζᴿ) 
+end
 ####
 #### Vertical advection terms
 ####

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -30,6 +30,7 @@ const WENOVectorInvariantVort{N, FT, XT, YT, ZT, VI, WF, PP} =
 const WENOVectorInvariant{N, FT, XT, YT, ZT, VI, WF, PP} =      
       VectorInvariant{WENO{N, FT, XT, YT, ZT, WF, PP}, VI} where {N, FT, XT, YT, ZT, VI<:SmoothnessStencil, WF, PP}
 
+required_halo_size(scheme::WENOVectorInvariant{N}) where N = N + 1
 
 ######
 ###### Horizontally-vector-invariant formulation of momentum scheme

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -42,7 +42,7 @@ Base.show(io::IO, a::VectorInvariant) =
               "    └── $(summary(a.scheme)) \n",
               "$(smoothness_summary(a))")
 
-Adapt.adapt_structure(to, scheme::VectorInvariant{S}) where S = VectorInvariant{S}(Adapt.adapt(to, scheme), Adapt.adapt(to, stencil))
+Adapt.adapt_structure(to, vi::VectorInvariant{S}) where S = VectorInvariant{S}(Adapt.adapt(to, vi.scheme), Adapt.adapt(to, vi.stencil))
 
 ######
 ###### Horizontally-vector-invariant formulation of momentum scheme

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -24,7 +24,7 @@ const VectorInvariantEnstrophyConserving = VectorInvariant{<:EnstrophyConserving
 
 const WENOVectorInvariant{VI} = VectorInvariant{<:WENO, VI} where VI
 
-required_halo_size(scheme::WENOVectorInvariant) = required_halo_size(scheme.advection) + 1
+required_halo_size(scheme::WENOVectorInvariant) = required_halo_size(scheme.scheme) + 1
 
 smoothness_variable(::VelocityStencil) = "Velocity"
 smoothness_variable(::VelocityStencil) = "Vorticity"

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -357,7 +357,7 @@ for (interp, dir, val, cT) in zip([:xᶠᵃᵃ, :yᵃᶠᵃ, :zᵃᵃᶠ], [:x, 
             end
 
             @inline function $interpolate_func(i, j, k, grid, 
-                                               scheme::WENOVectorInvariant{N, FT, XT, YT, ZT}, 
+                                               scheme::WENO{N, FT, XT, YT, ZT}, 
                                                ψ, idx, loc, VI::Type{VorticityStencil}, args...) where {N, FT, XT, YT, ZT}
 
                 @inbounds begin
@@ -368,7 +368,7 @@ for (interp, dir, val, cT) in zip([:xᶠᵃᵃ, :yᵃᶠᵃ, :zᵃᵃᶠ], [:x, 
             end
 
             @inline function $interpolate_func(i, j, k, grid, 
-                                               scheme::WENOVectorInvariant{N, FT, XT, YT, ZT}, 
+                                               scheme::WENO{N, FT, XT, YT, ZT}, 
                                                ψ, idx, loc, VI::Type{VelocityStencil}, args...) where {N, FT, XT, YT, ZT}
 
                 @inbounds begin

--- a/src/Advection/weno_reconstruction.jl
+++ b/src/Advection/weno_reconstruction.jl
@@ -2,12 +2,7 @@
 ##### Weighted Essentially Non-Oscillatory (WENO) advection scheme
 #####
 
-abstract type SmoothnessStencil end
-
-struct VorticityStencil <:SmoothnessStencil end
-struct VelocityStencil <:SmoothnessStencil end
-
-struct WENO{N, FT, XT, YT, ZT, VI, WF, PP, CA, SI} <: AbstractUpwindBiasedAdvectionScheme{N, FT}
+struct WENO{N, FT, XT, YT, ZT, WF, PP, CA, SI} <: AbstractUpwindBiasedAdvectionScheme{N, FT}
     
     "Coefficient for ENO reconstruction on x-faces" 
     coeff_xᶠᵃᵃ::XT
@@ -30,16 +25,16 @@ struct WENO{N, FT, XT, YT, ZT, VI, WF, PP, CA, SI} <: AbstractUpwindBiasedAdvect
     "Reconstruction scheme used for symmetric interpolation"
     advecting_velocity_scheme :: SI
 
-    function WENO{N, FT, VI, WF}(coeff_xᶠᵃᵃ::XT, coeff_xᶜᵃᵃ::XT,
-                                 coeff_yᵃᶠᵃ::YT, coeff_yᵃᶜᵃ::YT, 
-                                 coeff_zᵃᵃᶠ::ZT, coeff_zᵃᵃᶜ::ZT,
-                                 bounds::PP, buffer_scheme::CA,
-                                 advecting_velocity_scheme :: SI) where {N, FT, XT, YT, ZT, VI, WF, PP, CA, SI}
+    function WENO{N, FT, WF}(coeff_xᶠᵃᵃ::XT, coeff_xᶜᵃᵃ::XT,
+                             coeff_yᵃᶠᵃ::YT, coeff_yᵃᶜᵃ::YT, 
+                             coeff_zᵃᵃᶠ::ZT, coeff_zᵃᵃᶜ::ZT,
+                             bounds::PP, buffer_scheme::CA,
+                             advecting_velocity_scheme :: SI) where {N, FT, XT, YT, ZT, WF, PP, CA, SI}
 
-            return new{N, FT, XT, YT, ZT, VI, WF, PP, CA, SI}(coeff_xᶠᵃᵃ, coeff_xᶜᵃᵃ, 
-                                                              coeff_yᵃᶠᵃ, coeff_yᵃᶜᵃ, 
-                                                              coeff_zᵃᵃᶠ, coeff_zᵃᵃᶜ,
-                                                              bounds, buffer_scheme, advecting_velocity_scheme)
+            return new{N, FT, XT, YT, ZT, WF, PP, CA, SI}(coeff_xᶠᵃᵃ, coeff_xᶜᵃᵃ, 
+                                                          coeff_yᵃᶠᵃ, coeff_yᵃᶜᵃ, 
+                                                          coeff_zᵃᵃᶠ, coeff_zᵃᵃᶜ,
+                                                          bounds, buffer_scheme, advecting_velocity_scheme)
     end
 end
 
@@ -47,8 +42,7 @@ end
     WENO([FT=Float64;] 
          order = 5,
          grid = nothing, 
-         zweno = true, 
-         vector_invariant = nothing,
+         zweno = true,
          bounds = nothing)
                
 Construct a weigthed essentially non-oscillatory advection scheme of order `order`.
@@ -71,11 +65,11 @@ Examples
 julia> using Oceananigans;
 
 julia> WENO()
-WENO reconstruction order 5 in Flux form 
+WENO reconstruction order 5 
  Smoothness formulation: 
     └── Z-weno  
  Boundary scheme: 
-    └── WENO reconstruction order 3 in Flux form
+    └── WENO reconstruction order 3 
  Symmetric scheme: 
     └── Centered reconstruction order 4
  Directions:
@@ -114,7 +108,6 @@ function WENO(FT::DataType=Float64;
               order = 5,
               grid = nothing, 
               zweno = true, 
-              vector_invariant = nothing,
               bounds = nothing)
     
     if !(grid isa Nothing) 
@@ -132,14 +125,10 @@ function WENO(FT::DataType=Float64;
 
         weno_coefficients = compute_reconstruction_coefficients(grid, FT, :WENO; order = N)
         buffer_scheme   = WENO(FT; grid, order = order - 2, zweno, vector_invariant, bounds)
-        if vector_invariant isa Nothing
-            advecting_velocity_scheme = Centered(FT; grid, order = order - 1)
-        else
-            advecting_velocity_scheme = nothing
-        end
+        advecting_velocity_scheme = Centered(FT; grid, order = order - 1)
     end
 
-    return WENO{N, FT, VI, zweno}(weno_coefficients..., bounds, buffer_scheme, advecting_velocity_scheme)
+    return WENO{N, FT, zweno}(weno_coefficients..., bounds, buffer_scheme, advecting_velocity_scheme)
 end
 
 WENO(grid, FT::DataType=Float64; kwargs...) = WENO(FT; grid, kwargs...)
@@ -152,17 +141,6 @@ WENOFifthOrder(grid=nothing, FT::DataType=Float64;  kwargs...) = WENO(grid, FT; 
 const ZWENO        = WENO{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, true}
 const PositiveWENO = WENO{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Tuple}
 
-const WENOVectorInvariantVel{N, FT, XT, YT, ZT, VI, WF, PP}  = 
-      WENO{N, FT, XT, YT, ZT, VI, WF, PP} where {N, FT, XT, YT, ZT, VI<:VelocityStencil, WF, PP}
-const WENOVectorInvariantVort{N, FT, XT, YT, ZT, VI, WF, PP} = 
-      WENO{N, FT, XT, YT, ZT, VI, WF, PP} where {N, FT, XT, YT, ZT, VI<:VorticityStencil, WF, PP}
-
-const WENOVectorInvariant{N, FT, XT, YT, ZT, VI, WF, PP} = 
-      WENO{N, FT, XT, YT, ZT, VI, WF, PP} where {N, FT, XT, YT, ZT, VI<:SmoothnessStencil, WF, PP}
-
-formulation(scheme::WENO)                = "Flux form"
-formulation(scheme::WENOVectorInvariant) = "Vector Invariant form"
-
 required_halo_size(scheme::WENOVectorInvariant{N}) where N = N + 1
 
 Base.summary(a::WENO{N}) where N = string("WENO reconstruction order ", N*2-1, " in ", formulation(a))
@@ -170,7 +148,7 @@ Base.summary(a::WENO{N}) where N = string("WENO reconstruction order ", N*2-1, "
 Base.show(io::IO, a::WENO{N, FT, RX, RY, RZ, VI, WF, PP}) where {N, FT, RX, RY, RZ, VI, WF, PP} =
     print(io, summary(a), " \n",
               " Smoothness formulation: ", "\n",
-              "    └── $(WF ? "Z-weno" : "JS-weno") $(VI<:SmoothnessStencil ? "using $VI" : "") \n",
+              "    └── $(WF ? "Z-weno" : "JS-weno") \n",
               a.bounds isa Nothing ? "" : " Bounds : \n    └── $(a.bounds) \n",
               " Boundary scheme: ", "\n",
               "    └── ", summary(a.buffer_scheme) , "\n",
@@ -181,13 +159,13 @@ Base.show(io::IO, a::WENO{N, FT, RX, RY, RZ, VI, WF, PP}) where {N, FT, RX, RY, 
               "    ├── Y $(RY == Nothing ? "regular" : "stretched") \n",
               "    └── Z $(RZ == Nothing ? "regular" : "stretched")" )
 
-Adapt.adapt_structure(to, scheme::WENO{N, FT, XT, YT, ZT, VI, WF, PP}) where {N, FT, XT, YT, ZT, VI, WF, PP} =
-     WENO{N, FT, VI, WF}(Adapt.adapt(to, scheme.coeff_xᶠᵃᵃ), Adapt.adapt(to, scheme.coeff_xᶜᵃᵃ),
-                         Adapt.adapt(to, scheme.coeff_yᵃᶠᵃ), Adapt.adapt(to, scheme.coeff_yᵃᶜᵃ),
-                         Adapt.adapt(to, scheme.coeff_zᵃᵃᶠ), Adapt.adapt(to, scheme.coeff_zᵃᵃᶜ),
-                         Adapt.adapt(to, scheme.bounds),
-                         Adapt.adapt(to, scheme.buffer_scheme),
-                         Adapt.adapt(to, scheme.advecting_velocity_scheme))
+Adapt.adapt_structure(to, scheme::WENO{N, FT, XT, YT, ZT, WF, PP}) where {N, FT, XT, YT, ZT, WF, PP} =
+     WENO{N, FT, WF}(Adapt.adapt(to, scheme.coeff_xᶠᵃᵃ), Adapt.adapt(to, scheme.coeff_xᶜᵃᵃ),
+                     Adapt.adapt(to, scheme.coeff_yᵃᶠᵃ), Adapt.adapt(to, scheme.coeff_yᵃᶜᵃ),
+                     Adapt.adapt(to, scheme.coeff_zᵃᵃᶠ), Adapt.adapt(to, scheme.coeff_zᵃᵃᶜ),
+                     Adapt.adapt(to, scheme.bounds),
+                     Adapt.adapt(to, scheme.buffer_scheme),
+                     Adapt.adapt(to, scheme.advecting_velocity_scheme))
 
 # Retrieve precomputed coefficients (+2 for julia's 1 based indices)
 @inline retrieve_coeff(scheme::WENO, r, ::Val{1}, i, ::Type{Face})   = @inbounds scheme.coeff_xᶠᵃᵃ[r+2][i] 

--- a/src/Advection/weno_reconstruction.jl
+++ b/src/Advection/weno_reconstruction.jl
@@ -120,11 +120,10 @@ function WENO(FT::DataType=Float64;
         # WENO(order = 1) is equivalent to UpwindBiased(order = 1)
         return UpwindBiased(order = 1)
     else
-        VI = typeof(vector_invariant)
         N  = Int((order + 1) ÷ 2)
 
         weno_coefficients = compute_reconstruction_coefficients(grid, FT, :WENO; order = N)
-        buffer_scheme   = WENO(FT; grid, order = order - 2, zweno, vector_invariant, bounds)
+        buffer_scheme   = WENO(FT; grid, order = order - 2, zweno, bounds)
         advecting_velocity_scheme = Centered(FT; grid, order = order - 1)
     end
 
@@ -141,9 +140,9 @@ WENOFifthOrder(grid=nothing, FT::DataType=Float64;  kwargs...) = WENO(grid, FT; 
 const ZWENO        = WENO{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, true}
 const PositiveWENO = WENO{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Tuple}
 
-Base.summary(a::WENO{N}) where N = string("WENO reconstruction order ", N*2-1, " in ", formulation(a))
+Base.summary(a::WENO{N}) where N = string("WENO reconstruction order ", N*2-1)
 
-Base.show(io::IO, a::WENO{N, FT, RX, RY, RZ, VI, WF, PP}) where {N, FT, RX, RY, RZ, VI, WF, PP} =
+Base.show(io::IO, a::WENO{N, FT, RX, RY, RZ, WF, PP}) where {N, FT, RX, RY, RZ, WF, PP} =
     print(io, summary(a), " \n",
               " Smoothness formulation: ", "\n",
               "    └── $(WF ? "Z-weno" : "JS-weno") \n",

--- a/src/Advection/weno_reconstruction.jl
+++ b/src/Advection/weno_reconstruction.jl
@@ -141,8 +141,6 @@ WENOFifthOrder(grid=nothing, FT::DataType=Float64;  kwargs...) = WENO(grid, FT; 
 const ZWENO        = WENO{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, true}
 const PositiveWENO = WENO{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Tuple}
 
-required_halo_size(scheme::WENOVectorInvariant{N}) where N = N + 1
-
 Base.summary(a::WENO{N}) where N = string("WENO reconstruction order ", N*2-1, " in ", formulation(a))
 
 Base.show(io::IO, a::WENO{N, FT, RX, RY, RZ, VI, WF, PP}) where {N, FT, RX, RY, RZ, VI, WF, PP} =

--- a/src/ImmersedBoundaries/conditional_fluxes.jl
+++ b/src/ImmersedBoundaries/conditional_fluxes.jl
@@ -174,7 +174,7 @@ for (bias, shift) in zip((:symmetric, :left_biased, :right_biased), (:none, :lef
     end
 end
 
-using Oceananigans.Advection: LOADV, HOADV
+using Oceananigans.Advection: LOADV, HOADV, WENO, SmoothnessStencil, VorticityStencil, VelocityStencil
 
 for bias in (:symmetric, :left_biased, :right_biased)
     for (d, ξ) in enumerate((:x, :y, :z))
@@ -202,7 +202,7 @@ for bias in (:symmetric, :left_biased, :right_biased)
                            $interp(i, j, k, ibg, scheme, args...))
             
                 # Conditional high-order interpolation for Vector Invariant WENO in Bounded directions
-                @inline $alt_interp(i, j, k, ibg::ImmersedBoundaryGrid, scheme::WENOVectorInvariant, ζ, VI, u, v) =
+                @inline $alt_interp(i, j, k, ibg::ImmersedBoundaryGrid, scheme::WENO, ζ, VI<:SmoothnessStencil, u, v) =
                     ifelse($near_boundary(i, j, k, ibg, scheme),
                             $alt_interp(i, j, k, ibg, scheme.buffer_scheme, ζ, VI, u, v),
                             $interp(i, j, k, ibg, scheme, ζ, VI, u, v))
@@ -210,8 +210,6 @@ for bias in (:symmetric, :left_biased, :right_biased)
         end
     end
 end
-
-using Oceananigans.Advection: VorticityStencil, VelocityStencil
 
 for bias in (:left_biased, :right_biased)
     for (d, dir) in zip((:x, :y), (:xᶜᵃᵃ, :yᵃᶜᵃ))

--- a/src/ImmersedBoundaries/conditional_fluxes.jl
+++ b/src/ImmersedBoundaries/conditional_fluxes.jl
@@ -202,7 +202,7 @@ for bias in (:symmetric, :left_biased, :right_biased)
                            $interp(i, j, k, ibg, scheme, args...))
             
                 # Conditional high-order interpolation for Vector Invariant WENO in Bounded directions
-                @inline $alt_interp(i, j, k, ibg::ImmersedBoundaryGrid, scheme::WENO, ζ, VI<:SmoothnessStencil, u, v) =
+                @inline $alt_interp(i, j, k, ibg::ImmersedBoundaryGrid, scheme::WENO, ζ, VI::Type{<:SmoothnessStencil}, u, v) =
                     ifelse($near_boundary(i, j, k, ibg, scheme),
                             $alt_interp(i, j, k, ibg, scheme.buffer_scheme, ζ, VI, u, v),
                             $interp(i, j, k, ibg, scheme, ζ, VI, u, v))

--- a/src/ImmersedBoundaries/conditional_fluxes.jl
+++ b/src/ImmersedBoundaries/conditional_fluxes.jl
@@ -211,7 +211,7 @@ for bias in (:symmetric, :left_biased, :right_biased)
     end
 end
 
-using Oceananigans.Advection: WENOVectorInvariantVel, VorticityStencil, VelocityStencil
+using Oceananigans.Advection: VorticityStencil, VelocityStencil
 
 for bias in (:left_biased, :right_biased)
     for (d, dir) in zip((:x, :y), (:xᶜᵃᵃ, :yᵃᶜᵃ))
@@ -222,7 +222,7 @@ for bias in (:left_biased, :right_biased)
 
         @eval begin
             # Conditional Interpolation for VelocityStencil WENO vector invariant scheme
-            @inline $alt_interp(i, j, k, ibg::ImmersedBoundaryGrid, scheme::WENOVectorInvariantVel, ζ, ::Type{VelocityStencil}, u, v) =
+            @inline $alt_interp(i, j, k, ibg::ImmersedBoundaryGrid, scheme::WENO, ζ, ::Type{VelocityStencil}, u, v) =
                 ifelse($near_horizontal_boundary(i, j, k, ibg, scheme),
                     $alt_interp(i, j, k, ibg, scheme, ζ, VorticityStencil, u, v),
                     $interp(i, j, k, ibg, scheme, ζ, VelocityStencil, u, v))

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -210,7 +210,7 @@ end
 
 validate_momentum_advection(momentum_advection, grid) = momentum_advection
 validate_momentum_advection(momentum_advection, grid::AbstractHorizontallyCurvilinearGrid) = momentum_advection_squawk(momentum_advection, grid)
-validate_momentum_advection(momentum_advection::Union{VectorInvariantSchemes, Nothing}, grid::AbstractHorizontallyCurvilinearGrid) = momentum_advection
+validate_momentum_advection(momentum_advection::Union{VectorInvariant, Nothing}, grid::AbstractHorizontallyCurvilinearGrid) = momentum_advection
 
 function validate_model_halo(grid, momentum_advection, tracer_advection, closure)
   user_halo = halo_size(grid)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -4,7 +4,7 @@ using OrderedCollections: OrderedDict
 using Oceananigans: AbstractModel, AbstractOutputWriter, AbstractDiagnostic
 
 using Oceananigans.Architectures: AbstractArchitecture, GPU
-using Oceananigans.Advection: AbstractAdvectionScheme, CenteredSecondOrder, VectorInvariantSchemes, VectorInvariant, WENOVectorInvariant
+using Oceananigans.Advection: AbstractAdvectionScheme, CenteredSecondOrder, VectorInvariant, WENOVectorInvariant
 using Oceananigans.BuoyancyModels: validate_buoyancy, regularize_buoyancy, SeawaterBuoyancy, g_Earth
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
 using Oceananigans.Fields: Field, CenterField, tracernames, VelocityFields, TracerFields

--- a/src/Models/ShallowWaterModels/shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_model.jl
@@ -206,13 +206,13 @@ function ShallowWaterModel(;
     return model
 end
 
-using Oceananigans.Advection: VectorInvariantSchemes
+using Oceananigans.Advection: VectorInvariant
 
 validate_momentum_advection(momentum_advection, formulation) = momentum_advection
 validate_momentum_advection(momentum_advection, ::VectorInvariantFormulation) =
     throw(ArgumentError("VectorInvariantFormulation requires a vector invariant momentum advection scheme. \n"* 
                         "Use `momentum_advection = VectorInvariant()`."))
-validate_momentum_advection(momentum_advection::Union{VectorInvariantSchemes, Nothing}, ::VectorInvariantFormulation) = momentum_advection
+validate_momentum_advection(momentum_advection::Union{VectorInvariant, Nothing}, ::VectorInvariantFormulation) = momentum_advection
 
 formulation(model::ShallowWaterModel)  = model.formulation
 architecture(model::ShallowWaterModel) = model.architecture

--- a/test/regression_tests/shallow_water_bickley_jet_regression.jl
+++ b/test/regression_tests/shallow_water_bickley_jet_regression.jl
@@ -6,7 +6,7 @@ Lx, Ly, Lz = 2π, 20, 10
 Nx, Ny = 128, 128
 
 advection(formulation::ConservativeFormulation) = WENO()
-advection(formulation::VectorInvariantFormulation) = WENO(vector_invariant=VelocityStencil())
+advection(formulation::VectorInvariantFormulation) = VectorInvariant(scheme = WENO(), stencil=VelocityStencil())
 
 function run_shallow_water_regression(arch, formulation; regenerate_data = false)
     grid = RectilinearGrid(arch, size = (Nx, Ny),

--- a/validation/advection/gaussian_bump_advection.jl
+++ b/validation/advection/gaussian_bump_advection.jl
@@ -94,7 +94,7 @@ model = HydrostaticFreeSurfaceModel(; grid = ibg,
                                     forcing = (; u = u_forcing, v = v_forcing, b = b_forcing),
                                     boundary_conditions = (u = u_bcs, v = v_bcs),
                                     closure, 
-                                    momentum_advection = WENOFifthOrder(nothing, vector_invariant = VelocityStencil()))
+                                    momentum_advection = VectorInvariant(scheme = WENO(), stencil = VelocityStencil()))
 
 g  = model.free_surface.gravitational_acceleration
 b = model.tracers.b

--- a/validation/bickley_jet/bickley_jet.jl
+++ b/validation/bickley_jet/bickley_jet.jl
@@ -104,8 +104,8 @@ function visualize_bickley_jet(name)
     end
 end
 
-advection_schemes = [WENO(vector_invariant=VelocityStencil()),
-                     WENO(vector_invariant=VorticityStencil()),
+advection_schemes = [VectorInvariant(scheme=WENO(), stencil=VelocityStencil()),
+                     VectorInvariant(scheme=WENO(), stencil=VorticityStencil()),
                      WENO(),
                      VectorInvariant()]
 

--- a/validation/bickley_jet/immersed_bickley_jet.jl
+++ b/validation/bickley_jet/immersed_bickley_jet.jl
@@ -162,8 +162,8 @@ function visualize_bickley_jet(experiment_name)
     mp4(anim, experiment_name * ".mp4", fps = 8)
 end
 
-advection_schemes = [WENO(vector_invariant=VelocityStencil()),
-                     WENO(vector_invariant=VorticityStencil()),
+advection_schemes = [VectorInvariant(scheme=WENO(), stencil=VelocityStencil()),
+                     VectorInvariant(scheme=WENO(), stencil=VorticityStencil()),
                      WENO(),
                      VectorInvariant()]
 

--- a/validation/bickley_jet/spherical_bickley_jet.jl
+++ b/validation/bickley_jet/spherical_bickley_jet.jl
@@ -196,8 +196,8 @@ function visualize_bickley_jet(experiment_name)
     mp4(anim, experiment_name * ".mp4", fps = 8)
 end
 
-advection_schemes = [WENO(vector_invariant=VelocityStencil()),
-                     WENO(vector_invariant=VorticityStencil()),
+advection_schemes = [VectorInvariant(scheme=WENO(), stencil=VelocityStencil()),
+                     VectorInvariant(scheme=WENO(), stencil=VorticityStencil()),
                      VectorInvariant()]
 
 for Nx in [64, 128, 256, 512, 1024]

--- a/validation/convergence_tests/src/TwoDimensionalBurgersAdvection.jl
+++ b/validation/convergence_tests/src/TwoDimensionalBurgersAdvection.jl
@@ -44,7 +44,7 @@ function run_test(; Nx, Δt, stop_iteration, order, U = 0,
 
     model = ShallowWaterModel( grid = grid,
          gravitational_acceleration = 0.0,
-                 momentum_advection = WENO(vector_invariant = VelocityStencil(), order = order),
+                 momentum_advection = VectorInvariant(scheme=WENO(; order), stencil=VelocityStencil()),
                 boundary_conditions = (u = u_bcs, v = v_bcs),
                            coriolis = nothing,
                         formulation = VectorInvariantFormulation())

--- a/validation/convergence_tests/src/TwoDimensionalVortexAdvection.jl
+++ b/validation/convergence_tests/src/TwoDimensionalVortexAdvection.jl
@@ -36,8 +36,8 @@ function run_test(; Nx, Δt, stop_iteration, U = 0, order,
 
     model = ShallowWaterModel( grid = grid,
          gravitational_acceleration = 2.0,
-                 momentum_advection = WENO(vector_invariant = VorticityStencil(), order = order),
-                     mass_advection = WENO(order = order),
+                 momentum_advection = VectorInvariant(scheme=WENO(; order), stencil=VorticityStencil()),
+                     mass_advection = WENO(; order),
                            coriolis = nothing,
                             closure = nothing,
                         formulation = VectorInvariantFormulation())
@@ -82,8 +82,8 @@ function run_test(; Nx, Δt, stop_iteration, U = 0, order,
 
     model = ShallowWaterModel( grid = grid,
          gravitational_acceleration = 2.0,
-                 momentum_advection = WENO(vector_invariant = VelocityStencil(), order = order),
-                     mass_advection = WENO(order = order),
+                 momentum_advection = VectorInvariant(scheme=WENO(; order), stencil=VelocityStencil()),
+                     mass_advection = WENO(; order),
                            coriolis = nothing,
                             closure = nothing,
                         formulation = VectorInvariantFormulation())

--- a/validation/immersed_boundaries/immersed_bickley_jet.jl
+++ b/validation/immersed_boundaries/immersed_bickley_jet.jl
@@ -166,12 +166,10 @@ function visualize_bickley_jet(experiment_name)
     mp4(anim, experiment_name * ".mp4", fps = 8)
 end
 
-advection_schemes = [WENO(vector_invariant=VelocityStencil()),
-                     WENO(vector_invariant=VorticityStencil()),
+advection_schemes = [VectorInvariant(scheme=WENO(), stencil=VelocityStencil()),
+                     VectorInvariant(scheme=WENO(), stencil=VorticityStencil()),
                      WENO(),
                      VectorInvariant()]
-
-advection_schemes = [WENO(vector_invariant = VelocityStencil())]
 
 for Nx in [128]
     for advection in advection_schemes

--- a/validation/multi_region/multi_region_turbulence.jl
+++ b/validation/multi_region/multi_region_turbulence.jl
@@ -28,7 +28,7 @@ v_init = Array(interior(set!(Field((Center, Face, Center), grid), ϵ)))
 u_init_mrg = multi_region_object_from_array(u_init, mrg)
 v_init_mrg = multi_region_object_from_array(v_init, mrg)
 
-momentum_advection = WENO(vector_invariant=VelocityStencil())
+momentum_advection = VectorInvariant(scheme=WENO(), stencil=VelocityStencil())
 
 free_surface = ImplicitFreeSurface(gravitational_acceleration=1, solver_method = :HeptadiagonalIterativeSolver)
 # free_surface = ExplicitFreeSurface(gravitational_acceleration=1) 

--- a/validation/near_global_lat_lon/annual_cycle_earth_bathymetry.jl
+++ b/validation/near_global_lat_lon/annual_cycle_earth_bathymetry.jl
@@ -116,8 +116,7 @@ target_sea_surface_temperature = T★ = arch_array(arch, T★)
 κh = 1e+3
 κz = 1e-4
 
-vertical_closure = VerticalScalarDiffusivity(VerticallyImplicitTimeDiscretization(), 
-                                     ν = νz, κ = κz)
+vertical_closure = VerticalScalarDiffusivity(VerticallyImplicitTimeDiscretization(), ν = νz, κ = κz)
 
 horizontal_closure = HorizontalScalarDiffusivity(ν = νh, κ = κh)
                                        
@@ -190,7 +189,7 @@ equation_of_state=LinearEquationOfState(thermal_expansion=2e-4)
 
 model = HydrostaticFreeSurfaceModel(grid = grid,
                                     free_surface = free_surface,
-                                    momentum_advection = WENO(vector_invariant=VelocityStencil()),
+                                    momentum_advection = VectorInvariant(scheme=WENO(), stencil=VelocityStencil()),
                                     tracer_advection = WENO(),
                                     coriolis = HydrostaticSphericalCoriolis(),
                                     boundary_conditions = (u=u_bcs, v=v_bcs, T=T_bcs),

--- a/validation/near_global_lat_lon/near_global_quarter_degree.jl
+++ b/validation/near_global_lat_lon/near_global_quarter_degree.jl
@@ -228,7 +228,7 @@ buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState())
 
 model = HydrostaticFreeSurfaceModel(; grid,
                                       free_surface,
-                                      momentum_advection = WENO(vector_invariant = VelocityStencil()),
+                                      momentum_advection = VectorInvariant(scheme=WENO(), stencil=VelocityStencil()),
                                       coriolis = HydrostaticSphericalCoriolis(),
                                       buoyancy,
                                       tracers = (:T, :S),

--- a/validation/shallow_water_model/near_global_shallow_water_quarter_degree.jl
+++ b/validation/shallow_water_model/near_global_shallow_water_quarter_degree.jl
@@ -171,7 +171,7 @@ biharmonic_viscosity   = HorizontalScalarBiharmonicDiffusivity(ν=νhb, discrete
 
 model = ShallowWaterModel(grid = grid,
 			              gravitational_acceleration = 9.8055,
-                          momentum_advection = WENO(vector_invariant = VorticityStencil()),
+                          momentum_advection = VectorInvariant(scheme=WENO(), stencil=VorticityStencil()),
                           mass_advection = WENO(),
                           bathymetry = bat,
                           coriolis = HydrostaticSphericalCoriolis(),

--- a/validation/shallow_water_model/shallow_water_Bickley_jet.jl
+++ b/validation/shallow_water_model/shallow_water_Bickley_jet.jl
@@ -21,8 +21,8 @@ coriolis = FPlane(f=1)
 solution = Dict()
 
 @inline weno_advection(::Val{:conservative}, order)     = WENO(; order)
-@inline weno_advection(::Val{:vorticitystencil}, order) = WENO(; order, vector_invariant = VorticityStencil())
-@inline weno_advection(::Val{:velocitystencil}, order)  = WENO(; order, vector_invariant = VelocityStencil())
+@inline weno_advection(::Val{:vorticitystencil}, order) = VectorInvariant(scheme=WENO(; order), stencil=VorticityStencil())
+@inline weno_advection(::Val{:velocitystencil}, order)  = VectorInvariant(scheme=WENO(; order), stencil=VelocityStencil())
 
 @inline Formulation(::Val{:conservative})     = ConservativeFormulation()
 @inline Formulation(::Val{:vorticitystencil}) = VectorInvariantFormulation()

--- a/validation/shallow_water_model/single_geostrophic_vortex.jl
+++ b/validation/shallow_water_model/single_geostrophic_vortex.jl
@@ -100,8 +100,8 @@ function run_shallow_water_experiment(model, solution, form, order)
 end
 
 @inline weno_advection(::Val{:conservative}, order)     = WENO(; order)
-@inline weno_advection(::Val{:vorticitystencil}, order) = WENO(; order, vector_invariant = VorticityStencil())
-@inline weno_advection(::Val{:velocitystencil}, order)  = WENO(; order, vector_invariant = VelocityStencil())
+@inline weno_advection(::Val{:vorticitystencil}, order) = VectorInvariant(scheme=WENO(; order), stencil=VorticityStencil())
+@inline weno_advection(::Val{:velocitystencil}, order)  = VectorInvariant(scheme=WENO(; order), stencil=VelocityStencil())
 
 @inline Formulation(::Val{:conservative})     = ConservativeFormulation()
 @inline Formulation(::Val{:vorticitystencil}) = VectorInvariantFormulation()

--- a/validation/shallow_water_model/vortex_merger.jl
+++ b/validation/shallow_water_model/vortex_merger.jl
@@ -21,7 +21,7 @@ for Nh in [100, 200, 400, 800, 1600], stencil in [VorticityStencil, VelocitySten
                             gravitational_acceleration = g,
                             coriolis = FPlane(f = f),
                             mass_advection = WENO(),
-                            momentum_advection = WENO(vector_invariant = stencil()),
+                            momentum_advection = VectorInvariant(scheme=WENO(), stencil=stencil()),
                             formulation = VectorInvariantFormulation())
 
     # Model initialization

--- a/validation/solid_body_rotation/rossby_haurwitz.jl
+++ b/validation/solid_body_rotation/rossby_haurwitz.jl
@@ -127,7 +127,7 @@ function run_rossby_haurwitz(; architecture = CPU(),
     return simulation.output_writers[:fields].filepath
 end
 
-filepath_w = run_rossby_haurwitz(architecture=GPU(), Nx=512, Ny=256, advection_scheme=WENO(vector_invariant=VelocityStencil()), prefix = "WENOVectorInvariantVel")
-filepath_w = run_rossby_haurwitz(architecture=GPU(), Nx=512, Ny=256, advection_scheme=WENO(vector_invariant=VorticityStencil()), prefix = "WENOVectorInvariantVort")
+filepath_w = run_rossby_haurwitz(architecture=GPU(), Nx=512, Ny=256, advection_scheme=VectorInvariant(scheme=WENO(), stencil=VelocityStencil()), prefix = "WENOVectorInvariantVel")
+filepath_w = run_rossby_haurwitz(architecture=GPU(), Nx=512, Ny=256, advection_scheme=VectorInvariant(scheme=WENO(), stencil=VorticityStencil()), prefix = "WENOVectorInvariantVort")
 filepath_w = run_rossby_haurwitz(architecture=GPU(), Nx=512, Ny=256, advection_scheme=VectorInvariant(), prefix = "VectorInvariant")
 


### PR DESCRIPTION
swap orders of WENO reconstruction and VectorInvariant advection so instead of 
```
WENO(grid, vector_invariant = VelocityStencil(), order = 5)
```
we write
```
reconstruction_scheme = WENO(grid, order = 5)
VectorInvariant(scheme = reconstruction_scheme, stencil = VelocityStencil())
```

This means that now `VectorInvariant` works with any reconstruction scheme. I.e., it is possible to write also
```
reconstruction_scheme = UpwindFifthOrder()
VectorInvariant(scheme = reconstruction_scheme)
```

Closes #2271 