### PR TITLE
Remove type instability in AB2/3

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
@@ -100,12 +100,12 @@ end
 
 # AB3 step
 @inline function U★(i, j, k, grid, ::AdamsBashforth3Scheme, ϕᵐ, ϕᵐ⁻¹, ϕᵐ⁻²)
-    FT = eltype(ϕᵐ)
+    FT = eltype(grid)
     return FT(α) * ϕᵐ[i, j, k]   + FT(θ) * ϕᵐ⁻¹[i, j, k] + FT(β) * ϕᵐ⁻²[i, j, k]
 end
 
 @inline function η★(i, j, k, grid, ::AdamsBashforth3Scheme, ηᵐ⁺¹, ηᵐ, ηᵐ⁻¹, ηᵐ⁻²)
-    FT = eltype(ηᵐ)
+    FT = eltype(grid)
     return FT(δ) * ηᵐ⁺¹[i, j, k] + FT(μ) * ηᵐ[i, j, k]   + FT(γ) * ηᵐ⁻¹[i, j, k] + FT(ϵ) * ηᵐ⁻²[i, j, k]
 end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
@@ -99,8 +99,15 @@ end
 # Time stepping extrapolation U★, and η★
 
 # AB3 step
-@inline U★(i, j, k, grid, ::AdamsBashforth3Scheme, ϕᵐ, ϕᵐ⁻¹, ϕᵐ⁻²)       = α * ϕᵐ[i, j, k]   + θ * ϕᵐ⁻¹[i, j, k] + β * ϕᵐ⁻²[i, j, k]
-@inline η★(i, j, k, grid, ::AdamsBashforth3Scheme, ηᵐ⁺¹, ηᵐ, ηᵐ⁻¹, ηᵐ⁻²) = δ * ηᵐ⁺¹[i, j, k] + μ * ηᵐ[i, j, k]   + γ * ηᵐ⁻¹[i, j, k] + ϵ * ηᵐ⁻²[i, j, k]
+@inline function U★(i, j, k, grid, ::AdamsBashforth3Scheme, ϕᵐ, ϕᵐ⁻¹, ϕᵐ⁻²)
+    FT = eltype(ϕᵐ)
+    return FT(α) * ϕᵐ[i, j, k]   + FT(θ) * ϕᵐ⁻¹[i, j, k] + FT(β) * ϕᵐ⁻²[i, j, k]
+end
+
+@inline function η★(i, j, k, grid, ::AdamsBashforth3Scheme, ηᵐ⁺¹, ηᵐ, ηᵐ⁻¹, ηᵐ⁻²)
+    FT = eltype(ηᵐ)
+    return FT(δ) * ηᵐ⁺¹[i, j, k] + FT(μ) * ηᵐ[i, j, k]   + FT(γ) * ηᵐ⁻¹[i, j, k] + FT(ϵ) * ηᵐ⁻²[i, j, k]
+end
 
 # Forward Backward Step
 @inline U★(i, j, k, grid, ::ForwardBackwardScheme, ϕ, args...) = ϕ[i, j, k] 
@@ -261,9 +268,9 @@ function barotropic_split_explicit_corrector!(u, v, free_surface, grid)
         u, v, U̅, V̅, U, V, Hᶠᶜ, Hᶜᶠ)
 end
 
-@kernel function _calc_ab2_tendencies!(G⁻, Gⁿ, χ)
+@kernel function _calc_ab2_tendencies!(G⁻, Gⁿ, χ::FT) where FT
     i, j, k = @index(Global, NTuple)
-    @inbounds G⁻[i, j, k] = (1.5 + χ) *  Gⁿ[i, j, k] - G⁻[i, j, k] * (0.5 + χ)
+    @inbounds G⁻[i, j, k] = (FT(1.5) + χ) *  Gⁿ[i, j, k] - G⁻[i, j, k] * (FT(0.5) + χ)
 end
 
 """


### PR DESCRIPTION
I don't know how relevant these changes are, but I found some more type instabilities in the split explicit free surface model's adams bashforth time integrator. Removing them similar to #3212 

Alternatively we could also hardcode the constants

https://github.com/CliMA/Oceananigans.jl/blob/9140a74536784396d368cf8205432433a9deea3d/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl#L11-L19

as Float32

```julia
const β = 0.281105f0
const α = 1.5f0 + β
```
etc. as this will directly upcast to Float64 if that's used, but not cause a type instability with Float32. But this will again cause problems if we ever want to use something else than Float32/64... Now just the `U★, η★` get a bit lengthier!
