### PR TITLE
Defines some binary operations with `ZeroField`

### DIFF
--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -125,6 +125,12 @@ function define_binary_operator(op)
 
         $op(a::AF, b::Number) = $op(location(a), a, b)
         $op(a::Number, b::AF) = $op(location(b), a, b)
+
+        $op(a::AF, b::ConstantField) = $op(location(a), a, b.constant)
+        $op(a::ConstantField, b::AF) = $op(location(b), a.constant, b)
+
+        $op(a::Number, b::ConstantField) = ConstantField($op(a, b.constant))
+        $op(a::ConstantField, b::Number) = ConstantField($op(a.constant, b))
     end
 end
 
@@ -195,10 +201,10 @@ import Base: +, -, *, /, ==
 using Oceananigans.Fields: ZeroField, ConstantField
 
 ==(::ZeroField, ::ZeroField) = true
-==(c1::ConstantField, c2::ConstantField) = c1.constant == c2.constant
 
 ==(zf::ZeroField, cf::ConstantField) = 0 == cf.constant
 ==(cf::ConstantField, zf::ZeroField) = ==(zf, cf)
+==(c1::ConstantField, c2::ConstantField) = c1.constant == c2.constant
 
 +(a::ZeroField, b::AbstractField) = b
 +(a::AbstractField, b::ZeroField) = +(b, a)

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -188,6 +188,38 @@ macro binary(ops...)
 end
 
 #####
+##### BinaryOperations with ZeroField
+#####
+
+import Base: +, -, *, /, ==
+using Oceananigans.Fields: ZeroField
+
+==(::ZeroField, ::ZeroField) = true
+
++(a::ZeroField, b::AbstractField) = b
++(a::AbstractField, b::ZeroField) = +(b, a)
++(a::ZeroField, b::Number) = b
++(a::Number, b::ZeroField) = +(b, a)
+
+-(a::ZeroField, b::AbstractField) = -b
+-(b::AbstractField, a::ZeroField) = b
+-(a::ZeroField, b::Number) = -b
+-(b::Number, a::ZeroField) = b
+
+*(a::ZeroField, b::AbstractField) = a
+*(b::AbstractField, a::ZeroField) = *(a, b)
+*(a::ZeroField, b::Number) = a
+*(b::Number, a::ZeroField) = *(a, b)
+
+/(a::ZeroField, b::AbstractField) = a
+/(b::AbstractField, a::ZeroField) = Inf
+/(a::ZeroField, b::Number) = a
+/(b::Number, a::ZeroField) = Inf
+
+^(a::ZeroField, b::Number) = a
+
+
+#####
 ##### Nested computations
 #####
 

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -225,7 +225,7 @@ using Oceananigans.Fields: ZeroField, ConstantField
 /(a::ZeroField, b::AbstractField) = a
 /(a::AbstractField, b::ZeroField) = ConstantField(convert(eltype(a), Inf))
 /(a::ZeroField, b::Number) = a
-/(a::Number, b::ZeroField) = ConstantField(a/convert(eltype(a), 0))
+/(a::Number, b::ZeroField) = ConstantField(a / convert(eltype(a), 0))
 
 
 #####

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -207,24 +207,24 @@ using Oceananigans.Fields: ZeroField, ConstantField
 ==(c1::ConstantField, c2::ConstantField) = c1.constant == c2.constant
 
 +(a::ZeroField, b::AbstractField) = b
-+(a::AbstractField, b::ZeroField) = +(b, a)
++(a::AbstractField, b::ZeroField) = a
 +(a::ZeroField, b::Number) = ConstantField(b)
-+(a::Number, b::ZeroField) = +(b, a)
++(a::Number, b::ZeroField) = ConstantField(a)
 
 -(a::ZeroField, b::AbstractField) = -b
--(b::AbstractField, a::ZeroField) = b
+-(a::AbstractField, b::ZeroField) = a
 -(a::ZeroField, b::Number) = ConstantField(-b)
--(b::Number, a::ZeroField) = ConstantField(b)
+-(a::Number, b::ZeroField) = ConstantField(a)
 
 *(a::ZeroField, b::AbstractField) = a
-*(b::AbstractField, a::ZeroField) = *(a, b)
+*(a::AbstractField, b::ZeroField) = b
 *(a::ZeroField, b::Number) = a
