### PR TITLE
Informative error message for non-regularly spaced grids in `NonhydrostaticModel`

### DIFF
--- a/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
+++ b/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
@@ -27,7 +27,7 @@ PressureSolver(arch, grid::HRegRectilinearGrid) = FourierTridiagonalPoissonSolve
 PressureSolver(arch, ibg::ImmersedBoundaryGrid) = PressureSolver(arch, ibg.underlying_grid)
 
 # fall back
-PressureSolver(arch, grid) = error("Pressure solver for NonhydrostaticModel only supports horizontally regularly spaced grids at the moment.")
+PressureSolver(arch, grid) = error("None of the implemented pressure solvers for NonhydrostaticModel support horizontally-stretched grids.")
 
 #####
 ##### NonhydrostaticModel definition

--- a/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
+++ b/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
@@ -26,6 +26,9 @@ PressureSolver(arch, grid::HRegRectilinearGrid) = FourierTridiagonalPoissonSolve
 # *Evil grin*
 PressureSolver(arch, ibg::ImmersedBoundaryGrid) = PressureSolver(arch, ibg.underlying_grid)
 
+# fall back
+PressureSolver(arch, grid) = error("Pressure solver for NonhydrostaticModel only supports horizontally regularly spaced grids at the moment.")
+
 #####
 ##### NonhydrostaticModel definition
 #####

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -78,7 +78,7 @@ Keyword arguments
 
   - `grid`: (required) The resolution and discrete geometry on which the `model` is solved. The
             architecture (CPU/GPU) that the model is solve on is inferred from the architecture
-            of the `grid`. Note that the grid needs to be regurarly spaced in the horizontal
+            of the `grid`. Note that the grid needs to be regularly spaced in the horizontal
             dimensions, ``x`` and ``y``.
   - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
   - `buoyancy`: The buoyancy model. See `Oceananigans.BuoyancyModels`.

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -77,9 +77,9 @@ Keyword arguments
 =================
 
   - `grid`: (required) The resolution and discrete geometry on which the `model` is solved. The
-            architecture (CPU/GPU) that the model is solve is inferred from the architecture
-            of the `grid`. The grid needs to be regurarly spaced in the horizontal dimensions,
-            ``x`` and ``y``.
+            architecture (CPU/GPU) that the model is solve on is inferred from the architecture
+            of the `grid`. Note that the grid needs to be regurarly spaced in the horizontal
+            dimensions, ``x`` and ``y``.
   - `advection`: The scheme that advects velocities and tracers. See `Oceananigans.Advection`.
   - `buoyancy`: The buoyancy model. See `Oceananigans.BuoyancyModels`.
   - `coriolis`: Parameters for the background rotation rate of the model.

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -123,7 +123,7 @@ function NonhydrostaticModel(;    grid,
     )
 
     # At the moment, pressure solver requires horizontally regularly spaced grids.
-    !isa(typeof(grid), Union{HRegRectilinearGrid, RegRectilinearGrid, ImmersedBoundaryGrid}) &&
+    !isa(grid, Union{HRegRectilinearGrid, RegRectilinearGrid, ImmersedBoundaryGrid}) &&
         error("NonhydrostaticModel only supports horizontally regularly spaced grids at the moment.")
 
     arch = architecture(grid)

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -122,10 +122,6 @@ function NonhydrostaticModel(;    grid,
                       auxiliary_fields = NamedTuple()
     )
 
-    # At the moment, pressure solver requires horizontally regularly spaced grids.
-    !isa(grid, Union{HRegRectilinearGrid, RegRectilinearGrid, ImmersedBoundaryGrid}) &&
-        error("NonhydrostaticModel only supports horizontally regularly spaced grids at the moment.")
-
     arch = architecture(grid)
 
     tracers = tupleit(tracers) # supports tracers=:c keyword argument (for example)

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -10,7 +10,7 @@ using Oceananigans.BuoyancyModels: validate_buoyancy, regularize_buoyancy, Seawa
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
 using Oceananigans.Fields: BackgroundFields, Field, tracernames, VelocityFields, TracerFields, PressureFields
 using Oceananigans.Forcings: model_forcing
-using Oceananigans.Grids: inflate_halo_size, with_halo, architecture, HRegRectilinearGrid, RegRectilinearGrid
+using Oceananigans.Grids: inflate_halo_size, with_halo, architecture
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 using Oceananigans.Solvers: FFTBasedPoissonSolver
 using Oceananigans.TimeSteppers: Clock, TimeStepper, update_state!


### PR DESCRIPTION
This PR adds an informative error when a grid with non-regularly spaced $x$ or $y$ dimensions is provided in the `NonhydrostaticModel`.

Closes #2940