### PR TITLE
More informative message when user provides smaller halo size than ImmersedBoundraryGrid requires

### DIFF
--- a/src/Fields/regridding_fields.jl
+++ b/src/Fields/regridding_fields.jl
@@ -15,10 +15,6 @@ const c = Center()
 
 Regrid field `b` onto the grid of field `a`. 
 
-!!! warning "Functionality limitation"
-    Currently `regrid!` only regrids in the vertical ``z`` direction and works only on
-    fields that have data only in ``z`` direction.
-
 Example
 =======
 

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -223,14 +223,14 @@ validate_momentum_advection(momentum_advection, grid::AbstractHorizontallyCurvil
 validate_momentum_advection(momentum_advection::Union{VectorInvariant, Nothing}, grid::AbstractHorizontallyCurvilinearGrid) = momentum_advection
 
 function validate_model_halo(grid, momentum_advection, tracer_advection, closure)
-  user_halo = halo_size(grid)
-  required_halo = inflate_halo_size(1, 1, 1, grid,
-                                    momentum_advection,
-                                    tracer_advection,
-                                    closure)
+    user_halo = halo_size(grid)
+    required_halo = inflate_halo_size(1, 1, 1, grid,
+                                      momentum_advection,
+                                      tracer_advection,
+                                      closure)
 
-  any(user_halo .< required_halo) &&
-    throw(ArgumentError("The grid halo $user_halo must be at least equal to $required_halo. Note that an ImmersedBoundaryGrid requires an extra halo point."))
+    any(user_halo .< required_halo) &&
+        throw(ArgumentError("The grid halo $user_halo must be at least equal to $required_halo. Note that an ImmersedBoundaryGrid requires an extra halo point in all directions compared to a non-immersed grid."))
 end
 
 initialize_model!(model::HydrostaticFreeSurfaceModel) = initialize_free_surface!(model.free_surface, model.grid, model.velocities)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -230,7 +230,7 @@ function validate_model_halo(grid, momentum_advection, tracer_advection, closure
                                       closure)
 
     any(user_halo .< required_halo) &&
-        throw(ArgumentError("The grid halo $user_halo must be at least equal to $required_halo. Note that an ImmersedBoundaryGrid requires an extra halo point in all directions compared to a non-immersed grid."))
+        throw(ArgumentError("The grid halo $user_halo must be at least equal to $required_halo. Note that an ImmersedBoundaryGrid requires an extra halo point in all non-flat directions compared to a non-immersed boundary grid."))
 end
 
 initialize_model!(model::HydrostaticFreeSurfaceModel) = initialize_free_surface!(model.free_surface, model.grid, model.velocities)

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -227,7 +227,7 @@ function inflate_grid_halo_size(grid, tendency_terms...)
 
     if any(user_halo .< required_halo) # Replace grid
         @warn "Inflating model grid halo size to ($Hx, $Hy, $Hz) and recreating grid. " *
-              "Note that an ImmersedBoundaryGrid requires an extra halo point in all directions compared to a non-immersed grid."
+              "Note that an ImmersedBoundaryGrid requires an extra halo point in all non-flat directions compared to a non-immersed boundary grid."
               "The model grid will be different from the input grid. To avoid this warning, " *
               "pass halo=($Hx, $Hy, $Hz) when constructing the grid."
 

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -227,7 +227,7 @@ function inflate_grid_halo_size(grid, tendency_terms...)
 
     if any(user_halo .< required_halo) # Replace grid
         @warn "Inflating model grid halo size to ($Hx, $Hy, $Hz) and recreating grid. " *
-              "Note that an ImmersedBoundaryGrid requires an extra halo point. "
+              "Note that an ImmersedBoundaryGrid requires an extra halo point in all directions compared to a non-immersed grid."
               "The model grid will be different from the input grid. To avoid this warning, " *
               "pass halo=($Hx, $Hy, $Hz) when constructing the grid."
 


### PR DESCRIPTION
Closes #2983

The PR also took the opportunity to remove the warning from the `regrid!` docstring since the warning does not hold after merging #2881 