### PR TITLE
Don't push docs preview

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -168,6 +168,6 @@ deploydocs(
           repo = "github.com/CliMA/OceananigansDocumentation.git",
       versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
      forcepush = true,
-  push_preview = true,
+  push_preview = false,
      devbranch = "main"
 )


### PR DESCRIPTION
Unfortunately the previews clog up the [OceananigansDocumentation](https://github.com/CliMA/OceananigansDocumentation) repository and we need to perform manual cleanup often...

I suggest we drop the doc previews for the moment. We could build the docs manually _or_ temporarily enable them for a particular PR that includes Doc changes and then disable them again.