### PR TITLE
`getregion` for `KernelFunctionOperation`

### DIFF
--- a/src/MultiRegion/multi_region_abstract_operations.jl
+++ b/src/MultiRegion/multi_region_abstract_operations.jl
@@ -23,7 +23,7 @@ sync_all_devices!(f::MultiRegionAbstractOperation)  = sync_all_devices!(devices(
 @inline switch_device!(f::MultiRegionAbstractOperation, d) = switch_device!(f.grid, d)
 @inline getdevice(f::MultiRegionAbstractOperation, d)      = getdevice(f.grid, d)
 
-for T in [:BinaryOperation, :UnaryOperation, :MultiaryOperation, :Derivative, :KernelFunctionOperation]
+for T in [:BinaryOperation, :UnaryOperation, :MultiaryOperation, :Derivative]
     @eval begin
         @inline getregion(f::$T{LX, LY, LZ}, r) where {LX, LY, LZ} =
                           $T{LX, LY, LZ}(Tuple(_getregion(getproperty(f, n), r) for n in fieldnames($T))...)
@@ -32,3 +32,13 @@ for T in [:BinaryOperation, :UnaryOperation, :MultiaryOperation, :Derivative, :K
                            $T{LX, LY, LZ}(Tuple(getregion(getproperty(f, n), r) for n in fieldnames($T))...)
     end
 end
+
+@inline getregion(k::KernelFunctionOperation{LX, LY, LZ}, r) where {LX, LY, LZ} = 
+                KernelFunctionOperation{LX, LY, LZ}(k.kernel_function,
+                                                   _getregion(k.grid, r), 
+                                                   _getregion(k.arguments, r)...)
+
+@inline _getregion(k::KernelFunctionOperation{LX, LY, LZ}, r) where {LX, LY, LZ} = 
+                KernelFunctionOperation{LX, LY, LZ}(k.kernel_function,
+                                                    getregion(k.grid, r), 
+                                                    getregion(k.arguments, r)...)

--- a/src/MultiRegion/multi_region_abstract_operations.jl
+++ b/src/MultiRegion/multi_region_abstract_operations.jl
@@ -33,12 +33,12 @@ for T in [:BinaryOperation, :UnaryOperation, :MultiaryOperation, :Derivative]
     end
 end
 
-@inline getregion(k::KernelFunctionOperation{LX, LY, LZ}, r) where {LX, LY, LZ} = 
-                KernelFunctionOperation{LX, LY, LZ}(k.kernel_function,
-                                                   _getregion(k.grid, r), 
-                                                   _getregion(k.arguments, r)...)
+@inline getregion(κ::KernelFunctionOperation{LX, LY, LZ}, r) where {LX, LY, LZ} = 
+                KernelFunctionOperation{LX, LY, LZ}(_getregion(κ.kernel_function, r),
+                                                    _getregion(κ.grid, r), 
+                                                    _getregion(κ.arguments, r)...)
 
-@inline _getregion(k::KernelFunctionOperation{LX, LY, LZ}, r) where {LX, LY, LZ} = 
-                KernelFunctionOperation{LX, LY, LZ}(k.kernel_function,
-                                                    getregion(k.grid, r), 
-                                                    getregion(k.arguments, r)...)
+@inline _getregion(κ::KernelFunctionOperation{LX, LY, LZ}, r) where {LX, LY, LZ} = 
+                KernelFunctionOperation{LX, LY, LZ}(getregion(κ.kernel_function, r),
+                                                    getregion(κ.grid, r), 
+                                                    getregion(κ.arguments, r)...)


### PR DESCRIPTION
getregion was not working on `KernelFunctionOperation`s after the update from `computed_dependecies` to `arguments` because of the splatting in the constructor.

This PR fixes it

@siddharthabishnu 