### PR TITLE
Fixes `diffusivity()` for Smagorinsky-Lilly closure

### DIFF
--- a/src/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/TurbulenceClosures/TurbulenceClosures.jl
@@ -24,6 +24,8 @@ export
     DiffusivityFields,
     calculate_diffusivities!,
 
+    viscosity, diffusivity,
+
     ∇_dot_qᶜ,
     ∂ⱼ_τ₁ⱼ,
     ∂ⱼ_τ₂ⱼ,

--- a/src/TurbulenceClosures/turbulence_closure_implementations/smagorinsky_lilly.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/smagorinsky_lilly.jl
@@ -16,7 +16,7 @@ struct SmagorinskyLilly{TD, FT, P} <: AbstractScalarDiffusivity{TD, ThreeDimensi
 end
 
 @inline viscosity(::SmagorinskyLilly, K) = K.νₑ
-@inline diffusivity(::SmagorinskyLilly, K, ::Val{id}) where id = K.νₑ / closure.Pr[id]
+@inline diffusivity(closure::SmagorinskyLilly, K, ::Val{id}) where id = K.νₑ / closure.Pr[id]
 
 """
     SmagorinskyLilly(time_discretization = ExplicitTimeDiscretization, [FT=Float64;] C=0.16, Pr=1)

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -8,11 +8,6 @@ for closure in closures
     end
 end
 
-function closure_instantiation(closurename)
-    closure = getproperty(TurbulenceClosures, closurename)()
-    return true
-end
-
 function constant_isotropic_diffusivity_basic(T=Float64; ν=T(0.3), κ=T(0.7))
     closure = ScalarDiffusivity(T; κ=(T=κ, S=κ), ν=ν)
     return closure.ν == ν && closure.κ.T == κ
@@ -193,13 +188,14 @@ end
 
     @testset "Closure instantiation" begin
         @info "  Testing closure instantiation..."
-        for closure in closures
-            @test closure_instantiation(closure)
+        for closurename in closures
+            closure = getproperty(TurbulenceClosures, closurename)()
+            @test closure isa TurbulenceClosures.AbstractTurbulenceClosure
 
             grid = RectilinearGrid(CPU(), size=(1, 1, 1), extent=(1, 2, 3))
-            model = NonhydrostaticModel(; grid, closure, tracers=:c)
-            @test diffusivity(closure, model.diffusivity_fields, Val(:c)) isa Union{Number, Field}
-            @test viscosity(closure, model.diffusivity_fields) isa Union{Number, Field}
+            model = NonhydrostaticModel(grid=grid, closure=closure, tracers=:c)
+            @test diffusivity(model.closure, model.diffusivity_fields, Val(:c)) isa Union{Number, Field, AbstractOperations.AbstractOperation}
+            @test viscosity(model.closure, model.diffusivity_fields) isa Union{Number, Field}
         end
     end
 

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -194,8 +194,14 @@ end
 
             grid = RectilinearGrid(CPU(), size=(1, 1, 1), extent=(1, 2, 3))
             model = NonhydrostaticModel(grid=grid, closure=closure, tracers=:c)
-            @test diffusivity(model.closure, model.diffusivity_fields, Val(:c)) isa Union{Number, Field, AbstractOperations.AbstractOperation}
-            @test viscosity(model.closure, model.diffusivity_fields) isa Union{Number, Field}
+            c = model.tracers.c
+            u = model.velocities.u
+            κ = diffusivity(model.closure, model.diffusivity_fields, Val(:c)) 
+            κ_dx_c = κ * ∂x(c)
+            ν = viscosity(model.closure, model.diffusivity_fields)
+            ν_dx_u = ν * ∂x(c)
+            @test ν_dx_u[1, 1, 1] == 0.0
+            @test κ_dx_c[1, 1, 1] == 0.0
         end
     end
 

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -195,6 +195,11 @@ end
         @info "  Testing closure instantiation..."
         for closure in closures
             @test closure_instantiation(closure)
+
+            grid = RectilinearGrid(CPU(), size=(1, 1, 1), extent=(1, 2, 3))
+            model = NonhydrostaticModel(; grid, closure, tracers=:c)
+            @test diffusivity(closure, model.diffusivity_fields, Val(:c)) isa Union{Number, Field}
+            @test viscosity(closure, model.diffusivity_fields) isa Union{Number, Field}
         end
     end
 


### PR DESCRIPTION
A recent PR broke the user-facing `diffusivity()` function for `SmagorinskyLilly` and this fixes it. It also adds a test to catch this in the future and exports `diffusivity()` at the `TurbulenceClosure` level, since it's a user-facing function.