### PR TITLE
Calculate the biased interpolate only in the upwinding direction

### DIFF
--- a/src/Advection/flat_advective_fluxes.jl
+++ b/src/Advection/flat_advective_fluxes.jl
@@ -23,16 +23,19 @@ end
 
 Grids = [:XFlatGrid, :YFlatGrid, :ZFlatGrid, :XFlatGrid, :YFlatGrid, :ZFlatGrid]
 
-for side in (:left_biased, :right_biased, :symmetric)
-    for (dir, Grid) in zip([:xᶠᵃᵃ, :yᵃᶠᵃ, :zᵃᵃᶠ, :xᶜᵃᵃ, :yᵃᶜᵃ, :zᵃᵃᶜ], Grids)
-        interp_function = Symbol(side, :_interpolate_, dir)
-        @eval begin
-            $interp_function(i, j, k, grid::$Grid, scheme, ψ, args...) = @inbounds ψ[i, j, k]
-            $interp_function(i, j, k, grid::$Grid, scheme, ψ::Function, args...) = @inbounds ψ(i, j, k, grid, args...)
-        end
-    end
+for (dir, Grid) in zip([:xᶠᵃᵃ, :yᵃᶠᵃ, :zᵃᵃᶠ, :xᶜᵃᵃ, :yᵃᶜᵃ, :zᵃᵃᶜ], Grids)
+    biased_interp_function    = Symbol(:biased_interpolate_, dir)
+    symmetric_interp_function = Symbol(:symmetric_interpolate_, dir)
+    @eval begin
+        $biased_interp_function(i, j, k, grid::$Grid, dir, scheme, ψ, args...)           = @inbounds ψ[i, j, k]
+        $biased_interp_function(i, j, k, grid::$Grid, dir, scheme, ψ::Function, args...) = @inbounds ψ(i, j, k, grid, args...)
+
+        $symmetric_interp_function(i, j, k, grid::$Grid, scheme, ψ, args...)           = @inbounds ψ[i, j, k]
+        $symmetric_interp_function(i, j, k, grid::$Grid, scheme, ψ::Function, args...) = @inbounds ψ(i, j, k, grid, args...)
+     end
 end
 
+# Disambiguation
 @inline symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid::XFlatGrid, scheme::AbstractUpwindBiasedAdvectionScheme, c) = @inbounds c[i, j, k]
 @inline symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid::YFlatGrid, scheme::AbstractUpwindBiasedAdvectionScheme, c) = @inbounds c[i, j, k]
 @inline symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid::ZFlatGrid, scheme::AbstractUpwindBiasedAdvectionScheme, c) = @inbounds c[i, j, k]

--- a/src/Advection/reconstruction_coefficients.jl
+++ b/src/Advection/reconstruction_coefficients.jl
@@ -8,13 +8,13 @@
 @inline symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, ψ, args...) = inner_symmetric_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, ψ, j, Center, args...)
 @inline symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, ψ, args...) = inner_symmetric_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, ψ, k, Center, args...)
 
-@inline biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(D), ψ, i, Face, args...)
-@inline biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(D), ψ, j, Face, args...)
-@inline biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(D), ψ, k, Face, args...)
+@inline biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, ψ, args...) = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, ψ, i, Face, args...)
+@inline biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, ψ, args...) = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, ψ, j, Face, args...)
+@inline biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, side, ψ, args...) = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, side, ψ, k, Face, args...)
 
-@inline biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, Val(D), ψ, i, Center, args...)
-@inline biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, Val(D), ψ, j, Center, args...)
-@inline biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, Val(D), ψ, k, Center, args...)
+@inline biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, side, ψ, args...) = inner_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, side, ψ, i, Center, args...)
+@inline biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, side, ψ, args...) = inner_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, side, ψ, j, Center, args...)
+@inline biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, side, ψ, args...) = inner_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, side, ψ, k, Center, args...)
 
 struct FirstDerivative end
 struct SecondDerivative end

--- a/src/Advection/reconstruction_coefficients.jl
+++ b/src/Advection/reconstruction_coefficients.jl
@@ -8,21 +8,13 @@
 @inline symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, ψ, args...) = inner_symmetric_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, ψ, j, Center, args...)
 @inline symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, ψ, args...) = inner_symmetric_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, ψ, k, Center, args...)
 
-@inline left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, ψ, args...)  = inner_left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, ψ, i, Face, args...)
-@inline left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, ψ, args...)  = inner_left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, ψ, j, Face, args...)
-@inline left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, ψ, args...)  = inner_left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, ψ, k, Face, args...)
+@inline biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(D), ψ, i, Face, args...)
+@inline biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(D), ψ, j, Face, args...)
+@inline biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(D), ψ, k, Face, args...)
 
-@inline right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, ψ, args...) = inner_right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, ψ, i, Face, args...)
-@inline right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, ψ, args...) = inner_right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, ψ, j, Face, args...)
-@inline right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, ψ, args...) = inner_right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, ψ, k, Face, args...)
-
-@inline left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, ψ, args...)  = inner_left_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, ψ, i, Center, args...)
-@inline left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, ψ, args...)  = inner_left_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, ψ, j, Center, args...)
-@inline left_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, ψ, args...)  = inner_left_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, ψ, k, Center, args...)
-
-@inline right_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, ψ, args...) = inner_right_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, ψ, i, Center, args...)
-@inline right_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, ψ, args...) = inner_right_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, ψ, j, Center, args...)
-@inline right_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, ψ, args...) = inner_right_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, ψ, k, Center, args...)
+@inline biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i+1, j, k, grid, scheme, Val(D), ψ, i, Center, args...)
+@inline biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j+1, k, grid, scheme, Val(D), ψ, j, Center, args...)
+@inline biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, ::Val{D}, ψ, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k+1, grid, scheme, Val(D), ψ, k, Center, args...)
 
 struct FirstDerivative end
 struct SecondDerivative end
@@ -96,13 +88,12 @@ for buffer in [1, 2, 3, 4, 5, 6]
     order_symm = 2buffer
 
     coeff_symm  = Symbol(:coeff, order_symm, :_symm)
-    coeff_left  = Symbol(:coeff, order_bias, :_left)
-    coeff_right = Symbol(:coeff, order_bias, :_right)
+    coeff_bias  = Symbol(:coeff, order_bias, :_bias)
     @eval begin
-        const $coeff_symm  = stencil_coefficients(50, $(buffer - 1), collect(1:100), collect(1:100); order = $order_symm)
+        const $coeff_symm(::Val{D}) where D = stencil_coefficients(50, $(buffer - 1), collect(1:100), collect(1:100); order = $order_symm)
         if $order_bias > 1
-            const $coeff_left  = stencil_coefficients(50, $(buffer - 2), collect(1:100), collect(1:100); order = $order_bias)
-            const $coeff_right = stencil_coefficients(50, $(buffer - 1), collect(1:100), collect(1:100); order = $order_bias)
+            const $coeff_bias(::Val{:left})  = stencil_coefficients(50, $(buffer - 2), collect(1:100), collect(1:100); order = $order_bias)
+            const $coeff_bias(::Val{:right}) = stencil_coefficients(50, $(buffer - 1), collect(1:100), collect(1:100); order = $order_bias)
         end
     end
 end
@@ -149,25 +140,28 @@ julia> calc_reconstruction_stencil(3, :left, :x)
         rng = rng .+ 1
     end
     stencil_full = Vector(undef, N)
-    coeff = Symbol(:coeff, order, :_, shift)
+    coeff = Symbol(:coeff, order, :_, biased_or_symm(Val(shift)))
     for (idx, n) in enumerate(rng)
         c = n - buffer - 1
         if func
             stencil_full[idx] = dir == :x ? 
-                                :($coeff[$(order - idx + 1)] * ψ(i + $c, j, k, grid, args...)) :
+                                :($coeff(Val(shift))[$(order - idx + 1)] * ψ(i + $c, j, k, grid, args...)) :
                                 dir == :y ?
-                                :($coeff[$(order - idx + 1)] * ψ(i, j + $c, k, grid, args...)) :
-                                :($coeff[$(order - idx + 1)] * ψ(i, j, k + $c, grid, args...))
+                                :($coeff(Val(shift))[$(order - idx + 1)] * ψ(i, j + $c, k, grid, args...)) :
+                                :($coeff(Val(shift))[$(order - idx + 1)] * ψ(i, j, k + $c, grid, args...))
         else
             stencil_full[idx] =  dir == :x ? 
