### PR TITLE
Small improvements to the docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,20 +29,22 @@ const EXAMPLES_DIR = joinpath(@__DIR__, "..", "examples")
 const OUTPUT_DIR   = joinpath(@__DIR__, "src/generated")
 
 examples = [
-    "one_dimensional_diffusion.jl",
-    "two_dimensional_turbulence.jl",
-    "internal_wave.jl",
-    "convecting_plankton.jl",
-    "ocean_wind_mixing_and_convection.jl",
-    "langmuir_turbulence.jl",
-    "baroclinic_adjustment.jl",
-    "kelvin_helmholtz_instability.jl",
-    "shallow_water_Bickley_jet.jl",
-    "horizontal_convection.jl",
-    "tilted_bottom_boundary_layer.jl"
+    "One-dimensional diffusion"          => "one_dimensional_diffusion",
+    "Two-dimensional turbulence"         => "two_dimensional_turbulence",
+    "Internal wave"                      => "internal_wave",
+    "Convecting plankton"                => "convecting_plankton",
+    "Ocean wind mixing and convection"   => "ocean_wind_mixing_and_convection",
+    "Langmuir turbulence"                => "langmuir_turbulence",
+    "Baroclinic adjustment"              => "baroclinic_adjustment",
+    "Kelvin-Helmholtz instability"       => "kelvin_helmholtz_instability",
+    "Shallow water Bickley jet"          => "shallow_water_Bickley_jet",
+    "Horizontal convection"              => "horizontal_convection",
+    "Tilted bottom boundary layer"       => "tilted_bottom_boundary_layer"
 ]
 
-for example in examples
+example_scripts = [ val * ".jl" for (key, val) in examples ]
+
+for example in example_scripts
     example_filepath = joinpath(EXAMPLES_DIR, example)
     Literate.markdown(example_filepath, OUTPUT_DIR; flavor = Literate.DocumenterFlavor())
 end
@@ -51,19 +53,7 @@ end
 ##### Organize page hierarchies
 #####
 
-example_pages = [
-    "One-dimensional diffusion"          => "generated/one_dimensional_diffusion.md",
-    "Two-dimensional turbulence"         => "generated/two_dimensional_turbulence.md",
-    "Internal wave"                      => "generated/internal_wave.md",
-    "Convecting plankton"                => "generated/convecting_plankton.md",
-    "Ocean wind mixing and convection"   => "generated/ocean_wind_mixing_and_convection.md",
-    "Langmuir turbulence"                => "generated/langmuir_turbulence.md",
-    "Baroclinic adjustment"              => "generated/baroclinic_adjustment.md",
-    "Kelvin-Helmholtz instability"       => "generated/kelvin_helmholtz_instability.md",
-    "Shallow water Bickley jet"          => "generated/shallow_water_Bickley_jet.md",
-    "Horizontal convection"              => "generated/horizontal_convection.md",
-    "Tilted bottom boundary layer"       => "generated/tilted_bottom_boundary_layer.md"
- ]
+example_pages = [ key => "generated/$val.md" for (key, val) in examples ]
 
 model_setup_pages = [
     "Overview" => "model_setup/overview.md",

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -136,6 +136,12 @@ model = NonhydrostaticModel(; grid, buoyancy, coriolis, closure,
                             boundary_conditions = (u=u_bcs, v=v_bcs),
                             background_fields = (; b=B_field))
 
+# Let's introduce a bit of random noise in the bottom of the domain to speed up the onset of
+# turbulence:
+
+noise(x, y, z) = 1e-3 * randn() * exp(-(10z)^2/grid.Lz^2)
+set!(model, u=noise, w=noise)
+
 # ## Create and run a simulation
 #
 # We are now ready to create the simulation. We begin by setting the initial time step
@@ -143,7 +149,7 @@ model = NonhydrostaticModel(; grid, buoyancy, coriolis, closure,
 
 using Oceananigans.Units
 
-simulation = Simulation(model, Δt = 0.5 * minimum_zspacing(grid) / V∞, stop_time = 2days)
+simulation = Simulation(model, Δt = 0.5 * minimum_zspacing(grid) / V∞, stop_time = 1days)
 
 # We use `TimeStepWizard` to adapt our time-step and print a progress message,
 


### PR DESCRIPTION
This PR does two things:

- Changes `docs/make.jl` to only define the example names once. They were being defined twice before, with some redundancy. Now it'll be easier to comment a given example out when building the docs locally, for example.
- Speeds up the tilted BBL example. I'm doing that by starting it with some noise, which makes turbulence appear much sooner, which allows us to run it for only one day (half the previous time).