### PR TITLE
Adds `parameters` keyword to `UniformStokesDrift`

### DIFF
--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -53,18 +53,19 @@ wavenumber = 2π / wavelength # m⁻¹
 
 ## The vertical scale over which the Stokes drift of a monochromatic surface wave
 ## decays away from the surface is `1/2wavenumber`, or
-vertical_scale = wavelength / 4π
+const vertical_scale = wavelength / 4π
 
 ## Stokes drift velocity at the surface
-Uˢ = amplitude^2 * wavenumber * frequency # m s⁻¹
+const Uˢ = amplitude^2 * wavenumber * frequency # m s⁻¹
 
+# The `const` declarations ensure that Stokes drift functions compile on the GPU.
+# To run this example on the GPU, one only needs to include `architecture = GPU()` in the
+# constructor for `RectilinearGrid` above.
+#
 # We only need the vertical derivative of the Stokes drift, which is
 
-∂z_uˢ(z, t, p) = 1 / p.vertical_scale * p.Uˢ * exp(z / p.vertical_scale)
-stokes_drift = UniformStokesDrift(∂z_uˢ=∂z_uˢ, parameters = (; vertical_scale, Uˢ))
+∂z_uˢ(z, t) = 1 / vertical_scale * Uˢ * exp(z / vertical_scale)
 
-# Note that passing `vertical_scale` and `Uˢ` as parameters ensures that this simulation
-# runs on GPUs.
 #
 # !!! info "The Craik-Leibovich equations in Oceananigans"
 #     Oceananigans implements the Craik-Leibovich approximation for surface wave effects
@@ -126,7 +127,7 @@ model = NonhydrostaticModel(; grid, coriolis,
                             tracers = :b,
                             buoyancy = BuoyancyTracer(),
                             closure = AnisotropicMinimumDissipation(),
-                            stokes_drift = stokes_drift,
+                            stokes_drift = UniformStokesDrift(∂z_uˢ=∂z_uˢ),
                             boundary_conditions = (u=u_boundary_conditions, b=b_boundary_conditions))
 
 # ## Initial conditions

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -62,7 +62,11 @@ const Uˢ = amplitude^2 * wavenumber * frequency # m s⁻¹
 # To run this example on the GPU, one only needs to include `architecture = GPU()` in the
 # constructor for `RectilinearGrid` above.
 #
-# We only need the vertical derivative of the Stokes drift, which is
+# The Stokes drift profile is
+
+uˢ(z) = Uˢ * exp(z / vertical_scale)
+
+# and its `z`-derivative is
 
 ∂z_uˢ(z, t) = 1 / vertical_scale * Uˢ * exp(z / vertical_scale)
 

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -59,7 +59,7 @@ const vertical_scale = wavelength / 4π
 const Uˢ = amplitude^2 * wavenumber * frequency # m s⁻¹
 
 # The `const` declarations ensure that Stokes drift functions compile on the GPU.
-# To run this example on the GPU, one only needs to include `architecture = GPU()` in the
+# To run this example on the GPU, include `GPU()` in the
 # constructor for `RectilinearGrid` above.
 #
 # The Stokes drift profile is

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -81,7 +81,7 @@ uˢ(z) = Uˢ * exp(z / vertical_scale)
 #
 # The vertical derivative of the Stokes drift is
 
-∂z_uˢ(z, t) = 1 / vertical_scale * Uˢ * exp(z / vertical_scale)
+∂z_uˢ(z, t, p) = 1 / p.vertical_scale * Uˢ * exp(z / p.vertical_scale)
 
 # Finally, we note that the time-derivative of the Stokes drift must be provided
 # if the Stokes drift and surface wave field undergoes _forced_ changes in time.
@@ -132,7 +132,7 @@ model = NonhydrostaticModel(; grid, coriolis,
                             tracers = :b,
                             buoyancy = BuoyancyTracer(),
                             closure = AnisotropicMinimumDissipation(),
-                            stokes_drift = UniformStokesDrift(∂z_uˢ=∂z_uˢ),
+                            stokes_drift = UniformStokesDrift(∂z_uˢ=∂z_uˢ, parameters = (; vertical_scale)),
                             boundary_conditions = (u=u_boundary_conditions, b=b_boundary_conditions))
 
 # ## Initial conditions

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -68,11 +68,10 @@ const USD = UniformStokesDrift
 @inline ∂t_vˢ(i, j, k, grid, sw::USD, args...) = sw.∂t_vˢ(znode(k, grid, Center()), args...)
 @inline ∂t_wˢ(i, j, k, grid::AbstractGrid{FT}, sw::USD, args...) where FT = zero(FT)
 