-                                :($coeff[$(order - idx + 1)] * ψ[i + $c, j, k]) :
+                                :($coeff(Val(shift))[$(order - idx + 1)] * ψ[i + $c, j, k]) :
                                 dir == :y ?
-                                :($coeff[$(order - idx + 1)] * ψ[i, j + $c, k]) :
-                                :($coeff[$(order - idx + 1)] * ψ[i, j, k + $c])
+                                :($coeff(Val(shift))[$(order - idx + 1)] * ψ[i, j + $c, k]) :
+                                :($coeff(Val(shift))[$(order - idx + 1)] * ψ[i, j, k + $c])
         end
     end
     return Expr(:call, :+, stencil_full...)
 end
+
+biased_or_symm(::Val{D})     where D = :bias
+biased_or_symm(::Val{:symm}) where D = :symm
 
 #####
 ##### Shenanigans for stretched directions

--- a/src/Advection/topologically_conditional_interpolation.jl
+++ b/src/Advection/topologically_conditional_interpolation.jl
@@ -26,72 +26,127 @@ const AUGXYZ = AUG{<:Any, <:Bounded, <:Bounded, <:Bounded}
 # Left-biased buffers are smaller by one grid point on the right side; vice versa for right-biased buffers
 # Center interpolation stencil look at i + 1 (i.e., require one less point on the left)
 
-@inline    outside_symmetric_bufferᶠ(i, N, adv) = (i >= boundary_buffer(adv) + 1) & (i <= N + 1 - boundary_buffer(adv))
-@inline    outside_symmetric_bufferᶜ(i, N, adv) = (i >= boundary_buffer(adv))     & (i <= N + 1 - boundary_buffer(adv))
-@inline  outside_left_biased_bufferᶠ(i, N, adv) = (i >= boundary_buffer(adv) + 1) & (i <= N + 1 - (boundary_buffer(adv) - 1))
-@inline  outside_left_biased_bufferᶜ(i, N, adv) = (i >= boundary_buffer(adv))     & (i <= N + 1 - (boundary_buffer(adv) - 1))
-@inline outside_right_biased_bufferᶠ(i, N, adv) = (i >= boundary_buffer(adv))     & (i <= N + 1 - boundary_buffer(adv))
-@inline outside_right_biased_bufferᶜ(i, N, adv) = (i >= boundary_buffer(adv) - 1) & (i <= N + 1 - boundary_buffer(adv))
+@inline outside_symmetric_bufferᶠ(i, N, adv) = (i >= boundary_buffer(adv) + 1) & (i <= N + 1 - boundary_buffer(adv))
+@inline outside_symmetric_bufferᶜ(i, N, adv) = (i >= boundary_buffer(adv))     & (i <= N + 1 - boundary_buffer(adv))
+
+@inline outside_biased_bufferᶠ(i, N, adv, ::Val{:left})  = (i >= boundary_buffer(adv) + 1) & (i <= N + 1 - (boundary_buffer(adv) - 1))
+@inline outside_biased_bufferᶜ(i, N, adv, ::Val{:left})  = (i >= boundary_buffer(adv))     & (i <= N + 1 - (boundary_buffer(adv) - 1))
+@inline outside_biased_bufferᶠ(i, N, adv, ::Val{:right}) = (i >= boundary_buffer(adv))     & (i <= N + 1 - boundary_buffer(adv))
+@inline outside_biased_bufferᶜ(i, N, adv, ::Val{:right}) = (i >= boundary_buffer(adv) - 1) & (i <= N + 1 - boundary_buffer(adv))
 
 # Separate High order advection from low order advection
 const HOADV = Union{WENO, Centered, UpwindBiased} 
 const LOADV = Union{VectorInvariant, UpwindBiased{1}, Centered{1}}
 
-for bias in (:symmetric, :left_biased, :right_biased)
+for (d, ξ) in enumerate((:x, :y, :z))
 
-    for (d, ξ) in enumerate((:x, :y, :z))
+    code = [:ᵃ, :ᵃ, :ᵃ]
 
-        code = [:ᵃ, :ᵃ, :ᵃ]
+    for loc in (:ᶜ, :ᶠ)
+        code[d] = loc
+        second_order_interp = Symbol(:ℑ, ξ, code...)
+        interp = Symbol(:symmetric_interpolate_, ξ, code...)
+        alt_interp = Symbol(:_, interp)
 
-        for loc in (:ᶜ, :ᶠ)
-            code[d] = loc
-            second_order_interp = Symbol(:ℑ, ξ, code...)
-            interp = Symbol(bias, :_interpolate_, ξ, code...)
-            alt_interp = Symbol(:_, interp)
+        # Simple translation for Periodic directions and low-order advection schemes (fallback)
+        @eval $alt_interp(i, j, k, grid::AUG, scheme::LOADV, args...) = $interp(i, j, k, grid, scheme, args...)
+        @eval $alt_interp(i, j, k, grid::AUG, scheme::HOADV, args...) = $interp(i, j, k, grid, scheme, args...)
 
-            # Simple translation for Periodic directions and low-order advection schemes (fallback)
-            @eval $alt_interp(i, j, k, grid::AUG, scheme::LOADV, args...) = $interp(i, j, k, grid, scheme, args...)
-            @eval $alt_interp(i, j, k, grid::AUG, scheme::HOADV, args...) = $interp(i, j, k, grid, scheme, args...)
+        # Disambiguation
+        for GridType in [:AUGX, :AUGY, :AUGZ, :AUGXY, :AUGXZ, :AUGYZ, :AUGXYZ]
+            @eval $alt_interp(i, j, k, grid::$GridType, scheme::LOADV, args...) = $interp(i, j, k, grid, scheme, args...)
+        end
 
-            # Disambiguation
-            for GridType in [:AUGX, :AUGY, :AUGZ, :AUGXY, :AUGXZ, :AUGYZ, :AUGXYZ]
-                @eval $alt_interp(i, j, k, grid::$GridType, scheme::LOADV, args...) = $interp(i, j, k, grid, scheme, args...)
+        outside_buffer = Symbol(:outside_symmetric_buffer, loc)
+
+        # Conditional high-order interpolation in Bounded directions
+        if ξ == :x
+            @eval begin
+                @inline $alt_interp(i, j, k, grid::AUGX, scheme::HOADV, ψ) =
+                    ifelse($outside_buffer(i, grid.Nx, scheme),
+                            $interp(i, j, k, grid, scheme, ψ),
+                            $alt_interp(i, j, k, grid, scheme.buffer_scheme, ψ))
+
+                @inline $alt_interp(i, j, k, grid::AUGX, scheme::WENO, ζ, VI::AbstractSmoothnessStencil, u, v) =
+                    ifelse($outside_buffer(i, grid.Nx, scheme),
+                            $interp(i, j, k, grid, scheme, ζ, VI, u, v),
+                            $alt_interp(i, j, k, grid, scheme.buffer_scheme, ζ, VI, u, v))
             end
+        elseif ξ == :y
+            @eval begin
+                @inline $alt_interp(i, j, k, grid::AUGY, scheme::HOADV, ψ) =
+                    ifelse($outside_buffer(j, grid.Ny, scheme),
+                            $interp(i, j, k, grid, scheme, ψ),
+                            $alt_interp(i, j, k, grid, scheme.buffer_scheme, ψ))
 
-            outside_buffer = Symbol(:outside_, bias, :_buffer, loc)
+                @inline $alt_interp(i, j, k, grid::AUGY, scheme::WENO, ζ, VI::AbstractSmoothnessStencil, u, v) =
+                    ifelse($outside_buffer(j, grid.Ny, scheme),
+                            $interp(i, j, k, grid, scheme, ζ, VI, u, v),
+                            $alt_interp(i, j, k, grid, scheme.buffer_scheme, ζ, VI, u, v))
+            end
+        elseif ξ == :z
+            @eval begin
+                @inline $alt_interp(i, j, k, grid::AUGZ, scheme::HOADV, ψ) =
+                    ifelse($outside_buffer(k, grid.Nz, scheme),
+                            $interp(i, j, k, grid, scheme, ψ),
+                            $alt_interp(i, j, k, grid, scheme.buffer_scheme, ψ))
+            end
+        end
+    end
+end
 
-            # Conditional high-order interpolation in Bounded directions
-            if ξ == :x
-                @eval begin
-                    @inline $alt_interp(i, j, k, grid::AUGX, scheme::HOADV, ψ) =
-                        ifelse($outside_buffer(i, grid.Nx, scheme),
-                               $interp(i, j, k, grid, scheme, ψ),
-                               $alt_interp(i, j, k, grid, scheme.buffer_scheme, ψ))
+for (d, ξ) in enumerate((:x, :y, :z))
 
