### PR TITLE
Make `construct_regionally` handle multiple return values

### DIFF
--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -7,6 +7,7 @@ using OffsetArrays: IdOffsetRange
 #####
 ##### Convenience functions
 #####
+
 const BoundedTopology = Union{Bounded, LeftConnected}
 
 Base.length(::Type{Face}, topo, N) = N

--- a/src/Grids/inactive_node.jl
+++ b/src/Grids/inactive_node.jl
@@ -27,12 +27,14 @@ within an immersed boundary. Cells that are staggered with respect to tracer cel
 which lie _on_ the boundary are considered active.
 """
 @inline inactive_cell(i, j, k, grid) = false
+@inline active_cell(i, j, k, grid) = !inactive_cell(i, j, k, grid)
 
 # We use metaprogramming to handle all the permutations between
 # Bounded, LeftConnected, and RightConnected topologies.
 # Note that LeftConnected is equivalent to "RightBounded" and
 # RightConnected is equivalent to "LeftBounded".
 # So LeftConnected and RightConnected are "half Bounded" topologies.
+
 Topos = (:Bounded, :LeftConnected, :RightConnected)
 
 for PrimaryTopo in Topos

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -241,7 +241,6 @@ all_z_nodes(loc, ibg::IBG) = all_z_nodes(loc, ibg.underlying_grid)
 @inline cpu_face_constructor_y(ibg::IBG) = cpu_face_constructor_y(ibg.underlying_grid)
 @inline cpu_face_constructor_z(ibg::IBG) = cpu_face_constructor_z(ibg.underlying_grid)
 
-
 function on_architecture(arch, ibg::IBG)
     underlying_grid   = on_architecture(arch, ibg.underlying_grid)
     immersed_boundary = on_architecture(arch, ibg.immersed_boundary)

--- a/src/ImmersedBoundaries/active_cells_map.jl
+++ b/src/ImmersedBoundaries/active_cells_map.jl
@@ -1,7 +1,7 @@
 using Oceananigans
 using Oceananigans.Grids: AbstractGrid
 
-import Oceananigans.Utils: active_cells_work_layout, calc_tendency_index
+import Oceananigans.Utils: active_cells_work_layout
 
 using KernelAbstractions: @kernel, @index
 

--- a/src/ImmersedBoundaries/active_cells_map.jl
+++ b/src/ImmersedBoundaries/active_cells_map.jl
@@ -1,6 +1,8 @@
 using Oceananigans
 using Oceananigans.Grids: AbstractGrid
-import Oceananigans.Utils: only_active_cells_in_worksize, calc_tendency_index
+
+import Oceananigans.Utils: active_cells_work_layout, calc_tendency_index
+
 using KernelAbstractions: @kernel, @index
 
 const ActiveCellsIBG = ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:AbstractArray}
@@ -8,7 +10,7 @@ const ActiveCellsIBG = ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <
 @inline use_only_active_cells(grid::AbstractGrid)   = false
 @inline use_only_active_cells(grid::ActiveCellsIBG) = true
 
-@inline only_active_cells_in_worksize(size, grid::ActiveCellsIBG) = min(length(grid.active_cells_map), 256), length(grid.active_cells_map)
+@inline active_cells_work_layout(size, grid::ActiveCellsIBG) = min(length(grid.active_cells_map), 256), length(grid.active_cells_map)
 @inline calc_tendency_index(idx, grid::ActiveCellsIBG)            = Int.(grid.active_cells_map[idx])
 
 function ImmersedBoundaryGrid{TX, TY, TZ}(grid, ib; calculate_active_cells_map = false) where {TX, TY, TZ} 

--- a/src/ImmersedBoundaries/active_cells_map.jl
+++ b/src/ImmersedBoundaries/active_cells_map.jl
@@ -20,7 +20,7 @@ function ImmersedBoundaryGrid{TX, TY, TZ}(grid, ib; calculate_active_cells_map =
         map = active_cells_map(grid, ib)
         map = arch_array(architecture(grid), map)
     else
-        active_cells_map = nothing
+        map = nothing
     end
 
     return ImmersedBoundaryGrid{TX, TY, TZ}(grid, ib, map)

--- a/src/ImmersedBoundaries/active_cells_map.jl
+++ b/src/ImmersedBoundaries/active_cells_map.jl
@@ -17,13 +17,13 @@ function ImmersedBoundaryGrid{TX, TY, TZ}(grid, ib; calculate_active_cells_map =
 
     # Create the cells map on the CPU, then switch it to the GPU
     if calculate_active_cells_map 
-        active_cells_map    = create_cells_map(grid, ib)
-        active_cells_map    = arch_array(architecture(grid), active_cells_map)
+        map = active_cells_map(grid, ib)
+        map = arch_array(architecture(grid), map)
     else
         active_cells_map = nothing
     end
 
-    return ImmersedBoundaryGrid{TX, TY, TZ}(grid, ib, active_cells_map)
+    return ImmersedBoundaryGrid{TX, TY, TZ}(grid, ib, map)
 end
 
 active_cell(i, j, k, grid, ib) = !immersed_cell(i, j, k, grid, ib)
@@ -39,7 +39,7 @@ const MAXUInt8  = 2^8  - 1
 const MAXUInt16 = 2^16 - 1
 const MAXUInt32 = 2^32 - 1
 
-function create_cells_map(grid, ib)
+function active_cells_map(grid, ib)
     active_cells_field = compute_active_cells(grid, ib)
     full_indices       = arch_array(CPU(), findall(interior(active_cells_field)))
     

--- a/src/ImmersedBoundaries/active_cells_map.jl
+++ b/src/ImmersedBoundaries/active_cells_map.jl
@@ -1,9 +1,9 @@
 using Oceananigans
 using Oceananigans.Grids: AbstractGrid, active_cell
 
-import Oceananigans.Utils: active_cells_work_layout
-
 using KernelAbstractions: @kernel, @index
+
+import Oceananigans.Utils: active_cells_work_layout
 
 const ActiveCellsIBG = ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:AbstractArray}
 
@@ -11,7 +11,7 @@ const ActiveCellsIBG = ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <
 @inline use_only_active_cells(grid::ActiveCellsIBG) = true
 
 @inline active_cells_work_layout(size, grid::ActiveCellsIBG) = min(length(grid.active_cells_map), 256), length(grid.active_cells_map)
-@inline active_linear_index_to_ntuple(idx, grid::ActiveCellsIBG) = map(Int, grid.active_cells_map[idx])
+@inline active_linear_index_to_ntuple(idx, grid::ActiveCellsIBG) = Base.map(Int, grid.active_cells_map[idx])
 
 function ImmersedBoundaryGrid{TX, TY, TZ}(grid, ib; calculate_active_cells_map = false) where {TX, TY, TZ} 
 

--- a/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
@@ -3,10 +3,10 @@ import Oceananigans: tracer_tendency_kernel_function
 
 using Oceananigans.Architectures: device_event
 using Oceananigans: fields, prognostic_fields, TimeStepCallsite, TendencyCallsite, UpdateStateCallsite
-using Oceananigans.Utils: work_layout, calc_tendency_index
+using Oceananigans.Utils: work_layout
 using Oceananigans.Fields: immersed_boundary_condition
 
-using Oceananigans.ImmersedBoundaries: use_only_active_cells, ActiveCellsIBG
+using Oceananigans.ImmersedBoundaries: use_only_active_cells, ActiveCellsIBG, active_linear_index_to_ntuple
 
 """
     calculate_tendencies!(model::HydrostaticFreeSurfaceModel, callbacks)
