### PR TITLE
Fix in lat-lon grid `Δy` metric

### DIFF
--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -534,7 +534,7 @@ end
 
     @inbounds begin
         Δyᶜᶠ[j′] = Δyᶜᶠᵃ(1, j′, 1, grid)
-        Δyᶠᶜ[j′] = Δyᶜᶠᵃ(1, j′, 1, grid)
+        Δyᶠᶜ[j′] = Δyᶠᶜᵃ(1, j′, 1, grid)
     end
 end
 


### PR DESCRIPTION
I guess it doesn't make any difference since both Δφ spacings between faces or centers are the same. But for the sake of sanity it should be changed. Thus, I removed the "bug" label.