### PR TITLE
Deal with x->y, λ->φ, etc when filling halos for metrics/coords in `ConformalCubedSphereGrid`

### DIFF
--- a/src/MultiRegion/multi_region_cubed_sphere_grid.jl
+++ b/src/MultiRegion/multi_region_cubed_sphere_grid.jl
@@ -210,82 +210,41 @@ function ConformalCubedSphereGrid(arch::AbstractArchitecture=CPU(), FT=Float64;
                                                                                            region_grids,
                                                                                            devices)
 
-    # the following fills the coordinate and metric halos using halo-filling algorithms
-    ccacoords = (:λᶜᶜᵃ, :φᶜᶜᵃ)
-    fcacoords = (:λᶠᶜᵃ, :φᶠᶜᵃ)
-    cfacoords = (:λᶜᶠᵃ, :φᶜᶠᵃ)
+    fields₁ = (:Δxᶜᶜᵃ,  :Δxᶠᶜᵃ,  :Δxᶜᶠᵃ,  :λᶜᶜᵃ,   :λᶠᶜᵃ,   :λᶜᶠᵃ,   :Azᶜᶜᵃ,  :Azᶠᶜᵃ)
+    LXs₁    = (:Center, :Face,   :Center, :Center, :Face,   :Center, :Center, :Face)
+    LYs₁    = (:Center, :Center, :Face,   :Center, :Center, :Face,   :Center, :Center)
 
-    for (ccacoord, fcacoord, cfacoord) in zip(ccacoords, fcacoords, cfacoords)
+    fields₂ = (:Δyᶜᶜᵃ,  :Δyᶜᶠᵃ,  :Δyᶠᶜᵃ,  :φᶜᶜᵃ,   :φᶜᶠᵃ,   :φᶠᶜᵃ,   :Azᶜᶜᵃ,  :Azᶜᶠᵃ)
+    LXs₂    = (:Center, :Center, :Face,   :Center, :Center, :Face,   :Center, :Center)
+    LYs₂    = (:Center, :Face,   :Center, :Center, :Face,   :Center, :Center, :Face)
+
+    for (field₁, LX₁, LY₁, field₂, LX₂, LY₂) in zip(fields₁, LXs₁, LYs₁, fields₂, LXs₂, LYs₂)
         expr = quote
-            $(Symbol(ccacoord)) = Field{Center, Center, Nothing}($(grid))
-            $(Symbol(fcacoord)) = Field{Face,   Center, Nothing}($(grid))
-            $(Symbol(cfacoord)) = Field{Center, Face,   Nothing}($(grid))
+            $(Symbol(field₁)) = Field{$(Symbol(LX₁)), $(Symbol(LY₁)), Nothing}($(grid))
+            $(Symbol(field₂)) = Field{$(Symbol(LX₂)), $(Symbol(LY₂)), Nothing}($(grid))
 
             CUDA.@allowscalar begin
                 for region in 1:6
-                    getregion($(Symbol(ccacoord)), region).data .= getregion($(grid), region).$(Symbol(ccacoord))
-                    getregion($(Symbol(fcacoord)), region).data .= getregion($(grid), region).$(Symbol(fcacoord))
-                    getregion($(Symbol(cfacoord)), region).data .= getregion($(grid), region).$(Symbol(cfacoord))
+                    getregion($(Symbol(field₁)), region).data .= getregion($(grid), region).$(Symbol(field₁))
+                    getregion($(Symbol(field₂)), region).data .= getregion($(grid), region).$(Symbol(field₂))
                 end
             end
 
             if $(horizontal_topology) == FullyConnected
-                for _ in 1:3
-                    fill_halo_regions!($(Symbol(ccacoord)))
-                    fill_halo_regions!($(Symbol(fcacoord)))
-                    fill_halo_regions!($(Symbol(cfacoord)))
+                for _ in 1:1
+                    fill_halo_regions!($(Symbol(field₁)))
+                    fill_halo_regions!($(Symbol(field₂)))
 
