### PR TITLE
Toggle immersed differences with immersed_inactive_node

### DIFF
--- a/src/ImmersedBoundaries/conditional_differences.jl
+++ b/src/ImmersedBoundaries/conditional_differences.jl
@@ -6,12 +6,29 @@ import Oceananigans.Operators:
     δzᶜᶜᶠ, δzᶜᶠᶠ, δzᶠᶜᶠ, δzᶠᶠᶠ,
     δzᶜᶜᶜ, δzᶜᶠᶜ, δzᶠᶜᶜ, δzᶠᶠᶜ
 
-@inline conditional_δx_f(LY, LZ, i, j, k, ibg::IBG, δx, args...) = ifelse(inactive_node(i, j, k, ibg, c, LY, LZ) | inactive_node(i-1, j, k, ibg, c, LY, LZ), zero(ibg), δx(i, j, k, ibg.underlying_grid, args...))
-@inline conditional_δx_c(LY, LZ, i, j, k, ibg::IBG, δx, args...) = ifelse(inactive_node(i, j, k, ibg, f, LY, LZ) | inactive_node(i+1, j, k, ibg, f, LY, LZ), zero(ibg), δx(i, j, k, ibg.underlying_grid, args...))
-@inline conditional_δy_f(LX, LZ, i, j, k, ibg::IBG, δy, args...) = ifelse(inactive_node(i, j, k, ibg, LX, c, LZ) | inactive_node(i, j-1, k, ibg, LX, c, LZ), zero(ibg), δy(i, j, k, ibg.underlying_grid, args...))
-@inline conditional_δy_c(LX, LZ, i, j, k, ibg::IBG, δy, args...) = ifelse(inactive_node(i, j, k, ibg, LX, f, LZ) | inactive_node(i, j+1, k, ibg, LX, f, LZ), zero(ibg), δy(i, j, k, ibg.underlying_grid, args...))
-@inline conditional_δz_f(LX, LY, i, j, k, ibg::IBG, δz, args...) = ifelse(inactive_node(i, j, k, ibg, LX, LY, c) | inactive_node(i, j, k-1, ibg, LX, LY, c), zero(ibg), δz(i, j, k, ibg.underlying_grid, args...))
-@inline conditional_δz_c(LX, LY, i, j, k, ibg::IBG, δz, args...) = ifelse(inactive_node(i, j, k, ibg, LX, LY, f) | inactive_node(i, j, k+1, ibg, LX, LY, f), zero(ibg), δz(i, j, k, ibg.underlying_grid, args...))
+@inline conditional_δx_f(LY, LZ, i, j, k, ibg::IBG, δx, args...) = ifelse(immersed_inactive_node(i, j, k, ibg, c, LY, LZ) |
+                                                                          immersed_inactive_node(i-1, j, k, ibg, c, LY, LZ),
+                                                                          zero(ibg), δx(i, j, k, ibg.underlying_grid, args...))
+
+@inline conditional_δx_c(LY, LZ, i, j, k, ibg::IBG, δx, args...) = ifelse(immersed_inactive_node(i,   j, k, ibg, f, LY, LZ) |
+                                                                          immersed_inactive_node(i+1, j, k, ibg, f, LY, LZ),
+                                                                          zero(ibg), δx(i, j, k, ibg.underlying_grid, args...))
+
+@inline conditional_δy_f(LX, LZ, i, j, k, ibg::IBG, δy, args...) = ifelse(immersed_inactive_node(i, j, k, ibg, LX, c, LZ) |
+                                                                          immersed_inactive_node(i, j-1, k, ibg, LX, c, LZ),
+                                                                          zero(ibg), δy(i, j, k, ibg.underlying_grid, args...))
+
+@inline conditional_δy_c(LX, LZ, i, j, k, ibg::IBG, δy, args...) = ifelse(immersed_inactive_node(i, j, k, ibg, LX, f, LZ) |
+                                                                          immersed_inactive_node(i, j+1, k, ibg, LX, f, LZ),
+                                                                          zero(ibg), δy(i, j, k, ibg.underlying_grid, args...))
+
+@inline conditional_δz_f(LX, LY, i, j, k, ibg::IBG, δz, args...) = ifelse(immersed_inactive_node(i, j, k, ibg, LX, LY, c) |
+                                                                          immersed_inactive_node(i, j, k-1, ibg, LX, LY, c),
+                                                                          zero(ibg), δz(i, j, k, ibg.underlying_grid, args...))
+
+@inline conditional_δz_c(LX, LY, i, j, k, ibg::IBG, δz, args...) = ifelse(immersed_inactive_node(i, j, k, ibg, LX, LY, f) |
+                                                                          immersed_inactive_node(i, j, k+1, ibg, LX, LY, f),
+                                                                          zero(ibg), δz(i, j, k, ibg.underlying_grid, args...))
 
 @inline translate_loc(a) = a == :ᶠ ? :f : :c
 


### PR DESCRIPTION
This PR toggles conditional differences with `immersed_inactive_node`, rather than `inactive_node`. The difference is that `inactive_node` returns `true` if the node is outside the domain (either immersed _or_ outside the domain in a `Bounded` direction). `immersed_inactive_node` only returns true if the node is within the immersed boundary:

https://github.com/CliMA/Oceananigans.jl/blob/f7acd8d0bd30dbe1ccb72854b6ea0ccab1eae0b5/src/ImmersedBoundaries/ImmersedBoundaries.jl#L220-L221

This matters for applying `ValueBoundaryCondition` or `GradientBoundaryCondition` across non-immersed boundaries, on `ImmersedBoundaryGrid`, because both of these are enforced by filling the halo regions on the other side of a `Bounded` direction. Thus we have to be able to correctly evaluate differences / interpolate across non-immersed `Bounded` boundaries.

Closes #3208 

We might want to add a test so this doesn't break in the future. It'd also be great to make this code more understandable (suggestions welcome...)

@hdrake