### PR TITLE
Extend `BatchedTridiagonalSolver` to all directions

### DIFF
--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -135,6 +135,20 @@ Abstract supertype for horizontally-curvilinear grids with elements of type `FT`
 """
 abstract type AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Arch} <: AbstractCurvilinearGrid{FT, TX, TY, TZ, Arch} end
 
+#####
+##### Directions (for tilted domains)
+#####
+
+abstract type AbstractDirection end
+
+struct XDirection <: AbstractDirection end
+
+struct YDirection <: AbstractDirection end
+
+struct ZDirection <: AbstractDirection end
+
+struct NegativeZDirection <: AbstractDirection end
+
 isrectilinear(grid) = false
 
 include("grid_utils.jl")

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -496,6 +496,16 @@ end
 ##### Directions (for tilted domains)
 #####
 
+struct XDirection end
+
+Base.summary(::XDirection) = "XDirection()"
+Base.show(io::IO, zdir::XDirection) = print(io, summary(zdir))
+
+struct YDirection end
+
+Base.summary(::YDirection) = "YDirection()"
+Base.show(io::IO, zdir::YDirection) = print(io, summary(zdir))
+
 struct ZDirection end
 
 Base.summary(::ZDirection) = "ZDirection()"

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -496,32 +496,19 @@ end
 ##### Directions (for tilted domains)
 #####
 
-struct XDirection end
-
-Base.summary(::XDirection) = "XDirection()"
-Base.show(io::IO, dir::XDirection) = print(io, summary(dir))
-
-struct YDirection end
-
-Base.summary(::YDirection) = "YDirection()"
-Base.show(io::IO, dir::YDirection) = print(io, summary(dir))
-
-struct ZDirection end
-
-Base.summary(::ZDirection) = "ZDirection()"
-Base.show(io::IO, dir::ZDirection) = print(io, summary(dir))
-
-struct NegativeZDirection end
-
-Base.summary(::NegativeZDirection) = "NegativeZDirection()"
-Base.show(io::IO, dir::NegativeZDirection) = print(io, summary(dir))
-
 -(::NegativeZDirection) = ZDirection()
 -(::ZDirection) = NegativeZDirection()
 
 #####
 ##### Show utils
 #####
+
+Base.summary(::XDirection) = "XDirection()"
+Base.summary(::YDirection) = "YDirection()"
+Base.summary(::ZDirection) = "ZDirection()"
+Base.summary(::NegativeZDirection) = "NegativeZDirection()"
+
+Base.show(io::IO, dir::AbstractDirection) = print(io, summary(dir))
 
 size_summary(sz) = string(sz[1], "×", sz[2], "×", sz[3])
 prettysummary(σ::AbstractFloat, plus=false) = writeshortest(σ, plus, false, true, -1, UInt8('e'), false, UInt8('.'), false, true)

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -509,12 +509,12 @@ Base.show(io::IO, dir::YDirection) = print(io, summary(dir))
 struct ZDirection end
 
 Base.summary(::ZDirection) = "ZDirection()"
-Base.show(io::IO, zdir::ZDirection) = print(io, summary(zdir))
+Base.show(io::IO, dir::ZDirection) = print(io, summary(dir))
 
 struct NegativeZDirection end
 
 Base.summary(::NegativeZDirection) = "NegativeZDirection()"
-Base.show(io::IO, zdir::NegativeZDirection) = print(io, summary(zdir))
+Base.show(io::IO, dir::NegativeZDirection) = print(io, summary(dir))
 
 -(::NegativeZDirection) = ZDirection()
 -(::ZDirection) = NegativeZDirection()

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -504,7 +504,7 @@ Base.show(io::IO, dir::XDirection) = print(io, summary(dir))
 struct YDirection end
 
 Base.summary(::YDirection) = "YDirection()"
-Base.show(io::IO, zdir::YDirection) = print(io, summary(zdir))
+Base.show(io::IO, dir::YDirection) = print(io, summary(dir))
 
 struct ZDirection end
 

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -499,7 +499,7 @@ end
 struct XDirection end
 
 Base.summary(::XDirection) = "XDirection()"
-Base.show(io::IO, zdir::XDirection) = print(io, summary(zdir))
+Base.show(io::IO, dir::XDirection) = print(io, summary(dir))
 
 struct YDirection end
 

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -41,8 +41,6 @@ using Oceananigans.Advection:
     advective_tracer_flux_y,
     advective_tracer_flux_z
 
-import Oceananigans.Solvers: launch_config
-    
 import Base: show, summary
 import Oceananigans.Advection: cell_advection_timescale
 
@@ -269,8 +267,6 @@ function on_architecture(arch, ibg::IBG)
     immersed_boundary = on_architecture(arch, ibg.immersed_boundary)
     return ImmersedBoundaryGrid(underlying_grid, immersed_boundary)
 end
-
-launch_config(ibg::ImmersedBoundaryGrid) = grid.underlying_grid
 
 isrectilinear(ibg::IBG) = isrectilinear(ibg.underlying_grid)
 

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -40,6 +40,8 @@ using Oceananigans.Advection:
     advective_tracer_flux_x,
     advective_tracer_flux_y,
     advective_tracer_flux_z
+
+import Oceananigans.Solvers: launch_config
     
 import Base: show, summary
 import Oceananigans.Advection: cell_advection_timescale
@@ -267,6 +269,8 @@ function on_architecture(arch, ibg::IBG)
     immersed_boundary = on_architecture(arch, ibg.immersed_boundary)
     return ImmersedBoundaryGrid(underlying_grid, immersed_boundary)
 end
+
+launch_config(ibg::ImmersedBoundaryGrid) = grid.underlying_grid
 
 isrectilinear(ibg::IBG) = isrectilinear(ibg.underlying_grid)
 

--- a/src/Solvers/batched_tridiagonal_solver.jl
+++ b/src/Solvers/batched_tridiagonal_solver.jl
@@ -1,5 +1,5 @@
 using Oceananigans.Architectures: arch_array
-using Oceananigans.Grids: XYRegRectilinearGrid, XZRegRectilinearGrid, YZRegRectilinearGrid, RegRectilinearGrid
+using Oceananigans.Grids: XYRegRectilinearGrid, XZRegRectilinearGrid, YZRegRectilinearGrid, RegRectilinearGrid, LatLonGrid, ImmersedBoundaryGrid
 
 import Oceananigans.Architectures: architecture
 
@@ -58,6 +58,8 @@ launch_config(::YZRegRectilinearGrid) = :yz
 launch_config(::XZRegRectilinearGrid) = :xz
 launch_config(::XYRegRectilinearGrid) = :xy
 launch_config(::RegRectilinearGrid) = :xy
+launch_config(ibg::ImmersedBoundaryGrid) = grid.underlying_grid
+launch_config(::LatLonGrid) = :xy
 
 """
     solve!(ϕ, solver::BatchedTridiagonalSolver, rhs, args...)