-                    @apply_regionally replace_horizontal_velocity_halos!((; u = $(Symbol(fcacoord)),
-                                                                            v = $(Symbol(cfacoord)),
-                                                                            w = nothing), $(grid), signed=false)
-                end
-            end
-            CUDA.@allowscalar begin
-                for region in 1:6
-                    getregion($(grid), region).$(Symbol(ccacoord)) .= getregion($(Symbol(ccacoord)), region).data
-                    getregion($(grid), region).$(Symbol(fcacoord)) .= getregion($(Symbol(fcacoord)), region).data
-                    getregion($(grid), region).$(Symbol(cfacoord)) .= getregion($(Symbol(cfacoord)), region).data
-                end
-            end
-        end
-        eval(expr)
-    end
-
-    ccametrics = (:Δxᶜᶜᵃ, :Δyᶜᶜᵃ, :Azᶜᶜᵃ)
-    fcametrics = (:Δxᶠᶜᵃ, :Δyᶠᶜᵃ, :Azᶠᶜᵃ)
-    cfametrics = (:Δyᶜᶠᵃ, :Δxᶜᶠᵃ, :Azᶜᶠᵃ)
-
-    for (ccametric, fcametric, cfametric) in zip(ccametrics, fcametrics, cfametrics)
-        expr = quote
-            $(Symbol(ccametric)) = Field{Center, Center, Nothing}($(grid))
-            $(Symbol(fcametric)) = Field{Face,   Center, Nothing}($(grid))
-            $(Symbol(cfametric)) = Field{Center, Face,   Nothing}($(grid))
-
-            CUDA.@allowscalar begin
-                for region in 1:6
-                    getregion($(Symbol(ccametric)), region).data .= getregion($(grid), region).$(Symbol(ccametric))
-                    getregion($(Symbol(fcametric)), region).data .= getregion($(grid), region).$(Symbol(fcametric))
-                    getregion($(Symbol(cfametric)), region).data .= getregion($(grid), region).$(Symbol(cfametric))
-                end
-            end
-
-            if $(horizontal_topology) == FullyConnected
-                for _ in 1:3
-                    fill_halo_regions!($(Symbol(ccametric)))
-                    fill_halo_regions!($(Symbol(fcametric)))
-                    fill_halo_regions!($(Symbol(cfametric)))
-
-                    @apply_regionally replace_horizontal_velocity_halos!((; u = $(Symbol(fcametric)),
-                                                                            v = $(Symbol(cfametric)),
+                    @apply_regionally replace_horizontal_velocity_halos!((; u = $(Symbol(field₁)),
+                                                                            v = $(Symbol(field₂)),
                                                                             w = nothing), $(grid), signed=false)
                 end
             end
 
             CUDA.@allowscalar begin
                 for region in 1:6
-                    getregion($(grid), region).$(Symbol(ccametric)) .= getregion($(Symbol(ccametric)), region).data
-                    getregion($(grid), region).$(Symbol(fcametric)) .= getregion($(Symbol(fcametric)), region).data
-                    getregion($(grid), region).$(Symbol(cfametric)) .= getregion($(Symbol(cfametric)), region).data
+                    getregion($(grid), region).$(Symbol(field₁)) .= getregion($(Symbol(field₁)), region).data
+                    getregion($(grid), region).$(Symbol(field₂)) .= getregion($(Symbol(field₂)), region).data
                 end
             end
         end # quote
@@ -293,7 +252,7 @@ function ConformalCubedSphereGrid(arch::AbstractArchitecture=CPU(), FT=Float64;
         eval(expr)
     end
 
-    " Halo filling for Face-Face coordinates , hardcoded for the default cubed-sphere connectivity. "
+    " Halo filling for Face-Face coordinates, hardcoded for the default cubed-sphere connectivity. "
     function fill_faceface_coordinates!(grid)
         length(grid.partition) != 6 && error("only works for CubedSpherePartition(R = 1) at the moment")
 


### PR DESCRIPTION
Closes #3254