-*(b::Number, a::ZeroField) = *(a, b)
+*(a::Number, b::ZeroField) = b
 
 /(a::ZeroField, b::AbstractField) = a
-/(b::AbstractField, a::ZeroField) = ConstantField(Inf)
+/(a::AbstractField, b::ZeroField) = ConstantField(Inf)
 /(a::ZeroField, b::Number) = a
-/(b::Number, a::ZeroField) = ConstantField(Inf)
+/(a::Number, b::ZeroField) = ConstantField(Inf)
 
 
 #####

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -216,8 +216,6 @@ using Oceananigans.Fields: ZeroField
 /(a::ZeroField, b::Number) = a
 /(b::Number, a::ZeroField) = Inf
 
-^(a::ZeroField, b::Number) = a
-
 
 #####
 ##### Nested computations

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -204,7 +204,7 @@ using Oceananigans.Fields: ZeroField, ConstantField
 ==(::ZeroField, ::ZeroField) = true
 
 ==(zf::ZeroField, cf::ConstantField) = 0 == cf.constant
-==(cf::ConstantField, zf::ZeroField) = ==(zf, cf)
+==(cf::ConstantField, zf::ZeroField) = 0 == cf.constant
 ==(c1::ConstantField, c2::ConstantField) = c1.constant == c2.constant
 
 +(a::ZeroField, b::AbstractField) = b
@@ -223,9 +223,9 @@ using Oceananigans.Fields: ZeroField, ConstantField
 *(a::Number, b::ZeroField) = b
 
 /(a::ZeroField, b::AbstractField) = a
-/(a::AbstractField, b::ZeroField) = ConstantField(Inf)
+/(a::AbstractField, b::ZeroField) = ConstantField(convert(eltype(a), Inf))
 /(a::ZeroField, b::Number) = a
-/(a::Number, b::ZeroField) = ConstantField(Inf)
+/(a::Number, b::ZeroField) = ConstantField(a/convert(eltype(a), 0))
 
 
 #####

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -57,6 +57,7 @@ function define_binary_operator(op)
 
         local location = Oceananigans.Fields.location
         local FunctionField = Oceananigans.Fields.FunctionField
+        local ConstantField = Oceananigans.Fields.ConstantField
         local AF = AbstractField
 
         @inline $op(i, j, k, grid::AbstractGrid, ▶a, ▶b, a, b) =

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -192,19 +192,23 @@ end
 #####
 
 import Base: +, -, *, /, ==
-using Oceananigans.Fields: ZeroField
+using Oceananigans.Fields: ZeroField, ConstantField
 
 ==(::ZeroField, ::ZeroField) = true
+==(c1::ConstantField, c2::ConstantField) = c1.constant == c2.constant
+
+==(zf::ZeroField, cf::ConstantField) = 0 == cf.constant
+==(cf::ConstantField, zf::ZeroField) = ==(zf, cf)
 
 +(a::ZeroField, b::AbstractField) = b
 +(a::AbstractField, b::ZeroField) = +(b, a)
-+(a::ZeroField, b::Number) = b
++(a::ZeroField, b::Number) = ConstantField(b)
 +(a::Number, b::ZeroField) = +(b, a)
 
 -(a::ZeroField, b::AbstractField) = -b
 -(b::AbstractField, a::ZeroField) = b
--(a::ZeroField, b::Number) = -b
--(b::Number, a::ZeroField) = b
+-(a::ZeroField, b::Number) = ConstantField(-b)
+-(b::Number, a::ZeroField) = ConstantField(b)
 
 *(a::ZeroField, b::AbstractField) = a
 *(b::AbstractField, a::ZeroField) = *(a, b)
@@ -212,9 +216,9 @@ using Oceananigans.Fields: ZeroField
 *(b::Number, a::ZeroField) = *(a, b)
 
 /(a::ZeroField, b::AbstractField) = a
-/(b::AbstractField, a::ZeroField) = Inf
+/(b::AbstractField, a::ZeroField) = ConstantField(Inf)
 /(a::ZeroField, b::Number) = a
-/(b::Number, a::ZeroField) = Inf
+/(b::Number, a::ZeroField) = ConstantField(Inf)
 
 
 #####

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -1,7 +1,7 @@
 include("dependencies_for_runtests.jl")
 
 using Oceananigans.Operators: ℑxyᶜᶠᵃ, ℑxyᶠᶜᵃ