-                    @inline $alt_interp(i, j, k, grid::AUGX, scheme::WENO, ζ, VI::AbstractSmoothnessStencil, u, v) =
-                        ifelse($outside_buffer(i, grid.Nx, scheme),
-                               $interp(i, j, k, grid, scheme, ζ, VI, u, v),
-                               $alt_interp(i, j, k, grid, scheme.buffer_scheme, ζ, VI, u, v))
-                end
-            elseif ξ == :y
-                @eval begin
-                    @inline $alt_interp(i, j, k, grid::AUGY, scheme::HOADV, ψ) =
-                        ifelse($outside_buffer(j, grid.Ny, scheme),
-                               $interp(i, j, k, grid, scheme, ψ),
-                               $alt_interp(i, j, k, grid, scheme.buffer_scheme, ψ))
+    code = [:ᵃ, :ᵃ, :ᵃ]
 
-                    @inline $alt_interp(i, j, k, grid::AUGY, scheme::WENO, ζ, VI::AbstractSmoothnessStencil, u, v) =
-                        ifelse($outside_buffer(j, grid.Ny, scheme),
-                               $interp(i, j, k, grid, scheme, ζ, VI, u, v),
-                               $alt_interp(i, j, k, grid, scheme.buffer_scheme, ζ, VI, u, v))
-                end
-            elseif ξ == :z
-                @eval begin
-                    @inline $alt_interp(i, j, k, grid::AUGZ, scheme::HOADV, ψ) =
-                        ifelse($outside_buffer(k, grid.Nz, scheme),
-                               $interp(i, j, k, grid, scheme, ψ),
-                               $alt_interp(i, j, k, grid, scheme.buffer_scheme, ψ))
-                end
+    for loc in (:ᶜ, :ᶠ)
+        code[d] = loc
+        second_order_interp = Symbol(:ℑ, ξ, code...)
+        interp = Symbol(:biased_interpolate_, ξ, code...)
+        alt_interp = Symbol(:_, interp)
+
+        # Simple translation for Periodic directions and low-order advection schemes (fallback)
+        @eval $alt_interp(i, j, k, grid::AUG, scheme::LOADV, ::Val{D}, args...) where D = $interp(i, j, k, grid, scheme, Val(D), args...)
+        @eval $alt_interp(i, j, k, grid::AUG, scheme::HOADV, ::Val{D}, args...) where D = $interp(i, j, k, grid, scheme, Val(D), args...)
+
+        # Disambiguation
+        for GridType in [:AUGX, :AUGY, :AUGZ, :AUGXY, :AUGXZ, :AUGYZ, :AUGXYZ]
+            @eval $alt_interp(i, j, k, grid::$GridType, scheme::LOADV, ::Val{D}, args...) where D = $interp(i, j, k, grid, scheme, Val(D), args...)
+        end
+
+        outside_buffer = Symbol(:outside_biased_buffer, loc)
+
+        # Conditional high-order interpolation in Bounded directions
+        if ξ == :x
+            @eval begin
+                @inline $alt_interp(i, j, k, grid::AUGX, scheme::HOADV, ::Val{D}, ψ) where D =
+                    ifelse($outside_buffer(i, grid.Nx, scheme, Val(D)),
+                            $interp(i, j, k, grid, scheme, Val(D), ψ),
+                            $alt_interp(i, j, k, grid, scheme.buffer_scheme, Val(D), ψ))
+
+                @inline $alt_interp(i, j, k, grid::AUGX, scheme::WENO, ::Val{D}, ζ, VI::AbstractSmoothnessStencil, u, v) where D =
+                    ifelse($outside_buffer(i, grid.Nx, scheme, Val(D)),
+                            $interp(i, j, k, grid, scheme, Val(D), ζ, VI, u, v),
+                            $alt_interp(i, j, k, grid, scheme.buffer_scheme, Val(D), ζ, VI, u, v))
+            end
+        elseif ξ == :y
+            @eval begin
+                @inline $alt_interp(i, j, k, grid::AUGY, scheme::HOADV, ::Val{D}, ψ) where D =
+                    ifelse($outside_buffer(j, grid.Ny, scheme, Val(D)),
+                            $interp(i, j, k, grid, scheme, Val(D), ψ),
+                            $alt_interp(i, j, k, grid, scheme.buffer_scheme, Val(D), ψ))
+
+                @inline $alt_interp(i, j, k, grid::AUGY, scheme::WENO, ::Val{D}, ζ, VI::AbstractSmoothnessStencil, u, v) where D =
+                    ifelse($outside_buffer(j, grid.Ny, scheme, Val(D)),
+                            $interp(i, j, k, grid, scheme, Val(D), ζ, VI, u, v),
+                            $alt_interp(i, j, k, grid, scheme.buffer_scheme, Val(D), ζ, VI, u, v))
+            end
+        elseif ξ == :z
+            @eval begin
+                @inline $alt_interp(i, j, k, grid::AUGZ, scheme::HOADV, ::Val{D}, ψ) where D =
+                    ifelse($outside_buffer(k, grid.Nz, scheme, Val(D)),
+                            $interp(i, j, k, grid, scheme, Val(D), ψ),
+                            $alt_interp(i, j, k, grid, scheme.buffer_scheme, Val(D), ψ))
             end
         end
     end

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -2,7 +2,7 @@
 ##### Momentum and tracer advective flux operators for upwind-biased advection schemes
 #####
 ##### See topologically_conditional_interpolation.jl for an explanation of the underscore-prepended
-##### functions _symmetric_interpolate_*, _biased_interpolate_*, and _biased_interpolate_*.
+##### functions _symmetric_interpolate_* and _biased_interpolate_*
 #####
 
 const UpwindScheme = AbstractUpwindBiasedAdvectionScheme

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -2,12 +2,13 @@
 ##### Momentum and tracer advective flux operators for upwind-biased advection schemes
 #####
 ##### See topologically_conditional_interpolation.jl for an explanation of the underscore-prepended
-##### functions _symmetric_interpolate_*, _left_biased_interpolate_*, and _right_biased_interpolate_*.
+##### functions _symmetric_interpolate_*, _biased_interpolate_*, and _biased_interpolate_*.
 #####
 
 const UpwindScheme = AbstractUpwindBiasedAdvectionScheme
 
 @inline upwind_biased_product(ũ, ψᴸ, ψᴿ) = ((ũ + abs(ũ)) * ψᴸ + (ũ - abs(ũ)) * ψᴿ) / 2
+@inline upwinding_direction(ũ)           = ifelse(ũ > 0, Val(:left), Val(:right))
 
 #####
 ##### Momentum advection operators
@@ -17,83 +18,83 @@ const UpwindScheme = AbstractUpwindBiasedAdvectionScheme
 
 @inline function advective_momentum_flux_Uu(i, j, k, grid, scheme::UpwindScheme, U, u)
 
-    ũ  =    _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U)
-    uᴸ =  _left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
-    uᴿ = _right_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, u)
+    ũ   = _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U)
+    dir = upwinding_direction(ũ) 
+    uᴿ  =  _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, dir, u)
 
-    return Axᶜᶜᶜ(i, j, k, grid) * upwind_biased_product(ũ, uᴸ, uᴿ)
+    return Axᶜᶜᶜ(i, j, k, grid) * ũ * uᴿ
 end
 
 @inline function advective_momentum_flux_Vu(i, j, k, grid, scheme::UpwindScheme, V, u)
 
-    ṽ  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V)
-    uᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
-    uᴿ = _right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, u)
+    ṽ   = _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V)
+    dir = upwinding_direction(ṽ) 
+    uᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, dir, u)
 
-    return Ayᶠᶠᶜ(i, j, k, grid) * upwind_biased_product(ṽ, uᴸ, uᴿ)
+    return Ayᶠᶠᶜ(i, j, k, grid) * ṽ * uᴿ
 end
 
 @inline function advective_momentum_flux_Wu(i, j, k, grid, scheme::UpwindScheme, W, u)
 
-    w̃  =    _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W)
-    uᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
-    uᴿ = _right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, u)
+    w̃   = _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W)
+    dir = upwinding_direction(w̃) 
+    uᴿ  =  _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, dir, u)
 
-    return Azᶠᶜᶠ(i, j, k, grid) * upwind_biased_product(w̃, uᴸ, uᴿ)
+    return Azᶠᶜᶠ(i, j, k, grid) * w̃ * uᴿ
 end
 
 @inline function advective_momentum_flux_Uv(i, j, k, grid, scheme::UpwindScheme, U, v)
 