@@ -203,7 +203,7 @@ end
 
 @kernel function calculate_hydrostatic_free_surface_Gu!(Gu, grid::ActiveCellsIBG, args...)
     idx = @index(Global, Linear)
-    i, j, k = calc_tendency_index(idx, grid)
+    i, j, k = active_linear_index_to_ntuple(idx, grid)
     @inbounds Gu[i, j, k] = hydrostatic_free_surface_u_velocity_tendency(i, j, k, grid, args...)
 end
 
@@ -215,7 +215,7 @@ end
 
 @kernel function calculate_hydrostatic_free_surface_Gv!(Gv, grid::ActiveCellsIBG, args...)
     idx = @index(Global, Linear)
-    i, j, k = calc_tendency_index(idx, grid)
+    i, j, k = active_linear_index_to_ntuple(idx, grid)
     @inbounds Gv[i, j, k] = hydrostatic_free_surface_v_velocity_tendency(i, j, k, grid, args...)
 end
 
@@ -231,7 +231,7 @@ end
 
 @kernel function calculate_hydrostatic_free_surface_Gc!(Gc, tendency_kernel_function, grid::ActiveCellsIBG, args...)
     idx = @index(Global, Linear)
-    i, j, k = calc_tendency_index(idx, grid)
+    i, j, k = active_linear_index_to_ntuple(idx, grid)
     @inbounds Gc[i, j, k] = tendency_kernel_function(i, j, k, grid, args...)
 end
 