-@inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds          ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂z_uˢ(znode(k, grid, Center()), args...)
-@inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds          ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(znode(k, grid, Center()), args...)
-@inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds begin (- ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(znode(k, grid, Face()), args...)
-                                                                                 - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(znode(k, grid, Face()), args...) )
-                                                                          end
+@inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds    ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂z_uˢ(znode(k, grid, Center()), args...)
+@inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds    ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(znode(k, grid, Center()), args...)
+@inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds (- ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(znode(k, grid, Face()), args...)
+                                                                           - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(znode(k, grid, Face()), args...) )
 
 stokes_tendecy_functions = (:∂t_uˢ, :∂t_vˢ, :∂t_wˢ)
 for func in stokes_tendecy_functions

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -81,6 +81,6 @@ const USDnoP = UniformStokesDrift{<:Nothing}
 @inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::USDnoP, U, time) = @inbounds    ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂z_uˢ(znode(k, grid, Center()), time)
 @inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::USDnoP, U, time) = @inbounds    ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(znode(k, grid, Center()), time)
 @inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::USDnoP, U, time) = @inbounds (- ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(znode(k, grid, Face()), time)
-                                                                           - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(znode(k, grid, Face()), time) )
+                                                                           - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(znode(k, grid, Face()), time))
 
 end # module

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -26,13 +26,13 @@ abstract type AbstractStokesDrift end
 ##### Functions for "no surface waves"
 #####
 
-@inline ∂t_uˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, args...) where FT = zero(FT)
-@inline ∂t_vˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, args...) where FT = zero(FT)
-@inline ∂t_wˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, args...) where FT = zero(FT)
+@inline ∂t_uˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, time) where FT = zero(FT)
+@inline ∂t_vˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, time) where FT = zero(FT)
+@inline ∂t_wˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, time) where FT = zero(FT)
 
-@inline x_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, args...) where FT = zero(FT)
-@inline y_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, args...) where FT = zero(FT)
-@inline z_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, args...) where FT = zero(FT)
+@inline x_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, time) where FT = zero(FT)
+@inline y_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, time) where FT = zero(FT)
+@inline z_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, time) where FT = zero(FT)
 
 #####
 ##### Uniform surface waves

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -39,7 +39,7 @@ abstract type AbstractStokesDrift end
 #####
 
 """
-    UniformStokesDrift{P, UZ, VZ, UT, VT} <: AbstractStokesDrift
+    UniformStokesDrift{UZ, VZ, UT, VT, P} <: AbstractStokesDrift
 
 Parameter struct for Stokes drift fields associated with surface waves.
 """

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -26,13 +26,13 @@ abstract type AbstractStokesDrift end
 ##### Functions for "no surface waves"
 #####
 
-@inline ∂t_uˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, time) where FT = zero(FT)
-@inline ∂t_vˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, time) where FT = zero(FT)
-@inline ∂t_wˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, time) where FT = zero(FT)
+@inline ∂t_uˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, args...) where FT = zero(FT)
+@inline ∂t_vˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, args...) where FT = zero(FT)
+@inline ∂t_wˢ(i, j, k, grid::AbstractGrid{FT}, ::Nothing, args...) where FT = zero(FT)
 
-@inline x_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, time) where FT = zero(FT)
-@inline y_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, time) where FT = zero(FT)
-@inline z_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, time) where FT = zero(FT)
+@inline x_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, args...) where FT = zero(FT)
+@inline y_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, args...) where FT = zero(FT)
+@inline z_curl_Uˢ_cross_U(i, j, k, grid::AbstractGrid{FT}, ::Nothing, U, args...) where FT = zero(FT)
 
 #####
 ##### Uniform surface waves
