### PR TITLE
Fix performance issue #2996

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/calculate_hydrostatic_free_surface_tendencies.jl
@@ -262,7 +262,7 @@ end
     @inbounds Gc[i, j, k] =  hydrostatic_free_surface_tracer_tendency(i, j, k, grid, args...)
 end
 
-""" Calculate the right-hand-side of the tracer advection-diffusion equation. """
+""" Calculate the right-hand-side of the subgrid scale energy equation. """
 @kernel function calculate_hydrostatic_free_surface_Ge!(Ge, grid, args)
     i, j, k = @index(Global, NTuple)
     @inbounds Ge[i, j, k] =  hydrostatic_turbulent_kinetic_energy_tendency(i, j, k, grid, args...)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
@@ -94,15 +94,15 @@ using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities: FlavorOfCATKE
 using Oceananigans.TurbulenceClosures.MEWSVerticalDiffusivities: MEWS
 
 """
-    unspecialized_hydrostatic_tracer_tendency(i, j, k, grid, 
-                                              val_tracer_index,
-                                              val_tracer_name::Val{tracer_name},
-                                              advection,
-                                              closure,
-                                              args...) where tracer_name
+    specialized_hydrostatic_tracer_tendency(i, j, k, grid, 
+                                            val_tracer_index,
+                                            val_tracer_name::Val{tracer_name},
+                                            advection,
+                                            closure,
+                                            args...) where tracer_name
 
 dispatches to the correct tendency kernel (trick to force CPU compilation). 
-Note that here the if... else... syntax is preferred to ifelse because there is _NO_ branch divergence
+Note that here the `if... else...` syntax is preferred to `ifelse` because there is _NO_ branch divergence
 (i.e., all threads will follow the same path)
 """
 @inline specialized_hydrostatic_tracer_tendency(i, j, k, grid, args...) =

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
@@ -90,52 +90,6 @@ implicitly during time-stepping.
              + forcings.v(i, j, k, grid, clock, model_fields))
 end
 
-using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities: FlavorOfCATKE
-using Oceananigans.TurbulenceClosures.MEWSVerticalDiffusivities: MEWS
-
-"""
-    specialized_hydrostatic_tracer_tendency(i, j, k, grid, 
-                                            val_tracer_index,
-                                            val_tracer_name::Val{tracer_name},
-                                            advection,
-                                            closure,
-                                            args...) where tracer_name
-
-dispatches to the correct tendency kernel (trick to force CPU compilation). 
-Note that here the `if... else...` syntax is preferred to `ifelse` because there is _NO_ branch divergence
-(i.e., all threads will follow the same path)
-"""
-@inline specialized_hydrostatic_tracer_tendency(i, j, k, grid, args...) =
-            hydrostatic_free_surface_tracer_tendency(i, j, k, grid, args...)
-
-@inline function specialized_hydrostatic_tracer_tendency(i, j, k, grid, 
-                                                         val_tracer_name::Val{:e},
-                                                         closure,
-                                                         args...) 
-    
-    catke_index = findfirst(c -> c isa FlavorOfCATKE, closures)
-
-    if isnothing(catke_index)
-        return hydrostatic_free_surface_tracer_tendency(i, j, k, grid, val_tracer_name, closure, args...)
-    else
-        return hydrostatic_turbulent_kinetic_energy_tendency(i, j, k, grid, val_tracer_name, closure, args...)
-    end                                         
-end
-
-@inline function specialized_hydrostatic_tracer_tendency(i, j, k, grid, 
-                                                         val_tracer_name::Val{:K},
-                                                         closure,
-                                                         args...) 
-
-    mews_index = findfirst(c -> c isa MEWS, closures)
-
-    if isnothing(mews_index)
-        return hydrostatic_free_surface_tracer_tendency(i, j, k, grid, val_tracer_name, closure, args...)
-    else
-        return hydrostatic_turbulent_kinetic_energy_tendency(i, j, k, grid, val_tracer_name, closure, args...)
-    end                                         
-end
-
 """
 Return the tendency for a tracer field with index `tracer_index` 
 at grid point `i, j, k`.
@@ -149,10 +103,10 @@ The tendency is called ``G_c`` and defined via
 where `c = C[tracer_index]`. 
 """
 @inline function hydrostatic_free_surface_tracer_tendency(i, j, k, grid,
-                                                          val_tracer_name,
-                                                          closure,
                                                           val_tracer_index::Val{tracer_index},
+                                                          val_tracer_name,
                                                           advection,
+                                                          closure,
                                                           c_immersed_bc,
                                                           buoyancy,
                                                           biogeochemistry,
@@ -200,10 +154,10 @@ The tendency is called ``G_η`` and defined via
 end
 
 @inline function hydrostatic_turbulent_kinetic_energy_tendency(i, j, k, grid,
-                                                               val_tracer_name,
-                                                               closure,
                                                                val_tracer_index::Val{tracer_index},
+                                                               val_tracer_name,
                                                                advection,
+                                                               closure,
                                                                e_immersed_bc,
                                                                buoyancy,
                                                                biogeochemistry,

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -2,6 +2,8 @@ using Oceananigans.Operators: Δzᵃᵃᶜ, Δzᵃᵃᶠ
 using Oceananigans.AbstractOperations: flip
 using Oceananigans.Solvers: BatchedTridiagonalSolver, solve!
 
+import Oceananigans.Solvers: get_coefficient
+
 #####
 ##### implicit_step! interface
 #####
@@ -123,12 +125,16 @@ function implicit_diffusion_solver(::VerticallyImplicitTimeDiscretization, grid)
                                  "grids that are Bounded in the z-direction.")
 
     z_solver = BatchedTridiagonalSolver(grid;
-                                        lower_diagonal = maybe_tupled_ivd_lower_diagonal,
-                                        diagonal = ivd_diagonal,
-                                        upper_diagonal = maybe_tupled_ivd_upper_diagonal)
+                                        lower_diagonal = Val(:maybe_tupled_ivd_lower_diagonal),
+                                        diagonal       = Val(:ivd_diagonal),
+                                        upper_diagonal = Val(:maybe_tupled_ivd_upper_diagonal))
 
     return z_solver
 end