--- a/src/Models/NonhydrostaticModels/calculate_nonhydrostatic_tendencies.jl
+++ b/src/Models/NonhydrostaticModels/calculate_nonhydrostatic_tendencies.jl
@@ -1,9 +1,9 @@
 import Oceananigans.TimeSteppers: calculate_tendencies!
 
 using Oceananigans: fields, TimeStepCallsite, TendencyCallsite, UpdateStateCallsite
-using Oceananigans.Utils: work_layout, calc_tendency_index
+using Oceananigans.Utils: work_layout
 
-using Oceananigans.ImmersedBoundaries: use_only_active_cells, ActiveCellsIBG
+using Oceananigans.ImmersedBoundaries: use_only_active_cells, ActiveCellsIBG, active_linear_index_to_ntuple
 
 """
     calculate_tendencies!(model::NonhydrostaticModel)
@@ -131,7 +131,7 @@ end
 
 @kernel function calculate_Gu!(Gu, grid::ActiveCellsIBG, args...)
     idx = @index(Global, Linear)
-    i, j, k = calc_tendency_index(idx, grid)
+    i, j, k = active_linear_index_to_ntuple(idx, grid)
     @inbounds Gu[i, j, k] = u_velocity_tendency(i, j, k, grid, args...)
 end
 
@@ -143,7 +143,7 @@ end
 
 @kernel function calculate_Gv!(Gv, grid::ActiveCellsIBG, args...)
     idx = @index(Global, Linear)
-    i, j, k = calc_tendency_index(idx, grid)
+    i, j, k = active_linear_index_to_ntuple(idx, grid)
     @inbounds Gv[i, j, k] = v_velocity_tendency(i, j, k, grid, args...)
 end
 
@@ -155,7 +155,7 @@ end
 
 @kernel function calculate_Gw!(Gw, grid::ActiveCellsIBG, args...)
     idx = @index(Global, Linear)
-    i, j, k = calc_tendency_index(idx, grid)
+    i, j, k = active_linear_index_to_ntuple(idx, grid)
     @inbounds Gw[i, j, k] = w_velocity_tendency(i, j, k, grid, args...)
 end
 
@@ -171,7 +171,7 @@ end
 
 @kernel function calculate_Gc!(Gc, grid::ActiveCellsIBG, args...)
     idx = @index(Global, Linear)
-    i, j, k = calc_tendency_index(idx, 1, 1, 1, grid)
+    i, j, k = active_linear_index_to_ntuple(idx, grid)
     @inbounds Gc[i, j, k] = tracer_tendency(i, j, k, grid, args...)
 end
 

--- a/src/MultiRegion/multi_region_boundary_conditions.jl
+++ b/src/MultiRegion/multi_region_boundary_conditions.jl
@@ -57,7 +57,7 @@ fill_halo_regions!(c::MultiRegionObject, ::Nothing, args...; kwargs...) = nothin
 
 # this can be used once we don't need to fill Value, Flux and Gradient anymore!
 # fill_halo_regions!(c::MultiRegionObject, bcs, loc, mrg::MultiRegionGrid, buffers, args...; kwargs...) = 
-#     apply_regionally!(fill_halo_regions!, c, bcs, loc, mrg, Reference(c.regions), Reference(buffers.regions), args...; kwargs...)
+#     apply_regionally!(fill_halo_regions!, c, bcs, loc, mrg, Reference(c.regional_objects), Reference(buffers.regional_objects), args...; kwargs...)
 
 # This results in too large parameter space required on the GPU for too many regions!! (we are passing the whole buffers and regions)
 function fill_halo_regions!(c::MultiRegionObject, bcs, indices, loc, mrg::MultiRegionGrid, buffers, args...; kwargs...) 
@@ -69,7 +69,7 @@ function fill_halo_regions!(c::MultiRegionObject, bcs, indices, loc, mrg::MultiR
     for task = 1:3
         barrier = device_event(arch)
         apply_regionally!(fill_halo_event!, task, halo_tuple, 
-                          c, indices, loc, arch, barrier, mrg, Reference(c.regions), Reference(buffers.regions), 
+                          c, indices, loc, arch, barrier, mrg, Reference(c.regional_objects), Reference(buffers.regional_objects), 
                           args...; kwargs...)
     end
 

--- a/src/MultiRegion/multi_region_field.jl
+++ b/src/MultiRegion/multi_region_field.jl
@@ -113,7 +113,7 @@ fill!(mrf::MultiRegionField, v) = apply_regionally!(fill!, mrf, v)
 compute_at!(mrf::GriddedMultiRegionField, time)  = apply_regionally!(compute_at!, mrf, time)
 compute_at!(mrf::MultiRegionComputedField, time) = apply_regionally!(compute_at!, mrf, time)
 
-@inline hasnan(field::MultiRegionField) = (&)(construct_regionally(hasnan, field).regions...)
+@inline hasnan(field::MultiRegionField) = (&)(construct_regionally(hasnan, field).regional_objects...)
 
 validate_indices(indices, loc, mrg::MultiRegionGrid) = 
     construct_regionally(validate_indices, indices, loc, mrg.region_grids)

--- a/src/MultiRegion/multi_region_grid.jl
+++ b/src/MultiRegion/multi_region_grid.jl
@@ -169,7 +169,7 @@ Base.show(io::IO, mrg::MultiRegionGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ} =
 function Base.:(==)(mrg1::MultiRegionGrid, mrg2::MultiRegionGrid)
     #check if grids are of the same type
     vals = construct_regionally(Base.:(==), mrg1, mrg2)
-    return all(vals.regions)
+    return all(vals.regional_objects)
 end
    
 # These are not used in the code, should we remove them?

--- a/src/MultiRegion/multi_region_models.jl
+++ b/src/MultiRegion/multi_region_models.jl
@@ -70,10 +70,10 @@ WENO(mrg::MultiRegionGrid, args...; kwargs...) = construct_regionally(WENO, mrg,
 
 function accurate_cell_advection_timescale(grid::MultiRegionGrid, velocities)
     Δt = construct_regionally(accurate_cell_advection_timescale, grid, velocities)
-    return minimum(Δt.regions)
+    return minimum(Δt.regional_objects)
 end
 
 function new_time_step(old_Δt, wizard, model::MultiRegionModel)
     Δt = construct_regionally(new_time_step, old_Δt, wizard, model)
-    return minimum(Δt.regions)
+    return minimum(Δt.regional_objects)
 end

--- a/src/MultiRegion/multi_region_reductions.jl
+++ b/src/MultiRegion/multi_region_reductions.jl
@@ -18,15 +18,15 @@ for reduction in reductions
     @eval begin
         function $(reduction)(f::Function, c::MultiRegionField; kwargs...)
             mr = construct_regionally($(reduction), f, c; kwargs...)
-            if mr.regions isa NTuple{<:Any, <:Number}
-                return $(reduction)([r for r in mr.regions]) 
+            if mr.regional_objects isa NTuple{<:Any, <:Number}
+                return $(reduction)([r for r in mr.regional_objects]) 
             else
-                FT   = eltype(first(mr.regions))
-                loc  = location(first(mr.regions))
+                FT   = eltype(first(mr.regional_objects))
+                loc  = location(first(mr.regional_objects))
                 validate_reduction_location!(loc, c.grid.partition)
-                mrg  = MultiRegionGrid{FT, loc[1], loc[2], loc[3]}(architecture(c), c.grid.partition, MultiRegionObject(collect_grid(mr.regions), devices(mr)), devices(mr))
-                data = MultiRegionObject(collect_data(mr.regions), devices(mr))
-                bcs  = MultiRegionObject(collect_bcs(mr.regions),  devices(mr))
+                mrg  = MultiRegionGrid{FT, loc[1], loc[2], loc[3]}(architecture(c), c.grid.partition, MultiRegionObject(collect_grid(mr.regional_objects), devices(mr)), devices(mr))
+                data = MultiRegionObject(collect_data(mr.regional_objects), devices(mr))
+                bcs  = MultiRegionObject(collect_bcs(mr.regional_objects),  devices(mr))
                 return Field{loc[1], loc[2], loc[3]}(mrg, data, bcs, c.operand, c.status) 
             end
         end
@@ -46,5 +46,5 @@ collect_grid(f::NTuple{N, <:Field}) where N = Tuple(f[i].grid for i in 1:N)
 const MRD = Union{MultiRegionField, MultiRegionObject}
 
 # make it more efficient?
-Statistics.dot(f::MRD,  g::MRD)  = sum([r for r in construct_regionally(dot, f, g).regions])
+Statistics.dot(f::MRD,  g::MRD)  = sum([r for r in construct_regionally(dot, f, g).regional_objects])
 Statistics.norm(f::MRD) = sqrt(dot(f, f))

--- a/src/MultiRegion/multi_region_utils.jl
+++ b/src/MultiRegion/multi_region_utils.jl
@@ -1,6 +1,6 @@
 import Oceananigans.Fields: flatten_tuple
 
-flatten_tuple(mro::MultiRegionObject) = flatten_tuple(mro.regions)
+flatten_tuple(mro::MultiRegionObject) = flatten_tuple(mro.regional_objects)
 
 validate_devices(partition, ::CPU, devices) = nothing
 validate_devices(p, ::CPU, ::Nothing) = nothing

--- a/src/MultiRegion/x_partitions.jl
+++ b/src/MultiRegion/x_partitions.jl
@@ -85,21 +85,21 @@ end
 function reconstruct_size(mrg, p::XPartition)
     Ny = mrg.region_grids[1].Ny
     Nz = mrg.region_grids[1].Nz
-    Nx = sum([grid.Nx for grid in mrg.region_grids.regions])
+    Nx = sum([grid.Nx for grid in mrg.region_grids.regional_objects])
     return (Nx, Ny, Nz)
 end
 
 function reconstruct_extent(mrg, p::XPartition)
     switch_device!(mrg.devices[1])
-    y = cpu_face_constructor_y(mrg.region_grids.regions[1])
-    z = cpu_face_constructor_z(mrg.region_grids.regions[1])
+    y = cpu_face_constructor_y(mrg.region_grids.regional_objects[1])
+    z = cpu_face_constructor_z(mrg.region_grids.regional_objects[1])
 
-    if cpu_face_constructor_x(mrg.region_grids.regions[1]) isa Tuple
-        x = (cpu_face_constructor_x(mrg.region_grids.regions[1])[1], 
-             cpu_face_constructor_x(mrg.region_grids.regions[length(p)])[end])
+    if cpu_face_constructor_x(mrg.region_grids.regional_objects[1]) isa Tuple
+        x = (cpu_face_constructor_x(mrg.region_grids.regional_objects[1])[1], 
+             cpu_face_constructor_x(mrg.region_grids.regional_objects[length(p)])[end])
     else
-        x = [cpu_face_constructor_x(mrg.region_grids.regions[1])...]
-        for (idx, grid) in enumerate(mrg.region_grids.regions[2:end])
+        x = [cpu_face_constructor_x(mrg.region_grids.regional_objects[1])...]
+        for (idx, grid) in enumerate(mrg.region_grids.regional_objects[2:end])
             switch_device!(mrg.devices[idx])
             x = [x..., cpu_face_constructor_x(grid)[2:end]...]
         end
@@ -110,13 +110,13 @@ end
 const FunctionMRO     = MultiRegionObject{<:Tuple{Vararg{<:Function}}}
 const ArrayMRO{T, N}  = MultiRegionObject{<:Tuple{Vararg{<:AbstractArray{T, N}}}} where {T, N}
 
-reconstruct_global_array(ma::FunctionMRO, args...) = ma.regions[1]
+reconstruct_global_array(ma::FunctionMRO, args...) = ma.regional_objects[1]
 
 function reconstruct_global_array(ma::ArrayMRO{T, N}, p::EqualXPartition, arch) where {T, N}
-    local_size = size(first(ma.regions))
+    local_size = size(first(ma.regional_objects))
     global_Nx  = local_size[1] * length(p)
     idxs = default_indices(length(local_size))
-    arr_out = zeros(eltype(first(ma.regions)), global_Nx, local_size[2:end]...)
+    arr_out = zeros(eltype(first(ma.regional_objects)), global_Nx, local_size[2:end]...)
     n = local_size[1]
     for r = 1:length(p)
         init = Int(n * (r - 1) + 1)

--- a/src/MultiRegion/y_partitions.jl
+++ b/src/MultiRegion/y_partitions.jl
@@ -77,22 +77,22 @@ end
 
 function reconstruct_size(mrg, p::YPartition)
     Nx = mrg.region_grids[1].Nx
-    Ny = sum([grid.Ny for grid in mrg.region_grids.regions]) 
+    Ny = sum([grid.Ny for grid in mrg.region_grids.regional_objects]) 
     Nz = mrg.region_grids[1].Nz
     return (Nx, Ny, Nz)
 end
 
 function reconstruct_extent(mrg, p::YPartition)
     switch_device!(mrg.devices[1])
-    x = cpu_face_constructor_x(mrg.region_grids.regions[1])
-    z = cpu_face_constructor_z(mrg.region_grids.regions[1])
+    x = cpu_face_constructor_x(mrg.region_grids.regional_objects[1])
+    z = cpu_face_constructor_z(mrg.region_grids.regional_objects[1])
 
-    if cpu_face_constructor_y(mrg.region_grids.regions[1]) isa Tuple
-        y = (cpu_face_constructor_y(mrg.region_grids.regions[1])[1], 
-             cpu_face_constructor_y(mrg.region_grids.regions[length(p)])[end])
+    if cpu_face_constructor_y(mrg.region_grids.regional_objects[1]) isa Tuple
+        y = (cpu_face_constructor_y(mrg.region_grids.regional_objects[1])[1], 
+             cpu_face_constructor_y(mrg.region_grids.regional_objects[length(p)])[end])
     else
-        y = [cpu_face_constructor_y(mrg.region_grids.regions[1])...]
-        for (idx, grid) in enumerate(mrg.region_grids.regions[2:end])
+        y = [cpu_face_constructor_y(mrg.region_grids.regional_objects[1])...]
+        for (idx, grid) in enumerate(mrg.region_grids.regional_objects[2:end])
             switch_device!(mrg.devices[idx])
             y = [y..., cpu_face_constructor_y(grid)[2:end]...]
         end
@@ -101,10 +101,10 @@ function reconstruct_extent(mrg, p::YPartition)
 end
 
 function reconstruct_global_array(ma::ArrayMRO{T, N}, p::EqualYPartition, arch) where {T, N}
-    local_size = size(first(ma.regions))
+    local_size = size(first(ma.regional_objects))
     global_Ny  = local_size[2] * length(p)
     idxs = default_indices(length(local_size))
-    arr_out = zeros(eltype(first(ma.regions)), local_size[1], global_Ny, local_size[3:end]...)
+    arr_out = zeros(eltype(first(ma.regional_objects)), local_size[1], global_Ny, local_size[3:end]...)
     n = local_size[2]
     for r = 1:length(p)
         init = Int(n * (r - 1) + 1)

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -65,13 +65,13 @@ function work_layout(grid, workdims::Symbol; include_right_boundaries=false, loc
 
 
     if only_active_cells
-        workgroup, worksize = only_active_cells_in_worksize(worksize, grid) 
+        workgroup, worksize = active_cells_work_layout(worksize, grid) 
     end
 
     return workgroup, worksize
 end
 
-only_active_cells_in_worksize(size, grid) = heuristic_workgroup(size...), size
+active_cells_work_layout(size, grid) = heuristic_workgroup(size...), size
 
 """
     launch!(arch, grid, layout, kernel!, args...; dependencies=nothing, kwargs...)
