### PR TITLE
WIP: Adding checkpointer for ShallowWaterModel

### DIFF
--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -57,9 +57,11 @@ Keyword arguments
              Default: `false`.
 
 - `properties`: List of model properties to checkpoint. This list must contain
-                `[:grid, :architecture, :timestepper, :particles]`.
+                `[:grid, :architecture, :timestepper, :particles]`, except when using a
+                 `ShallowWaterModel`, in which case `:particles` is not required.
                 Default: [:architecture, :grid, :clock, :coriolis, :buoyancy, :closure,
-                          :velocities, :tracers, :timestepper, :particles]
+                          :velocities, :tracers, :timestepper, :particles], except when using a
+                          `ShallowWaterModel`, in which case `:particles` is not added.
 """
 function Checkpointer(model; schedule,
                       dir = ".",

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -77,17 +77,15 @@ function test_hydrostatic_splash_checkpointer(arch, free_surface)
     return run_checkpointer_tests(true_model, test_model, 1e-6)
 end
 
-function test_shallow_water_checkpointer(arch, free_surface)
+function test_shallow_water_checkpointer(arch)
     #####
     ##### Create and run "true model"
     #####
 
-    using Oceananigans
-    using Oceananigans.Models: ShallowWaterModel
     Lx, Ly, Lz = 2π, 20, 10
     Nx, Ny = 16, 16
     
-    grid = RectilinearGrid(size = (Nx, Ny),
+    grid = RectilinearGrid(arch,size = (Nx, Ny),
                            x = (0, Lx), y = (-Ly/2, Ly/2),
                            topology = (Periodic, Bounded, Flat))
 
@@ -221,6 +219,7 @@ for arch in archs
     @testset "Checkpointer [$(typeof(arch))]" begin
         @info "  Testing Checkpointer [$(typeof(arch))]..."
         test_thermal_bubble_checkpointer_output(arch)
+        test_shallow_water_checkpointer(arch)
     
         for free_surface in [ExplicitFreeSurface(gravitational_acceleration=1),
                              ImplicitFreeSurface(gravitational_acceleration=1)]

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -138,8 +138,9 @@ function run_checkpointer_tests(true_model, test_model, Δt)
     test_model_equality(test_model, checkpointed_model)
 
     # This only applies to QuasiAdamsBashforthTimeStepper:
-    @test test_model.timestepper.previous_Δt == checkpointed_model.timestepper.previous_Δt
-
+    if test_model.timestepper isa QuasiAdamsBashforthTimeStepper
+     @test test_model.timestepper.previous_Δt == checkpointed_model.timestepper.previous_Δt
+    end
     #####
     ##### Test pickup from explicit checkpoint path
     #####


### PR DESCRIPTION
This is work in progress to solve #2866 so I would apprciate some advice:

1. I added a specific constructor of Checkpointer for when the model is a ShallowWater model
2. I added a set! function for when the model is a shallow water model (the difference of these two and the other ones is that they do not require the "particles" property.
3. I added a low-res test case 

Is OutputWriters/checkpointer a good place to put these methods in, or should they go somewhere in models/?
Is it okay to no add a new docstring to the new constructor and instead modify the existing one mentioning the difference with the ShallowWater case? If I add new one, the docs of Checkpointer will be huge.