### PR TITLE
Refactor of some stretched rectilinear grid tests

### DIFF
--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -369,6 +369,7 @@ function test_rectilinear_grid_correct_spacings(FT, N)
     # the user-supplied zᵃᵃᶠ
     @test all(isapprox.( grid.Δzᵃᵃᶠ[2:N], Δzᵃᵃᶠ.(2:N) ))
 
+    return nothing
 end
 
 #####

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -334,53 +334,40 @@ function test_architecturally_correct_stretched_grid(FT, arch, zᵃᵃᶠ)
     return nothing
 end
 
-function test_correct_constant_grid_spacings(FT, Nz)
-    grid = RectilinearGrid(CPU(), FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=collect(0:Nz))
+function test_rectilinear_grid_correct_spacings(FT, N)
+    S = 3
+    zᵃᵃᶠ(k) = tanh(S * (2 * (k - 1) / N - 1)) / tanh(S)
 
-    @test all(grid.Δzᵃᵃᶜ .== 1)
-    @test all(grid.Δzᵃᵃᶠ .== 1)
+    grid = RectilinearGrid(CPU(), FT, size=(N, N, N), x=collect(0:N), y=collect(0:N).^2, z=zᵃᵃᶠ)
 
-    return nothing
-end
+    @test all(grid.Δxᶜᵃᵃ .== 1)
+    @test all(grid.Δxᶠᵃᵃ .== 1)
 
-function test_correct_quadratic_grid_spacings(FT, Nz)
-    grid = RectilinearGrid(CPU(), FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=collect(0:Nz).^2)
+     yᵃᶠᵃ(j) = (j-1)^2
+     yᵃᶜᵃ(j) = (j^2 + (j-1)^2) / 2
+    Δyᵃᶠᵃ(j) = yᵃᶜᵃ(j) - yᵃᶜᵃ(j-1)
+    Δyᵃᶜᵃ(j) = j^2 - (j-1)^2
 
-     zᵃᵃᶠ(k) = (k-1)^2
-     zᵃᵃᶜ(k) = (k^2 + (k-1)^2) / 2
-    Δzᵃᵃᶠ(k) = k^2 - (k-1)^2
-    Δzᵃᵃᶜ(k) = zᵃᵃᶜ(k) - zᵃᵃᶜ(k-1)
-
-    @test all(isapprox.(  grid.zᵃᵃᶠ[1:Nz+1],  zᵃᵃᶠ.(1:Nz+1) ))
-    @test all(isapprox.(  grid.zᵃᵃᶜ[1:Nz],    zᵃᵃᶜ.(1:Nz)   ))
-    @test all(isapprox.( grid.Δzᵃᵃᶜ[1:Nz],   Δzᵃᵃᶠ.(1:Nz)   ))
+    @test all(isapprox.(  grid.yᵃᶠᵃ[1:N+1],  yᵃᶠᵃ.(1:N+1) ))
+    @test all(isapprox.(  grid.yᵃᶜᵃ[1:N],    yᵃᶜᵃ.(1:N)   ))
+    @test all(isapprox.( grid.Δyᵃᶜᵃ[1:N],   Δyᵃᶜᵃ.(1:N)   ))
 
     # Note that Δzᵃᵃᶠ[1] involves a halo point, which is not directly determined by
     # the user-supplied zᵃᵃᶠ
-    @test all(isapprox.( grid.Δzᵃᵃᶠ[2:Nz], Δzᵃᵃᶜ.(2:Nz) ))
+    @test all(isapprox.( grid.Δyᵃᶠᵃ[2:N], Δyᵃᶠᵃ.(2:N) ))
 
-    return nothing
-end
+     zᵃᵃᶜ(k) = (zᵃᵃᶠ(k)   + zᵃᵃᶠ(k+1)) / 2
+    Δzᵃᵃᶜ(k) =  zᵃᵃᶠ(k+1) - zᵃᵃᶠ(k)
+    Δzᵃᵃᶠ(k) =  zᵃᵃᶜ(k)   - zᵃᵃᶜ(k-1)
 
-function test_correct_tanh_grid_spacings(FT, Nz)
-    S = 3  # Stretching factor
-    zᵃᵃᶠ(k) = tanh(S * (2 * (k - 1) / Nz - 1)) / tanh(S)
-
-    grid = RectilinearGrid(CPU(), FT, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=zᵃᵃᶠ)
-
-     zᵃᵃᶜ(k) = (zᵃᵃᶠ(k) + zᵃᵃᶠ(k+1)) / 2
-    Δzᵃᵃᶠ(k) = zᵃᵃᶠ(k+1) - zᵃᵃᶠ(k)
-    Δzᵃᵃᶜ(k) = zᵃᵃᶜ(k)   - zᵃᵃᶜ(k-1)
-
-    @test all(isapprox.(  grid.zᵃᵃᶠ[1:Nz+1],  zᵃᵃᶠ.(1:Nz+1) ))
-    @test all(isapprox.(  grid.zᵃᵃᶜ[1:Nz],    zᵃᵃᶜ.(1:Nz)   ))
-    @test all(isapprox.( grid.Δzᵃᵃᶜ[1:Nz],   Δzᵃᵃᶠ.(1:Nz)   ))
+    @test all(isapprox.(  grid.zᵃᵃᶠ[1:N+1],  zᵃᵃᶠ.(1:N+1) ))
+    @test all(isapprox.(  grid.zᵃᵃᶜ[1:N],    zᵃᵃᶜ.(1:N)   ))
+    @test all(isapprox.( grid.Δzᵃᵃᶜ[1:N],   Δzᵃᵃᶜ.(1:N)   ))
 
     # Note that Δzᵃᵃᶠ[1] involves a halo point, which is not directly determined by
     # the user-supplied zᵃᵃᶠ