@@ -43,7 +43,8 @@ abstract type AbstractStokesDrift end
 
 Parameter struct for Stokes drift fields associated with surface waves.
 """
-struct UniformStokesDrift{UZ, VZ, UT, VT} <: AbstractStokesDrift
+struct UniformStokesDrift{P, UZ, VZ, UT, VT} <: AbstractStokesDrift
+    parameters :: P
     ∂z_uˢ :: UZ
     ∂z_vˢ :: VZ
     ∂t_uˢ :: UT
@@ -58,25 +59,29 @@ addzero(args...) = 0
 Construct a set of functions that describes the Stokes drift field beneath
 a uniform surface gravity wave field.
 """
-UniformStokesDrift(; ∂z_uˢ=addzero, ∂z_vˢ=addzero, ∂t_uˢ=addzero, ∂t_vˢ=addzero) =
-    UniformStokesDrift(∂z_uˢ, ∂z_vˢ, ∂t_uˢ, ∂t_vˢ)
+UniformStokesDrift(; ∂z_uˢ=addzero, ∂z_vˢ=addzero, ∂t_uˢ=addzero, ∂t_vˢ=addzero, parameters=nothing) =
+    UniformStokesDrift(parameters, ∂z_uˢ, ∂z_vˢ, ∂t_uˢ, ∂t_vˢ)
 
 const USD = UniformStokesDrift
 
-@inline ∂t_uˢ(i, j, k, grid, sw::USD, time) = sw.∂t_uˢ(znode(k, grid, Center()), time)
-@inline ∂t_vˢ(i, j, k, grid, sw::USD, time) = sw.∂t_vˢ(znode(k, grid, Center()), time)
+@inline ∂t_uˢ(i, j, k, grid, sw::USD, args...) = sw.∂t_uˢ(znode(k, grid, Center()), args...)
+@inline ∂t_vˢ(i, j, k, grid, sw::USD, args...) = sw.∂t_vˢ(znode(k, grid, Center()), args...)
+@inline ∂t_wˢ(i, j, k, grid::AbstractGrid{FT}, sw::USD, args...) where FT = zero(FT)
 
-@inline ∂t_wˢ(i, j, k, grid::AbstractGrid{FT}, sw::USD, time) where FT = zero(FT)
+@inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds          ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂z_uˢ(znode(k, grid, Center()), args...)
+@inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds          ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(znode(k, grid, Center()), args...)
+@inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds begin (- ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(znode(k, grid, Face()), args...)
+                                                                                 - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(znode(k, grid, Face()), args...) )
+end
 
-@inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, time) =
-    @inbounds ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂z_uˢ(znode(k, grid, Center()), time)
+functions = (:∂t_uˢ, :∂t_vˢ, :∂t_wˢ)
+for func in functions
+    @eval $func(i, j, k, grid::AbstractGrid{FT}, sw::USD{<:NamedTuple}, time) where FT = $func(i, j, k, grid, sw, time, sw.parameters)
+end
 
-@inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, time) = 
-    @inbounds ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(znode(k, grid, Center()), time)
-
-@inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, time) = @inbounds begin (
-    - ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(znode(k, grid, Face()), time)
-    - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(znode(k, grid, Face()), time) )
+functions = (:x_curl_Uˢ_cross_U, :y_curl_Uˢ_cross_U, :z_curl_Uˢ_cross_U)
+for func in functions
+    @eval $func(i, j, k, grid, sw::USD{<:NamedTuple}, U, time) = $func(i, j, k, grid, sw, U, time, sw.parameters)
 end
 
 end # module

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -39,11 +39,11 @@ abstract type AbstractStokesDrift end
 #####
 
 """
-    UniformStokesDrift{UZ, VZ, UT, VT, P} <: AbstractStokesDrift
+    UniformStokesDrift{P, UZ, VZ, UT, VT} <: AbstractStokesDrift
 
 Parameter struct for Stokes drift fields associated with surface waves.
 """
-struct UniformStokesDrift{UZ, VZ, UT, VT, P} <: AbstractStokesDrift
+struct UniformStokesDrift{P, UZ, VZ, UT, VT} <: AbstractStokesDrift
     ∂z_uˢ :: UZ
     ∂z_vˢ :: VZ
     ∂t_uˢ :: UT