-    ũ  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U)
-    vᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
-    vᴿ = _right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, v)
+    ũ   = _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U)
+    dir = upwinding_direction(ũ) 
+    vᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, dir, v)
  
-    return Axᶠᶠᶜ(i, j, k, grid) * upwind_biased_product(ũ, vᴸ, vᴿ)
+    return Axᶠᶠᶜ(i, j, k, grid) * ũ * vᴿ
 end
 
 @inline function advective_momentum_flux_Vv(i, j, k, grid, scheme::UpwindScheme, V, v)
 
-    ṽ  =    _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V)
-    vᴸ =  _left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
-    vᴿ = _right_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, v)
+    ṽ   = _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V)
+    dir = upwinding_direction(ṽ) 
+    vᴿ  = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, dir, v)
 
-    return Ayᶜᶜᶜ(i, j, k, grid) * upwind_biased_product(ṽ, vᴸ, vᴿ)
+    return Ayᶜᶜᶜ(i, j, k, grid) * ṽ * vᴿ
 end
 
 @inline function advective_momentum_flux_Wv(i, j, k, grid, scheme::UpwindScheme, W, v)
 
-    w̃  =    _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W)
-    vᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
-    vᴿ = _right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, v)
+    w̃   = _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W)
+    dir = upwinding_direction(w̃) 
+    vᴿ  = _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, dir, v)
 
-    return Azᶜᶠᶠ(i, j, k, grid) * upwind_biased_product(w̃, vᴸ, vᴿ)
+    return Azᶜᶠᶠ(i, j, k, grid) * w̃ * vᴿ
 end
 
 @inline function advective_momentum_flux_Uw(i, j, k, grid, scheme::UpwindScheme, U, w)
 
-    ũ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U)
-    wᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
-    wᴿ = _right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, w)
+    ũ   = _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U)
+    dir = upwinding_direction(ũ) 
+    wᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, dir, w)
 
-    return Axᶠᶜᶠ(i, j, k, grid) * upwind_biased_product(ũ, wᴸ, wᴿ)
+    return Axᶠᶜᶠ(i, j, k, grid) * ũ * wᴿ
 end
 
 @inline function advective_momentum_flux_Vw(i, j, k, grid, scheme::UpwindScheme, V, w)
 
-    ṽ  =    _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V)
-    wᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
-    wᴿ = _right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, w)
+    ṽ   = _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V)
+    dir = upwinding_direction(ṽ) 
+    wᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, dir, w)
 
-    return Ayᶜᶠᶠ(i, j, k, grid) * upwind_biased_product(ṽ, wᴸ, wᴿ)
+    return Ayᶜᶠᶠ(i, j, k, grid) * ṽ * wᴿ
 end
 
 @inline function advective_momentum_flux_Ww(i, j, k, grid, scheme::UpwindScheme, W, w)
 
-    w̃  =    _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W)
-    wᴸ =  _left_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
-    wᴿ = _right_biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, w)
+    w̃   = _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W)
+    dir = upwinding_direction(w̃) 
+    wᴿ  = _biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, dir, w)
 
-    return Azᶜᶜᶜ(i, j, k, grid) * upwind_biased_product(w̃, wᴸ, wᴿ)
+    return Azᶜᶜᶜ(i, j, k, grid) * w̃ * wᴿ
 end
 
 #####
@@ -103,26 +104,26 @@ end
 @inline function advective_tracer_flux_x(i, j, k, grid, scheme::UpwindScheme, U, c) 
 
     @inbounds ũ = U[i, j, k]
-    cᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
-    cᴿ = _right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, c)
+    dir = upwinding_direction(ũ) 
+    cᴿ = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, dir, c)
 
-    return Axᶠᶜᶜ(i, j, k, grid) * upwind_biased_product(ũ, cᴸ, cᴿ)
+    return Axᶠᶜᶜ(i, j, k, grid) * ũ * cᴿ
 end
 
 @inline function advective_tracer_flux_y(i, j, k, grid, scheme::UpwindScheme, V, c)
 
     @inbounds ṽ = V[i, j, k]
-    cᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
-    cᴿ = _right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, c)
+    dir = upwinding_direction(ṽ) 
+    cᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, dir, c)
 
-    return Ayᶜᶠᶜ(i, j, k, grid) * upwind_biased_product(ṽ, cᴸ, cᴿ)
+    return Ayᶜᶠᶜ(i, j, k, grid) * ṽ * cᴿ
 end
 
 @inline function advective_tracer_flux_z(i, j, k, grid, scheme::UpwindScheme, W, c)
 
     @inbounds w̃ = W[i, j, k]
-    cᴸ =  _left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
-    cᴿ = _right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, c)
+    dir = upwinding_direction(w̃) 
+    cᴿ = _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, dir, c)
 
-    return Azᶜᶜᶠ(i, j, k, grid) * upwind_biased_product(w̃, cᴸ, cᴿ) 
+    return Azᶜᶜᶠ(i, j, k, grid) * w̃ * cᴿ
 end

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -18,54 +18,60 @@ const UpwindScheme = AbstractUpwindBiasedAdvectionScheme
 
 @inline function advective_momentum_flux_Uu(i, j, k, grid, scheme::UpwindScheme, U, u)
 
-    ũ   = _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U)
-    dir = upwinding_direction(ũ) 
-    uᴿ  =  _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, dir, u)
+    ũ    = _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U)
+    side = upwinding_direction(ũ) 
+
+    uᴿ   =  _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, side, u)
 
     return Axᶜᶜᶜ(i, j, k, grid) * ũ * uᴿ
 end
 
 @inline function advective_momentum_flux_Vu(i, j, k, grid, scheme::UpwindScheme, V, u)
 
-    ṽ   = _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V)
-    dir = upwinding_direction(ṽ) 
-    uᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, dir, u)
+    ṽ    = _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V)
+    side = upwinding_direction(ṽ) 
+
+    uᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, u)
 
     return Ayᶠᶠᶜ(i, j, k, grid) * ṽ * uᴿ
 end
 
 @inline function advective_momentum_flux_Wu(i, j, k, grid, scheme::UpwindScheme, W, u)
 
-    w̃   = _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W)
-    dir = upwinding_direction(w̃) 
-    uᴿ  =  _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, dir, u)
+    w̃    = _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W)
+    side = upwinding_direction(w̃) 
+
+    uᴿ  =  _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, side, u)
 
     return Azᶠᶜᶠ(i, j, k, grid) * w̃ * uᴿ
 end
 
 @inline function advective_momentum_flux_Uv(i, j, k, grid, scheme::UpwindScheme, U, v)
 
-    ũ   = _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U)
-    dir = upwinding_direction(ũ) 
-    vᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, dir, v)
+    ũ    = _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U)
+    side = upwinding_direction(ũ) 
+
+    vᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, v)
  
     return Axᶠᶠᶜ(i, j, k, grid) * ũ * vᴿ
 end
 
 @inline function advective_momentum_flux_Vv(i, j, k, grid, scheme::UpwindScheme, V, v)
 
-    ṽ   = _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V)
-    dir = upwinding_direction(ṽ) 
-    vᴿ  = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, dir, v)
+    ṽ    = _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V)
+    side = upwinding_direction(ṽ) 
+
+    vᴿ  = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, side, v)
 
     return Ayᶜᶜᶜ(i, j, k, grid) * ṽ * vᴿ
 end
 
 @inline function advective_momentum_flux_Wv(i, j, k, grid, scheme::UpwindScheme, W, v)
 
-    w̃   = _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W)
-    dir = upwinding_direction(w̃) 
-    vᴿ  = _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, dir, v)
+    w̃    = _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W)
+    side = upwinding_direction(w̃) 
+
+    vᴿ  = _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, side, v)
 
     return Azᶜᶠᶠ(i, j, k, grid) * w̃ * vᴿ
 end
@@ -73,26 +79,29 @@ end
 @inline function advective_momentum_flux_Uw(i, j, k, grid, scheme::UpwindScheme, U, w)
 
     ũ   = _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U)
-    dir = upwinding_direction(ũ) 
-    wᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, dir, w)
+    side = upwinding_direction(ũ) 
+
+    wᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, w)
 
     return Axᶠᶜᶠ(i, j, k, grid) * ũ * wᴿ
 end
 
 @inline function advective_momentum_flux_Vw(i, j, k, grid, scheme::UpwindScheme, V, w)
 