--- a/src/Solvers/batched_tridiagonal_solver.jl
+++ b/src/Solvers/batched_tridiagonal_solver.jl
@@ -1,6 +1,5 @@
 using Oceananigans.Architectures: arch_array
 using Oceananigans.Grids: XYRegRectilinearGrid, XZRegRectilinearGrid, YZRegRectilinearGrid, RegRectilinearGrid, LatLonGrid
-using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 
 import Oceananigans.Architectures: architecture
 
@@ -59,7 +58,6 @@ launch_config(::YZRegRectilinearGrid) = :yz
 launch_config(::XZRegRectilinearGrid) = :xz
 launch_config(::XYRegRectilinearGrid) = :xy
 launch_config(::RegRectilinearGrid) = :xy
-launch_config(ibg::ImmersedBoundaryGrid) = grid.underlying_grid
 launch_config(::LatLonGrid) = :xy
 
 """

--- a/src/Solvers/batched_tridiagonal_solver.jl
+++ b/src/Solvers/batched_tridiagonal_solver.jl
@@ -20,7 +20,7 @@ architecture(solver::BatchedTridiagonalSolver) = architecture(solver.grid)
 
 
 """
-    BatchedTridiagonalSolver(grid; lower_diagonal, diagonal, upper_diagonal, parameters=nothing)
+    BatchedTridiagonalSolver(grid; lower_diagonal, diagonal, upper_diagonal, parameters=nothing, tridiagonal_direction=:z)
 
 Construct a solver for batched tridiagonal systems on `grid` of the form
 

