### PR TITLE
Add `regularize_biogeochemistry`

### DIFF
--- a/src/Biogeochemistry.jl
+++ b/src/Biogeochemistry.jl
@@ -31,6 +31,10 @@ update_biogeochemical_state!(bgc, model) = nothing
 @inline biogeochemical_auxiliary_fields(bgc) = NamedTuple()
 
 """
+    regularize_biogeochemistry(bgc, model) = AbstractBGCOrNothing
+
+Check that bgc is correctly setup for the particular model configuration.
+"""
     AbstractBiogeochemistry
 
 Abstract type for biogeochemical models. To define a biogeochemcial relaionship

--- a/src/Biogeochemistry.jl
+++ b/src/Biogeochemistry.jl
@@ -35,7 +35,7 @@ update_biogeochemical_state!(bgc, model) = nothing
 
 Check that bgc is correctly setup for the particular model configuration.
 """
-@inline materialize_biogeochemistry(bgc, tracers) = nothing
+@inline materialize_biogeochemistry(bgc, tracers) = bgc
 
 """
     AbstractBiogeochemistry

--- a/src/Biogeochemistry.jl
+++ b/src/Biogeochemistry.jl
@@ -31,9 +31,12 @@ update_biogeochemical_state!(bgc, model) = nothing
 @inline biogeochemical_auxiliary_fields(bgc) = NamedTuple()
 
 """
-    regularize_biogeochemistry(bgc, model) = AbstractBGCOrNothing
+    materialize_biogeochemistry(bgc, tracers)
 
 Check that bgc is correctly setup for the particular model configuration.
+"""
+@inlin materialize_biogeochemistry(bgc, tracers) = nothing
+
 """
     AbstractBiogeochemistry
 

--- a/src/Biogeochemistry.jl
+++ b/src/Biogeochemistry.jl
@@ -35,7 +35,7 @@ update_biogeochemical_state!(bgc, model) = nothing
 
 Check that bgc is correctly setup for the particular model configuration.
 """