+
+@inline get_coefficient(::Val{:maybe_tupled_ivd_lower_diagonal}, i, j, k, grid, p, args...) = maybe_tupled_ivd_lower_diagonal(i, j, k, grid, args...)
+@inline get_coefficient(::Val{:maybe_tupled_ivd_upper_diagonal}, i, j, k, grid, p, args...) = maybe_tupled_ivd_upper_diagonal(i, j, k, grid, args...)
+@inline get_coefficient(::Val{:ivd_diagonal}, i, j, k, grid, p, args...) = ivd_diagonal(i, j, k, grid, args...)
 
 #####
 ##### Implicit step functions

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -132,6 +132,8 @@ function implicit_diffusion_solver(::VerticallyImplicitTimeDiscretization, grid)
     return z_solver
 end
 
+# Extend the `get_coefficient` function to retrieve the correct `ivd_diagonal`, `ivd_lower_diagonal` and `ivd_upper_diagonal` functions
+# REMEMBER: `get_coefficient(f::Function, args...)` leads to massive performance decrease on the CPU (https://github.com/CliMA/Oceananigans.jl/issues/2996) 
 @inline get_coefficient(::Val{:maybe_tupled_ivd_lower_diagonal}, i, j, k, grid, p, args...) = maybe_tupled_ivd_lower_diagonal(i, j, k, grid, args...)
 @inline get_coefficient(::Val{:maybe_tupled_ivd_upper_diagonal}, i, j, k, grid, p, args...) = maybe_tupled_ivd_upper_diagonal(i, j, k, grid, args...)
 @inline get_coefficient(::Val{:ivd_diagonal}, i, j, k, grid, p, args...) = ivd_diagonal(i, j, k, grid, args...)


### PR DESCRIPTION
On main we are passing the tendency kernel function as an argument to the kernel. 
Apparently, this prevents compilation on the CPU.
Another place where this design was implemented is the vertically implicit solver, where we pass functions to calculate the tridiagonal matrix coefficients.

This PR fixes both problems.

After this PR we should remember that we cannot pass functions as kernel arguments, 
not even as properties of a struct! Instead we can pass `Val(:function_name)` and dispatch on that to call the correct `function_name` (as this PR implements for the vertically implicit solver)

Baroclinic adjustment test (with `Nx = Ny = 128, Nz = 10`)
on main:
```
[ Info: Initializing simulation...
[00.00%] i: 0, t: 0 seconds, wall time: 870.922 ms, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 16.500 minutes
[ Info:     ... simulation initialization complete (957.942 ms)
[ Info: Executing initial time step...
[ Info:     ... initial time step complete (19.178 seconds).
[15.28%] i: 20, t: 5.500 hours, wall time: 1.732 minutes, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 18.150 minutes
[32.08%] i: 40, t: 11.550 hours, wall time: 1.376 minutes, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 19.965 minutes
[50.57%] i: 60, t: 18.205 hours, wall time: 1.333 minutes, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 20 minutes
[69.09%] i: 80, t: 1.036 days, wall time: 1.219 minutes, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 20 minutes
[87.61%] i: 100, t: 1.314 days, wall time: 1.175 minutes, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 20 minutes
[ Info: Simulation is stopping after running for 7.623 minutes.
[ Info: Simulation time 1.500 days equals or exceeds stop time 1.500 days.
```

on this PR:
```
[ Info: Initializing simulation...
[00.00%] i: 0, t: 0 seconds, wall time: 9.474 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 16.500 minutes
[ Info:     ... simulation initialization complete (4.467 seconds)
[ Info: Executing initial time step...
[ Info:     ... initial time step complete (29.607 seconds).
[15.28%] i: 20, t: 5.500 hours, wall time: 45.943 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 18.150 minutes
[32.08%] i: 40, t: 11.550 hours, wall time: 14.963 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 19.965 minutes
[50.57%] i: 60, t: 18.205 hours, wall time: 15.328 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 20 minutes
[69.09%] i: 80, t: 1.036 days, wall time: 15.417 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 20 minutes
[87.61%] i: 100, t: 1.314 days, wall time: 14.862 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 20 minutes
[ Info: Simulation is stopping after running for 2.050 minutes.
[ Info: Simulation time 1.500 days equals or exceeds stop time 1.500 days.
```

on Oceananigans v0.79.2 (with KA 0.7.2):
```
[ Info: Initializing simulation...
[00.00%] i: 0, t: 0 seconds, wall time: 52.447 ms, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 16.500 minutes
[ Info:     ... simulation initialization complete (53.391 ms)
[ Info: Executing initial time step...
[ Info:     ... initial time step complete (748.379 ms).
[15.28%] i: 20, t: 5.500 hours, wall time: 14.167 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 18.150 minutes
[32.08%] i: 40, t: 11.550 hours, wall time: 14.841 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 19.965 minutes
[50.57%] i: 60, t: 18.205 hours, wall time: 14.606 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 20 minutes
[69.09%] i: 80, t: 1.036 days, wall time: 14.924 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 20 minutes
[87.61%] i: 100, t: 1.314 days, wall time: 13.987 seconds, max(u): (0.000e+00, 0.000e+00, 0.000e+00) m/s, next Δt: 20 minutes
[ Info: Simulation is stopping after running for 1.358 minutes.
[ Info: Simulation time 1.500 days equals or exceeds stop time 1.500 days.
```

