### PR TITLE
Restore netCDF output writer tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,7 @@ CUDA.allowscalar() do
             include("test_simulations.jl")
             include("test_diagnostics.jl")
             include("test_output_writers.jl")
+            include("test_netcdf_output_writer.jl")
             include("test_output_readers.jl")
         end
     end


### PR DESCRIPTION
This PR restores some test on netCDF output.

(The tests were removed, if I recall correctly, because at some point netCDF was creating issues on unix machines. Things seems fine now!)

Closes #2956