### PR TITLE
Add `update_biogeochemical_state!` to `update_state!` for hydrostatic free surface single column mode

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
@@ -66,6 +66,8 @@ function update_state!(model::HydrostaticFreeSurfaceModel, grid::SingleColumnGri
         callback.callsite isa UpdateStateCallsite && callback(model)
     end
 
+    update_biogeochemical_state!(model.biogeochemistry, model)
+
     return nothing
 end
 


### PR DESCRIPTION
Add `update_biogeochemical_state!` to `update_state!` for hydrostatic free surface single column mode because it's missing and therefore bgc doesn't work.