### PR TITLE
Add method for constants to `field`

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -43,6 +43,7 @@ function field(loc, a::AbstractArray, grid)
 end
 
 field(loc, a::Function, grid) = FunctionField(loc, a, grid)
+field(loc, a::Number, grid) = ConstantField(a)
 
 function field(loc, f::Field, grid)
     loc === location(f) && grid === f.grid && return f


### PR DESCRIPTION
This PR adds a method to the function `field` for converting various objects (functions, arrays, `Field`) into `Field` that leverages `ConstantField` when `object isa Number`.