--- a/src/Solvers/batched_tridiagonal_solver.jl
+++ b/src/Solvers/batched_tridiagonal_solver.jl
@@ -22,7 +22,7 @@ architecture(solver::BatchedTridiagonalSolver) = architecture(solver.grid)
 
 
 """
-    BatchedTridiagonalSolver(grid; lower_diagonal, diagonal, upper_diagonal, parameters=nothing, tridiagonal_direction=:z)
+    BatchedTridiagonalSolver(grid; lower_diagonal, diagonal, upper_diagonal, parameters=nothing, tridiagonal_direction=ZDirection())
 
 Construct a solver for batched tridiagonal systems on `grid` of the form
 

--- a/src/Solvers/batched_tridiagonal_solver.jl
+++ b/src/Solvers/batched_tridiagonal_solver.jl
@@ -1,5 +1,6 @@
 using Oceananigans.Architectures: arch_array
-using Oceananigans.Grids: XYRegRectilinearGrid, XZRegRectilinearGrid, YZRegRectilinearGrid, RegRectilinearGrid, LatLonGrid, ImmersedBoundaryGrid
+using Oceananigans.Grids: XYRegRectilinearGrid, XZRegRectilinearGrid, YZRegRectilinearGrid, RegRectilinearGrid, LatLonGrid
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 
 import Oceananigans.Architectures: architecture
 

--- a/src/Solvers/batched_tridiagonal_solver.jl
+++ b/src/Solvers/batched_tridiagonal_solver.jl
@@ -71,11 +71,11 @@ Reference implementation per Numerical Recipes, Press et. al 1992 (§ 2.4).
 function solve!(ϕ, solver::BatchedTridiagonalSolver, rhs, args... )
 
     launch_config = if solver.tridiagonal_direction == :x
-                        launch_config = :yz
+                        :yz
                     elseif solver.tridiagonal_direction == :y
-                        launch_config = :xz
+                        :xz
                     elseif solver.tridiagonal_direction == :z
-                        launch_config = :xy
+                        :xy
                     end
 
     launch!(architecture(solver), solver.grid, launch_config,

--- a/src/Solvers/batched_tridiagonal_solver.jl
+++ b/src/Solvers/batched_tridiagonal_solver.jl
@@ -72,11 +72,11 @@ Reference implementation per Numerical Recipes, Press et. al 1992 (§ 2.4).
 """
 function solve!(ϕ, solver::BatchedTridiagonalSolver, rhs, args... )
 
-    launch_config = if solver.tridiagonal_direction == XDirection()
+    launch_config = if solver.tridiagonal_direction isa XDirection
                         :yz
-                    elseif solver.tridiagonal_direction == YDirection()
+                    elseif solver.tridiagonal_direction isa YDirection
                         :xz
-                    elseif solver.tridiagonal_direction == ZDirection()
+                    elseif solver.tridiagonal_direction isa ZDirection
                         :xy
                     end
 

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -134,9 +134,9 @@ end
 
 # Extend the `get_coefficient` function to retrieve the correct `ivd_diagonal`, `ivd_lower_diagonal` and `ivd_upper_diagonal` functions
 # REMEMBER: `get_coefficient(f::Function, args...)` leads to massive performance decrease on the CPU (https://github.com/CliMA/Oceananigans.jl/issues/2996) 
-@inline get_coefficient(::Val{:maybe_tupled_ivd_lower_diagonal}, i, j, k, grid, p, args...) = maybe_tupled_ivd_lower_diagonal(i, j, k, grid, args...)
-@inline get_coefficient(::Val{:maybe_tupled_ivd_upper_diagonal}, i, j, k, grid, p, args...) = maybe_tupled_ivd_upper_diagonal(i, j, k, grid, args...)
-@inline get_coefficient(::Val{:ivd_diagonal}, i, j, k, grid, p, args...) = ivd_diagonal(i, j, k, grid, args...)
+@inline get_coefficient(::Val{:maybe_tupled_ivd_lower_diagonal}, i, j, k, grid, p, tridiag_dir, args...) = maybe_tupled_ivd_lower_diagonal(i, j, k, grid, args...)
+@inline get_coefficient(::Val{:maybe_tupled_ivd_upper_diagonal}, i, j, k, grid, p, tridiag_dir, args...) = maybe_tupled_ivd_upper_diagonal(i, j, k, grid, args...)
+@inline get_coefficient(::Val{:ivd_diagonal},                    i, j, k, grid, p, tridiag_dir, args...) = ivd_diagonal(i, j, k, grid, args...)
 
 #####
 ##### Implicit step functions