@@ -111,4 +111,3 @@ end
 @inline launch!(arch, grid, ::Val{workspec}, args...; kwargs...) where workspec =
     launch!(arch, grid, workspec, args...; kwargs...)
 
-@inline calc_tendency_index(idx, i, j, k, args...) = i, j, k

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -2,8 +2,6 @@
 ##### Utilities for launching kernels
 #####
 
-using KernelAbstractions
-using KernelAbstractions: @index
 using Oceananigans.Architectures
 using Oceananigans.Grids
 

--- a/src/Utils/multi_region_transformation.jl
+++ b/src/Utils/multi_region_transformation.jl
@@ -13,7 +13,7 @@ struct MultiRegionObject{R, D}
     regional_objects :: R
     devices :: D
 
-    function MultiRegionObject(regional_objects...; devices=tuple(CPU() for _ in regional_objects))
+    function MultiRegionObject(regional_objects...; devices=Tuple(CPU() for _ in regional_objects))
         R = typeof(regional_objects)
         D = typeof(devices)
         return new{R, D}(regional_objects, devices)
@@ -31,7 +31,7 @@ end
 
 Return a MultiRegionObject
 """
-MultiRegionObject(regional_objects::Tuple; devices=tuple(CPU() for _ in regional_objects)) =
+MultiRegionObject(regional_objects::Tuple; devices=Tuple(CPU() for _ in regional_objects)) =
     MultiRegionObject(regional_objects, devices)
 
 

--- a/src/Utils/multi_region_transformation.jl
+++ b/src/Utils/multi_region_transformation.jl
@@ -161,8 +161,7 @@ end
     if Nreturns == 1
         return MultiRegionObject(Tuple(regional_return_values), devs)
     else
-        # multiple returns
-        # return MultiRegionObject(Tuple(regional_return_values), devs)
+        return Tuple(MultiRegionObject(Tuple(regional_return_values[r][i] for r in 1:length(devs)), devs) for i in 1:Nreturns)
     end
 end
 
@@ -198,11 +197,15 @@ macro apply_regionally(expr)
         end
     elseif expr.head == :(=)
         ret = expr.args[1]
+        Nret = 1
+        if expr.args[1] isa Expr 
+            Nret = length(expr.args[1].args)
+        end
         exp = expr.args[2]
         func = exp.args[1]
         args = exp.args[2:end]
         multi_region = quote
-            $ret = construct_regionally($func, $(args...))
+            $ret = construct_regionally($Nret, $func, $(args...))
         end
         return quote
             $(esc(multi_region))
@@ -218,11 +221,15 @@ macro apply_regionally(expr)
                 end
             elseif arg isa Expr && arg.head == :(=)
                 ret = arg.args[1]
+                Nret = 1
+                if arg.args[1] isa Expr 
+                    Nret = length(arg.args[1].args)
+                end        
                 exp = arg.args[2]
                 func = exp.args[1]
                 args = exp.args[2:end]
                 new_expr.args[idx] = quote
-                    $ret = construct_regionally($func, $(args...))
+                    $ret = construct_regionally($Nret, $func, $(args...))
                 end
             end
         end


### PR DESCRIPTION
This is important for writing robust and readable code in our time-stepping algorithm.