### PR TITLE
Gather constants in `Constants` module

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.80.0"
+version = "0.81.0"
 
 [deps]
 AMGX = "c963dde9-0319-47f5-bf0c-b07d3c80ffa6"

--- a/benchmark/benchmark_implicit_surface_solvers.jl
+++ b/benchmark/benchmark_implicit_surface_solvers.jl
@@ -1,7 +1,8 @@
 using Oceananigans
+using Oceananigans.Constants: R_Earth
 using Oceananigans.Units
 using Oceananigans.Advection: VelocityStencil
-using Oceananigans.Coriolis: HydrostaticSphericalCoriolis, R_Earth
+using Oceananigans.Coriolis: HydrostaticSphericalCoriolis
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBottom
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: FFTImplicitFreeSurfaceSolver, MGImplicitFreeSurfaceSolver, finalize_solver!
 using Oceananigans.Solvers: initialize_AMGX, finalize_AMGX

--- a/docs/src/appendix/library.md
+++ b/docs/src/appendix/library.md
@@ -44,6 +44,13 @@ Modules = [Oceananigans.BuoyancyModels]
 Private = false
 ```
 
+## Constants
+
+```@autodocs
+Modules = [Oceananigans.Constants]
+Private = false
+```
+
 ## Coriolis
 
 ```@autodocs

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -44,7 +44,7 @@ grid = RectilinearGrid(size=(32, 32, 32), extent=(128, 128, 64))
 # (half the distance from wave crest to wave trough), which determine the wave
 # frequency and the vertical scale of the Stokes drift profile.
 
-using Oceananigans.BuoyancyModels: g_Earth
+using Oceananigans.Constants: g_Earth
 
  amplitude = 0.8 # m
 wavelength = 60  # m

--- a/src/BuoyancyModels/BuoyancyModels.jl
+++ b/src/BuoyancyModels/BuoyancyModels.jl
@@ -9,15 +9,13 @@ export
     BuoyancyField
 
 using Printf
+
 using Oceananigans.Grids
 using Oceananigans.Operators
+using Oceananigans.Constants: g_Earth
 using Oceananigans.BoundaryConditions: getbc
 
 import SeawaterPolynomials: ρ′, thermal_expansion, haline_contraction
-
-# Physical constants
-# https://en.wikipedia.org/wiki/Gravitational_acceleration#Gravity_model_for_Earth (30 Oct 2019)
-const g_Earth = 9.80665
 
 """
     AbstractBuoyancyModel{EOS}

--- a/src/Constants.jl
+++ b/src/Constants.jl
@@ -1,0 +1,31 @@
+module Constants
+
+export R_Earth, Ω_Earth, g_Earth
+
+using ..Units
+
+"""
+    const R_Earth
+    
+Mean radius of the Earth (in meters); see https://en.wikipedia.org/wiki/Earth
+"""
+const R_Earth = 6371kilometers
+
+"""
+    const Ω_Earth
+    
+Earth's rotation rate (in radians per second) which is equal to
+`2π / (1 sideral day) ≈ 2π / (23hours + 56minutes + 4.1seconds)`;
+see https://en.wikipedia.org/wiki/Earth%27s_rotation#Angular_speed
+"""
+const Ω_Earth = 7.292115e-5
+
+"""
+    const g_Earth
+
+Gravitational acceleration at the Earth's surface (in meters / second²);
+see https://en.wikipedia.org/wiki/Gravitational_acceleration#Gravity_model_for_Earth
+"""
+const g_Earth = 9.80665
+
+end # module

--- a/src/Constants.jl
+++ b/src/Constants.jl
@@ -23,7 +23,7 @@ const Ω_Earth = 7.292115e-5
 """
     const g_Earth
 
-Gravitational acceleration at the Earth's surface (in meters / second²);
+Gravitational acceleration at the Earth's surface (in meters per second²);
 see https://en.wikipedia.org/wiki/Gravitational_acceleration#Gravity_model_for_Earth
 """
 const g_Earth = 9.80665

--- a/src/Coriolis/Coriolis.jl
+++ b/src/Coriolis/Coriolis.jl
@@ -7,12 +7,10 @@ export
 
 using Printf
 using Adapt
+
 using Oceananigans.Grids
 using Oceananigans.Operators
-
-# Physical constants for constructors.
-const Ω_Earth = 7.292115e-5 # [s⁻¹] https://en.wikipedia.org/wiki/Earth%27s_rotation#Angular_speed
-const R_Earth = 6371.0e3    # Mean radius of the Earth [m] https://en.wikipedia.org/wiki/Earth
+using Oceananigans.Constants: R_Earth, Ω_Earth
 
 """
     AbstractRotation

--- a/src/CubedSpheres/conformal_cubed_sphere_grid.jl
+++ b/src/CubedSpheres/conformal_cubed_sphere_grid.jl
@@ -1,6 +1,9 @@
 using Rotations
+
 using Oceananigans.Grids
