### PR TITLE
Update `TimeStepWizard`

### DIFF
--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -108,7 +108,8 @@ simulation = Simulation(model, Δt=1e-2, stop_time=40.0)
 #
 # The `TimeStepWizard` manages the time-step adaptively, keeping the Courant-Freidrichs-Lewy 
 # (CFL) number close to `0.75` while ensuring the time-step does not increase beyond the 
-# maximum allowable value for numerical stability (`new_Δt ≤ max_change * old_Δt`).
+# maximum allowable value for numerical stability while avoiding the time-step to change more than
+# the predefined maximum change (`new_Δt ≤ max_change * old_Δt`).
 
 wizard = TimeStepWizard(cfl=0.75, max_change=1.2, max_Δt=1e-1)
 

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -108,7 +108,7 @@ simulation = Simulation(model, Δt=1e-2, stop_time=40.0)
 #
 # The `TimeStepWizard` manages the time-step adaptively, keeping the Courant-Freidrichs-Lewy 
 # (CFL) number close to `0.75` while ensuring the time-step does not increase beyond the 
-# maximum allowable value for numerical stability.
+# maximum allowable value for numerical stability (`new_Δt <= max_change * old_Δt`).
 
 wizard = TimeStepWizard(cfl=0.75, max_change=1.2, max_Δt=1e-1)
 

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -108,7 +108,7 @@ simulation = Simulation(model, Δt=1e-2, stop_time=40.0)
 #
 # The `TimeStepWizard` manages the time-step adaptively, keeping the Courant-Freidrichs-Lewy 
 # (CFL) number close to `0.75` while ensuring the time-step does not increase beyond the 
