### PR TITLE
Some docstring fixes/enhancements + Code cleanup

### DIFF
--- a/benchmark/benchmark_abstract_operations.jl
+++ b/benchmark/benchmark_abstract_operations.jl
@@ -25,9 +25,8 @@ print_system_info()
 for Arch in Archs
     N = Arch == CPU ? (32, 32, 32) : (256, 256, 256)
 
-    grid = RectilinearGrid(FT, size=N, extent=(1, 1, 1))
-    model = NonhydrostaticModel(architecture=Arch(), grid=grid,
-                                buoyancy=nothing, tracers=(:α, :β, :γ, :δ, :ζ))
+    grid = RectilinearGrid(Arch(), FT, size=N, extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid=grid, buoyancy=nothing, tracers=(:α, :β, :γ, :δ, :ζ))
 
     ε(x, y, z) = randn()
     ε⁺(x, y, z) = abs(randn())

--- a/benchmark/benchmark_advection_schemes.jl
+++ b/benchmark/benchmark_advection_schemes.jl
@@ -9,8 +9,8 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_advection_scheme(Arch, Scheme)
-    grid = RectilinearGrid(size=(192, 192, 192), extent=(1, 1, 1))
-    model = NonhydrostaticModel(architecture=Arch(), grid=grid, advection=Scheme())
+    grid = RectilinearGrid(Arch(); size=(192, 192, 192), extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid=grid, advection=Scheme())
 
     time_step!(model, 1) # warmup
 

--- a/benchmark/benchmark_equations_of_state.jl
+++ b/benchmark/benchmark_equations_of_state.jl
@@ -10,9 +10,9 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_equation_of_state(Arch, EOS)
-    grid = RectilinearGrid(size=(192, 192, 192), extent=(1, 1, 1))
+    grid = RectilinearGrid(Arch(), size=(192, 192, 192), extent=(1, 1, 1))
     buoyancy = SeawaterBuoyancy(equation_of_state=EOS())
-    model = NonhydrostaticModel(architecture=Arch(), grid=grid, buoyancy=buoyancy)
+    model = NonhydrostaticModel(grid=grid, buoyancy=buoyancy)
 
     time_step!(model, 1) # warmup
 

--- a/benchmark/benchmark_fourier_tridiagonal_poisson_solver.jl
+++ b/benchmark/benchmark_fourier_tridiagonal_poisson_solver.jl
@@ -10,8 +10,8 @@ using Oceananigans.Solvers
 # Benchmark function
 
 function benchmark_fourier_tridiagonal_poisson_solver(Arch, N, topo)
-    grid = RectilinearGrid(architecture=Arch(), topology=topo, size=(N, N, N), x=(0, 1), y=(0, 1), z=collect(0:N))
-    solver = FourierTridiagonalPoissonSolver(Arch(), grid)
+    grid = RectilinearGrid(Arch(), topology=topo, size=(N, N, N), x=(0, 1), y=(0, 1), z=collect(0:N))
+    solver = FourierTridiagonalPoissonSolver(grid)
 
     solve_poisson_equation!(solver) # warmup
 

--- a/benchmark/benchmark_lagrangian_particle_tracking.jl
+++ b/benchmark/benchmark_lagrangian_particle_tracking.jl
@@ -8,7 +8,7 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_particle_tracking(Arch, N_particles)
-    grid = RectilinearGrid(size=(128, 128, 128), extent=(1, 1, 1))
+    grid = RectilinearGrid(Arch(), size=(128, 128, 128), extent=(1, 1, 1))
 
     if N_particles == 0
         particles = nothing
@@ -20,7 +20,7 @@ function benchmark_particle_tracking(Arch, N_particles)
         particles = LagrangianParticles(x=x₀, y=y₀, z=z₀)
     end
 
-    model = NonhydrostaticModel(architecture=Arch(), grid=grid, particles=particles)
+    model = NonhydrostaticModel(grid=grid, particles=particles)
 
     time_step!(model, 1) # warmup
 

--- a/benchmark/benchmark_multithreading_single.jl
+++ b/benchmark/benchmark_multithreading_single.jl
@@ -7,7 +7,7 @@ using Benchmarks
 
 N = parse(Int, ARGS[1])
 grid = RectilinearGrid(size=(N, N, N), extent=(1, 1, 1))
