### PR TITLE
Fix small typoe in `tilted_bottom_boundary_layer.jl`

### DIFF
--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -22,13 +22,13 @@
 #
 # ## The domain
 #
-# We create a ``400 × 100`` meter ``x, z`` grid with ``128 × 32`` cells
-# and finer resolution near the bottom,
+# We create an grid with finer resolution near the bottom,
 
 using Oceananigans
+using Oceananigans.Units
 
-Lx = 200 # m
-Lz = 100 # m
+Lx = 200meters
+Lz = 100meters
 Nx = 64
 Nz = 64
 


### PR DESCRIPTION
I'm also making a minor suggestion that instead indicating the grid dimensions with a comment, we do it with code.