### PR TITLE
Fixes calculation of diffusive CFL for LES with Tuple closures

### DIFF
--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -70,4 +70,4 @@ cell_diffusion_timescale(::ConvectiveAdjustmentVerticalDiffusivity{<:VerticallyI
                          diffusivities, grid) = Inf
 
 cell_diffusion_timescale(closure::Tuple, diffusivities, grid) =
-    min(Tuple(cell_diffusion_timescale(c, diffusivities, grid) for c in closure)...)
+    min(Tuple(cell_diffusion_timescale(c, diff, grid) for (c, diff) in zip(closure, diffusivities))...)

--- a/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
+++ b/src/TurbulenceClosures/turbulence_closure_diagnostics.jl
@@ -69,5 +69,5 @@ end
 cell_diffusion_timescale(::ConvectiveAdjustmentVerticalDiffusivity{<:VerticallyImplicitTimeDiscretization},
                          diffusivities, grid) = Inf
 
-cell_diffusion_timescale(closure::Tuple, diffusivities, grid) =
-    min(Tuple(cell_diffusion_timescale(c, diff, grid) for (c, diff) in zip(closure, diffusivities))...)
+cell_diffusion_timescale(closure::Tuple, diffusivity_fields, grid) =
+    minimum(cell_diffusion_timescale(c, diffusivities, grid) for (c, diffusivities) in zip(closure, diffusivity_fields))

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -101,6 +101,7 @@ function time_step_with_variable_isotropic_diffusivity(arch)
                                 κ = (x, y, z, t) -> exp(z) * cos(x) * cos(y) * cos(t))
 
     model = NonhydrostaticModel(; grid, closure)
+
     time_step!(model, 1, euler=true)
     return true
 end
@@ -126,8 +127,8 @@ function time_step_with_variable_discrete_diffusivity(arch)
     closure_κ = ScalarDiffusivity(κ = κd, discrete_form=true, loc = (Center, Face, Center))
 
     model = NonhydrostaticModel(grid=RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 2, 3)), tracers = (:T, :S), closure=(closure_ν, closure_κ))
-    time_step!(model, 1, euler=true)
 
+    time_step!(model, 1, euler=true)
     return true
 end
 
@@ -276,6 +277,6 @@ end
         end
 
         # now test also a case for a tuple of closures
-        compute_closure_specific_diffusive_cfl((ScalarDiffusivity(), ScalarBiharmonicDiffusivity()))
+        compute_closure_specific_diffusive_cfl((ScalarDiffusivity(), ScalarBiharmonicDiffusivity(), SmagorinskyLilly(), AnisotropicMinimumDissipation()))
     end
 end


### PR DESCRIPTION
When trying to run a LES with a Tuple closure (such as `closure = (ScalarDiffusivity(), SmagorinskyLilly())`), the calculation of a diffusive timescale fails on main:

```
julia> cell_diffusion_timescale(model.closure, model.diffusivity_fields, model.grid)
ERROR: type Tuple has no field νₑ
Stacktrace:
  [1] getproperty
    @ ./Base.jl:38 [inlined]
  [2] cell_diffusion_timescale(closure::SmagorinskyLilly{Oceananigans.TurbulenceClosures.ExplicitTimeDiscretization, Float64, NamedTuple{(:b,), Tuple{Float64}}}, diffusivities::Tuple{Nothing, NamedTuple{(:νₑ,), Tuple{Field{Center, Center, Center, Nothing, RectilinearGrid{Float64, Periodic, Periodic, Bounded, Float64, Float64, OffsetArrays.OffsetVector{Float64, Vector{Float64}}, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}, OffsetArrays.OffsetVector{Float64, Vector{Float64}}, CPU}, Tuple{Colon, Colon, Colon}, OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, Float64, FieldBoundaryConditions{BoundaryCondition{Oceananigans.BoundaryConditions.Periodic, Nothing}, BoundaryCondition{Oceananigans.BoundaryConditions.Periodic, Nothing}, BoundaryCondition{Oceananigans.BoundaryConditions.Periodic, Nothing}, BoundaryCondition{Oceananigans.BoundaryConditions.Periodic, Nothing}, BoundaryCondition{Oceananigans.BoundaryConditions.Flux, Nothing}, BoundaryCondition{Oceananigans.BoundaryConditions.Flux, Nothing}, BoundaryCondition{Oceananigans.BoundaryConditions.Flux, Nothing}}, Nothing, Oceananigans.Fields.FieldBoundaryBuffers{Nothing, Nothing, Nothing, Nothing}}}}}, grid::RectilinearGrid{Float64, Periodic, Periodic, Bounded, Float64, Float64, OffsetArrays.OffsetVector{Float64, Vector{Float64}}, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}, OffsetArrays.OffsetVector{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}, OffsetArrays.OffsetVector{Float64, Vector{Float64}}, CPU})
    @ Oceananigans.TurbulenceClosures /glade/work/tomasc/.julia/packages/Oceananigans/yF0dQ/src/TurbulenceClosures/turbulence_closure_diagnostics.jl:51
```

This PR fixes that and generalizes a test so that this issue can be caught in the future.