--- a/test/test_batched_tridiagonal_solver.jl
+++ b/test/test_batched_tridiagonal_solver.jl
@@ -76,7 +76,7 @@ end
 function can_solve_batched_tridiagonal_system_with_3D_RHS(arch, Nx, Ny, Nz; tridiagonal_direction = ZDirection())
     ArrayType = array_type(arch)
 
-    N = if tridiagonal_direction == XDirection()
+    N = if tridiagonal_direction isa XDirection
             Nx
         elseif tridiagonal_direction == YDirection()
             Ny

--- a/test/test_batched_tridiagonal_solver.jl
+++ b/test/test_batched_tridiagonal_solver.jl
@@ -19,13 +19,13 @@ function can_solve_single_tridiagonal_system(arch, N; tridiagonal_direction=ZDir
     # Convert to CuArray if needed.
     a, b, c, f = ArrayType.([a, b, c, f])
 
-    if tridiagonal_direction == XDirection()
+    if tridiagonal_direction isa XDirection
         ϕ = reshape(zeros(N), (N, 1, 1)) |> ArrayType
         grid = RectilinearGrid(arch, size=(N, 1, 1), extent=(1, 1, 1))
-    elseif tridiagonal_direction == YDirection()
+    elseif tridiagonal_direction isa YDirection
         ϕ = reshape(zeros(N), (1, N, 1)) |> ArrayType
         grid = RectilinearGrid(arch, size=(1, N, 1), extent=(1, 1, 1))
-    elseif tridiagonal_direction == ZDirection()
+    elseif tridiagonal_direction isa ZDirection
         ϕ = reshape(zeros(N), (1, 1, N)) |> ArrayType
         grid = RectilinearGrid(arch, size=(1, 1, N), extent=(1, 1, 1))
     end
@@ -80,7 +80,7 @@ function can_solve_batched_tridiagonal_system_with_3D_RHS(arch, Nx, Ny, Nz; trid
             Nx
         elseif tridiagonal_direction == YDirection()
             Ny
-        elseif tridiagonal_direction == ZDirection()
+        elseif tridiagonal_direction isa ZDirection
             Nz
         end
     a = rand(N-1)
@@ -92,15 +92,15 @@ function can_solve_batched_tridiagonal_system_with_3D_RHS(arch, Nx, Ny, Nz; trid
     ϕ_correct = zeros(Nx, Ny, Nz)
 
     # Solve the systems with backslash on the CPU to avoid scalar operations on the GPU.
-    if tridiagonal_direction == XDirection()
+    if tridiagonal_direction isa XDirection
         for j = 1:Ny, k = 1:Nz
             ϕ_correct[:, j, k] .= M \ f[:, j, k]
         end
-    elseif tridiagonal_direction == YDirection()
+    elseif tridiagonal_direction isa YDirection
         for i = 1:Nx, k = 1:Nz
             ϕ_correct[i, :, k] .= M \ f[i, :, k]
         end
-    elseif tridiagonal_direction == ZDirection()
+    elseif tridiagonal_direction isa ZDirection
         for i = 1:Nx, j = 1:Ny
             ϕ_correct[i, j, :] .= M \ f[i, j, :]
         end

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -275,7 +275,7 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
 
     @testset "Coriolis" begin
         for arch in archs, FT in [Float64], Coriolis in Planes
-            @info "  Testing that time stepping works [$(typeof(arch)), $FT, $Coriolis]..."
+            @info "  Testing that time stepping works with Coriolis [$(typeof(arch)), $FT, $Coriolis]..."
             @test time_stepping_works_with_coriolis(arch, FT, Coriolis)
         end
     end


### PR DESCRIPTION
This PR extends `BatchedTridiagonalSolver` to also work when the tridiagonal direction is `x` and `y`, in addition to `z`.

This is one necessary step to getting the `NonhydrostaticModel` to work with grids that are irregularly-spacing in the `x` and `y` directions.

Related to https://github.com/CliMA/Oceananigans.jl/issues/3116