### PR TITLE
Return zero for `closure == nothing`

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -71,6 +71,7 @@ export
     IsopycnalSkewSymmetricDiffusivity,
     FluxTapering,
     VerticallyImplicitTimeDiscretization,
+    viscosity, diffusivity,
 
     # Lagrangian particle tracking
     LagrangianParticles,

--- a/src/TurbulenceClosures/turbulence_closure_implementations/nothing_closure.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/nothing_closure.jl
@@ -5,3 +5,6 @@
 
 calculate_diffusivities!(diffusivities, ::Nothing, args...) = nothing
 calculate_diffusivities!(::Nothing, ::Nothing, args...) = nothing
+
+@inline viscosity(::Nothing, ::Nothing) = 0.0
+@inline diffusivity(::Nothing, ::Nothing, ::Val{id}) where id = 0.0

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -200,7 +200,7 @@ end
             κ = diffusivity(model.closure, model.diffusivity_fields, Val(:c)) 
             κ_dx_c = κ * ∂x(c)
             ν = viscosity(model.closure, model.diffusivity_fields)
-            ν_dx_u = ν * ∂x(c)
+            ν_dx_u = ν * ∂x(u)
             @test ν_dx_u[1, 1, 1] == 0.0
             @test κ_dx_c[1, 1, 1] == 0.0
         end


### PR DESCRIPTION
This is useful for writing general code from the user perspective. Ideally we'd want to return `zero(FT)`, but there's nowhere obvious to get the float type, so I think this is okay for now.