### PR TITLE
Removes binary operation from Smagorinsky diffusivity calculation

### DIFF
--- a/src/TurbulenceClosures/turbulence_closure_utils.jl
+++ b/src/TurbulenceClosures/turbulence_closure_utils.jl
@@ -34,7 +34,7 @@ end
     @inbounds νₑ[i, j, k] = calc_nonlinear_νᶜᶜᶜ(i, j, k, grid, closure, args...)
 end
 
-@kernel function calculate_nonlinear_tracer_diffusivity!(κₑ, grid, closure, tracer, tracer_index, U)
+@kernel function calculate_nonlinear_tracer_diffusivity!(κₑ, grid, closure, tracer, tracer_index, args...)
     i, j, k = @index(Global, NTuple)
-    @inbounds κₑ[i, j, k] = calc_nonlinear_κᶜᶜᶜ(i, j, k, grid, closure, tracer, tracer_index, U)
+    @inbounds κₑ[i, j, k] = calc_nonlinear_κᶜᶜᶜ(i, j, k, grid, closure, tracer, tracer_index, args...)
 end


### PR DESCRIPTION
This PR changes the calculation of the diffusivities in the `SmagorinskyLilly` so that binary operations are avoided. At the moment it does so by creating a `calc_nonlinear_κᶜᶜᶜ()` kernel, similar to what is done for the AMD closure.

Closes https://github.com/CliMA/Oceananigans.jl/issues/2869