-    ṽ   = _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V)
-    dir = upwinding_direction(ṽ) 
-    wᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, dir, w)
+    ṽ    = _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V)
+    side = upwinding_direction(ṽ)
+
+    wᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, w)
 
     return Ayᶜᶠᶠ(i, j, k, grid) * ṽ * wᴿ
 end
 
 @inline function advective_momentum_flux_Ww(i, j, k, grid, scheme::UpwindScheme, W, w)
 
-    w̃   = _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W)
-    dir = upwinding_direction(w̃) 
-    wᴿ  = _biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, dir, w)
+    w̃    = _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W)
+    side = upwinding_direction(w̃) 
+
+    wᴿ  = _biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, side, w)
 
     return Azᶜᶜᶜ(i, j, k, grid) * w̃ * wᴿ
 end
@@ -104,8 +113,9 @@ end
 @inline function advective_tracer_flux_x(i, j, k, grid, scheme::UpwindScheme, U, c) 
 
     @inbounds ũ = U[i, j, k]
-    dir = upwinding_direction(ũ) 
-    cᴿ = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, dir, c)
+    side = upwinding_direction(ũ) 
+
+    cᴿ = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, c)
 
     return Axᶠᶜᶜ(i, j, k, grid) * ũ * cᴿ
 end
@@ -113,8 +123,9 @@ end
 @inline function advective_tracer_flux_y(i, j, k, grid, scheme::UpwindScheme, V, c)
 
     @inbounds ṽ = V[i, j, k]
-    dir = upwinding_direction(ṽ) 
-    cᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, dir, c)
+    side = upwinding_direction(ṽ) 
+
+    cᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, c)
 
     return Ayᶜᶠᶜ(i, j, k, grid) * ṽ * cᴿ
 end

--- a/src/Advection/upwind_biased_advective_fluxes.jl
+++ b/src/Advection/upwind_biased_advective_fluxes.jl
@@ -20,7 +20,6 @@ const UpwindScheme = AbstractUpwindBiasedAdvectionScheme
 
     ũ    = _symmetric_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, U)
     side = upwinding_direction(ũ) 
-
     uᴿ   =  _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme, side, u)
 
     return Axᶜᶜᶜ(i, j, k, grid) * ũ * uᴿ
@@ -30,8 +29,7 @@ end
 
     ṽ    = _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, V)
     side = upwinding_direction(ṽ) 
-
-    uᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, u)
+    uᴿ   = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, u)
 
     return Ayᶠᶠᶜ(i, j, k, grid) * ṽ * uᴿ
 end
@@ -40,8 +38,7 @@ end
 
     w̃    = _symmetric_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, W)
     side = upwinding_direction(w̃) 
-
-    uᴿ  =  _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, side, u)
+    uᴿ   =  _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, side, u)
 
     return Azᶠᶜᶠ(i, j, k, grid) * w̃ * uᴿ
 end
@@ -50,8 +47,7 @@ end
 
     ũ    = _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, U)
     side = upwinding_direction(ũ) 
-
-    vᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, v)
+    vᴿ   = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, v)
  
     return Axᶠᶠᶜ(i, j, k, grid) * ũ * vᴿ
 end
@@ -60,8 +56,7 @@ end
 
     ṽ    = _symmetric_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, V)
     side = upwinding_direction(ṽ) 
-
-    vᴿ  = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, side, v)
+    vᴿ   = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme, side, v)
 
     return Ayᶜᶜᶜ(i, j, k, grid) * ṽ * vᴿ
 end
@@ -70,8 +65,7 @@ end
 
     w̃    = _symmetric_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, W)
     side = upwinding_direction(w̃) 
-
-    vᴿ  = _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, side, v)
+    vᴿ   = _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, side, v)
 
     return Azᶜᶠᶠ(i, j, k, grid) * w̃ * vᴿ
 end
@@ -80,8 +74,7 @@ end
 
     ũ   = _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, U)
     side = upwinding_direction(ũ) 
-
-    wᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, w)
+    wᴿ   = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, w)
 
     return Axᶠᶜᶠ(i, j, k, grid) * ũ * wᴿ
 end
@@ -90,8 +83,7 @@ end
 
     ṽ    = _symmetric_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, V)
     side = upwinding_direction(ṽ)
-
-    wᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, w)
+    wᴿ   = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, w)
 
     return Ayᶜᶠᶠ(i, j, k, grid) * ṽ * wᴿ
 end
@@ -100,8 +92,7 @@ end
 
     w̃    = _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W)
     side = upwinding_direction(w̃) 
-
-    wᴿ  = _biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, side, w)
+    wᴿ   = _biased_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, side, w)
 
     return Azᶜᶜᶜ(i, j, k, grid) * w̃ * wᴿ
 end
@@ -114,8 +105,7 @@ end
 
     @inbounds ũ = U[i, j, k]
     side = upwinding_direction(ũ) 
-
-    cᴿ = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, c)
+    cᴿ   = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, side, c)
 
     return Axᶠᶜᶜ(i, j, k, grid) * ũ * cᴿ
 end
@@ -124,8 +114,7 @@ end
 
     @inbounds ṽ = V[i, j, k]
     side = upwinding_direction(ṽ) 
-
-    cᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, c)
+    cᴿ   = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, side, c)
 
     return Ayᶜᶠᶜ(i, j, k, grid) * ṽ * cᴿ
 end
@@ -133,8 +122,8 @@ end
 @inline function advective_tracer_flux_z(i, j, k, grid, scheme::UpwindScheme, W, c)
 
     @inbounds w̃ = W[i, j, k]
-    dir = upwinding_direction(w̃) 
-    cᴿ = _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, dir, c)
+    side = upwinding_direction(w̃) 
+    cᴿ   = _biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, side, c)
 
     return Azᶜᶜᶠ(i, j, k, grid) * w̃ * cᴿ
 end

--- a/src/Advection/upwind_biased_reconstruction.jl
+++ b/src/Advection/upwind_biased_reconstruction.jl
@@ -98,49 +98,50 @@ UpwindBiasedFifthOrder(grid=nothing, FT::DataType=Float64) = UpwindBiased(grid, 
 @inline symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme::AbstractUpwindBiasedAdvectionScheme, w) = @inbounds symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme.advecting_velocity_scheme, w)
 
 # uniform upwind biased reconstruction
-for side in (:left, :right)
-    stencil_x = Symbol(:inner_, side, :_biased_interpolate_xᶠᵃᵃ)
-    stencil_y = Symbol(:inner_, side, :_biased_interpolate_yᵃᶠᵃ)
-    stencil_z = Symbol(:inner_, side, :_biased_interpolate_zᵃᵃᶠ)
-
-    for buffer in [1, 2, 3, 4, 5, 6]
-        @eval begin
-            @inline $stencil_x(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, <:Nothing}, ψ, idx, loc, args...)           where FT = @inbounds $(calc_reconstruction_stencil(buffer, side, :x, false))
-            @inline $stencil_x(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, <:Nothing}, ψ::Function, idx, loc, args...) where FT = @inbounds $(calc_reconstruction_stencil(buffer, side, :x,  true))
-        
-            @inline $stencil_y(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, <:Nothing}, ψ, idx, loc, args...)           where {FT, XT} = @inbounds $(calc_reconstruction_stencil(buffer, side, :y, false))
-            @inline $stencil_y(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, <:Nothing}, ψ::Function, idx, loc, args...) where {FT, XT} = @inbounds $(calc_reconstruction_stencil(buffer, side, :y,  true))
-        
-            @inline $stencil_z(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, YT, <:Nothing}, ψ, idx, loc, args...)           where {FT, XT, YT} = @inbounds $(calc_reconstruction_stencil(buffer, side, :z, false))
-            @inline $stencil_z(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, YT, <:Nothing}, ψ::Function, idx, loc, args...) where {FT, XT, YT} = @inbounds $(calc_reconstruction_stencil(buffer, side, :z,  true))
+for buffer in [1, 2, 3, 4, 5, 6]
+    @eval begin
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, <:Nothing}, ::Val{:left},  ψ, idx, loc, args...)           where {FT} = @inbounds $(calc_reconstruction_stencil(buffer, :left,  :x, false))
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, <:Nothing}, ::Val{:left},  ψ::Function, idx, loc, args...) where {FT} = @inbounds $(calc_reconstruction_stencil(buffer, :left,  :x,  true))
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, <:Nothing}, ::Val{:right}, ψ, idx, loc, args...)           where {FT} = @inbounds $(calc_reconstruction_stencil(buffer, :right, :x, false))
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, <:Nothing}, ::Val{:right}, ψ::Function, idx, loc, args...) where {FT} = @inbounds $(calc_reconstruction_stencil(buffer, :right, :x,  true))    
     