@@ -63,7 +63,7 @@ UniformStokesDrift(; ∂z_uˢ=addzero, ∂z_vˢ=addzero, ∂t_uˢ=addzero, ∂t_
     UniformStokesDrift(∂z_uˢ, ∂z_vˢ, ∂t_uˢ, ∂t_vˢ, parameters)
 
 const USD = UniformStokesDrift
-const USDnoP = UniformStokesDrift{<:Any, <:Any, <:Any, <:Any, <:Nothing}
+const USDnoP = UniformStokesDrift{<:Nothing}
 
 @inline ∂t_uˢ(i, j, k, grid, sw::USD, time) = sw.∂t_uˢ(znode(k, grid, Center()), time, sw.parameters)
 @inline ∂t_vˢ(i, j, k, grid, sw::USD, time) = sw.∂t_vˢ(znode(k, grid, Center()), time, sw.parameters)

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -57,7 +57,7 @@ addzero(args...) = 0
     UniformStokesDrift(; ∂z_uˢ=addzero, ∂z_vˢ=addzero, ∂t_uˢ=addzero, ∂t_vˢ=addzero, parameters=nothing)
 
 Construct a set of functions that describes the Stokes drift field beneath
-a uniform surface gravity wave field.
+a horizontally-uniform surface gravity wave field.
 """
 UniformStokesDrift(; ∂z_uˢ=addzero, ∂z_vˢ=addzero, ∂t_uˢ=addzero, ∂t_vˢ=addzero, parameters=nothing) =
     UniformStokesDrift(∂z_uˢ, ∂z_vˢ, ∂t_uˢ, ∂t_vˢ, parameters)

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -39,7 +39,7 @@ abstract type AbstractStokesDrift end
 #####
 
 """
-    UniformStokesDrift{UZ, VZ, UT, VT} <: AbstractStokesDrift
+    UniformStokesDrift{P, UZ, VZ, UT, VT} <: AbstractStokesDrift
 
 Parameter struct for Stokes drift fields associated with surface waves.
 """
@@ -54,7 +54,7 @@ end
 addzero(args...) = 0
 
 """
-    UniformStokesDrift(; ∂z_uˢ=addzero, ∂z_vˢ=addzero, ∂t_uˢ=addzero, ∂t_vˢ=addzero)
+    UniformStokesDrift(; ∂z_uˢ=addzero, ∂z_vˢ=addzero, ∂t_uˢ=addzero, ∂t_vˢ=addzero, parameters=nothing)
 
 Construct a set of functions that describes the Stokes drift field beneath
 a uniform surface gravity wave field.
@@ -72,15 +72,15 @@ const USD = UniformStokesDrift
 @inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds          ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(znode(k, grid, Center()), args...)
 @inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, args...) = @inbounds begin (- ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(znode(k, grid, Face()), args...)
                                                                                  - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(znode(k, grid, Face()), args...) )
-end
+                                                                          end
 
-functions = (:∂t_uˢ, :∂t_vˢ, :∂t_wˢ)
-for func in functions
+stokes_tendecy_functions = (:∂t_uˢ, :∂t_vˢ, :∂t_wˢ)
+for func in stokes_tendecy_functions
     @eval $func(i, j, k, grid::AbstractGrid{FT}, sw::USD{<:NamedTuple}, time) where FT = $func(i, j, k, grid, sw, time, sw.parameters)
 end
 
-functions = (:x_curl_Uˢ_cross_U, :y_curl_Uˢ_cross_U, :z_curl_Uˢ_cross_U)
-for func in functions
+stokes_curl_functions = (:x_curl_Uˢ_cross_U, :y_curl_Uˢ_cross_U, :z_curl_Uˢ_cross_U)
+for func in stokes_curl_functions
     @eval $func(i, j, k, grid, sw::USD{<:NamedTuple}, U, time) = $func(i, j, k, grid, sw, U, time, sw.parameters)
 end
 

--- a/src/StokesDrift.jl
+++ b/src/StokesDrift.jl
@@ -43,12 +43,12 @@ abstract type AbstractStokesDrift end
 
 Parameter struct for Stokes drift fields associated with surface waves.
 """
-struct UniformStokesDrift{P, UZ, VZ, UT, VT} <: AbstractStokesDrift
-    parameters :: P
+struct UniformStokesDrift{UZ, VZ, UT, VT, P} <: AbstractStokesDrift
     ∂z_uˢ :: UZ
     ∂z_vˢ :: VZ
     ∂t_uˢ :: UT
     ∂t_vˢ :: VT
+    parameters :: P
 end
 
 addzero(args...) = 0
@@ -60,7 +60,7 @@ Construct a set of functions that describes the Stokes drift field beneath
 a uniform surface gravity wave field.
 """
 UniformStokesDrift(; ∂z_uˢ=addzero, ∂z_vˢ=addzero, ∂t_uˢ=addzero, ∂t_vˢ=addzero, parameters=nothing) =
