### PR TITLE
Initialize `SplitExplicitFreeSurface` with a CFL condition

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
@@ -50,8 +50,8 @@ Keyword Arguments
 
 - `timestepper`: Time stepping scheme used, either `ForwardBackwardScheme()` or `AdamsBashforth3Scheme()`.
 """
-SplitExplicitFreeSurface(; gravitational_acceleration = g_Earth, kwargs...) =
-    SplitExplicitFreeSurface(nothing, nothing, nothing, gravitational_acceleration, SplitExplicitSettings(; kwargs...))
+SplitExplicitFreeSurface(; gravitational_acceleration = g_Earth, kwargs...) = 
+    SplitExplicitFreeSurface(nothing, nothing, nothing, gravitational_acceleration, SplitExplicitSettings(; gravitational_acceleration, kwargs...))
 
 # The new constructor is defined later on after the state, settings, auxiliary have been defined
 function FreeSurface(free_surface::SplitExplicitFreeSurface, velocities, grid)
@@ -64,7 +64,7 @@ function FreeSurface(free_surface::SplitExplicitFreeSurface, velocities, grid)
 end
 
 function SplitExplicitFreeSurface(grid; gravitational_acceleration = g_Earth,
-                                        settings = SplitExplicitSettings(eltype(grid); substeps = 200))
+                                        settings = SplitExplicitSettings(eltype(grid); gravitational_acceleration, substeps = 200))
 
     η = ZFaceField(grid, indices = (:, :, size(grid, 3)+1))
 
@@ -193,7 +193,7 @@ function SplitExplicitAuxiliaryFields(grid::AbstractGrid)
     kernel_size    = :xy
     kernel_offsets = (0, 0)
 
-    return SplitExplicitAuxiliaryFields(; Gᵁ, Gⱽ, Hᶠᶜ, Hᶜᶠ, Hᶜᶜ, kernel_size, kernel_offsets)
+    return SplitExplicitAuxiliaryFields(Gᵁ, Gⱽ, Hᶠᶜ, Hᶜᶠ, Hᶜᶜ, kernel_size, kernel_offsets)
 end
 
 """
@@ -247,9 +247,32 @@ Return `SplitExplicitSettings`. For a description of the keyword arguments, see
 the [`SplitExplicitFreeSurface`](@ref).
 """
 function SplitExplicitSettings(FT::DataType=Float64;
-                               substeps = 200, 
+                               substeps = 50, 
+                               CFL    = nothing,
+                               grid   = nothing,
+                               Δt_max = nothing,
+                               gravitational_acceleration,
                                barotropic_averaging_kernel = averaging_shape_function,
                                timestepper = ForwardBackwardScheme())
+
+    if !isnothing(substep) && !isnothing(CFL)
+        throw(ArgumentError("either specify a CFL or a number of substeps"))
+    end
+
+    if !isnothing(CFL)
+        if isnothing(Δt_max) || isnothing(grid)
+            throw(ArgumentError("Need to specify the grid and Δt_max kwargs to calculate the barotropic substeps from the CFL"))
+        end
+
+        Δx = minimum_xspacing(grid)
+        Δy = minimum_xspacing(grid)
+        Δs = sqrt(1 / (1 / Δx^2 + 1 / Δy^2))
+
+        wave_speed = sqrt(gravitational_acceleration * grid.Lz)
+        
+        Δtᴮ = CFL * Δs / wave_speed
+        substeps = 2 * Δt_max / Δtᴮ
+    end
 
     τᶠ = range(0, 2, length = substeps+1)
     Δτ = τᶠ[2] - τᶠ[1]

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
@@ -255,7 +255,7 @@ function SplitExplicitSettings(FT::DataType=Float64;
                                barotropic_averaging_kernel = averaging_shape_function,
                                timestepper = ForwardBackwardScheme())
     
-    if (!isnothing(substep) && !isnothing(CFL)) || (isnothing(substep) && isnothing(CFL))
+    if (!isnothing(substeps) && !isnothing(CFL)) || (isnothing(substeps) && isnothing(CFL))
         throw(ArgumentError("either specify a CFL or a number of substeps"))
     end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
@@ -247,16 +247,16 @@ Return `SplitExplicitSettings`. For a description of the keyword arguments, see
 the [`SplitExplicitFreeSurface`](@ref).
 """
 function SplitExplicitSettings(FT::DataType=Float64;
-                               substeps = 50, 
+                               substeps = nothing, 
                                CFL    = nothing,
                                grid   = nothing,
                                Δt_max = nothing,
                                gravitational_acceleration,
                                barotropic_averaging_kernel = averaging_shape_function,
                                timestepper = ForwardBackwardScheme())