-        end
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, <:Nothing}, ::Val{:left},  ψ, idx, loc, args...)           where {FT, XT} = @inbounds $(calc_reconstruction_stencil(buffer, :left,  :y, false))
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, <:Nothing}, ::Val{:left},  ψ::Function, idx, loc, args...) where {FT, XT} = @inbounds $(calc_reconstruction_stencil(buffer, :left,  :y,  true))
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, <:Nothing}, ::Val{:right}, ψ, idx, loc, args...)           where {FT, XT} = @inbounds $(calc_reconstruction_stencil(buffer, :right, :y, false))
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, <:Nothing}, ::Val{:right}, ψ::Function, idx, loc, args...) where {FT, XT} = @inbounds $(calc_reconstruction_stencil(buffer, :right, :y,  true))
+        
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, YT, <:Nothing}, ::Val{:left},  ψ, idx, loc, args...)           where {FT, XT, YT} = @inbounds $(calc_reconstruction_stencil(buffer, :left,  :z, false))
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, YT, <:Nothing}, ::Val{:left},  ψ::Function, idx, loc, args...) where {FT, XT, YT} = @inbounds $(calc_reconstruction_stencil(buffer, :left,  :z,  true))
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, YT, <:Nothing}, ::Val{:right}, ψ, idx, loc, args...)           where {FT, XT, YT} = @inbounds $(calc_reconstruction_stencil(buffer, :right, :z, false))
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UpwindBiased{$buffer, FT, XT, YT, <:Nothing}, ::Val{:right}, ψ::Function, idx, loc, args...) where {FT, XT, YT} = @inbounds $(calc_reconstruction_stencil(buffer, :right, :z,  true))
     end
 end
 
 # stretched upwind biased reconstruction
-for (sd, side) in enumerate((:left, :right)), (dir, ξ, val) in zip((:xᶠᵃᵃ, :yᵃᶠᵃ, :zᵃᵃᶠ), (:x, :y, :z), (1, 2, 3))
-    stencil = Symbol(:inner_, side, :_biased_interpolate_, dir)
+for (dir, ξ, val) in zip((:xᶠᵃᵃ, :yᵃᶠᵃ, :zᵃᵃᶠ), (:x, :y, :z), (1, 2, 3))
+    stencil = Symbol(:inner_biased_interpolate_, dir)
 
     for buffer in [1, 2, 3, 4, 5, 6]
         @eval begin
-            @inline $stencil(i, j, k, grid, scheme::UpwindBiased{$buffer}, ψ, idx, loc, args...)           = @inbounds sum($(reconstruction_stencil(buffer, side, ξ, false)) .* retrieve_coeff(scheme, Val($sd), Val($val), idx, loc))
-            @inline $stencil(i, j, k, grid, scheme::UpwindBiased{$buffer}, ψ::Function, idx, loc, args...) = @inbounds sum($(reconstruction_stencil(buffer, side, ξ,  true)) .* retrieve_coeff(scheme, Val($sd), Val($val), idx, loc))
+            @inline $stencil(i, j, k, grid, scheme::UpwindBiased{$buffer}, ::Val{:left},  ψ, idx, loc, args...)           = @inbounds sum($(reconstruction_stencil(buffer, :left,  ξ, false)) .* retrieve_coeff(scheme, Val(:left),  Val($val), idx, loc))
+            @inline $stencil(i, j, k, grid, scheme::UpwindBiased{$buffer}, ::Val{:left},  ψ::Function, idx, loc, args...) = @inbounds sum($(reconstruction_stencil(buffer, :left,  ξ,  true)) .* retrieve_coeff(scheme, Val(:left),  Val($val), idx, loc))
+            @inline $stencil(i, j, k, grid, scheme::UpwindBiased{$buffer}, ::Val{:right}, ψ, idx, loc, args...)           = @inbounds sum($(reconstruction_stencil(buffer, :right, ξ, false)) .* retrieve_coeff(scheme, Val(:right), Val($val), idx, loc))
+            @inline $stencil(i, j, k, grid, scheme::UpwindBiased{$buffer}, ::Val{:right}, ψ::Function, idx, loc, args...) = @inbounds sum($(reconstruction_stencil(buffer, :right, ξ,  true)) .* retrieve_coeff(scheme, Val(:right), Val($val), idx, loc))
         end
     end
 end
 
-# Retrieve precomputed coefficients 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{1}, ::Val{1}, i, ::Type{Face})   = @inbounds scheme.coeff_xᶠᵃᵃ[1][i] 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{1}, ::Val{1}, i, ::Type{Center}) = @inbounds scheme.coeff_xᶜᵃᵃ[1][i] 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{1}, ::Val{2}, i, ::Type{Face})   = @inbounds scheme.coeff_yᵃᶠᵃ[1][i] 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{1}, ::Val{2}, i, ::Type{Center}) = @inbounds scheme.coeff_yᵃᶜᵃ[1][i] 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{1}, ::Val{3}, i, ::Type{Face})   = @inbounds scheme.coeff_zᵃᵃᶠ[1][i] 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{1}, ::Val{3}, i, ::Type{Center}) = @inbounds scheme.coeff_zᵃᵃᶜ[1][i] 
+# Retrieve precomputed coefficients
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:left}, ::Val{1}, i, ::Type{Face})   = @inbounds scheme.coeff_xᶠᵃᵃ[1][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:left}, ::Val{1}, i, ::Type{Center}) = @inbounds scheme.coeff_xᶜᵃᵃ[1][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:left}, ::Val{2}, i, ::Type{Face})   = @inbounds scheme.coeff_yᵃᶠᵃ[1][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:left}, ::Val{2}, i, ::Type{Center}) = @inbounds scheme.coeff_yᵃᶜᵃ[1][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:left}, ::Val{3}, i, ::Type{Face})   = @inbounds scheme.coeff_zᵃᵃᶠ[1][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:left}, ::Val{3}, i, ::Type{Center}) = @inbounds scheme.coeff_zᵃᵃᶜ[1][i] 
 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{2}, ::Val{1}, i, ::Type{Face})   = @inbounds scheme.coeff_xᶠᵃᵃ[2][i] 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{2}, ::Val{1}, i, ::Type{Center}) = @inbounds scheme.coeff_xᶜᵃᵃ[2][i] 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{2}, ::Val{2}, i, ::Type{Face})   = @inbounds scheme.coeff_yᵃᶠᵃ[2][i] 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{2}, ::Val{2}, i, ::Type{Center}) = @inbounds scheme.coeff_yᵃᶜᵃ[2][i] 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{2}, ::Val{3}, i, ::Type{Face})   = @inbounds scheme.coeff_zᵃᵃᶠ[2][i] 
-@inline retrieve_coeff(scheme::UpwindBiased, ::Val{2}, ::Val{3}, i, ::Type{Center}) = @inbounds scheme.coeff_zᵃᵃᶜ[2][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:right}, ::Val{1}, i, ::Type{Face})   = @inbounds scheme.coeff_xᶠᵃᵃ[2][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:right}, ::Val{1}, i, ::Type{Center}) = @inbounds scheme.coeff_xᶜᵃᵃ[2][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:right}, ::Val{2}, i, ::Type{Face})   = @inbounds scheme.coeff_yᵃᶠᵃ[2][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:right}, ::Val{2}, i, ::Type{Center}) = @inbounds scheme.coeff_yᵃᶜᵃ[2][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:right}, ::Val{3}, i, ::Type{Face})   = @inbounds scheme.coeff_zᵃᵃᶠ[2][i] 
+@inline retrieve_coeff(scheme::UpwindBiased, ::Val{:right}, ::Val{3}, i, ::Type{Center}) = @inbounds scheme.coeff_zᵃᵃᶜ[2][i] 

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -196,8 +196,8 @@ const UpwindFullVectorInvariant      = VectorInvariant{<:Any, <:Any, <:AbstractU
     Sζ = scheme.vorticity_stencil
 
     @inbounds v̂ = ℑxᶠᵃᵃ(i, j, k, grid, ℑyᵃᶜᵃ, Δx_qᶜᶠᶜ, v) / Δxᶠᶜᶜ(i, j, k, grid) 
-    ζᴸ =  _left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, ζ₃ᶠᶠᶜ, Sζ, u, v)
-    ζᴿ = _right_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, ζ₃ᶠᶠᶜ, Sζ, u, v)
+    dir = upwinding_direction(v̂)
+    ζᴿ  = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, dir, ζ₃ᶠᶠᶜ, Sζ, u, v)
 
     return - upwind_biased_product(v̂, ζᴸ, ζᴿ)
 end
