### PR TITLE
Update Julia version warning

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -4,8 +4,8 @@ data-driven, ocean-flavored fluid dynamics on CPUs and GPUs.
 """
 module Oceananigans
 
-if VERSION < v"1.8"
-    @warn "Oceananigans is tested on Julia v1.8 and therefore it is strongly recommended you run Oceananigans on Julia v1.8 or newer."
+if VERSION < v"1.9"
+    @warn "Oceananigans is tested on Julia v1.9 and therefore it is strongly recommended you run Oceananigans on Julia v1.9 or newer."
 end
 
 export


### PR DESCRIPTION
After discussion in #3177 I noticed that the warning only warns for Julia v1.7 and earlier... But it should warn for Julia v1.8 as well.

(Although, if we decide to add a compat entry for Julia v1.9 as a response to #3184 then the warning is rendered redundant.)