### PR TITLE
(0.86.0) Removes all support for <1.9 Julia versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -55,7 +55,7 @@ PencilFFTs = "0.13.5, 0.14, 0.15"
 Rotations = "1.0"
 SeawaterPolynomials = "0.3.2"
 StructArrays = "0.4, 0.5, 0.6"
-julia = "1.6"
+julia = "^1.9"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -55,7 +55,7 @@ PencilFFTs = "0.13.5, 0.14, 0.15"
 Rotations = "1.0"
 SeawaterPolynomials = "0.3.2"
 StructArrays = "0.4, 0.5, 0.6"
-julia = "^1.9"
+julia = "1.9"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.85.0"
+version = "0.86.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Oceananigans.jl is developed by the [Climate Modeling Alliance](https://clima.ca
 
 Oceananigans is a [registered Julia package](https://julialang.org/packages/). So to install it,
 
-1. [Download Julia](https://julialang.org/downloads/) (version 1.9 or higher).
+1. [Download Julia](https://julialang.org/downloads/) (version 1.9 or later).
 
 2. Launch Julia and type
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Oceananigans.jl is developed by the [Climate Modeling Alliance](https://clima.ca
 
 Oceananigans is a [registered Julia package](https://julialang.org/packages/). So to install it,
 
-1. [Download Julia](https://julialang.org/downloads/).
+1. [Download Julia](https://julialang.org/downloads/) (version 1.9 or higher).
 
 2. Launch Julia and type
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,7 +25,7 @@ julia> Pkg.add("Oceananigans")
 ```
 
 !!! compat "Julia 1.9 is required"
-    While most scripts will run on Julia 1.6, 1.7, or 1.8, Oceananigans is continuously tested _only_ on Julia 1.9.
+   Oceananigans requires Julia 1.9 or later.
 
 If you're [new to Julia](https://docs.julialang.org/en/v1/manual/getting-started/) and its [wonderful `Pkg` manager](https://docs.julialang.org/en/v1/stdlib/Pkg/), the [Oceananigans wiki](https://github.com/CliMA/Oceananigans.jl/wiki) provides [more detailed installation instructions](https://github.com/CliMA/Oceananigans.jl/wiki/Installation-and-getting-started-with-Oceananigans).
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,8 +24,7 @@ julia> using Pkg
 julia> Pkg.add("Oceananigans")
 ```
 
-!!! compat "Julia 1.6 is required; Julia 1.9 or newer is suggested"
-    The latest version of Oceananigans strongly suggests _at least_ Julia 1.9 or later to run.
+!!! compat "Julia 1.9 is required"
     While most scripts will run on Julia 1.6, 1.7, or 1.8, Oceananigans is continuously tested _only_ on Julia 1.9.
 
 If you're [new to Julia](https://docs.julialang.org/en/v1/manual/getting-started/) and its [wonderful `Pkg` manager](https://docs.julialang.org/en/v1/stdlib/Pkg/), the [Oceananigans wiki](https://github.com/CliMA/Oceananigans.jl/wiki) provides [more detailed installation instructions](https://github.com/CliMA/Oceananigans.jl/wiki/Installation-and-getting-started-with-Oceananigans).

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -545,9 +545,6 @@ const MinimumReduction = typeof(Base.minimum!)
 const AllReduction     = typeof(Base.all!)
 const AnyReduction     = typeof(Base.any!)
 
-
-check_version_larger_than_7() = VERSION.minor > 7
-
 initialize_reduced_field!(::SumReduction,     f, r::ReducedField, c) = Base.initarray!(interior(r), f, Base.add_sum, true, interior(c))
 initialize_reduced_field!(::ProdReduction,    f, r::ReducedField, c) = Base.initarray!(interior(r), f, Base.mul_prod, true, interior(c))
 initialize_reduced_field!(::AllReduction,     f, r::ReducedField, c) = Base.initarray!(interior(r), f, &, true, interior(c))

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -545,13 +545,6 @@ const MinimumReduction = typeof(Base.minimum!)
 const AllReduction     = typeof(Base.all!)
 const AnyReduction     = typeof(Base.any!)
 
-check_version_larger_than_7() = VERSION.minor > 7
-
-initialize_reduced_field!(::SumReduction,  f, r::ReducedField, c) = check_version_larger_than_7() ? Base.initarray!(interior(r), f, Base.add_sum, true, interior(c))  : Base.initarray!(interior(r), Base.add_sum, true, interior(c))
-initialize_reduced_field!(::ProdReduction, f, r::ReducedField, c) = check_version_larger_than_7() ? Base.initarray!(interior(r), f, Base.mul_prod, true, interior(c)) : Base.initarray!(interior(r), Base.mul_prod, true, interior(c))
-initialize_reduced_field!(::AllReduction,  f, r::ReducedField, c) = check_version_larger_than_7() ? Base.initarray!(interior(r), f, &, true, interior(c))             : Base.initarray!(interior(r), &, true, interior(c))
-initialize_reduced_field!(::AnyReduction,  f, r::ReducedField, c) = check_version_larger_than_7() ? Base.initarray!(interior(r), f, |, true, interior(c))             : Base.initarray!(interior(r), |, true, interior(c))
-
 initialize_reduced_field!(::MaximumReduction, f, r::ReducedField, c) = Base.mapfirst!(f, interior(r), interior(c))
 initialize_reduced_field!(::MinimumReduction, f, r::ReducedField, c) = Base.mapfirst!(f, interior(r), interior(c))
 

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -545,6 +545,13 @@ const MinimumReduction = typeof(Base.minimum!)
 const AllReduction     = typeof(Base.all!)
 const AnyReduction     = typeof(Base.any!)
 
+
+check_version_larger_than_7() = VERSION.minor > 7
+
+initialize_reduced_field!(::SumReduction,     f, r::ReducedField, c) = Base.initarray!(interior(r), f, Base.add_sum, true, interior(c))
+initialize_reduced_field!(::ProdReduction,    f, r::ReducedField, c) = Base.initarray!(interior(r), f, Base.mul_prod, true, interior(c))
+initialize_reduced_field!(::AllReduction,     f, r::ReducedField, c) = Base.initarray!(interior(r), f, &, true, interior(c))
+initialize_reduced_field!(::AnyReduction,     f, r::ReducedField, c) = Base.initarray!(interior(r), f, |, true, interior(c))             
 initialize_reduced_field!(::MaximumReduction, f, r::ReducedField, c) = Base.mapfirst!(f, interior(r), interior(c))
 initialize_reduced_field!(::MinimumReduction, f, r::ReducedField, c) = Base.mapfirst!(f, interior(r), interior(c))
 

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -4,10 +4,6 @@ data-driven, ocean-flavored fluid dynamics on CPUs and GPUs.
 """
 module Oceananigans
 
-if VERSION < v"1.8"
-    @warn "Oceananigans is tested on Julia v1.8 and therefore it is strongly recommended you run Oceananigans on Julia v1.8 or newer."
-end
-
 export
     # Architectures
     CPU, GPU, 


### PR DESCRIPTION
Removes all support for <1.9 Julia versions and update `Project.toml`.

Closes #3184 