-using Oceananigans.Fields: compute_at!, indices
+using Oceananigans.Fields: ZeroField, compute_at!, indices
 using Oceananigans.BuoyancyModels: BuoyancyField
 
 function simple_binary_operation(op, a, b, num1, num2)
@@ -133,7 +133,6 @@ for arch in archs
             @test 1 * ZeroField() == ZeroField()
             @test ZeroField() / 1 == ZeroField()
             @test 1 / ZeroField() == Inf
-            @test ZeroField()^2   == ZeroField()
         end
 
         @testset "Multiary operations [$(typeof(arch))]" begin

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -133,6 +133,16 @@ for arch in archs
             @test 1 * ZeroField() == ZeroField()
             @test ZeroField() / 1 == ZeroField()
             @test 1 / ZeroField() == ConstantField(Inf)
+
+            @test ConstantField(1) + u == 1 + u
+            @test ConstantField(1) - u == 1 - u
+            @test ConstantField(1) * u == 1 * u
+            @test u / ConstantField(1) == u / 1
+
+            @test ConstantField(1) + 1 == ConstantField(2)
+            @test ConstantField(1) - 1 == ConstantField(0)
+            @test ConstantField(1) * 2 == ConstantField(2)
+            @test ConstantField(1) / 2 == ConstantField(1/2)
         end
 
         @testset "Multiary operations [$(typeof(arch))]" begin

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -1,7 +1,7 @@
 include("dependencies_for_runtests.jl")
 
 using Oceananigans.Operators: ℑxyᶜᶠᵃ, ℑxyᶠᶜᵃ
-using Oceananigans.Fields: ZeroField, compute_at!, indices
+using Oceananigans.Fields: ZeroField, ConstantField, compute_at!, indices
 using Oceananigans.BuoyancyModels: BuoyancyField
 
 function simple_binary_operation(op, a, b, num1, num2)
@@ -123,16 +123,16 @@ for arch in archs
             @test ZeroField() * u == ZeroField()
             @test u * ZeroField() == ZeroField()
             @test ZeroField() / u == ZeroField()
-            @test u / ZeroField() == Inf
+            @test u / ZeroField() == ConstantField(Inf)
 
-            @test ZeroField() + 1 == 1
-            @test 1 + ZeroField() == 1
-            @test ZeroField() - 1 == -1
-            @test 1 - ZeroField() == 1
+            @test ZeroField() + 1 == ConstantField(1)
+            @test 1 + ZeroField() == ConstantField(1)
+            @test ZeroField() - 1 == ConstantField(-1)
+            @test 1 - ZeroField() == ConstantField(1)
             @test ZeroField() * 1 == ZeroField()
             @test 1 * ZeroField() == ZeroField()
             @test ZeroField() / 1 == ZeroField()
-            @test 1 / ZeroField() == Inf
+            @test 1 / ZeroField() == ConstantField(Inf)
         end
 
         @testset "Multiary operations [$(typeof(arch))]" begin

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -115,6 +115,25 @@ for arch in archs
                     @test CUDA.@allowscalar typeof(op(ψ, ϕ)[2, 2, 2]) <: Number
                 end
             end
+
+            @test ZeroField() + u == u
+            @test u + ZeroField() == u
+            @test ZeroField() - u == -u
+            @test u - ZeroField() == u
+            @test ZeroField() * u == ZeroField()
+            @test u * ZeroField() == ZeroField()
+            @test ZeroField() / u == ZeroField()
+            @test u / ZeroField() == Inf
+
+            @test ZeroField() + 1 == 1
+            @test 1 + ZeroField() == 1
+            @test ZeroField() - 1 == -1
+            @test 1 - ZeroField() == 1
+            @test ZeroField() * 1 == ZeroField()
+            @test 1 * ZeroField() == ZeroField()
+            @test ZeroField() / 1 == ZeroField()
+            @test 1 / ZeroField() == Inf
+            @test ZeroField()^2   == ZeroField()
         end
 
         @testset "Multiary operations [$(typeof(arch))]" begin


### PR DESCRIPTION
This PR defines some binary operations involving `ZeroField`s that might be useful, and adds tests for those operations. The issue came up at https://github.com/tomchor/Oceanostics.jl/pull/104