### PR TITLE
Fixes `display()` of `LinearEquationOfState`

### DIFF
--- a/src/BuoyancyModels/linear_equation_of_state.jl
+++ b/src/BuoyancyModels/linear_equation_of_state.jl
@@ -12,7 +12,7 @@ Base.summary(eos::LinearEquationOfState) =
     string("LinearEquationOfState(thermal_expansion=", prettysummary(eos.thermal_expansion),
                                ", haline_contraction=", prettysummary(eos.haline_contraction), ")")
 
-Base.show(io, eos::LinearEquationOfState) = print(io, summary(eos))
+Base.show(io::IO, eos::LinearEquationOfState) = print(io, summary(eos))
 
 """
     LinearEquationOfState([FT=Float64;] thermal_expansion=1.67e-4, haline_contraction=7.80e-4)


### PR DESCRIPTION
On main:

```julia
julia> a = Oceananigans.BuoyancyModels.LinearEquationOfState()
Error showing value of type LinearEquationOfState{Float64}:
ERROR: MethodError: no method matching display(::LinearEquationOfState{Float64})
Closest candidates are:
  display(::Any) at multimedia.jl:324
  display(::AbstractDisplay, ::AbstractString, ::Any) at multimedia.jl:216
  display(::AbstractString, ::Any) at multimedia.jl:217
```

This PR:

```julia
julia> a = Oceananigans.BuoyancyModels.LinearEquationOfState()
LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078)
```