-@inlin materialize_biogeochemistry(bgc, tracers) = nothing
+@inline materialize_biogeochemistry(bgc, tracers) = nothing
 
 """
     AbstractBiogeochemistry

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -6,7 +6,7 @@ using Oceananigans.Architectures: AbstractArchitecture, GPU
 using Oceananigans.Advection: AbstractAdvectionScheme, CenteredSecondOrder, VectorInvariant
 using Oceananigans.BuoyancyModels: validate_buoyancy, regularize_buoyancy, SeawaterBuoyancy, g_Earth
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
-using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochemistry, biogeochemical_auxiliary_fields, regularize_biogeochemistry
+using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochemistry, biogeochemical_auxiliary_fields, materialize_biogeochemistry
 using Oceananigans.Fields: Field, CenterField, tracernames, VelocityFields, TracerFields
 using Oceananigans.Forcings: model_forcing
 using Oceananigans.Grids: halo_size, inflate_halo_size, with_halo, AbstractRectilinearGrid
@@ -132,7 +132,7 @@ function HydrostaticFreeSurfaceModel(; grid,
     tracers, auxiliary_fields = validate_biogeochemistry(tracers, merge(auxiliary_fields, biogeochemical_auxiliary_fields(biogeochemistry)), biogeochemistry, grid, clock)
     validate_buoyancy(buoyancy, tracernames(tracers))
     buoyancy = regularize_buoyancy(buoyancy)
-    biogeochemistry = regularize_biogeochemistry(biogeochemistry, model)
+    biogeochemistry = materialize_biogeochemistry(biogeochemistry, tracers)
 
     # Collect boundary conditions for all model prognostic fields and, if specified, some model
     # auxiliary fields. Boundary conditions are "regularized" based on the _name_ of the field:

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -6,7 +6,7 @@ using Oceananigans.Architectures: AbstractArchitecture, GPU
 using Oceananigans.Advection: AbstractAdvectionScheme, CenteredSecondOrder, VectorInvariant
 using Oceananigans.BuoyancyModels: validate_buoyancy, regularize_buoyancy, SeawaterBuoyancy, g_Earth
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
-using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochemistry, biogeochemical_auxiliary_fields
+using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochemistry, biogeochemical_auxiliary_fields, regularize_biogeochemistry
 using Oceananigans.Fields: Field, CenterField, tracernames, VelocityFields, TracerFields
 using Oceananigans.Forcings: model_forcing
 using Oceananigans.Grids: halo_size, inflate_halo_size, with_halo, AbstractRectilinearGrid
@@ -132,6 +132,7 @@ function HydrostaticFreeSurfaceModel(; grid,
     tracers, auxiliary_fields = validate_biogeochemistry(tracers, merge(auxiliary_fields, biogeochemical_auxiliary_fields(biogeochemistry)), biogeochemistry, grid, clock)
     validate_buoyancy(buoyancy, tracernames(tracers))
     buoyancy = regularize_buoyancy(buoyancy)
+    biogeochemistry = regularize_biogeochemistry(biogeochemistry, model)
 
     # Collect boundary conditions for all model prognostic fields and, if specified, some model
     # auxiliary fields. Boundary conditions are "regularized" based on the _name_ of the field:

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -5,7 +5,7 @@ using Oceananigans.Architectures: AbstractArchitecture
 using Oceananigans.Distributed: DistributedArch
 using Oceananigans.Advection: CenteredSecondOrder
 using Oceananigans.BuoyancyModels: validate_buoyancy, regularize_buoyancy, SeawaterBuoyancy
-using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochemistry, biogeochemical_auxiliary_fields, regularize_biogeochemistry
+using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochemistry, biogeochemical_auxiliary_fields, materialize_biogeochemistry
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
 using Oceananigans.Fields: BackgroundFields, Field, tracernames, VelocityFields, TracerFields, PressureFields
 using Oceananigans.Forcings: model_forcing
@@ -139,7 +139,7 @@ function NonhydrostaticModel(;    grid,
     tracers, auxiliary_fields = validate_biogeochemistry(tracers, merge(auxiliary_fields, biogeochemical_auxiliary_fields(biogeochemistry)), biogeochemistry, grid, clock)
     validate_buoyancy(buoyancy, tracernames(tracers))
     buoyancy = regularize_buoyancy(buoyancy)
-    biogeochemistry = regularize_biogeochemistry(biogeochemistry, model)
+    biogeochemistry = materialize_biogeochemistry(biogeochemistry, tracers)
 
     # Adjust halos when the advection scheme or turbulence closure requires it.
     # Note that halos are isotropic by default; however we respect user-input here

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -5,7 +5,7 @@ using Oceananigans.Architectures: AbstractArchitecture
 using Oceananigans.Distributed: DistributedArch
 using Oceananigans.Advection: CenteredSecondOrder
 using Oceananigans.BuoyancyModels: validate_buoyancy, regularize_buoyancy, SeawaterBuoyancy
-using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochemistry, biogeochemical_auxiliary_fields
+using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochemistry, biogeochemical_auxiliary_fields, regularize_biogeochemistry
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
 using Oceananigans.Fields: BackgroundFields, Field, tracernames, VelocityFields, TracerFields, PressureFields
 using Oceananigans.Forcings: model_forcing
@@ -139,6 +139,7 @@ function NonhydrostaticModel(;    grid,
     tracers, auxiliary_fields = validate_biogeochemistry(tracers, merge(auxiliary_fields, biogeochemical_auxiliary_fields(biogeochemistry)), biogeochemistry, grid, clock)
     validate_buoyancy(buoyancy, tracernames(tracers))
     buoyancy = regularize_buoyancy(buoyancy)
+    biogeochemistry = regularize_biogeochemistry(biogeochemistry, model)
 
     # Adjust halos when the advection scheme or turbulence closure requires it.
     # Note that halos are isotropic by default; however we respect user-input here


### PR DESCRIPTION
I've added `regularize_biogeochemistry` in the same vain as `regularize_forcing` because I think this would be useful to finalise model setups. For example, I want todo something similar to:
https://github.com/CliMA/Oceananigans.jl/blob/02d6aec489bc8cb40be7c10792c2798b50cf2afd/src/Forcings/continuous_forcing.jl#L100-L110
where I setup a model with symbols specifying some tracers, and then once the model is built change them to indices so that they can be given to a GPU kernel.