### PR TITLE
Small changes to tilted bottom boundary layer example

### DIFF
--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -128,10 +128,12 @@ v_bcs = FieldBoundaryConditions(bottom = drag_bc_v)
 # and a constant viscosity and diffusivity.
 
 ν = 1e-4 # m² s⁻¹, small-ish
-κ = ν
-closure = ScalarDiffusivity(; ν, κ)
+closure = ScalarDiffusivity(ν=ν, κ=ν)
 
-model = NonhydrostaticModel(; grid, buoyancy, coriolis, closure,
+model = NonhydrostaticModel(; grid,
+                            buoyancy = buoyancy,
+                            closure = closure,
+                            coriolis = coriolis,
                             timestepper = :RungeKutta3,
                             advection = UpwindBiasedFifthOrder(),
                             tracers = :b,

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -127,7 +127,6 @@ v_bcs = FieldBoundaryConditions(bottom = drag_bc_v)
 # `UpwindBiasedFifthOrder` advection scheme, a `RungeKutta3` timestepper,
 # and a constant viscosity and diffusivity. Here we use a smallish value of ``10^{-4} m² s⁻¹``.
 
-ν = 1e-4 # m² s⁻¹, small-ish
 closure = ScalarDiffusivity(ν=ν, κ=ν)
 
 model = NonhydrostaticModel(; grid,

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -129,10 +129,7 @@ v_bcs = FieldBoundaryConditions(bottom = drag_bc_v)
 
 closure = ScalarDiffusivity(ν=1e-4, κ=1e-4)
 
-model = NonhydrostaticModel(; grid,
-                            buoyancy = buoyancy,
-                            closure = closure,
-                            coriolis = coriolis,
+model = NonhydrostaticModel(; grid, buoyancy, coriolis, closure,
                             timestepper = :RungeKutta3,
                             advection = UpwindBiasedFifthOrder(),
                             tracers = :b,

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -127,7 +127,7 @@ v_bcs = FieldBoundaryConditions(bottom = drag_bc_v)
 # `UpwindBiasedFifthOrder` advection scheme, a `RungeKutta3` timestepper,
 # and a constant viscosity and diffusivity. Here we use a smallish value of ``10^{-4} m² s⁻¹``.
 
-closure = ScalarDiffusivity(ν=ν, κ=ν)
+closure = ScalarDiffusivity(ν=1e-4, κ=1e-4)
 
 model = NonhydrostaticModel(; grid,
                             buoyancy = buoyancy,

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -125,7 +125,7 @@ v_bcs = FieldBoundaryConditions(bottom = drag_bc_v)
 #
 # We are now ready to create the model. We create a `NonhydrostaticModel` with an
 # `UpwindBiasedFifthOrder` advection scheme, a `RungeKutta3` timestepper,
-# and a constant viscosity and diffusivity.
+# and a constant viscosity and diffusivity. Here we use a smallish value of ``10^{-4} m² s⁻¹``.
 
 ν = 1e-4 # m² s⁻¹, small-ish
 closure = ScalarDiffusivity(ν=ν, κ=ν)


### PR DESCRIPTION
This PR changes ~two things~ about the BBL example:

- The variable `κ` was used for both the von Karman constant and for the eddy diffusivity. Now it's just used for the von Karman constant
- ~When calling `NonhydrostaticModel` we were using ordered arguments, which could make a new user interpret that they should know the order of the arguments when calling `NonhydrostaticModel`. Now this call is made in a more usual way with keyword arguments, where the order doesn't matter.~