@@ -207,8 +207,8 @@ end
     Sζ = scheme.vorticity_stencil
 
     @inbounds û  =  ℑyᵃᶠᵃ(i, j, k, grid, ℑxᶜᵃᵃ, Δy_qᶠᶜᶜ, u) / Δyᶜᶠᶜ(i, j, k, grid)
-    ζᴸ =  _left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, ζ₃ᶠᶠᶜ, Sζ, u, v)
-    ζᴿ = _right_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, ζ₃ᶠᶠᶜ, Sζ, u, v)
+    dir = upwinding_direction(û)
+    ζᴿ  = _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, dir, ζ₃ᶠᶠᶜ, Sζ, u, v)
 
     return + upwind_biased_product(û, ζᴸ, ζᴿ)
 end
@@ -218,14 +218,14 @@ end
     Sζ = scheme.vorticity_stencil
 
     @inbounds v̂ = ℑxᶠᵃᵃ(i, j, k, grid, ℑyᵃᶜᵃ, Δx_qᶜᶠᶜ, v) / Δxᶠᶜᶜ(i, j, k, grid) 
-    ζᴸ =  _left_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, ζ₃ᶠᶠᶜ, Sζ, u, v)
-    ζᴿ = _right_biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, ζ₃ᶠᶠᶜ, Sζ, u, v)
+    dir = upwinding_direction(v̂)
+    ζᴿ  = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, dir, ζ₃ᶠᶠᶜ, Sζ, u, v)
 
     Sδ = scheme.divergence_stencil
     
     @inbounds û = u[i, j, k]
-    δᴸ =  _left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme.divergence_scheme, div_xyᶜᶜᶜ, Sδ, u, v)
-    δᴿ = _right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme.divergence_scheme, div_xyᶜᶜᶜ, Sδ, u, v)
+    dir = upwinding_direction(û)
+    δᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme.divergence_scheme, dir, div_xyᶜᶜᶜ, Sδ, u, v)
 
     return upwind_biased_product(û, δᴸ, δᴿ) - upwind_biased_product(v̂, ζᴸ, ζᴿ)
 end
@@ -235,14 +235,14 @@ end
     Sζ = scheme.vorticity_stencil
 
     @inbounds û  =  ℑyᵃᶠᵃ(i, j, k, grid, ℑxᶜᵃᵃ, Δy_qᶠᶜᶜ, u) / Δyᶜᶠᶜ(i, j, k, grid)
-    ζᴸ =  _left_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, ζ₃ᶠᶠᶜ, Sζ, u, v)
-    ζᴿ = _right_biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, ζ₃ᶠᶠᶜ, Sζ, u, v)
+    dir = upwinding_direction(û)
+    ζᴿ  = _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, dir, ζ₃ᶠᶠᶜ, Sζ, u, v)
 
     Sδ = scheme.divergence_stencil
 
     @inbounds v̂ = v[i, j, k]
-    δᴸ =  _left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme.divergence_scheme, div_xyᶜᶜᶜ, Sδ, u, v)
-    δᴿ = _right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme.divergence_scheme, div_xyᶜᶜᶜ, Sδ, u, v)
+    dir = upwinding_direction(v̂)
+    δᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme.divergence_scheme, dir, div_xyᶜᶜᶜ, Sδ, u, v)
 
     return upwind_biased_product(û, ζᴸ, ζᴿ) + upwind_biased_product(v̂, δᴸ, δᴿ)
 end
@@ -269,18 +269,11 @@ const UZ{N} = UpwindBiased{N, <:Any, <:Any, <:Any, <:Nothing}
 # To adapt passing smoothness stencils to upwind biased schemes (not weno) 
 for buffer in 1:6
     @eval begin
-        @inline inner_left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::U{$buffer},  f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, f, idx, loc, args...)
-        @inline inner_left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UX{$buffer}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_left_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, f, idx, loc, args...)
-        @inline inner_left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::U{$buffer},  f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, f, idx, loc, args...)
-        @inline inner_left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UY{$buffer}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_left_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, f, idx, loc, args...)
-        @inline inner_left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::U{$buffer},  f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, f, idx, loc, args...)
-        @inline inner_left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UZ{$buffer}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_left_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, f, idx, loc, args...)
-
-        @inline inner_right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::U{$buffer},  f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, f, idx, loc, args...)
-        @inline inner_right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UX{$buffer}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_right_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, f, idx, loc, args...)
-        @inline inner_right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::U{$buffer},  f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, f, idx, loc, args...)
-        @inline inner_right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UY{$buffer}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_right_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, f, idx, loc, args...)
-        @inline inner_right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::U{$buffer},  f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, f, idx, loc, args...)
-        @inline inner_right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UZ{$buffer}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_right_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, f, idx, loc, args...)
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UX{$buffer}, ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UY{$buffer}, ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::U{$buffer},  ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UZ{$buffer}, ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
     end
 end

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -199,7 +199,7 @@ const UpwindFullVectorInvariant      = VectorInvariant{<:Any, <:Any, <:AbstractU
     dir = upwinding_direction(v̂)
     ζᴿ  = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, dir, ζ₃ᶠᶠᶜ, Sζ, u, v)
 
-    return - upwind_biased_product(v̂, ζᴸ, ζᴿ)
+    return - v̂ * ζᴿ
 end
 
 @inline function horizontal_advection_V(i, j, k, grid, scheme::UpwindVorticityVectorInvariant, u, v) 
@@ -210,7 +210,7 @@ end
     dir = upwinding_direction(û)
     ζᴿ  = _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, dir, ζ₃ᶠᶠᶜ, Sζ, u, v)
 
-    return + upwind_biased_product(û, ζᴸ, ζᴿ)
+    return û * ζᴿ
 end
 
 @inline function horizontal_advection_U(i, j, k, grid, scheme::UpwindFullVectorInvariant, u, v)
@@ -227,7 +227,7 @@ end
     dir = upwinding_direction(û)
     δᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme.divergence_scheme, dir, div_xyᶜᶜᶜ, Sδ, u, v)
 
-    return upwind_biased_product(û, δᴸ, δᴿ) - upwind_biased_product(v̂, ζᴸ, ζᴿ)
+    return û * δᴿ - v̂ * ζᴿ
 end
 
 @inline function horizontal_advection_V(i, j, k, grid, scheme::UpwindFullVectorInvariant, u, v) 
@@ -244,7 +244,7 @@ end
     dir = upwinding_direction(v̂)
     δᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme.divergence_scheme, dir, div_xyᶜᶜᶜ, Sδ, u, v)
 
-    return upwind_biased_product(û, ζᴸ, ζᴿ) + upwind_biased_product(v̂, δᴸ, δᴿ)
+    return û * ζᴿ + v̂ * δᴿ
 end
 
 ######

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -269,11 +269,18 @@ const UZ{N} = UpwindBiased{N, <:Any, <:Any, <:Any, <:Nothing}
 # To adapt passing smoothness stencils to upwind biased schemes (not weno) 
 for buffer in 1:6
     @eval begin
-        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
-        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UX{$buffer}, ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
-        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
-        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UY{$buffer}, ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
-        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::U{$buffer},  ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
-        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UZ{$buffer}, ::Val{D}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(D), f, idx, loc, args...)
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UX{$buffer}, ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UY{$buffer}, ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::U{$buffer},  ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UZ{$buffer}, ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UX{$buffer}, ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UY{$buffer}, ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::U{$buffer},  ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UZ{$buffer}, ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
     end
 end

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -196,8 +196,8 @@ const UpwindFullVectorInvariant      = VectorInvariant{<:Any, <:Any, <:AbstractU
     Sζ = scheme.vorticity_stencil
 
     @inbounds v̂ = ℑxᶠᵃᵃ(i, j, k, grid, ℑyᵃᶜᵃ, Δx_qᶜᶠᶜ, v) / Δxᶠᶜᶜ(i, j, k, grid) 
-    dir = upwinding_direction(v̂)
-    ζᴿ  = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, dir, ζ₃ᶠᶠᶜ, Sζ, u, v)
+    sidev = upwinding_direction(v̂)
+    ζᴿ    = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, sidev, ζ₃ᶠᶠᶜ, Sζ, u, v)
 
     return - v̂ * ζᴿ
 end
