### PR TITLE
Fixes bug in error for `validate_index`

### DIFF
--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -196,7 +196,7 @@ validate_index(idx::UnitRange, ::Type{Nothing}, topo, N, H) = UnitRange(1, 1)
 
 function validate_index(idx::UnitRange, loc, topo, N, H)
     all_idx = all_indices(loc, topo, N, H)
-    (first(idx) ∈ all_idx && last(idx) ∈ all_idx) || throw(ArgumentError("The indices $idx must slice $I"))
+    (first(idx) ∈ all_idx && last(idx) ∈ all_idx) || throw(ArgumentError("The indices $idx are out of range"))
     return idx
 end
 

--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -196,7 +196,7 @@ validate_index(idx::UnitRange, ::Type{Nothing}, topo, N, H) = UnitRange(1, 1)
 
 function validate_index(idx::UnitRange, loc, topo, N, H)
     all_idx = all_indices(loc, topo, N, H)
-    (first(idx) ∈ all_idx && last(idx) ∈ all_idx) || throw(ArgumentError("The indices $idx are out of range"))
+    (first(idx) ∈ all_idx && last(idx) ∈ all_idx) || throw(ArgumentError("The indices $idx must slice $all_idx"))
     return idx
 end
 


### PR DESCRIPTION
At the moment the error throwing in the function `validate_index()` isn't working due to an undefined variable. For indices that aren't valid, the error ends up being not useful:

```julia
caused by: UndefVarError: I not defined
Stacktrace:
  [1] validate_index(idx::UnitRange{Int64}, loc::Type, topo::Type, N::Int64, H::Int64)
    @ Oceananigans.Fields /glade/work/tomasc/.julia/packages/Oceananigans/7G5bN/src/Fields/field.jl:90
  [2] validate_index
    @ /glade/work/tomasc/.julia/packages/Oceananigans/7G5bN/src/Fields/field.jl:94 [inlined]
```

This PR fixes that with a simpler error message.