-using Oceananigans.Grids: R_Earth, interior_indices
+
+using Oceananigans.Grids: interior_indices
+using Oceananigans.Constants: R_Earth
 
 import Base: show, size, eltype
 import Oceananigans.Grids: topology, architecture, halo_size, on_architecture

--- a/src/Distributed/distributed_grids.jl
+++ b/src/Distributed/distributed_grids.jl
@@ -1,15 +1,16 @@
 using MPI
 using OffsetArrays
-using Oceananigans.Utils: getnamewrapper
-using Oceananigans.Grids: topology, size, halo_size, architecture, pop_flat_elements
-using Oceananigans.Grids: validate_rectilinear_grid_args, validate_lat_lon_grid_args
-using Oceananigans.Grids: generate_coordinate, with_precomputed_metrics
-using Oceananigans.Grids: cpu_face_constructor_x, cpu_face_constructor_y, cpu_face_constructor_z
-using Oceananigans.Grids: R_Earth, metrics_precomputed
-using Oceananigans.ImmersedBoundaries: AbstractGridFittedBottom, GridFittedBoundary, compute_mask
 
 using Oceananigans.Fields
 using Oceananigans.ImmersedBoundaries
+
+using Oceananigans.Utils: getnamewrapper
+using Oceananigans.Constants: R_Earth
+using Oceananigans.Grids: topology, size, halo_size, architecture, pop_flat_elements
+using Oceananigans.Grids: validate_rectilinear_grid_args, validate_lat_lon_grid_args
+using Oceananigans.Grids: generate_coordinate, metrics_precomputed, with_precomputed_metrics
+using Oceananigans.Grids: cpu_face_constructor_x, cpu_face_constructor_y, cpu_face_constructor_z
+using Oceananigans.ImmersedBoundaries: AbstractGridFittedBottom, GridFittedBoundary, compute_mask
 
 import Oceananigans.Grids: RectilinearGrid, LatitudeLongitudeGrid, with_halo
 

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -1,6 +1,6 @@
 using KernelAbstractions: @kernel, @index
 
-const R_Earth = 6371.0e3    # Mean radius of the Earth [m] https://en.wikipedia.org/wiki/Earth
+using Oceananigans.Constants: R_Earth
 
 struct LatitudeLongitudeGrid{FT, TX, TY, TZ, M, MY, FX, FY, FZ, VX, VY, VZ, Arch} <: AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Arch}
     architecture :: Arch

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -10,7 +10,7 @@ end
 
 export
     # Architectures
-    CPU, GPU, 
+    CPU, GPU,
 
     # Logging
     OceananigansLogger,
@@ -19,7 +19,7 @@ export
     Center, Face,
     Periodic, Bounded, Flat, 
     FullyConnected, LeftConnected, RightConnected,
-    RectilinearGrid, 
+    RectilinearGrid,
     LatitudeLongitudeGrid,
     OrthogonalSphericalShellGrid,
     xnodes, ynodes, znodes, nodes,
@@ -87,7 +87,7 @@ export
 
     # Hydrostatic free surface model stuff
     VectorInvariant, ExplicitFreeSurface, ImplicitFreeSurface, SplitExplicitFreeSurface,
-    HydrostaticSphericalCoriolis, 
+    HydrostaticSphericalCoriolis,
     PrescribedVelocityFields,
 
     # Time stepping
@@ -114,7 +114,7 @@ export
     ∂x, ∂y, ∂z, @at, KernelFunctionOperation,
 
     # MultiRegion and Cubed sphere
-    MultiRegionGrid, XPartition, 
+    MultiRegionGrid, XPartition,
     ConformalCubedSphereGrid,
 
     # Utils
@@ -194,6 +194,7 @@ function tracer_tendency_kernel_function end
 # Basics
 include("Architectures.jl")
 include("Units.jl")
+include("Constants.jl")
 include("Grids/Grids.jl")
 include("Utils/Utils.jl")
 include("Logger.jl")

--- a/test/test_coriolis.jl
+++ b/test/test_coriolis.jl
@@ -1,6 +1,6 @@
 include("dependencies_for_runtests.jl")
 
-using Oceananigans.Coriolis: Ω_Earth
+using Oceananigans.Constants: Ω_Earth
 using Oceananigans.Advection: EnergyConservingScheme, EnstrophyConservingScheme
 
 function instantiate_fplane_1(FT)

--- a/test/test_implicit_free_surface_solver.jl
+++ b/test/test_implicit_free_surface_solver.jl
@@ -1,7 +1,7 @@
 include("dependencies_for_runtests.jl")
 
 using Statistics
-using Oceananigans.BuoyancyModels: g_Earth
+using Oceananigans.Constants: g_Earth
 using Oceananigans.Architectures: device_event
 using Oceananigans.Operators
 using Oceananigans.Grids: inactive_cell


### PR DESCRIPTION
Prior of these PR constants (like Earth's radius) were multiply defined. Now all constants are gathered in a module loaded just after units.

Closes #2981