-# maximum allowable value for numerical stability (`new_Δt <= max_change * old_Δt`).
+# maximum allowable value for numerical stability (`new_Δt ≤ max_change * old_Δt`).
 
 wizard = TimeStepWizard(cfl=0.75, max_change=1.2, max_Δt=1e-1)
 

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -74,7 +74,7 @@ function TimeStepWizard(FT=Float64;
     # check if user gave max_change or min_change values that are invalid
     min_change ≥ 1 && throw(ArgumentError("min_change must be < 1. You provided min_change = $min_change."))
   
-    max_change ≥ 1 && throw(ArgumentError("max_change must be > 1. You provided max_change = $max_change."))
+    max_change ≤ 1 && throw(ArgumentError("max_change must be > 1. You provided max_change = $max_change."))
   
     # user wants to limit by diffusive CFL and did not provide custom function to calculate timescale
     if isfinite(diffusive_cfl) && (cell_diffusion_timescale === infinite_diffusion_timescale)

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -34,8 +34,8 @@ Callback for adapting simulation to maintain the advective Courant-Freidrichs-Le
 number to `cfl`, the `diffusive_cfl`, while also maintaining `max_Δt`, `min_Δt`, and
 satisfying `max_change` and `min_change` criteria so that the simulation's timestep
 `simulation.Δt` is not adapted "too quickly". In other words, `max_change` is the maximum
-and `min_change` is the minimum relative change of the time step and are therefore non-dimensional
-(`min_change * old_Δt <= new_Δt <= max_change * old_Δt`).
+and `min_change` is the minimum relative change of the time step and are, therefore, non-dimensional
+(`min_change * old_Δt ≤ new_Δt ≤ max_change * old_Δt`).
 
 For more information on the CFL number, see its [wikipedia entry]
 (https://en.wikipedia.org/wiki/Courant%E2%80%93Friedrichs%E2%80%93Lewy_condition).

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -33,7 +33,9 @@ Base.summary(wizard::TimeStepWizard) = string("TimeStepWizard(",
 Callback for adapting simulation to maintain the advective Courant-Freidrichs-Lewy (CFL)
 number to `cfl`, the `diffusive_cfl`, while also maintaining `max_Δt`, `min_Δt`, and
 satisfying `max_change` and `min_change` criteria so that the simulation's timestep
-`simulation.Δt` is not adapted "too quickly".
+`simulation.Δt` is not adapted "too quickly". In other words, `max_change` is the maximum
+and `min_change` is the minimum relative change of the time step and are therefore non-dimensional
+(`min_change * old_Δt <= new_Δt <= max_change * old_Δt`).
 
 For more information on the CFL number, see its [wikipedia entry]
 (https://en.wikipedia.org/wiki/Courant%E2%80%93Friedrichs%E2%80%93Lewy_condition).

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -72,10 +72,9 @@ function TimeStepWizard(FT=Float64;
                         cell_diffusion_timescale = infinite_diffusion_timescale)
     
     # check if user gave max_change or min_change values that are invalid
-    if min_change >= 1.0 || max_change <= 1.0
-        throw(ArgumentError("Invalid value: min_change should be < 1 and max_change should be > 1. " *
-                            "You provided min_change = $min_change and max_change = $max_change."))
-    end
+    min_change ≥ 1 && throw(ArgumentError("min_change must be < 1"))
+
+    max_change ≥ 1 && throw(ArgumentError("max_change must be > 1"))
   
     # user wants to limit by diffusive CFL and did not provide custom function to calculate timescale
     if isfinite(diffusive_cfl) && (cell_diffusion_timescale === infinite_diffusion_timescale)

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -70,7 +70,13 @@ function TimeStepWizard(FT=Float64;
                         min_Δt = 0.0,
                         cell_advection_timescale = cell_advection_timescale,
                         cell_diffusion_timescale = infinite_diffusion_timescale)
-
+    
+    # check if user gave max_change or min_change values that are invalid
+    if min_change >= 1.0 || max_change <= 1.0
+        throw(ArgumentError("Invalid value: min_change should be < 1 and max_change should be > 1. " *
+                            "You provided min_change = $min_change and max_change = $max_change."))
+    end
+  
     # user wants to limit by diffusive CFL and did not provide custom function to calculate timescale
     if isfinite(diffusive_cfl) && (cell_diffusion_timescale === infinite_diffusion_timescale)
        cell_diffusion_timescale = TurbulenceClosures.cell_diffusion_timescale

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -46,7 +46,7 @@ For more information on the CFL number, see its [wikipedia entry]
 Example
 =======
 
-To use `TimeStepWizard`, adapt in a [`Callback`](@ref) and add it to a `Simulation`:
+To use `TimeStepWizard`, insert it into a [`Callback`](@ref) and add it to a `Simulation`:
 
 ```julia
 julia> simulation = Simulation(model, Δt=0.9, stop_iteration=100)

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -30,12 +30,15 @@ Base.summary(wizard::TimeStepWizard) = string("TimeStepWizard(",
                    cell_advection_timescale = cell_advection_timescale,
                    cell_diffusion_timescale = infinite_diffusion_timescale)
 
-Callback for adapting simulation to maintain the advective Courant-Freidrichs-Lewy (CFL)
-number to `cfl`, the `diffusive_cfl`, while also maintaining `max_Δt`, `min_Δt`, and
-satisfying `max_change` and `min_change` criteria so that the simulation's timestep
-`simulation.Δt` is not adapted "too quickly". In other words, `max_change` is the maximum
-and `min_change` is the minimum relative change of the time step and are, therefore, non-dimensional
-(`min_change * old_Δt ≤ new_Δt ≤ max_change * old_Δt`).
+Callback function that adjusts the simulation time step to meet specified target values 
+for advective and diffusive Courant-Friedrichs-Lewy (CFL) numbers (`cfl` and `diffusive_cfl`), 
+subject to the limits
+
+```julia
+    max(min_Δt, min_change * previous_Δt) ≤ new_Δt ≤ min(max_Δt, max_change * previous_Δt)
+```
+
+where `new_Δt` is the new time step calculated by `TimeStepWizard`.
 
 For more information on the CFL number, see its [wikipedia entry]
 (https://en.wikipedia.org/wiki/Courant%E2%80%93Friedrichs%E2%80%93Lewy_condition).

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -35,7 +35,7 @@ for advective and diffusive Courant-Friedrichs-Lewy (CFL) numbers (`cfl` and `di
 subject to the limits
 
 ```julia
-    max(min_Δt, min_change * previous_Δt) ≤ new_Δt ≤ min(max_Δt, max_change * previous_Δt)
+max(min_Δt, min_change * previous_Δt) ≤ new_Δt ≤ min(max_Δt, max_change * previous_Δt)
 ```
 
 where `new_Δt` is the new time step calculated by the `TimeStepWizard`.

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -38,7 +38,7 @@ subject to the limits
     max(min_Δt, min_change * previous_Δt) ≤ new_Δt ≤ min(max_Δt, max_change * previous_Δt)
 ```
 
-where `new_Δt` is the new time step calculated by `TimeStepWizard`.
+where `new_Δt` is the new time step calculated by the `TimeStepWizard`.
 
 For more information on the CFL number, see its [wikipedia entry]
 (https://en.wikipedia.org/wiki/Courant%E2%80%93Friedrichs%E2%80%93Lewy_condition).

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -46,7 +46,7 @@ For more information on the CFL number, see its [wikipedia entry]
 Example
 =======
 
-To use `TimeStepWizard`, insert it into a [`Callback`](@ref) and add it to a `Simulation`:
+To use `TimeStepWizard`, insert it into a [`Callback`](@ref) and then add the `Callback` to a `Simulation`:
 
 ```julia
 julia> simulation = Simulation(model, Δt=0.9, stop_iteration=100)

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -72,9 +72,9 @@ function TimeStepWizard(FT=Float64;
                         cell_diffusion_timescale = infinite_diffusion_timescale)
     
     # check if user gave max_change or min_change values that are invalid
-    min_change ≥ 1 && throw(ArgumentError("min_change must be < 1"))
-
-    max_change ≥ 1 && throw(ArgumentError("max_change must be > 1"))
+    min_change ≥ 1 && throw(ArgumentError("min_change must be < 1. You provided min_change = $min_change."))
+  
+    max_change ≥ 1 && throw(ArgumentError("max_change must be > 1. You provided max_change = $max_change."))
   
     # user wants to limit by diffusive CFL and did not provide custom function to calculate timescale
     if isfinite(diffusive_cfl) && (cell_diffusion_timescale === infinite_diffusion_timescale)


### PR DESCRIPTION
Reopens #3244 and #3245 

If I understand it correctly, it does not make sense to have `min_change > 1` or `max_change < 1`. Am I right?
If so, should we add at least a warning for those cases?


Please, let me know if I 'reopened' the PR correctly.