### PR TITLE
Fix race condition affecting `HydrostaticFreeSurfaceModel` with `isnothing(free_surface)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.78.1"
+version = "0.78.2"
 
 [deps]
 AMGX = "c963dde9-0319-47f5-bf0c-b07d3c80ffa6"

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_ab2_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_ab2_step.jl
@@ -13,7 +13,7 @@ function ab2_step!(model::HydrostaticFreeSurfaceModel, Δt, χ)
 
     # Step locally velocity and tracers
     @apply_regionally prognostic_field_events = local_ab2_step!(model, Δt, χ)
-    
+
     # blocking step for implicit free surface, non blocking for explicit
     prognostic_field_events = ab2_step_free_surface!(model.free_surface, model, Δt, χ, prognostic_field_events)
 
@@ -35,7 +35,7 @@ function local_ab2_step!(model, Δt, χ)
     explicit_tracer_step_events   = ab2_step_tracers!(model.tracers, model, Δt, χ)
     
     prognostic_field_events = (tuple(explicit_velocity_step_events...),
-        tuple(explicit_tracer_step_events...))
+                               tuple(explicit_tracer_step_events...))
 
     return prognostic_field_events    
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -3,7 +3,7 @@
 #####
 
 using Oceananigans.Grids: Center, Face
-using Oceananigans.Fields: AbstractField, FunctionField
+using Oceananigans.Fields: AbstractField, FunctionField, flatten_tuple
 using Oceananigans.TimeSteppers: tick!
 using Oceananigans.LagrangianParticleTracking: update_particle_properties!
 
@@ -76,7 +76,7 @@ end
 @inline datatuple(obj::PrescribedVelocityFields) = (; u = datatuple(obj.u), v = datatuple(obj.v), w = datatuple(obj.w))
 
 ab2_step_velocities!(::PrescribedVelocityFields, args...) = [NoneEvent()]
-ab2_step_free_surface!(::Nothing, args...) = NoneEvent()
+ab2_step_free_surface!(::Nothing, model, Δt, χ, prognostic_field_events) = MultiEvent(flatten_tuple(prognostic_field_events))
 compute_w_from_continuity!(::PrescribedVelocityFields, args...) = nothing
 
 validate_velocity_boundary_conditions(::PrescribedVelocityFields) = nothing

--- a/src/MultiRegion/multi_region_utils.jl
+++ b/src/MultiRegion/multi_region_utils.jl
@@ -1,3 +1,6 @@
+import Oceananigans.Fields: flatten_tuple
+
+flatten_tuple(mro::MultiRegionObject) = flatten_tuple(mro.regions)
 
 validate_devices(partition, ::CPU, devices) = nothing
 validate_devices(p, ::CPU, ::Nothing) = nothing
@@ -17,6 +20,7 @@ function validate_devices(partition, ::GPU, devices::Number)
     @assert devices <= length(partition)
     return devices
 end
+
 assign_devices(p, ::Nothing) = Tuple(CPU() for i in 1:length(p))
 
 function assign_devices(p::AbstractPartition, dev::Number) 


### PR DESCRIPTION
Affects calibration with single column models (but mostly on the GPU?) and tracer simulations with `PrescribedVelocityFields`.

cc @adelinehillier 

closes #2809 