-    @test all(isapprox.( grid.Δzᵃᵃᶠ[2:Nz], Δzᵃᵃᶜ.(2:Nz) ))
+    @test all(isapprox.( grid.Δzᵃᵃᶠ[2:N], Δzᵃᵃᶠ.(2:N) ))
 
-   return nothing
 end
 
 #####
@@ -708,10 +695,8 @@ end
 
             @testset "Vertically stretched rectilinear grid spacings [$(typeof(arch)), $FT]" begin
                 @info "    Testing vertically stretched rectilinear grid spacings [$(typeof(arch)), $FT]..."
-                for Nz in [16, 17]
-                    test_correct_constant_grid_spacings(FT, Nz)
-                    test_correct_quadratic_grid_spacings(FT, Nz)
-                    test_correct_tanh_grid_spacings(FT, Nz)
+                for N in [16, 17]
+                    test_rectilinear_grid_correct_spacings(FT, N)
                 end
             end
 

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -338,6 +338,7 @@ function test_rectilinear_grid_correct_spacings(FT, N)
     S = 3
     zᵃᵃᶠ(k) = tanh(S * (2 * (k - 1) / N - 1)) / tanh(S)
 
+    # a grid with regular x-spacing, quadratic y-spacing, and tanh-like z-spacing
     grid = RectilinearGrid(CPU(), FT, size=(N, N, N), x=collect(0:N), y=collect(0:N).^2, z=zᵃᵃᶠ)
 
     @test all(grid.Δxᶜᵃᵃ .== 1)

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -347,7 +347,7 @@ function test_rectilinear_grid_correct_spacings(FT, N)
      yᵃᶠᵃ(j) = (j-1)^2
      yᵃᶜᵃ(j) = (j^2 + (j-1)^2) / 2
     Δyᵃᶠᵃ(j) = yᵃᶜᵃ(j) - yᵃᶜᵃ(j-1)
-    Δyᵃᶜᵃ(j) = j^2 - (j-1)^2
+    Δyᵃᶜᵃ(j) = yᵃᶠᵃ(j+1) - yᵃᶠᵃ(j)
 
     @test all(isapprox.(  grid.yᵃᶠᵃ[1:N+1],  yᵃᶠᵃ.(1:N+1) ))
     @test all(isapprox.(  grid.yᵃᶜᵃ[1:N],    yᵃᶜᵃ.(1:N)   ))

--- a/test/test_netcdf_output_writer.jl
+++ b/test/test_netcdf_output_writer.jl
@@ -518,7 +518,7 @@ function test_netcdf_spatial_average(arch)
     set!(model, c=1)
 
     Δt = 1/64 # Nice floating-point number
-    simulation = Simulation(model, Δt=Δt, stop_time=50Δt)
+    simulation = Simulation(model, Δt=Δt, stop_iteration=10)
 
     ∫c_dx = Field(Average(model.tracers.c, dims=(1)))
     ∫∫c_dxdy = Field(Average(model.tracers.c, dims=(1, 2)))
@@ -530,7 +530,7 @@ function test_netcdf_spatial_average(arch)
                                                               array_type = Array{Float64},
                                                               verbose = true,
                                                               filename = volume_avg_nc_filepath,
-                                                              schedule = TimeInterval(10Δt))
+                                                              schedule = IterationInterval(2))
     run!(simulation)
 
     ds = NCDataset(volume_avg_nc_filepath)


### PR DESCRIPTION
I noticed that in a couple of tests in `test_grids.jl` the code was written in way that leads to some not-so-clear statements such as:

https://github.com/CliMA/Oceananigans.jl/blob/182e75c80645af0d6a7105ed2d8d4fcbceb7bccc/test/test_grids.jl#L381

The above seems wrong at first but it's actually correct since `Δzᵃᵃᶜ()` is defined the same way as `grid.Δzᵃᵃᶠ`.

This PR changes that to make the notation clearer (i.e. `grid.Δzᵃᵃᶠ[2:Nz] == Δzᵃᵃᶠ.(2:Nz)`) and condenses 3 separate test functions for stretched grids (needing three separate grid instantiations) into one function (with the same tests).

EDIT:

This also implements a suggestion by @glwagner in https://github.com/CliMA/Oceananigans.jl/pull/2865 that couldn't be implemented then. I'll open another PR in the near future to further condense some other tests.