### PR TITLE
Flips sign for `gravity_unit_vector` to match its description (attempt #2)

### DIFF
--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -221,7 +221,7 @@ To simulate gravitational accelerations that don't align with the vertical (`z`)
 we wrap the buoyancy model in
 `Buoyancy()` function call, which takes the keyword arguments `model` and `gravity_unit_vector`,
 
-```jldoctest buoyancy
+```jldoctest buoyancy; filter = r".*@ Oceananigans.BuoyancyModels.*"
 julia> θ = 45; # degrees
 
 julia> g̃ = (0, sind(θ), cosd(θ));
@@ -229,9 +229,10 @@ julia> g̃ = (0, sind(θ), cosd(θ));
 julia> model = NonhydrostaticModel(; grid, 
                                    buoyancy=Buoyancy(model=BuoyancyTracer(), gravity_unit_vector=g̃), 
                                    tracers=:b)
-┌ Info: The meaning of `gravity_unit_vector` changed in version 0.80.0.
+┌ Warning: The meaning of `gravity_unit_vector` changed in version 0.80.0.
 │ In versions 0.79 and earlier, `gravity_unit_vector` indicated the direction _opposite_ to gravity.
-└ In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration.
+│ In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration.
+└ @ Oceananigans.BuoyancyModels ~/builds/tartarus-16/clima/oceananigans/src/BuoyancyModels/buoyancy.jl:48
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 ├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper

--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -23,11 +23,11 @@ end
 
 
 ```jldoctest buoyancy
-julia> grid = RectilinearGrid(size=(64, 64, 64), extent=(1, 1, 1));
+julia> grid = RectilinearGrid(size=(8, 8, 8), extent=(1, 1, 1));
 
 julia> model = NonhydrostaticModel(; grid, buoyancy=nothing)
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: ()
 ├── closure: Nothing
@@ -35,13 +35,13 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 └── coriolis: Nothing
 ```
 
-`buoyancy=nothing` is the default option for`NonhydrostaticModel`, so omitting `buoyancy`
-from the `NonhydrostaticModel` constructor yields an identical result:
+The option `buoyancy = nothing` is the default for [`NonhydrostaticModel`](@ref), so omitting the
+`buoyancy` keyword argument from the `NonhydrostaticModel` constructor yields the same:
 
 ```jldoctest buoyancy
 julia> model = NonhydrostaticModel(; grid)
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: ()
 ├── closure: Nothing
@@ -50,13 +50,13 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 ```
 
 To create a `HydrostaticFreeSurfaceModel` without a buoyancy term we explicitly
-specify `buoyancy=nothing` flag. The default tracers `T` and `S` for `HydrostaticFreeSurfaceModel`
-may be eliminated when `buoyancy=nothing` by specifying `tracers=()`:
+specify `buoyancy = nothing`. The default tracers `T` and `S` for `HydrostaticFreeSurfaceModel`
+may be eliminated when `buoyancy = nothing` by specifying `tracers = ()`:
 
 ```jldoctest buoyancy
 julia> model = HydrostaticFreeSurfaceModel(; grid, buoyancy=nothing, tracers=())
 HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: ()
 ├── closure: Nothing
@@ -74,24 +74,24 @@ a buoyancy tracer by including `:b` in `tracers` and specifying  `buoyancy = Buo
 ```jldoctest buoyancy
 julia> model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=:b)
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: b
 ├── closure: Nothing
-├── buoyancy: BuoyancyTracer with -ĝ = ZDirection
+├── buoyancy: BuoyancyTracer with ĝ = NegativeZDirection()
 └── coriolis: Nothing
 ```
 
-We follow the same pattern to create a `HydrostaticFreeSurfaceModel` with buoyancy as a tracer:
+Similarly for a `HydrostaticFreeSurfaceModel` with buoyancy as a tracer:
 
 ```jldoctest buoyancy
 julia> model = HydrostaticFreeSurfaceModel(; grid, buoyancy=BuoyancyTracer(), tracers=:b)
 HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: b
 ├── closure: Nothing
-├── buoyancy: BuoyancyTracer with -ĝ = ZDirection
+├── buoyancy: BuoyancyTracer with ĝ = NegativeZDirection()
 ├── free surface: ImplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 │   └── solver: FFTImplicitFreeSurfaceSolver
 └── coriolis: Nothing
@@ -100,34 +100,35 @@ HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 
 ## Seawater buoyancy
 
 `NonhydrostaticModel` and `HydrostaticFreeSurfaceModel` support modeling the buoyancy of seawater
-as a function of gravitational acceleration, conservative temperature ``T`` and absolute salinity ``S``.
-The relationship between ``T``, ``S``, the geopotential height, and the density perturbation from
-a reference value is called the `equation_of_state`.
+as a function of the gravitational acceleration, the conservative temperature ``T``, and the absolute
+salinity ``S``. The relationship between ``T``, ``S``, the geopotential height, and the density
+perturbation from a reference value is called the `equation_of_state`.
 
 Specifying `buoyancy = SeawaterBuoyancy()` returns a buoyancy model with a linear equation of state,
-[Earth standard](https://en.wikipedia.org/wiki/Standard_gravity) `gravitational_acceleration = 9.80665` (``\text{m}\,\text{s}^{-2}``) and requires the tracers `:T` and `:S`:
+[Earth standard](https://en.wikipedia.org/wiki/Standard_gravity) `gravitational_acceleration = 9.80665` (in 
+S.I. units ``\text{m}\,\text{s}^{-2}``) and requires to add `:T` and `:S` as tracers:
 
 ```jldoctest buoyancy
 julia> model = NonhydrostaticModel(; grid, buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: (T, S)
 ├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with -ĝ = ZDirection
+├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with ĝ = NegativeZDirection()
 └── coriolis: Nothing
 ```
-
-With `HydrostaticFreeSurfaceModel`,
+With `HydrostaticFreeSurfaceModel`, these are the default choices for `buoyancy` and `tracers` so,
+either including them or not we get:
 
 ```jldoctest buoyancy
 julia> model = HydrostaticFreeSurfaceModel(; grid, buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
 HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: (T, S)
 ├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with -ĝ = ZDirection
+├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with ĝ = NegativeZDirection()
 ├── free surface: ImplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 │   └── solver: FFTImplicitFreeSurfaceSolver
 └── coriolis: Nothing
@@ -138,11 +139,11 @@ is identical to the default,
 ```jldoctest buoyancy
 julia> model = HydrostaticFreeSurfaceModel(; grid)
 HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: (T, S)
 ├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with -ĝ = ZDirection
+├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with ĝ = NegativeZDirection()
 ├── free surface: ImplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 │   └── solver: FFTImplicitFreeSurfaceSolver
 └── coriolis: Nothing
@@ -159,11 +160,11 @@ SeawaterBuoyancy{Float64}:
 
 julia> model = NonhydrostaticModel(; grid, buoyancy=buoyancy, tracers=(:T, :S))
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: (T, S)
 ├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy with g=1.3 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with -ĝ = ZDirection
+├── buoyancy: SeawaterBuoyancy with g=1.3 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with ĝ = NegativeZDirection()
 └── coriolis: Nothing
 ```
 
@@ -183,9 +184,9 @@ SeawaterBuoyancy{Float64}:
 
 ### Idealized nonlinear equations of state
 
-Instead of a linear equation of state, five idealized (second-order) nonlinear equation of state as described by
-[Roquet15Idealized](@cite) may be used. These equations of state are provided via the
-[SeawaterPolynomials.jl](https://github.com/CliMA/SeawaterPolynomials.jl) package.
+Instead of a linear equation of state, five idealized (second-order) nonlinear equation of state
+as described by [Roquet15Idealized](@cite) may be used. These equations of state are provided
+via the [SeawaterPolynomials.jl](https://github.com/CliMA/SeawaterPolynomials.jl) package.
 
 ```jldoctest buoyancy
 julia> using SeawaterPolynomials.SecondOrderSeawaterPolynomials
@@ -228,11 +229,14 @@ julia> g̃ = (0, sind(θ), cosd(θ));
 julia> model = NonhydrostaticModel(; grid, 
                                    buoyancy=Buoyancy(model=BuoyancyTracer(), gravity_unit_vector=g̃), 
                                    tracers=:b)
+┌ Info: The meaning of `gravity_unit_vector` changed in version 0.80.0.
+│ In versions 0.79 and earlier, `gravity_unit_vector` indicated the direction _opposite_ to gravity.
+└ In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration.
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 64×64×64 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: b
 ├── closure: Nothing
-├── buoyancy: BuoyancyTracer with -ĝ = Tuple{Int64, Float64, Float64}
+├── buoyancy: BuoyancyTracer with ĝ = Tuple{Float64, Float64, Float64}
 └── coriolis: Nothing
 ```

--- a/src/BuoyancyModels/buoyancy.jl
+++ b/src/BuoyancyModels/buoyancy.jl
@@ -15,7 +15,7 @@ The buoyancy acceleration acts in the direction opposite to gravity.
 Example
 =======
 
-```jldoctest
+```jldoctest; filter = r"└ @ Oceananigans.BuoyancyModels.*"
 
 using Oceananigans
 
@@ -30,9 +30,10 @@ model = NonhydrostaticModel(grid=grid, buoyancy=buoyancy, tracers=:b)
 
 # output
 
-┌ Info: The meaning of `gravity_unit_vector` changed in version 0.80.0.
+┌ Warning: The meaning of `gravity_unit_vector` changed in version 0.80.0.
 │ In versions 0.79 and earlier, `gravity_unit_vector` indicated the direction _opposite_ to gravity.
-└ In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration.
+│ In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration.
+└ @ Oceananigans.BuoyancyModels ~/builds/tartarus-16/clima/oceananigans/src/BuoyancyModels/buoyancy.jl:48
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 ├── grid: 1×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
@@ -44,7 +45,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 """
 function Buoyancy(; model, gravity_unit_vector=NegativeZDirection())
     gravity_unit_vector != NegativeZDirection() &&
-        @info """The meaning of `gravity_unit_vector` changed in version 0.80.0.
+        @warn """The meaning of `gravity_unit_vector` changed in version 0.80.0.
                  In versions 0.79 and earlier, `gravity_unit_vector` indicated the direction _opposite_ to gravity.
                  In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration."""
     gravity_unit_vector = validate_unit_vector(gravity_unit_vector)

--- a/src/BuoyancyModels/buoyancy.jl
+++ b/src/BuoyancyModels/buoyancy.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Grids: ZDirection, validate_unit_vector
+using Oceananigans.Grids: NegativeZDirection, validate_unit_vector
 
 struct Buoyancy{M, G}
     model :: M
@@ -6,11 +6,11 @@ struct Buoyancy{M, G}
 end
 
 """
-    Buoyancy(; model, gravity_unit_vector=ZDirection())
+    Buoyancy(; model, gravity_unit_vector=NegativeZDirection())
 
-Uses a given buoyancy `model` to create buoyancy in a model. The optional keyword argument 
-`gravity_unit_vector` can be used to specify the direction opposite to the gravitational
-acceleration (which we take here to mean the "vertical" direction).
+Construct a `buoyancy` given a buoyancy `model`. Optional keyword argument `gravity_unit_vector`
+can be used to specify the direction of gravity (default `NegativeZDirection()`).
+The buoyancy acceleration acts in the direction opposite to gravity.
 
 Example
 =======
@@ -19,10 +19,10 @@ Example
 
 using Oceananigans
 
-grid = RectilinearGrid(size=(1, 8, 8), extent=(1, 1000, 100))
+grid = RectilinearGrid(size=(1, 8, 8), extent=(1, 1, 1))
 
 θ = 45 # degrees
-g̃ = (0, sind(θ), cosd(θ))
+g̃ = (0, sind(θ), cosd(θ));
 
 buoyancy = Buoyancy(model=BuoyancyTracer(), gravity_unit_vector=g̃)
 
@@ -30,28 +30,35 @@ model = NonhydrostaticModel(grid=grid, buoyancy=buoyancy, tracers=:b)
 
 # output
 
+┌ Info: The meaning of `gravity_unit_vector` changed in version 0.80.0.
+│ In versions 0.79 and earlier, `gravity_unit_vector` indicated the direction _opposite_ to gravity.
+└ In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration.
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 ├── grid: 1×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: b
 ├── closure: Nothing
-├── buoyancy: BuoyancyTracer with -ĝ = Tuple{Int64, Float64, Float64}
+├── buoyancy: BuoyancyTracer with ĝ = Tuple{Float64, Float64, Float64}
 └── coriolis: Nothing
 ```
 """
-function Buoyancy(; model, gravity_unit_vector=ZDirection())
+function Buoyancy(; model, gravity_unit_vector=NegativeZDirection())
+    gravity_unit_vector != NegativeZDirection() &&
+        @info """The meaning of `gravity_unit_vector` changed in version 0.80.0.
+                 In versions 0.79 and earlier, `gravity_unit_vector` indicated the direction _opposite_ to gravity.
+                 In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration."""
     gravity_unit_vector = validate_unit_vector(gravity_unit_vector)
     return Buoyancy(model, gravity_unit_vector)
 end
 
 
-@inline ĝ_x(buoyancy) = @inbounds buoyancy.gravity_unit_vector[1]
-@inline ĝ_y(buoyancy) = @inbounds buoyancy.gravity_unit_vector[2]
-@inline ĝ_z(buoyancy) = @inbounds buoyancy.gravity_unit_vector[3]
+@inline ĝ_x(buoyancy) = @inbounds -buoyancy.gravity_unit_vector[1]
+@inline ĝ_y(buoyancy) = @inbounds -buoyancy.gravity_unit_vector[2]
+@inline ĝ_z(buoyancy) = @inbounds -buoyancy.gravity_unit_vector[3]
 
-@inline ĝ_x(::Buoyancy{M, ZDirection}) where M = 0
-@inline ĝ_y(::Buoyancy{M, ZDirection}) where M = 0
-@inline ĝ_z(::Buoyancy{M, ZDirection}) where M = 1
+@inline ĝ_x(::Buoyancy{M, NegativeZDirection}) where M = 0
+@inline ĝ_y(::Buoyancy{M, NegativeZDirection}) where M = 0
+@inline ĝ_z(::Buoyancy{M, NegativeZDirection}) where M = 1
 
 #####
 ##### For convenience
@@ -70,7 +77,6 @@ end
 regularize_buoyancy(b) = b
 regularize_buoyancy(b::AbstractBuoyancyModel) = Buoyancy(model=b)
 
-Base.summary(buoyancy::Buoyancy) = string(summary(buoyancy.model), " with -ĝ = ", summary(buoyancy.gravity_unit_vector))
+Base.summary(buoyancy::Buoyancy) = string(summary(buoyancy.model), " with ĝ = ", summary(buoyancy.gravity_unit_vector))
 
-Base.show(io::IO, buoyancy::Buoyancy) = summary(buoyancy)
-
+Base.show(io::IO, buoyancy::Buoyancy) = print(io, sprint(show, buoyancy.model), "\nwith `gravity_unit_vector` = ", summary(buoyancy.gravity_unit_vector))

--- a/src/BuoyancyModels/g_dot_b.jl
+++ b/src/BuoyancyModels/g_dot_b.jl
@@ -2,6 +2,6 @@
 @inline y_dot_g_b(i, j, k, grid, buoyancy, C) = ĝ_y(buoyancy) * buoyancy_perturbation(i, j, k, grid, buoyancy.model, C)
 @inline z_dot_g_b(i, j, k, grid, buoyancy, C) = ĝ_z(buoyancy) * buoyancy_perturbation(i, j, k, grid, buoyancy.model, C)
 
-@inline x_dot_g_b(i, j, k, grid,  ::Buoyancy{M, ZDirection}, C) where M = 0
-@inline y_dot_g_b(i, j, k, grid,  ::Buoyancy{M, ZDirection}, C) where M = 0
-@inline z_dot_g_b(i, j, k, grid, b::Buoyancy{M, ZDirection}, C) where M = buoyancy_perturbation(i, j, k, grid, b.model, C)
+@inline x_dot_g_b(i, j, k, grid,  ::Buoyancy{M, NegativeZDirection}, C) where M = 0
+@inline y_dot_g_b(i, j, k, grid,  ::Buoyancy{M, NegativeZDirection}, C) where M = 0
+@inline z_dot_g_b(i, j, k, grid, b::Buoyancy{M, NegativeZDirection}, C) where M = buoyancy_perturbation(i, j, k, grid, b.model, C)

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -416,7 +416,12 @@ end
 #####
 
 struct ZDirection end
-Base.summary(::ZDirection) = "ZDirection"
+Base.summary(::ZDirection) = "ZDirection()"
+Base.show(io::IO, zdir::ZDirection) = print(io, summary(zdir))
+
+struct NegativeZDirection end
+Base.summary(::NegativeZDirection) = "NegativeZDirection()"
+Base.show(io::IO, zdir::NegativeZDirection) = print(io, summary(zdir))
 
 #####
 ##### Show utils

--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -174,14 +174,18 @@ function validate_vertically_stretched_grid_xy(TX, TY, FT, x, y)
 end
 
 validate_unit_vector(ê::ZDirection) = ê
+validate_unit_vector(ê::NegativeZDirection) = ê
 
 function validate_unit_vector(ê)
     length(ê) == 3 || throw(ArgumentError("unit vector must have length 3"))
 
+    # ensures that all components of ê are of the same type
+    ê = Tuple([ê...])
+
     ex, ey, ez = ê
 
     ex^2 + ey^2 + ez^2 ≈ 1 ||
-        throw(ArgumentError("unit vector `ê` must have ê[1]² + ê[2]² + ê[3]² ≈ 1"))
+        throw(ArgumentError("unit vector `ê` must satisfy ê[1]² + ê[2]² + ê[3]² ≈ 1"))
 
     return tuple(ê...)
 end


### PR DESCRIPTION
This is the second attempt at flipping the sign of `gravity_unit_vector`. The first attempt (https://github.com/CliMA/Oceananigans.jl/pull/2963) had an issue where the doctests were getting stuck with no apparent cause.

For this attempt, I proceeded more carefully, step by step to try and pinpoint what was happening. The good news is that the doctests are now passing locally. The bad news is that I still don't know why they were getting stuck in https://github.com/CliMA/Oceananigans.jl/pull/2963.

Since tests pass locally for me (I tested everything except the examples) I'm hopefully that this time they'll also pass on buildkite.

@navidcy your modifications to https://github.com/CliMA/Oceananigans.jl/pull/2963 are also included here!