### PR TITLE
Fix bug when throwing exception during grid validation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.78.4"
+version = "0.78.5"
 
 [deps]
 AMGX = "c963dde9-0319-47f5-bf0c-b07d3c80ffa6"

--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -110,7 +110,7 @@ function validate_dimension_specification(T, ξ::AbstractVector, dir, N, FT)
     Nξ = length(ξ)
     N⁺¹ = N + 1
     if Nξ < N⁺¹
-        throw(ArgumentError("length($dir) = $Nξ has too few interfaces for the dimension size $N!"))
+        throw(ArgumentError("length($dir) = $Nξ has too few interfaces for the dimension size $(N)!"))
     elseif Nξ > N⁺¹
         msg = "length($dir) = $Nξ is greater than $N+1, where $N was passed to `size`.\n" *
               "$dir cell interfaces will be constructed from $dir[1:$N⁺¹]."


### PR DESCRIPTION
Currently an error during grid validation is actually not printed, instead you get
```
ERROR: UndefVarError: N! not defined
```
as string interpolation is expecting a variable called `N!` when the variable is `N`.

This PR fixes this.