-    UniformStokesDrift(parameters, ∂z_uˢ, ∂z_vˢ, ∂t_uˢ, ∂t_vˢ)
+    UniformStokesDrift(∂z_uˢ, ∂z_vˢ, ∂t_uˢ, ∂t_vˢ, parameters)
 
 const USD = UniformStokesDrift
 

--- a/test/test_stokes_drift.jl
+++ b/test/test_stokes_drift.jl
@@ -1,10 +1,10 @@
 include("dependencies_for_runtests.jl")
 
 function instantiate_stokes_drift()
-    ∂t_uˢ(z, t, p) = exp(z/p.vertical_scale) * cos(t)
-    ∂t_vˢ(z, t, p) = exp(z/p.vertical_scale) * cos(t)
-    ∂z_uˢ(z, t, p) = exp(z/p.vertical_scale) * cos(t)
-    ∂z_vˢ(z, t, p) = exp(z/p.vertical_scale) * cos(t)
+    ∂t_uˢ(z, t, h) = exp(z/h) * cos(t)
+    ∂t_vˢ(z, t, h) = exp(z/h) * cos(t)
+    ∂z_uˢ(z, t, h) = exp(z/h) * cos(t)
+    ∂z_vˢ(z, t, h) = exp(z/h) * cos(t)
     stokes_drift = UniformStokesDrift(∂t_uˢ=∂t_uˢ, ∂t_vˢ=∂t_vˢ,
                                       ∂z_uˢ=∂z_uˢ, ∂z_vˢ=∂z_vˢ, parameters=20)
 

--- a/test/test_stokes_drift.jl
+++ b/test/test_stokes_drift.jl
@@ -6,7 +6,7 @@ function instantiate_stokes_drift()
     ∂z_uˢ(z, t, p) = exp(z/p.vertical_scale) * cos(t)
     ∂z_vˢ(z, t, p) = exp(z/p.vertical_scale) * cos(t)
     stokes_drift = UniformStokesDrift(∂t_uˢ=∂t_uˢ, ∂t_vˢ=∂t_vˢ,
-                                      ∂z_uˢ=∂z_uˢ, ∂z_vˢ=∂z_vˢ, parameters=(; vertical_scale = 20))
+                                      ∂z_uˢ=∂z_uˢ, ∂z_vˢ=∂z_vˢ, parameters=20)
 
     return true
 end

--- a/test/test_stokes_drift.jl
+++ b/test/test_stokes_drift.jl
@@ -1,10 +1,12 @@
+include("dependencies_for_runtests.jl")
+
 function instantiate_stokes_drift()
-    ∂t_uˢ(z, t) = exp(z/20) * cos(t)
-    ∂t_vˢ(z, t) = exp(z/20) * cos(t)
-    ∂z_uˢ(z, t) = exp(z/20) * cos(t)
-    ∂z_vˢ(z, t) = exp(z/20) * cos(t)
+    ∂t_uˢ(z, t, p) = exp(z/p.vertical_scale) * cos(t)
+    ∂t_vˢ(z, t, p) = exp(z/p.vertical_scale) * cos(t)
+    ∂z_uˢ(z, t, p) = exp(z/p.vertical_scale) * cos(t)
+    ∂z_vˢ(z, t, p) = exp(z/p.vertical_scale) * cos(t)
     stokes_drift = UniformStokesDrift(∂t_uˢ=∂t_uˢ, ∂t_vˢ=∂t_vˢ,
-                                      ∂z_uˢ=∂z_uˢ, ∂z_vˢ=∂z_vˢ)
+                                      ∂z_uˢ=∂z_uˢ, ∂z_vˢ=∂z_vˢ, parameters=(; vertical_scale = 20))
 
     return true
 end


### PR DESCRIPTION
This PR adds a `parameters` keyword to `UniformStokesDrift`.

At the moment this only gets activated if `parameters isa NamedTuple`. Do we want to be more general than that?

Closes https://github.com/CliMA/Oceananigans.jl/issues/2960