### PR TITLE
Adds `get_face()` method for `FunctionField`

### DIFF
--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -9,7 +9,7 @@ using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 import Base: getindex, size, show, minimum, maximum, length
 import Statistics: mean
 
-import Oceananigans.Fields: AbstractField, Field, FieldBoundaryBuffers, minimum, maximum, mean, location, set!
+import Oceananigans.Fields: AbstractField, FunctionField, Field, FieldBoundaryBuffers, minimum, maximum, mean, location, set!
 import Oceananigans.Grids: new_data
 import Oceananigans.BoundaryConditions: FieldBoundaryConditions
 
@@ -125,7 +125,12 @@ Base.size(data::CubedSphereData) = (size(data.faces[1])..., length(data.faces))
           field.indices,
           get_face(field.operand, face_index),
           nothing)
-    
+
+@inline get_face(field::FunctionField, face_index) =
+    FunctionField(location(field),
+                  field.func,
+                  get_face(field.grid, face_index))
+ 
 faces(field::AbstractCubedSphereField) = Tuple(get_face(field, face_index) for face_index in 1:length(field.data.faces))
 
 function Base.fill!(csf::CubedSphereField, val)

--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -50,6 +50,8 @@ const CubedSphereField{LX, LY, LZ} =
     Union{Field{LX, LY, LZ, <:Nothing, <:ConformalCubedSphereGrid},
           Field{LX, LY, LZ, <:AbstractOperation, <:ConformalCubedSphereGrid}}
 
+const CubedSphereFunctionField{LX, LY, LZ} = FunctionField{LX, LY, LZ, <:Any, <:Any, <:Any, <:ConformalCubedSphereGrid}
+
 const CubedSphereAbstractField{LX, LY, LZ} = AbstractField{LX, LY, LZ, <:ConformalCubedSphereGrid}
 
 const AbstractCubedSphereField{LX, LY, LZ} =
@@ -126,11 +128,11 @@ Base.size(data::CubedSphereData) = (size(data.faces[1])..., length(data.faces))
           get_face(field.operand, face_index),
           nothing)
 
-@inline get_face(field::FunctionField, face_index) =
+@inline get_face(field::CubedSphereFunctionField, face_index) =
     FunctionField(location(field),
                   field.func,
                   get_face(field.grid, face_index))
- 
+
 faces(field::AbstractCubedSphereField) = Tuple(get_face(field, face_index) for face_index in 1:length(field.data.faces))
 
 function Base.fill!(csf::CubedSphereField, val)


### PR DESCRIPTION
I've been facing some trouble in https://github.com/CliMA/Oceananigans.jl/pull/2842/ for cubed sphere grids and I think that's why. Locally this change makes the tests there pass.

Admittedly I know very little about cubed spheres, so input is appreciated.