### PR TITLE
More docs built optimization

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -43,6 +43,7 @@ end
     # The examples that take longer to run should be first. This ensures thats
     # docs built using extra workers is as efficient as possible.
     example_scripts = [
+        "shallow_water_Bickley_jet.jl",
         "baroclinic_adjustment.jl",
         "kelvin_helmholtz_instability.jl",
         "langmuir_turbulence.jl",
@@ -50,7 +51,6 @@ end
         "horizontal_convection.jl",
         "convecting_plankton.jl",
         "tilted_bottom_boundary_layer.jl",
-        "shallow_water_Bickley_jet.jl",
         "two_dimensional_turbulence.jl",
         "internal_wave.jl",
         "one_dimensional_diffusion.jl",


### PR DESCRIPTION
The shallow water example needs ~25 min to run while all other examples need ~1min (2D) or up to ~7min (Baroclinic instability).

This PR forces the workers that run the examples for the docs to start from the shallow water example. This way we minimize the time that the one worker ends up running the swe example while the other one sits and waits.

This PR is related to #3169 but it does _not_ resolve the issue.