@@ -207,8 +207,8 @@ end
     Sζ = scheme.vorticity_stencil
 
     @inbounds û  =  ℑyᵃᶠᵃ(i, j, k, grid, ℑxᶜᵃᵃ, Δy_qᶠᶜᶜ, u) / Δyᶜᶠᶜ(i, j, k, grid)
-    dir = upwinding_direction(û)
-    ζᴿ  = _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, dir, ζ₃ᶠᶠᶜ, Sζ, u, v)
+    sideu = upwinding_direction(û)
+    ζᴿ    = _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, sideu, ζ₃ᶠᶠᶜ, Sζ, u, v)
 
     return û * ζᴿ
 end
@@ -218,14 +218,14 @@ end
     Sζ = scheme.vorticity_stencil
 
     @inbounds v̂ = ℑxᶠᵃᵃ(i, j, k, grid, ℑyᵃᶜᵃ, Δx_qᶜᶠᶜ, v) / Δxᶠᶜᶜ(i, j, k, grid) 
-    dir = upwinding_direction(v̂)
-    ζᴿ  = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, dir, ζ₃ᶠᶠᶜ, Sζ, u, v)
+    sidev = upwinding_direction(v̂)
+    ζᴿ    = _biased_interpolate_yᵃᶜᵃ(i, j, k, grid, scheme.vorticity_scheme, sidev, ζ₃ᶠᶠᶜ, Sζ, u, v)
 
     Sδ = scheme.divergence_stencil
     
     @inbounds û = u[i, j, k]
-    dir = upwinding_direction(û)
-    δᴿ  = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme.divergence_scheme, dir, div_xyᶜᶜᶜ, Sδ, u, v)
+    sideu = upwinding_direction(û)
+    δᴿ    = _biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme.divergence_scheme, sideu, div_xyᶜᶜᶜ, Sδ, u, v)
 
     return û * δᴿ - v̂ * ζᴿ
 end
@@ -235,14 +235,14 @@ end
     Sζ = scheme.vorticity_stencil
 
     @inbounds û  =  ℑyᵃᶠᵃ(i, j, k, grid, ℑxᶜᵃᵃ, Δy_qᶠᶜᶜ, u) / Δyᶜᶠᶜ(i, j, k, grid)
-    dir = upwinding_direction(û)
-    ζᴿ  = _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, dir, ζ₃ᶠᶠᶜ, Sζ, u, v)
+    sideu = upwinding_direction(û)
+    ζᴿ    = _biased_interpolate_xᶜᵃᵃ(i, j, k, grid, scheme.vorticity_scheme, sideu, ζ₃ᶠᶠᶜ, Sζ, u, v)
 
     Sδ = scheme.divergence_stencil
 
     @inbounds v̂ = v[i, j, k]
-    dir = upwinding_direction(v̂)
-    δᴿ  = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme.divergence_scheme, dir, div_xyᶜᶜᶜ, Sδ, u, v)
+    sidev = upwinding_direction(v̂)
+    δᴿ    = _biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme.divergence_scheme, sidev, div_xyᶜᶜᶜ, Sδ, u, v)
 
     return û * ζᴿ + v̂ * δᴿ
 end
@@ -269,18 +269,18 @@ const UZ{N} = UpwindBiased{N, <:Any, <:Any, <:Any, <:Nothing}
 # To adapt passing smoothness stencils to upwind biased schemes (not weno) 
 for buffer in 1:6
     @eval begin
-        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
-        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UX{$buffer}, ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
-        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
-        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UY{$buffer}, ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
-        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::U{$buffer},  ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
-        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UZ{$buffer}, ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UX{$buffer}, ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UY{$buffer}, ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::U{$buffer},  ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UZ{$buffer}, ::Val{:left}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:left), f, idx, loc, args...)
 
-        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
-        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UX{$buffer}, ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
-        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
-        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UY{$buffer}, ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
-        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::U{$buffer},  ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
-        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UZ{$buffer}, ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) where D = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme::UX{$buffer}, ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_xᶠᵃᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::U{$buffer},  ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme::UY{$buffer}, ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_yᵃᶠᵃ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::U{$buffer},  ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
+        @inline inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme::UZ{$buffer}, ::Val{:right}, f::Function, idx, loc, VI::AbstractSmoothnessStencil, args...) = inner_biased_interpolate_zᵃᵃᶠ(i, j, k, grid, scheme, Val(:right), f, idx, loc, args...)
     end
 end

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -319,7 +319,7 @@ using Oceananigans.Operators: ℑyᵃᶠᵃ, ℑxᶠᵃᵃ
 @inline function metaprogrammed_stencil_sum(buffer)
     elem = Vector(undef, buffer)
     for stencil = 1:buffer
-        elem[stencil] = :(@inbounds w[$stencil] * func(scheme, Val($(stencil-1), Val(D)), ψ[$stencil], cT, Val(val), idx, loc))
+        elem[stencil] = :(@inbounds w[$stencil] * func(scheme, Val($(stencil-1)), Val(D), ψ[$stencil], cT, Val(val), idx, loc))
     end
 
     return Expr(:call, :+, elem...)

--- a/src/ImmersedBoundaries/conditional_fluxes.jl
+++ b/src/ImmersedBoundaries/conditional_fluxes.jl
@@ -264,7 +264,7 @@ for (d, ξ) in enumerate((:x, :y, :z))
             
             # Conditional high-order interpolation for Vector Invariant WENO in Bounded directions
             @inline $alt_interp(i, j, k, ibg::ImmersedBoundaryGrid, scheme::WENO, ::Val{D}, ζ, VI::AbstractSmoothnessStencil, u, v) where D =
-                ifelse($near_boundary(i, j, k, ibg, schem, Val(D)),
+                ifelse($near_boundary(i, j, k, ibg, scheme, Val(D)),
                         $alt_interp(i, j, k, ibg, scheme.buffer_scheme, Val(D), ζ, VI, u, v),
                         $interp(i, j, k, ibg, scheme, Val(D), ζ, VI, u, v))
         end    

--- a/src/ImmersedBoundaries/conditional_fluxes.jl
+++ b/src/ImmersedBoundaries/conditional_fluxes.jl
@@ -195,7 +195,7 @@ for buffer in [1, 2, 3, 4, 5, 6]
                           $(calc_inactive_stencil(buffer,   :right, :x, :ᶜ; xside = :ᶜ)...), 
                           $(calc_inactive_stencil(buffer,   :right, :x, :ᶜ; xside = :ᶜ, yshift = 1)...))
 
-        @inline near_y_horizontal_boundary(i, j, k, ibg, ::AbstractAdvectionScheme{$buffer}, ::Val{:tight}) = 
+        @inline near_y_horizontal_boundary(i, j, k, ibg, ::AbstractAdvectionScheme{$buffer}, ::Val{:right}) = 
             @inbounds (|)($(calc_inactive_stencil(buffer+1, :right, :y, :ᶜ; xside = :ᶜ)...), 
                           $(calc_inactive_stencil(buffer,   :right, :y, :ᶜ; yside = :ᶜ)...), 
                           $(calc_inactive_stencil(buffer,   :right, :y, :ᶜ; yside = :ᶜ, xshift = 1)...))
@@ -254,7 +254,7 @@ for (d, ξ) in enumerate((:x, :y, :z))
             using Oceananigans.Advection: $interp
 
             # Fallback for low order interpolation
-            @inline $alt_interp(i, j, k, ibg::ImmersedBoundaryGrid, scheme::LOADV, args...) = $interp(i, j, k, ibg, scheme, args...)
+            @inline $alt_interp(i, j, k, ibg::ImmersedBoundaryGrid, scheme::LOADV, ::Val{D}, args...) where D = $interp(i, j, k, ibg, scheme, Val(D), args...)
 
             # Conditional high-order interpolation in Bounded directions
             @inline $alt_interp(i, j, k, ibg::ImmersedBoundaryGrid, scheme::HOADV, ::Val{D}, args...) where D =


### PR DESCRIPTION
Testing this branch vs main in a 3D example with `momentum_advection = VectorInvariant(vorticity_scheme = WENO(), divergence_scheme = WENO(), vertical_scheme = WENO())` and `tracer_advection = WENO()`

This branch:
![Screenshot 2023-02-21 at 4 34 22 PM](https://user-images.githubusercontent.com/33547697/220463656-0ab7389b-2dc1-415e-98d1-c2d772b0b302.png)


Main:
![Screenshot 2023-02-21 at 4 34 02 PM](https://user-images.githubusercontent.com/33547697/220463630-48b3c9a1-f18c-4623-99e0-b383adeed088.png)

