### PR TITLE
Adding interior of a field with indices in `OutputWriter`

### DIFF
--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -176,7 +176,15 @@ function Field(loc::Tuple,
 end
     
 Field(z::ZeroField; kw...) = z
-Field(f::Field; indices=f.indices) = view(f, indices...) # hmm...
+
+function Field(f::Field; indices=f.indices)
+    if indices == (:, :, :)
+        return f
+    end
+
+    return view(f, indices...) # hmm...
+end
+
 
 """
     CenterField(grid, T=eltype(grid); kw...)

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -211,7 +211,7 @@ regular_dimensions(grid) = ()
 
 parent_index_range(::Colon,                       loc, topo, halo) = Colon()
 parent_index_range(::Base.Slice{<:IdOffsetRange}, loc, topo, halo) = Colon()
-parent_index_range(index::UnitRange,              loc, topo, halo) = index .+ interior_parent_offset(loc, topo, halo)
+parent_index_range(index::UnitRange,              loc, topo, halo) = UnitRange(1, length(index)) #index .+ interior_parent_offset(loc, topo, halo)
 
 parent_index_range(index::UnitRange, ::Nothing, ::Flat, halo) = index
 parent_index_range(index::UnitRange, ::Nothing, ::AT,   halo) = 1:1 # or Colon()


### PR DESCRIPTION
Attempt to close #3260.

```Julia
using Oceananigans

model = HydrostaticFreeSurfaceModel(grid = RectilinearGrid(size = (5, 5, 4), x = (-1e3, 1e3), y = (-1e3, 1e3), z = (-1e3, 0)))

ηᵢ(x, y, z) = 1 * exp(-(x^2 + y^2) / 2 * (2e2)^2)

set!(model, η = ηᵢ)

simulation = Simulation(model, Δt=100, stop_time = 1000)

simulation.output_writers[:surface] = JLD2OutputWriter(model, (η=model.free_surface.η,),
                                                       schedule = TimeInterval(200),
                                                       filename = "surface",
                                                       overwrite_existing = true)
```
```Julia
JLD2OutputWriter scheduled on TimeInterval(3.333 minutes):
├── filepath: ./surface.jld2
├── 1 outputs: η
├── array type: Array{Float64}
├── including: [:grid, :coriolis, :buoyancy, :closure]
└── max filesize: Inf YiB
```