### PR TITLE
Increased `interpolate` speed

### DIFF
--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -19,25 +19,21 @@ using a binary search. The input array `vec` has to be monotonically increasing.
 Code credit: https://computersciencehub.io/julia/code-for-binary-search-algorithm-julia
 """
 @inline function index_binary_search(vec, val, array_size)
-    if issorted(vec) 
-        low = 0
-        high = array_size - 1
+    low = 0
+    high = array_size - 1
 
-        while low + 1 < high 
-            mid = middle_point(low, high)
-            if @inbounds vec[mid + 1] == val 
-                return (mid + 1, mid + 1)
-            elseif @inbounds vec[mid + 1] < val
-                low = mid
-            else
-                high = mid
-            end
+    while low + 1 < high 
+        mid = middle_point(low, high)
+        if @inbounds vec[mid + 1] == val 
+            return (mid + 1, mid + 1)
+        elseif @inbounds vec[mid + 1] < val
+            low = mid
+        else
+            high = mid
         end
-
-        return (low + 1, high + 1)
-    else
-        throw(error("Vector not sorted, unable to search value"))
     end
+
+    return (low + 1, high + 1)
 end
 
 @inline function fractional_index(array_size::Int, val::FT, vec) where {FT}

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -16,7 +16,7 @@ vec[low] <= val && vec[high] >= val
 
 using a binary search. The input array `vec` has to be monotonically increasing.
 
-Code credit: https://computersciencehub.io/julia/code-for-binary-search-algorithm-julia
+Code credit: https://gist.github.com/cuongld2/8e4fed9ba44ea2b4598f90e7d5b6c612/155f9cb595314c8db3a266c3316889443b068017
 """
 @inline function index_binary_search(vec, val, array_size)
     low = 0

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -25,9 +25,9 @@ Code credit: https://computersciencehub.io/julia/code-for-binary-search-algorith
 
         while low + 1 < high 
             mid = middle_point(low, high)
-            if vec[mid + 1] == val 
+            if @inbounds vec[mid + 1] == val 
                 return (mid + 1, mid + 1)
-            elseif vec[mid + 1] < val
+            elseif @inbounds vec[mid + 1] < val
                 low = mid
             else
                 high = mid


### PR DESCRIPTION
Hi all,

I noticed that some of the array indexing in `interpolate` weren't `@inbounds`'ed so added them, and then also noticed that `issorted` tooke a good fraction of the time when interpolating fields on irregular grids so I removed that since the funciton is only used internally and is always going to be given sorted vectors.

This results in a ~5x speedup so seems worth it.