-model = NonhydrostaticModel(architecture=CPU(), grid=grid)
+model = NonhydrostaticModel(grid=grid)
 
 time_step!(model, 1) # warmup
 

--- a/benchmark/benchmark_shallow_water_model.jl
+++ b/benchmark/benchmark_shallow_water_model.jl
@@ -11,8 +11,8 @@ pyplot()
 # Benchmark function
 
 function benchmark_shallow_water_model(Arch, FT, N)
-    grid = RectilinearGrid(FT, size=(N, N), extent=(1, 1), topology=(Periodic, Periodic, Flat), halo=(3, 3))
-    model = ShallowWaterModel(architecture=Arch(), grid=grid, gravitational_acceleration=1.0)
+    grid = RectilinearGrid(Arch(), FT, size=(N, N), extent=(1, 1), topology=(Periodic, Periodic, Flat), halo=(3, 3))
+    model = ShallowWaterModel(grid=grid, gravitational_acceleration=1.0)
     set!(model, h=1)
 
     time_step!(model, 1) # warmup

--- a/benchmark/benchmark_time_steppers.jl
+++ b/benchmark/benchmark_time_steppers.jl
@@ -8,8 +8,8 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_time_stepper(Arch, N, TimeStepper)
-    grid = RectilinearGrid(size=(N, N, N), extent=(1, 1, 1))
-    model = NonhydrostaticModel(architecture=Arch(), grid=grid, timestepper=TimeStepper)
+    grid = RectilinearGrid(Arch(), size=(N, N, N), extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid=grid, timestepper=TimeStepper)
 
     time_step!(model, 1) # warmup
 

--- a/benchmark/benchmark_topologies.jl
+++ b/benchmark/benchmark_topologies.jl
@@ -8,8 +8,8 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_topology(Arch, N, topo)
-    grid = RectilinearGrid(topology=topo, size=(N, N, N), extent=(1, 1, 1))
-    model = NonhydrostaticModel(architecture=Arch(), grid=grid)
+    grid = RectilinearGrid(Arch(), topology=topo, size=(N, N, N), extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid=grid)
 
     time_step!(model, 1) # warmup
 

--- a/benchmark/benchmark_tracers.jl
+++ b/benchmark/benchmark_tracers.jl
@@ -30,8 +30,8 @@ end
 
 function benchmark_tracers(Arch, N, n_tracers)
     n_active, n_passive = n_tracers
