### PR TITLE
(0.84.0) Fix `NetCDFOutputWriter` compression kwarg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.83.0"
+version = "0.84.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -210,7 +210,7 @@ Keyword arguments
                         for more information about its `mode` option.
 
 - `deflatelevel`: Determines the NetCDF compression level of data (integer 0-9; 0 (default) means no compression
-                  and 9 means maximum compression). See [NCDatasets.jl documentation](https://alexander-barth.github.io/NCDatasets.jl/stable/variables/#Creating-a-variable).
+                  and 9 means maximum compression). See [NCDatasets.jl documentation](https://alexander-barth.github.io/NCDatasets.jl/stable/variables/#Creating-a-variable)
                   for more information.
 
 ## Miscellaneous keywords

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -210,7 +210,7 @@ Keyword arguments
                         for more information about its `mode` option.
 
 - `deflatelevel`: Determines the NetCDF compression level of data (integer 0-9; 0 (default) means no compression
-                  and 9 means maximum compression). See [NCDatasets.jl documentation](https://alexander-barth.github.io/NCDatasets.jl/stable/variables/#Creating-a-variable)
+                  and 9 means maximum compression). See [NCDatasets.jl documentation](https://alexander-barth.github.io/NCDatasets.jl/stable/variables/#Creating-a-variable).
                   for more information.
 
 ## Miscellaneous keywords

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -395,7 +395,7 @@ function NetCDFOutputWriter(model, outputs; filename, schedule,
     if mode == "c"
         for (dim_name, dim_array) in dims
             defVar(dataset, dim_name, array_type(dim_array), (dim_name,),
-                   compression=compression, attrib=default_dimension_attributes[dim_name])
+                   deflatelevel=compression, attrib=default_dimension_attributes[dim_name])
         end
 
         # DateTime and TimeDate are both <: AbstractTime
@@ -446,7 +446,7 @@ function define_output_variable!(dataset, output, name, array_type, compression,
     name ∉ keys(dimensions) && error("Custom output $name needs dimensions!")
 
     defVar(dataset, name, eltype(array_type), (dimensions[name]..., "time"),
-           compression=compression, attrib=output_attributes)
+           deflatelevel=compression, attrib=output_attributes)
 
     return nothing
 end
@@ -456,7 +456,7 @@ end
 define_output_variable!(dataset, output::AbstractField, name, array_type, compression, output_attributes, dimensions) =
     defVar(dataset, name, eltype(array_type),
            (netcdf_spatial_dimensions(output)..., "time"),
-           compression=compression, attrib=output_attributes)
+           deflatelevel=compression, attrib=output_attributes)
 
 """ Defines empty field variable for `WindowedTimeAverage`s over fields. """
 define_output_variable!(dataset, output::WindowedTimeAverage{<:AbstractField}, args...) =
@@ -573,7 +573,7 @@ function define_output_variable!(dataset, output::LagrangianParticles, name, arr
     particle_fields = eltype(output.properties) |> fieldnames .|> string
     for particle_field in particle_fields
         defVar(dataset, particle_field, eltype(array_type),
-               ("particle_id", "time"), compression=compression)
+               ("particle_id", "time"), deflatelevel=compression)
     end
 end
 


### PR DESCRIPTION
To use compression in `NCDatasets` , the keyword for `defVar` should be `deflatelevel` instead of `compression`. `defVar` does not show any warning message for unrecognized keywords.