-
-    if !isnothing(substep) && !isnothing(CFL)
-        @warn "Both the number of substeps and a CFL are specified, the number of substeps will be calculated based on the CFL"
+    
+    if (!isnothing(substep) && !isnothing(CFL)) || (isnothing(substep) && isnothing(CFL))
+        throw(ArgumentError("either specify a CFL or a number of substeps"))
     end
 
     if !isnothing(CFL)

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
@@ -256,7 +256,7 @@ function SplitExplicitSettings(FT::DataType=Float64;
                                timestepper = ForwardBackwardScheme())
 
     if !isnothing(substep) && !isnothing(CFL)
-        throw(ArgumentError("either specify a CFL or a number of substeps"))
+        @warn "Both the number of substeps and a CFL are specified, the number of substeps will be calculated based on the CFL"
     end
 
     if !isnothing(CFL)

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
@@ -248,20 +248,20 @@ the [`SplitExplicitFreeSurface`](@ref).
 """
 function SplitExplicitSettings(FT::DataType=Float64;
                                substeps = nothing, 
-                               CFL    = nothing,
+                               cfl    = nothing,
                                grid   = nothing,
-                               Δt_max = nothing,
+                               max_Δt = nothing,
                                gravitational_acceleration,
                                barotropic_averaging_kernel = averaging_shape_function,
                                timestepper = ForwardBackwardScheme())
     
-    if (!isnothing(substeps) && !isnothing(CFL)) || (isnothing(substeps) && isnothing(CFL))
-        throw(ArgumentError("either specify a CFL or a number of substeps"))
+    if (!isnothing(substeps) && !isnothing(cfl)) || (isnothing(substeps) && isnothing(cfl))
+        throw(ArgumentError("either specify a cfl or a number of substeps"))
     end
 
-    if !isnothing(CFL)
+    if !isnothing(cfl)
         if isnothing(Δt_max) || isnothing(grid)
-            throw(ArgumentError("Need to specify the grid and Δt_max kwargs to calculate the barotropic substeps from the CFL"))
+            throw(ArgumentError("Need to specify the grid and Δt_max kwargs to calculate the barotropic substeps from the cfl"))
         end
 
         Δx = minimum_xspacing(grid)
@@ -270,8 +270,8 @@ function SplitExplicitSettings(FT::DataType=Float64;
 
         wave_speed = sqrt(gravitational_acceleration * grid.Lz)
         
-        Δtᴮ = CFL * Δs / wave_speed
-        substeps = 2 * Δt_max / Δtᴮ
+        Δtᴮ = cfl * Δs / wave_speed
+        substeps = 2 * max_Δt / Δtᴮ
     end
 
     τᶠ = range(0, 2, length = substeps+1)

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface.jl
@@ -251,7 +251,7 @@ function SplitExplicitSettings(FT::DataType=Float64;
                                cfl    = nothing,
                                grid   = nothing,
                                max_Δt = nothing,
-                               gravitational_acceleration,
+                               gravitational_acceleration = g_Earth,
                                barotropic_averaging_kernel = averaging_shape_function,
                                timestepper = ForwardBackwardScheme())
     

--- a/test/test_split_explicit_free_surface_solver.jl
+++ b/test/test_split_explicit_free_surface_solver.jl
@@ -19,7 +19,7 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels: constant_averaging_kerne
                                    x = (0, Lx), y = (0, Ly), z = (-Lz, 0),
                                    halo=(1, 1, 1))
 
-            settings = SplitExplicitSettings(; barotropic_averaging_kernel = constant_averaging_kernel)
+            settings = SplitExplicitSettings(; substeps = 200, barotropic_averaging_kernel = constant_averaging_kernel)
             sefs = SplitExplicitFreeSurface(grid; settings)
 
             sefs.η .= 0

--- a/test/test_split_explicit_vertical_integrals.jl
+++ b/test/test_split_explicit_vertical_integrals.jl
@@ -16,7 +16,7 @@ import Oceananigans.Models.HydrostaticFreeSurfaceModels: compute_barotropic_mode
         Lx = Ly = Lz = 2π
         grid = RectilinearGrid(arch, topology = topology, size = (Nx, Ny, Nz), x = (0, Lx), y = (0, Ly), z = (-Lz, 0))
 
-        tmp = SplitExplicitFreeSurface()
+        tmp = SplitExplicitFreeSurface(; substeps = 200)
         sefs = SplitExplicitState(grid)
         sefs = SplitExplicitAuxiliaryFields(grid)
         sefs = SplitExplicitFreeSurface(grid)


### PR DESCRIPTION
This PR allows initializing the `SplitExplicitFreeSurface` with the following keyword arguments:

```julia
free_surface = SplitExplicitFreeSurface(; CFL = 0.7, Δt_max = 10minutes, grid)
```