-    grid = RectilinearGrid(size=(N, N, N), extent=(1, 1, 1))
-    model = NonhydrostaticModel(architecture=Arch(), grid=grid, buoyancy=buoyancy(n_active),
+    grid = RectilinearGrid(Arch(), size=(N, N, N), extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid=grid, buoyancy=buoyancy(n_active),
                                 tracers=tracer_list(n_active, n_passive))
 
     time_step!(model, 1) # warmup

--- a/benchmark/benchmark_turbulence_closures.jl
+++ b/benchmark/benchmark_turbulence_closures.jl
@@ -9,8 +9,8 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_closure(Arch, Closure)
-    grid = RectilinearGrid(size=(128, 128, 128), extent=(1, 1, 1))
-    model = NonhydrostaticModel(architecture=Arch(), grid=grid, closure=Closure())
+    grid = RectilinearGrid(Arch(), size=(128, 128, 128), extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid=grid, closure=Closure())
 
     time_step!(model, 1) # warmup
 

--- a/benchmark/benchmark_vertically_stretched_nonhydrostatic_model.jl
+++ b/benchmark/benchmark_vertically_stretched_nonhydrostatic_model.jl
@@ -8,8 +8,8 @@ using Benchmarks
 # Benchmark function
 
 function benchmark_vertically_stretched_nonhydrostatic_model(Arch, FT, N)
-    grid = RectilinearGrid(architecture=Arch(), size=(N, N, N), x=(0, 1), y=(0, 1), z=collect(0:N))
-    model = NonhydrostaticModel(architecture=Arch(), grid=grid)
+    grid = RectilinearGrid(Arch(), FT, size=(N, N, N), x=(0, 1), y=(0, 1), z=collect(0:N))
+    model = NonhydrostaticModel(grid=grid)
 
     time_step!(model, 1) # warmup
 

--- a/benchmark/distributed_nonhydrostatic_model_threaded.jl
+++ b/benchmark/distributed_nonhydrostatic_model_threaded.jl
@@ -21,7 +21,7 @@ T = Threads.nthreads()
 
 topo = (Periodic, Periodic, Periodic)
 grid = RectilinearGrid(topology=topo, size=(Nx, Ny, Nz), extent=(1, 1, 1))
-model = NonhydrostaticModel(architecture=CPU(), grid=grid)
+model = NonhydrostaticModel(grid=grid)
 
 @info "Warming up serial nonhydrostatic model..."
 

--- a/benchmark/distributed_shallow_water_model_threaded.jl
+++ b/benchmark/distributed_shallow_water_model_threaded.jl
@@ -20,7 +20,7 @@ T = Threads.nthreads()
 
 topo = (Periodic, Periodic, Flat)   # Use Flat
 grid = RectilinearGrid(topology=topo, size=(Nx, Ny), extent=(1, 1), halo=(3, 3))
-model = ShallowWaterModel(architecture=CPU(), grid=grid, gravitational_acceleration=1.0)
+model = ShallowWaterModel(grid=grid, gravitational_acceleration=1.0)
 set!(model, h=1.0)
 
 @info "Warming up serial shallow water model..."

--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -137,7 +137,7 @@ There are three primary boundary condition classifications:
 In addition to these primary boundary conditions, `ImpenetrableBoundaryCondition` applies to velocity
 components in wall-normal directions.
 
-!!! warn `ImpenetrableBoundaryCondition`
+!!! warn "`ImpenetrableBoundaryCondition`"
     `ImpenetrableBoundaryCondition` is internally enforced for fields created inside the model constructor.
     As a result, `ImpenetrableBoundaryCondition` is only used for _additional_ velocity components
     that are not evolved by a model, such as a velocity component used for (`AdvectiveForcing`)[@ref].

--- a/src/AbstractOperations/grid_metrics.jl
+++ b/src/AbstractOperations/grid_metrics.jl
@@ -45,7 +45,7 @@ julia> using Oceananigans
 
 julia> using Oceananigans.AbstractOperations: Δz
 
-julia> grid = RectilinearGrid(size=(1, 1, 1), extent=(1, 2, 3)); c = CenterField(grid);
+julia> c = CenterField(RectilinearGrid(size=(1, 1, 1), extent=(1, 2, 3)));
 
 julia> c_dz = c * Δz # returns BinaryOperation between Field and GridMetricOperation
 BinaryOperation at (Center, Center, Center)
@@ -83,7 +83,7 @@ julia> using Oceananigans
 
 julia> using Oceananigans.AbstractOperations: volume
 
-julia> grid = RectilinearGrid(size=(2, 2, 2), extent=(1, 2, 3)); c = CenterField(grid);
+julia> c = CenterField(RectilinearGrid(size=(2, 2, 2), extent=(1, 2, 3)));
 
 julia> c .= 1;
 

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -55,7 +55,7 @@ Keyword arguments
 Examples
 ========
 ```jldoctest
-julia> using Oceananigans;
+julia> using Oceananigans
 
 julia> VectorInvariant()
 Vector Invariant reconstruction, maximum order 1 
@@ -68,7 +68,7 @@ Vector Invariant reconstruction, maximum order 1
 
 ```
 ```jldoctest
-julia> using Oceananigans;
+julia> using Oceananigans
 
 julia> VectorInvariant(vorticity_scheme = WENO(), divergence_scheme = WENO(), vertical_scheme = WENO(order = 3))
 Vector Invariant reconstruction, maximum order 5 

--- a/src/Advection/weno_reconstruction.jl
+++ b/src/Advection/weno_reconstruction.jl
@@ -58,7 +58,7 @@ Keyword arguments
 Examples
 ========
 ```jldoctest
-julia> using Oceananigans;
+julia> using Oceananigans
 
 julia> WENO()
 WENO reconstruction order 5
@@ -75,7 +75,7 @@ WENO reconstruction order 5
 ```
 
 ```jldoctest
-julia> using Oceananigans;
+julia> using Oceananigans
 
 julia> Nx, Nz = 16, 10;
 

--- a/src/Distributed/distributed_fft_based_poisson_solver.jl
+++ b/src/Distributed/distributed_fft_based_poisson_solver.jl
@@ -61,10 +61,10 @@ If `Nz < Rx`, but `Nz > Ry`, a similar algorithm applies with ``x`` and ``y`` sw
 
 1. `first(storage)` is initialized with layout ``(z, x, y)``.
 2. Transform along ``z``.
-3  Transpose + communicate to storage[2] in layout ``(x, z, y)``,
+3  Transpose + communicate to `storage[2]` in layout ``(x, z, y)``,
    which is distributed into `(Rx, Ry)` processes in ``(z, y)``.
 4. Transform along ``x``.
-5. Transpose + communicate to last(storage) in layout ``(y, x, z)``,
+5. Transpose + communicate to `last(storage)` in layout ``(y, x, z)``,
    which is distributed into `(Rx, Ry)` processes in ``(x, z)``.
 6. Transform in ``y``.
 

--- a/src/Models/ShallowWaterModels/shallow_water_advection_operators.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_advection_operators.jl
@@ -63,7 +63,7 @@ using Oceananigans.Operators: Ax_qᶠᶜᶜ, Ay_qᶜᶠᶜ
 """
     div_Uh(i, j, k, grid, advection, solution, formulation)
 
-Calculates the divergence of the mass flux into a cell,
+Calculate the divergence of the mass flux into a cell,
 
 ```
 1/Az * [δxᶜᵃᵃ(Δy * uh) + δyᵃᶜᵃ(Δx * vh)]
@@ -93,7 +93,7 @@ end
     div_Uc(i, j, k, grid, advection, solution, c, formulation)
 
 Calculate the divergence of the flux of a tracer quantity ``c`` being advected by
-a velocity field ``𝐔 = (u, v)``, ``∇·(𝐔c)``,
+a velocity field ``𝐔 = (u, v)``, ``𝛁·(𝐔c)``,
 
 ```
 1/Az * [δxᶜᵃᵃ(Δy * uh * ℑxᶠᵃᵃ(c) / h) + δyᵃᶜᵃ(Δx * vh * ℑyᵃᶠᵃ(c) / h)]
@@ -126,11 +126,11 @@ end
 """
     c_div_U(i, j, k, grid, solution, c, formulation)
 
-Calculates the product of the tracer concentration ``c`` with 
+Calculate the product of the tracer concentration ``c`` with 
 the horizontal divergence of the velocity field ``𝐔 = (u, v)``, ``c ∇·𝐔``,
 
 ```
-1/Az * [δxᶜᵃᵃ(Δy * uh / h) + δyᵃᶜᵃ(Δx * vh / h]
+c * 1/Az * [δxᶜᵃᵃ(Δy * uh / h) + δyᵃᶜᵃ(Δx * vh / h)]
 ```
 
 which ends up at the location `ccc`.

--- a/src/Operators/divergence_operators.jl
+++ b/src/Operators/divergence_operators.jl
@@ -5,7 +5,7 @@
 """
     divᶜᶜᶜ(i, j, k, grid, u, v, w)
 
-Calculates the divergence ``∇·𝐕`` of a vector field ``𝐕 = (u, v, w)``,
+Calculate the divergence ``𝛁·𝐕`` of a vector field ``𝐕 = (u, v, w)``,
 
 ```julia
 1/V * [δxᶜᵃᵃ(Ax * u) + δxᵃᶜᵃ(Ay * v) + δzᵃᵃᶜ(Az * w)]

--- a/src/Operators/vorticity_operators.jl
+++ b/src/Operators/vorticity_operators.jl
@@ -1,7 +1,11 @@
 """ Vertical circulation associated with horizontal velocities u, v. """
 @inline Γᶠᶠᶜ(i, j, k, grid, u, v) = δxᶠᵃᵃ(i, j, k, grid, Δy_qᶜᶠᶜ, v) - δyᵃᶠᵃ(i, j, k, grid, Δx_qᶠᶜᶜ, u)
 
-""" Vertical vorticity associated with horizontal velocities u, v. """
+"""
+     ζ₃ᶠᶠᶜ(i, j, k, grid, u, v)
+
+ The vertical vorticity associated with horizontal velocities ``u`` and ``v``.
+ """
 @inline ζ₃ᶠᶠᶜ(i, j, k, grid, u, v) = Γᶠᶠᶜ(i, j, k, grid, u, v) / Azᶠᶠᶜ(i, j, k, grid)
 
 #####
@@ -9,6 +13,11 @@
 ##### See: https://github.com/CliMA/Oceananigans.jl/issues/1584
 #####
 
+"""
+     Γᶠᶠᶜ(i, j, k, grid, u, v)
+
+ The vertical circulation associated with horizontal velocities ``u`` and ``v``.
+ """
 @inline function Γᶠᶠᶜ(i, j, k, grid::OrthogonalSphericalShellGrid, u, v)
     # South-west corner
     if i == 1 && j == 1

--- a/src/OutputReaders/field_dataset.jl
+++ b/src/OutputReaders/field_dataset.jl
@@ -24,7 +24,7 @@ linearly.
 - `grid`: May be specified to override the grid used in the JLD2 file.
 """
 function FieldDataset(filepath;
-                    architecture=CPU(), grid=nothing, backend=InMemory(), metadata_paths=["metadata"])
+                      architecture=CPU(), grid=nothing, backend=InMemory(), metadata_paths=["metadata"])
 
   file = jldopen(filepath)
 

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -29,7 +29,7 @@ Construct a `Checkpointer` that checkpoints the model to a JLD2 file on `schedul
 The `model.clock.iteration` is included in the filename to distinguish between multiple checkpoint files.
 
 To restart or "pickup" a model from a checkpoint, specify `pickup = true` when calling `run!`, ensuring
-that the checkpoint file is the current working directory. See [`run!`](@ref) for more details.
+that the checkpoint file is in directory `dir`. See [`run!`](@ref) for more details.
 
 Note that extra model `properties` can be safely specified, but removing crucial properties
 such as `:velocities` will make restoring from the checkpoint impossible.

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -1,9 +1,11 @@
 using Glob
-import Oceananigans.Fields: set!
 
+using Oceananigans
 using Oceananigans: fields, prognostic_fields
 using Oceananigans.Fields: offset_data
 using Oceananigans.TimeSteppers: RungeKutta3TimeStepper, QuasiAdamsBashforth2TimeStepper
+
+import Oceananigans.Fields: set!
 
 mutable struct Checkpointer{T, P} <: AbstractOutputWriter
     schedule :: T
@@ -26,13 +28,8 @@ end
 Construct a `Checkpointer` that checkpoints the model to a JLD2 file on `schedule.`
 The `model.clock.iteration` is included in the filename to distinguish between multiple checkpoint files.
 
-To restart or "pickup" a model from a checkpoint, specify `pickup=true` when calling `run!`, ensuring
-that the checkpoint file is the current working directory. See 
-
-```julia
-help> run!
-```
-for more details.
+To restart or "pickup" a model from a checkpoint, specify `pickup = true` when calling `run!`, ensuring
+that the checkpoint file is the current working directory. See [`run!`](@ref) for more details.
 
 Note that extra model `properties` can be safely specified, but removing crucial properties
 such as `:velocities` will make restoring from the checkpoint impossible.
@@ -42,9 +39,10 @@ but functions or objects containing functions cannot be serialized at this time.
 
 Keyword arguments
 =================
+
 - `schedule` (required): Schedule that determines when to checkpoint.
 
-- `dir`: Directory to save output to. Default: "." (current working directory).
+- `dir`: Directory to save output to. Default: `"."` (current working directory).
 
 - `prefix`: Descriptive filename prefixed to all output files. Default: "checkpoint".
 
@@ -99,13 +97,13 @@ end
 ##### Checkpointer utils
 #####
 
-""" Returns the full prefix (the `superprefix`) associated with `checkpointer`. """
+""" Return the full prefix (the `superprefix`) associated with `checkpointer`. """
 checkpoint_superprefix(prefix) = prefix * "_iteration"
 
 """
     checkpoint_path(iteration::Int, c::Checkpointer)
 
-Returns the path to the `c`heckpointer file associated with model `iteration`.
+Return the path to the `c`heckpointer file associated with model `iteration`.
 """
 checkpoint_path(iteration::Int, c::Checkpointer) =
     joinpath(c.dir, string(checkpoint_superprefix(c.prefix), iteration, ".jld2"))

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -51,59 +51,59 @@ functions, or callable objects.
 Keyword arguments
 =================
 
-  ## Filenaming
+## Filenaming
 
-  - `filename` (required): Descriptive filename. ".jld2" is appended to `filename` in the file path
-                           if `filename` does not end in ".jld2".
+- `filename` (required): Descriptive filename. `".jld2"` is appended to `filename` in the file path
+                        if `filename` does not end in `".jld2"`.
 
-  - `dir`: Directory to save output to. Default: "." (current working directory).
+- `dir`: Directory to save output to. Default: `"."` (current working directory).
 
-  ## Output frequency and time-averaging
+## Output frequency and time-averaging
 
-  - `schedule` (required): `AbstractSchedule` that determines when output is saved.
+- `schedule` (required): `AbstractSchedule` that determines when output is saved.
 
-  ## Slicing and type conversion prior to output
+## Slicing and type conversion prior to output
 
-  - `indices`: Specifies the indices to write to disk with a `Tuple` of `Colon`, `UnitRange`,
-               or `Int` elements. Indices must be `Colon`, `Int`, or contiguous `UnitRange`.
-               Defaults to `(:, :, :)` or "all indices". If `!with_halos`,
-               halo regions are removed from `indices`. For example, `indices = (:, :, 1)`
-               will save xy-slices of the bottom-most index.
+- `indices`: Specifies the indices to write to disk with a `Tuple` of `Colon`, `UnitRange`,
+             or `Int` elements. Indices must be `Colon`, `Int`, or contiguous `UnitRange`.
+             Defaults to `(:, :, :)` or "all indices". If `!with_halos`,
+             halo regions are removed from `indices`. For example, `indices = (:, :, 1)`
+             will save xy-slices of the bottom-most index.
 
-  - `with_halos` (Bool): Whether or not to slice halo regions from fields before writing output.
-                         Note, that to postprocess saved output (e.g., compute derivatives, etc)
-                         information about the boundary conditions is often crucial. In that case
-                         you might need to set `with_halos = true`.
+- `with_halos` (Bool): Whether or not to slice halo regions from fields before writing output.
+                       Note, that to postprocess saved output (e.g., compute derivatives, etc)
+                       information about the boundary conditions is often crucial. In that case
+                       you might need to set `with_halos = true`.
 
-  - `array_type`: The array type to which output arrays are converted to prior to saving.
-                  Default: `Array{Float32}`.
+- `array_type`: The array type to which output arrays are converted to prior to saving.
+                Default: `Array{Float32}`.
 
-  ## File management
+## File management
 
-  - `max_filesize`: The writer will stop writing to the output file once the file size exceeds `max_filesize`,
-                    and write to a new one with a consistent naming scheme ending in `part1`, `part2`, etc.
-                    Defaults to `Inf`.
+- `max_filesize`: The writer will stop writing to the output file once the file size exceeds `max_filesize`,
+                  and write to a new one with a consistent naming scheme ending in `part1`, `part2`, etc.
+                  Defaults to `Inf`.
 
-  - `overwrite_existing`: Remove existing files if their filenames conflict.
-                          Default: `false`.
+- `overwrite_existing`: Remove existing files if their filenames conflict.
+                        Default: `false`.
 
-  ## Output file metadata management
+## Output file metadata management
 
-  - `init`: A function of the form `init(file, model)` that runs when a JLD2 output file is initialized.
-            Default: `noinit(args...) = nothing`.
+- `init`: A function of the form `init(file, model)` that runs when a JLD2 output file is initialized.
+          Default: `noinit(args...) = nothing`.
 
-  - `including`: List of model properties to save with every file.
-                 Default: `[:grid, :coriolis, :buoyancy, :closure]`
+- `including`: List of model properties to save with every file.
+               Default: `[:grid, :coriolis, :buoyancy, :closure]`
 
-  ## Miscellaneous keywords
+## Miscellaneous keywords
 
-  - `verbose`: Log what the output writer is doing with statistics on compute/write times and file sizes.
-               Default: `false`.
+- `verbose`: Log what the output writer is doing with statistics on compute/write times and file sizes.
+             Default: `false`.
 
-  - `part`: The starting part number used if `max_filesize` is finite.
-            Default: 1.
+- `part`: The starting part number used if `max_filesize` is finite.
+          Default: 1.
 
-  - `jld2_kw`: Dict of kwargs to be passed to `jldopen` when data is written.
+- `jld2_kw`: Dict of kwargs to be passed to `jldopen` when data is written.
 
 Example
 =======

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -155,14 +155,19 @@ returns something to be written to disk. Custom output requires the spatial `dim
 
 Keyword arguments
 =================
