### PR TITLE
Make it easier to restart a simulation from a checkpoint with additional passive tracers

### DIFF
--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -209,16 +209,12 @@ function set!(model, filepath::AbstractString)
         model_fields = prognostic_fields(model)
 
         for name in propertynames(model_fields)
-            try
+            if string(name) ∈ keys(file) # Test if variable exist in checkpoint
                 parent_data = file["$name/data"]
                 model_field = model_fields[name]
                 copyto!(model_field.data.parent, parent_data)
-            catch err
-                if err isa KeyError
-                    @warn "Could not restore $name from checkpoint."
-                else
-                    rethrow(err)
-                end
+            else
+                @warn "Field $name does not exist in checkpoint and could not be restored."
             end
         end
 
@@ -240,7 +236,7 @@ end
 
 function set_time_stepper_tendencies!(timestepper, file, model_fields)
     for name in propertynames(model_fields)
-        try
+        if string(name) ∈ keys(file["timestepper/Gⁿ"]) # Test if variable tendencies exist in checkpoint
             # Tendency "n"
             parent_data = file["timestepper/Gⁿ/$name/data"]
 
@@ -252,12 +248,8 @@ function set_time_stepper_tendencies!(timestepper, file, model_fields)
 
             tendency⁻_field = timestepper.G⁻[name]
             copyto!(tendency⁻_field.data.parent, parent_data)
-        catch err
-            if err isa KeyError
-                @warn "Could not restore tendencies for $name from checkpoint."
-            else
-                rethrow(err)
-            end
+        else
+            @warn "Tendencies for $name do not exist in checkpoint and could not be restored."
         end
     end
 


### PR DESCRIPTION
This feature adds support for using a checkpoint file to initialize a model that contains additional passive tracers that weren't present in the original simulation. The use case in mind is whenever a user wants to start passive tracers only after simulation spin-up, for example.

At the moment, on main, this isn't possible since if we try to pickup a simulation but a given variable can't be found in the checkpointer file, the code throws a warning when trying to set the data for that variable, and an error when trying to set its tendencies.

This PR changes the code so that it throws an error for both cases. After this PR a user can then do:

```julia
using Oceananigans

grid = RectilinearGrid(size = (4, 4, 4), extent = (1,1,1))

model_spinup = NonhydrostaticModel(; grid, tracers = :b)
set!(model_spinup, b=1)

simulation = Simulation(model_spinup, Δt = 1, stop_time = 10)
simulation.output_writers[:checkpointer] = checkpointer = Checkpointer(model_spinup,
                                                                       schedule=TimeInterval(5),
                                                                       prefix="checkpoint")

run!(simulation)

using Oceananigans.OutputWriters: write_output!
write_output!(checkpointer, model_spinup)

model = NonhydrostaticModel(; grid,
                            tracers = (keys(model_spinup.tracers)..., :t1, :t2))

@info "Restarting model with more tracers"
checkpoint_file_path = Oceananigans.OutputWriters.checkpoint_path(true, simulation.output_writers)
set!(model, checkpoint_file_path)

simulation = Simulation(model, Δt = 1, stop_time = 20)

run!(simulation)
```

On main this throws a `KeyError`. On this branch this produces:

```julia
[ Info: Initializing simulation...
[ Info:     ... simulation initialization complete (1.614 seconds)
[ Info: Executing initial time step...
[ Info:     ... initial time step complete (20.304 seconds).
[ Info: Simulation is stopping after running for 22.039 seconds.
[ Info: Simulation time 10 seconds equals or exceeds stop time 10 seconds.
[ Info: Restarting model with more tracers
┌ Warning: Could not restore t1 from checkpoint.
└ @ Oceananigans.OutputWriters ~/repos/Oceananigans.jl/src/OutputWriters/checkpointer.jl:218
┌ Warning: Could not restore t2 from checkpoint.
└ @ Oceananigans.OutputWriters ~/repos/Oceananigans.jl/src/OutputWriters/checkpointer.jl:218
┌ Warning: Could not restore tendencies for t1 from checkpoint.
└ @ Oceananigans.OutputWriters ~/repos/Oceananigans.jl/src/OutputWriters/checkpointer.jl:257
┌ Warning: Could not restore tendencies for t2 from checkpoint.
└ @ Oceananigans.OutputWriters ~/repos/Oceananigans.jl/src/OutputWriters/checkpointer.jl:257
[ Info: Initializing simulation...
[ Info:     ... simulation initialization complete (514.400 μs)
[ Info: Executing initial time step...
[ Info:     ... initial time step complete (41.614 seconds).
[ Info: Simulation is stopping after running for 41.750 seconds.
[ Info: Simulation time 20 seconds equals or exceeds stop time 20 seconds.

julia> interior(model.tracers.b)
4×4×4 view(::Array{Float64, 3}, 4:7, 4:7, 4:7) with eltype Float64:
[:, :, 1] =
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0

[:, :, 2] =
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0

[:, :, 3] =
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0

[:, :, 4] =
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0

julia> interior(model.tracers.t1)
4×4×4 view(::Array{Float64, 3}, 4:7, 4:7, 4:7) with eltype Float64:
[:, :, 1] =
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0

[:, :, 2] =
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0

[:, :, 3] =
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0

[:, :, 4] =
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
```

One option to add safety is to modify `set!(model, filepath::AbstractString)` to take an option argument `skip_missing_variables = false` (or something), which would change the behavior from throwing a warning to throwing an error.

@whitleyv 