### PR TITLE
Start moving CUDA support into a package extension

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,6 +2,7 @@
 
 julia_version = "1.8.5"
 manifest_format = "2.0"
+project_hash = "d5f0410b4946a3cc3f1b299380c9432f13ef25ef"
 
 [[deps.AbstractFFTs]]
 deps = ["ChainRulesCore", "LinearAlgebra"]
@@ -62,9 +63,9 @@ version = "4.1.2"
 
 [[deps.CUDA_Driver_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
-git-tree-sha1 = "10ca2b63b496edc09258b3de5d1aa64094b18b1d"
+git-tree-sha1 = "498f45593f6ddc0adff64a9310bb6710e851781b"
 uuid = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-version = "0.5.0+0"
+version = "0.5.0+1"
 
 [[deps.CUDA_Runtime_Discovery]]
 deps = ["Libdl"]
@@ -74,9 +75,9 @@ version = "0.2.0"
 
 [[deps.CUDA_Runtime_jll]]
 deps = ["Artifacts", "CUDA_Driver_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
-git-tree-sha1 = "802b1f2220fd43251d343219adf478e6b7992bd4"
+git-tree-sha1 = "81eed046f28a0cdd0dc1f61d00a49061b7cc9433"
 uuid = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
-version = "0.5.0+0"
+version = "0.5.0+2"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ CubedSphere = "7445602f-e544-4518-8976-18f8e8ae6cdb"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 IncompleteLU = "40713840-3770-5561-ab4c-a76e7d0d7895"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -57,6 +58,9 @@ SeawaterPolynomials = "0.3.2"
 StructArrays = "0.4, 0.5, 0.6"
 julia = "1.6"
 
+[extensions]
+CUDAExt = "CUDA"
+
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
@@ -70,3 +74,6 @@ TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [targets]
 test = ["BenchmarkTools", "Coverage", "DataDeps", "InteractiveUtils", "Plots", "Test", "TimerOutputs", "TimesDates", "SafeTestsets"]
+
+[weakdeps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/benchmark/src/Benchmarks.jl
+++ b/benchmark/src/Benchmarks.jl
@@ -30,6 +30,7 @@ function __init__()
     Logging.global_logger(OceananigansLogger())
 end
 
+# TODO move to CUDAExt
 macro sync_gpu(expr)
     return CUDA.has_cuda() ? :($(esc(CUDA.@sync expr))) : :($(esc(expr)))
 end

--- a/ext/CUDAExt/Architectures.jl
+++ b/ext/CUDAExt/Architectures.jl
@@ -1,0 +1,46 @@
+module Architecture
+    using CUDA
+    using Oceananigans
+
+    import Oceananigans.Architectures: 
+        CPU, GPU, available,
+        device, architecture, array_type, arch_array, unified_array,
+        device_copy_to!, unsafe_free!
+
+    device(::GPU) = CUDA.CUDABackend(; always_inline=true)
+    architecture(::CuArray) = GPU()
+    available(::GPU) = CUDA.has_cuda()
+    array_type(::GPU) = CuArray
+
+    arch_array(::GPU, a::Array)   = CuArray(a)
+    arch_array(::CPU, a::CuArray) = Array(a)
+    arch_array(::GPU, a::CuArray) = a
+    arch_array(::GPU, a::SubArray{<:Any, <:Any, <:CuArray}) = a
+    arch_array(::CPU, a::SubArray{<:Any, <:Any, <:CuArray}) = Array(a)
+    arch_array(::GPU, a::SubArray{<:Any, <:Any, <:Array}) = CuArray(a)
+
+    unified_array(::GPU, a) = a
+
+    function unified_array(::GPU, arr::AbstractArray) 
+        buf = Mem.alloc(Mem.Unified, sizeof(arr))
+        vec = unsafe_wrap(CuArray{eltype(arr),length(size(arr))}, convert(CuPtr{eltype(arr)}, buf), size(arr))
+        finalizer(vec) do _
+            Mem.free(buf)
+        end
+        copyto!(vec, arr)
+        return vec
+    end
+
+    ## Only for contiguous data!! (i.e. only if the offset for pointer(dst::CuArrat, offset::Int) is 1)
+    @inline function device_copy_to!(dst::CuArray, src::CuArray; async::Bool = false) 
+        n = length(src)
+        context!(context(src)) do
+            GC.@preserve src dst begin
+                unsafe_copyto!(pointer(dst, 1), pointer(src, 1), n; async)
+            end
+        end
+        return dst
+    end
+
+    @inline unsafe_free!(a::CuArray) = CUDA.unsafe_free!(a)
+end

--- a/ext/CUDAExt/BoundaryConditions.jl
+++ b/ext/CUDAExt/BoundaryConditions.jl
@@ -1,0 +1,16 @@
+module BoundaryConditions
+    using CUDA
+    using Oceananigans
+
+    using Oceananigans.Architectures
+    import Oceananigans.BoundaryConditions: 
+        validate_boundary_condition_architecture
+
+    validate_boundary_condition_architecture(::CuArray, ::GPU, bc, side) = nothing
+
+    validate_boundary_condition_architecture(::CuArray, ::CPU, bc, side) =
+        throw(ArgumentError("$side $bc must use `Array` rather than `CuArray` on CPU architectures!"))
+
+    validate_boundary_condition_architecture(::Array, ::GPU, bc, side) =
+        throw(ArgumentError("$side $bc must use `CuArray` rather than `Array` on GPU architectures!"))
+end

--- a/ext/CUDAExt/CUDAExt.jl
+++ b/ext/CUDAExt/CUDAExt.jl
@@ -1,0 +1,18 @@
+module CUDAExt
+    using Oceananigans
+    using CUDA
+
+    function __init__()
+        if CUDA.has_cuda()
+            @debug "CUDA-enabled GPU(s) detected:"
+            for (gpu, dev) in enumerate(CUDA.devices())
+                @debug "$dev: $(CUDA.name(dev))"
+            end
+
+            CUDA.allowscalar(false)
+        end
+    end
+
+    include("Architectures.jl") 
+    include("BoundaryConditions.jl") 
+end

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -10,7 +10,6 @@ export
     apply_x_bcs!, apply_y_bcs!, apply_z_bcs!,
     fill_halo_regions!
 
-using CUDA
 using KernelAbstractions: @index, @kernel
 
 using Oceananigans.Architectures: CPU, GPU, device

--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -143,10 +143,3 @@ validate_boundary_condition_architecture(bc::BoundaryCondition, arch, side) =
 
 validate_boundary_condition_architecture(condition, arch, bc, side) = nothing
 validate_boundary_condition_architecture(::Array, ::CPU, bc, side) = nothing
-validate_boundary_condition_architecture(::CuArray, ::GPU, bc, side) = nothing
-
-validate_boundary_condition_architecture(::CuArray, ::CPU, bc, side) =
-    throw(ArgumentError("$side $bc must use `Array` rather than `CuArray` on CPU architectures!"))
-
-validate_boundary_condition_architecture(::Array, ::GPU, bc, side) =
-    throw(ArgumentError("$side $bc must use `CuArray` rather than `Array` on GPU architectures!"))

--- a/src/CubedSpheres/cubed_sphere_faces.jl
+++ b/src/CubedSpheres/cubed_sphere_faces.jl
@@ -1,5 +1,5 @@
 using Statistics
-using CUDA
+import CUDA: CuArray
 using Oceananigans.Architectures
 using Oceananigans.AbstractOperations: AbstractOperation
 

--- a/src/CubedSpheres/cubed_sphere_halo_filling.jl
+++ b/src/CubedSpheres/cubed_sphere_halo_filling.jl
@@ -1,4 +1,4 @@
-import CUDA
+import GPUArraysCore
 
 import Oceananigans.BoundaryConditions:
     fill_halo_regions!, fill_top_halo!, fill_bottom_halo!, fill_west_halo!, fill_east_halo!, fill_south_halo!, fill_north_halo!,
@@ -163,7 +163,7 @@ function fill_horizontal_velocity_halos!(u::CubedSphereField, v::CubedSphereFiel
 
     Nx, Ny, Nz, Nf = size(u.grid)
 
-    CUDA.@allowscalar @inbounds begin
+    GPUArraysCore.@allowscalar @inbounds begin
         # Face 1
         u.data[1][1,    Ny+1, :] .= -u.data[5][1,  Ny, :]
         u.data[1][Nx+1, 0,    :] .=  v.data[2][1,  1,  :]

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -2,6 +2,7 @@ using Oceananigans.BoundaryConditions: OBC, MCBC
 using Oceananigans.Grids: parent_index_range, index_range_offset, default_indices, all_indices, validate_indices
 
 using Adapt
+import GPUArraysCore
 using KernelAbstractions: @kernel, @index
 using Base: @propagate_inbounds
 
@@ -648,7 +649,7 @@ for reduction in (:sum, :maximum, :minimum, :all, :any, :prod)
             Base.$(reduction!)(identity, r, conditioned_c, init=false)
 
             if dims isa Colon
-                return CUDA.@allowscalar first(r)
+                return GPUArraysCore.@allowscalar first(r)
             else
                 return r
             end
@@ -687,7 +688,7 @@ Statistics.mean!(r::ReducedField, a::AbstractArray; kwargs...) = Statistics.mean
 function Statistics.norm(a::AbstractField; condition = nothing)
     r = zeros(a.grid, 1)
     Base.mapreducedim!(x -> x * x, +, r, condition_operand(a, condition, 0))
-    return CUDA.@allowscalar sqrt(r[1])
+    return GPUArraysCore.@allowscalar sqrt(r[1])
 end
 
 function Base.isapprox(a::AbstractField, b::AbstractField; kw...)

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -17,8 +17,7 @@ export minimum_xspacing, minimum_yspacing, minimum_zspacing
 export offset_data, new_data
 export on_architecture
 
-using CUDA
-using CUDA: has_cuda
+using GPUArraysCore
 using Adapt
 using OffsetArrays
 

--- a/src/Grids/grid_generation.jl
+++ b/src/Grids/grid_generation.jl
@@ -6,11 +6,11 @@
 get_domain_extent(::Nothing, N)             = (1, 1)
 get_domain_extent(coord, N)                 = (coord[1], coord[2])
 get_domain_extent(coord::Function, N)       = (coord(1), coord(N+1))
-get_domain_extent(coord::AbstractVector, N) = CUDA.@allowscalar (coord[1], coord[N+1])
+get_domain_extent(coord::AbstractVector, N) = GPUArraysCore.@allowscalar (coord[1], coord[N+1])
 
 get_coord_face(coord::Nothing, i) = 1
 get_coord_face(coord::Function, i) = coord(i)
-get_coord_face(coord::AbstractVector, i) = CUDA.@allowscalar coord[i]
+get_coord_face(coord::AbstractVector, i) = GPUArraysCore.@allowscalar coord[i]
 
 const AT = AbstractTopology
 lower_exterior_Δcoordᶠ(::AT, Fi, Hcoord) = [Fi[end - Hcoord + i] - Fi[end - Hcoord + i - 1] for i = 1:Hcoord]

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -41,7 +41,7 @@ function Base.:(==)(grid1::AbstractGrid, grid2::AbstractGrid)
     x1, y1, z1 = nodes(grid1, (Face(), Face(), Face()))
     x2, y2, z2 = nodes(grid2, (Face(), Face(), Face()))
 
-    CUDA.@allowscalar return x1 == x2 && y1 == y2 && z1 == z2
+    GPUArraysCore.@allowscalar return x1 == x2 && y1 == y2 && z1 == z2
 end
 
 const AT = AbstractTopology
@@ -134,8 +134,8 @@ constant grid spacing `Δ`, and interior extent `L`.
 @inline total_extent(::BoundedTopology, H, Δ, L) = L + 2H * Δ
 
 # Grid domains
-@inline domain(topo, N, ξ) = CUDA.@allowscalar ξ[1], ξ[N+1]
-@inline domain(::Flat, N, ξ) = CUDA.@allowscalar ξ[1], ξ[1]
+@inline domain(topo, N, ξ) = GPUArraysCore.@allowscalar ξ[1], ξ[N+1]
+@inline domain(::Flat, N, ξ) = GPUArraysCore.@allowscalar ξ[1], ξ[1]
 
 @inline x_domain(grid) = domain(topology(grid, 1)(), grid.Nx, grid.xᶠᵃᵃ)
 @inline y_domain(grid) = domain(topology(grid, 2)(), grid.Ny, grid.yᵃᶠᵃ)

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -185,7 +185,7 @@ function LatitudeLongitudeGrid(architecture::AbstractArchitecture = CPU(),
                                precompute_metrics = true,
                                halo = nothing)
 
-    if architecture == GPU() && !has_cuda() 
+    if architecture == GPU() && !available(architecture)
         throw(ArgumentError("Cannot create a GPU grid. No CUDA-enabled GPU was detected!"))
     end
 

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -256,7 +256,7 @@ function RectilinearGrid(architecture::AbstractArchitecture = CPU(),
                          extent = nothing,
                          topology = (Periodic, Periodic, Bounded))
 
-    if architecture == GPU() && !has_cuda() 
+    if architecture == GPU() && !available(architecture) 
         throw(ArgumentError("Cannot create a GPU grid. No CUDA-enabled GPU was detected!"))
     end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -1,4 +1,3 @@
-using CUDA: has_cuda
 using OrderedCollections: OrderedDict
 
 using Oceananigans: AbstractModel, AbstractOutputWriter, AbstractDiagnostic

--- a/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
@@ -1,4 +1,4 @@
-using CUDA: @allowscalar
+import GPUArraysCore: @allowscalar
 
 using Oceananigans: UpdateStateCallsite
 using Oceananigans.Grids: Flat, Bounded

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -1,4 +1,3 @@
-using CUDA: has_cuda
 using OrderedCollections: OrderedDict
 
 using Oceananigans: AbstractModel, AbstractOutputWriter, AbstractDiagnostic

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -124,7 +124,7 @@ using Printf
 using Logging
 using Statistics
 using LinearAlgebra
-using CUDA
+using GPUArraysCore
 using Adapt
 using DocStringExtensions
 using OffsetArrays
@@ -266,15 +266,10 @@ function __init__()
         # See: https://github.com/CliMA/Oceananigans.jl/issues/1113
         FFTW.set_num_threads(4*threads)
     end
+end
 
-    if CUDA.has_cuda()
-        @debug "CUDA-enabled GPU(s) detected:"
-        for (gpu, dev) in enumerate(CUDA.devices())
-            @debug "$dev: $(CUDA.name(dev))"
-        end
-
-        CUDA.allowscalar(false)
-    end
+if !isdefined(Base, :get_extension)
+  include("../ext/CUDAExt/CUDAExt.jl")
 end
 
 end # module

--- a/src/OutputWriters/OutputWriters.jl
+++ b/src/OutputWriters/OutputWriters.jl
@@ -6,7 +6,7 @@ export
     WindowedTimeAverage,
     TimeInterval, IterationInterval, WallTimeInterval, AveragedTimeInterval
 
-using CUDA
+
 
 using Oceananigans.Architectures
 using Oceananigans.Grids

--- a/src/OutputWriters/fetch_output.jl
+++ b/src/OutputWriters/fetch_output.jl
@@ -1,4 +1,4 @@
-using CUDA
+
 
 using Oceananigans.Fields: AbstractField, compute_at!
 using Oceananigans.LagrangianParticleTracking: LagrangianParticles

--- a/src/Solvers/Solvers.jl
+++ b/src/Solvers/Solvers.jl
@@ -10,6 +10,7 @@ export
 using Statistics
 using FFTW
 using CUDA
+using GPUArraysCore
 using SparseArrays
 using KernelAbstractions
 using KernelAbstractions.Extras.LoopInfo: @unroll

--- a/src/Solvers/fft_based_poisson_solver.jl
+++ b/src/Solvers/fft_based_poisson_solver.jl
@@ -108,7 +108,7 @@ function solve!(ϕ, solver::FFTBasedPoissonSolver, b, m=0)
     # If m === 0, the "zeroth mode" at `i, j, k = 1, 1, 1` is undetermined;
     # we set this to zero by default. Another slant on this "problem" is that
     # λx[1, 1, 1] + λy[1, 1, 1] + λz[1, 1, 1] = 0, which yields ϕ[1, 1, 1] = Inf or NaN.
-    m === 0 && CUDA.@allowscalar ϕc[1, 1, 1] = 0
+    m === 0 && GPUArraysCore.@allowscalar ϕc[1, 1, 1] = 0
 
     # Apply backward transforms in order
     [transform!(ϕc, solver.buffer) for transform! in solver.transforms.backward]

--- a/src/Solvers/fourier_tridiagonal_poisson_solver.jl
+++ b/src/Solvers/fourier_tridiagonal_poisson_solver.jl
@@ -45,7 +45,7 @@ function FourierTridiagonalPoissonSolver(grid, planner_flag=FFTW.PATIENT)
     transforms = plan_transforms(grid, sol_storage, planner_flag)
 
     # Lower and upper diagonals are the same
-    lower_diagonal = CUDA.@allowscalar [1 / Δzᵃᵃᶠ(1, 1, k, grid) for k in 2:Nz]
+    lower_diagonal = GPUArraysCore.@allowscalar [1 / Δzᵃᵃᶠ(1, 1, k, grid) for k in 2:Nz]
     lower_diagonal = arch_array(arch, lower_diagonal)
     upper_diagonal = lower_diagonal
 

--- a/src/Solvers/matrix_solver_utils.jl
+++ b/src/Solvers/matrix_solver_utils.jl
@@ -178,13 +178,13 @@ function compute_matrix_for_linear_operation(::GPU, template_field, linear_opera
     rowval = CuArray{Int}(undef, 0)
     nzval  = CuArray{eltype(grid)}(undef, 0)
 
-    CUDA.@allowscalar colptr[1] = 1
+    GPUArraysCore.@allowscalar colptr[1] = 1
 
     for k in 1:Nz, j in 1:Ny, i in 1:Nx
         parent(eᵢⱼₖ)  .= 0
         parent(Aeᵢⱼₖ) .= 0
 
-        CUDA.@allowscalar eᵢⱼₖ[i, j, k] = 1
+        GPUArraysCore.@allowscalar eᵢⱼₖ[i, j, k] = 1
 
         fill_halo_regions!(eᵢⱼₖ)
 
@@ -192,7 +192,7 @@ function compute_matrix_for_linear_operation(::GPU, template_field, linear_opera
 
         count = 0
         for n in 1:Nz, m in 1:Ny, l in 1:Nx
-            Aeᵢⱼₖₗₘₙ = CUDA.@allowscalar Aeᵢⱼₖ[l, m, n]
+            Aeᵢⱼₖₗₘₙ = GPUArraysCore.@allowscalar Aeᵢⱼₖ[l, m, n]
             if Aeᵢⱼₖₗₘₙ != 0
                 append!(rowval, Ny*Nx*(n-1) + Nx*(m-1) + l)
                 append!(nzval, Aeᵢⱼₖₗₘₙ)
@@ -200,7 +200,7 @@ function compute_matrix_for_linear_operation(::GPU, template_field, linear_opera
             end
         end
 
-        CUDA.@allowscalar colptr[Ny*Nx*(k-1) + Nx*(j-1) + i + 1] = colptr[Ny*Nx*(k-1) + Nx*(j-1) + i] + count
+        GPUArraysCore.@allowscalar colptr[Ny*Nx*(k-1) + Nx*(j-1) + i + 1] = colptr[Ny*Nx*(k-1) + Nx*(j-1) + i] + count
     end
 
     return CuSparseMatrixCSC(colptr, rowval, nzval, (Nx*Ny*Nz, Nx*Ny*Nz))

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -7,7 +7,7 @@ export
     Clock,
     tendencies
 
-using CUDA
+
 using KernelAbstractions
 using Oceananigans: AbstractModel, prognostic_fields
 using Oceananigans.Architectures: device

--- a/src/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/TurbulenceClosures/TurbulenceClosures.jl
@@ -33,7 +33,7 @@ export
 
     cell_diffusion_timescale
 
-using CUDA
+
 using KernelAbstractions
 using Adapt 
 

--- a/src/Utils/versioninfo.jl
+++ b/src/Utils/versioninfo.jl
@@ -2,6 +2,7 @@ using Pkg
 using InteractiveUtils
 using Oceananigans.Architectures
 
+# TODO: Move to CUDAExt
 function versioninfo_with_gpu()
     s = sprint(versioninfo)
     if CUDA.has_cuda()


### PR DESCRIPTION
Main motivation here is to make it possible to move CUDA with Julia 1.9 to a optional dependency,
making loading faster for non GPU workloads as well as making it easier for other GPU backends to be added.

Package extensions is a backwards compatible 1.9 feature, in 1.8 and prior we still have to load CUDA.jl by default
but on 1.9 this is no longer required.