-- `filename` (required): Descriptive filename. ".nc" is appended to `filename` if ".nc" is not detected.
 
-- `schedule` (required): `AbstractSchedule` that determines when output is saved.
+## Filenaming
+
+- `filename` (required): Descriptive filename. `".nc"` is appended to `filename` if `filename` does
+                         not end in `".nc"`.
 
 - `dir`: Directory to save output to.
 
-- `array_type`: The array type to which output arrays are converted to prior to saving.
-                Default: `Array{Float32}`.
+## Output frequency and time-averaging
+
+- `schedule` (required): `AbstractSchedule` that determines when output is saved.
+
+## Slicing and type conversion prior to output
 
 - `indices`: Tuple of indices of the output variables to include. Default is `(:, :, :)`, which
              includes the full fields.
@@ -172,22 +177,31 @@ Keyword arguments
                 information about the boundary conditions is often crucial. In that case
                 you might need to set `with_halos = true`.
 
+- `array_type`: The array type to which output arrays are converted to prior to saving.
+                Default: `Array{Float32}`.
+
+- `dimensions`: A `Dict` of dimension tuples to apply to outputs (required for function outputs).
+
+## File management
+
+- `overwrite_existing`: If `false`, `NetCDFOutputWriter` will be set to append to `filepath`. If `true`,
+                        `NetCDFOutputWriter` will overwrite `filepath` if it exists or create it if not.
+                        Default: `false`. See [NCDatasets.jl documentation](https://alexander-barth.github.io/NCDatasets.jl/stable/)
+                        for more information about its `mode` option.
+
+- `compression`: Determines the compression level of data (0-9; default: 0).
+
+## Miscellaneous keywords
+
 - `global_attributes`: Dict of model properties to save with every file. Default: `Dict()`.
 
 - `output_attributes`: Dict of attributes to be saved with each field variable (reasonable
                        defaults are provided for velocities, buoyancy, temperature, and salinity;
                        otherwise `output_attributes` *must* be user-provided).
 
-- `dimensions`: A `Dict` of dimension tuples to apply to outputs (required for function outputs)
-
-- `overwrite_existing`: If false, `NetCDFOutputWriter` will be set to append to `filepath`. If true, `NetCDFOutputWriter` 
-                        will overwrite `filepath` if it exists or create it if it does not.
-                        Default: `false`. See NCDatasets.jl documentation for more information about its `mode` option.
-
-- `compression`: Determines the compression level of data (0-9; default: 0)
-
 Examples
 ========
+
 Saving the ``u`` velocity field and temperature fields, the full 3D fields and surface 2D slices
 to separate NetCDF files:
 

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -271,8 +271,8 @@ f(model) = model.clock.time^2; # scalar output
 
 g(model) = model.clock.time .* exp.(znodes(Center, grid)) # vector/profile output
 
-h(model) = model.clock.time .* (   sin.(xnodes(Center, grid, reshape=true)[:, :, 1])
-                            .*     cos.(ynodes(Face, grid, reshape=true)[:, :, 1])) # xy slice output
+h(model) = model.clock.time .* (sin.(xnodes(Center, grid, reshape=true)[:, :, 1])
+                               .*  cos.(ynodes(Face, grid, reshape=true)[:, :, 1])) # xy slice output
 
 outputs = Dict("scalar" => f, "profile" => g, "slice" => h)
 


### PR DESCRIPTION
supersedes #2872 

basically similar except without changing, e.g., `grid=grid, ...` -> `; grid,...`.