### PR TITLE
Removes warning in `Buoyancy` for rotated gravity

### DIFF
--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -226,7 +226,7 @@ To simulate gravitational accelerations that don't align with the vertical (`z`)
 we wrap the buoyancy model in
 `Buoyancy()` function call, which takes the keyword arguments `model` and `gravity_unit_vector`,
 
-```jldoctest buoyancy; filter = r".*@ Oceananigans.BuoyancyModels.*"
+```jldoctest buoyancy
 julia> θ = 45; # degrees
 
 julia> g̃ = (0, sind(θ), cosd(θ));
@@ -234,10 +234,6 @@ julia> g̃ = (0, sind(θ), cosd(θ));
 julia> model = NonhydrostaticModel(; grid, 
                                    buoyancy=Buoyancy(model=BuoyancyTracer(), gravity_unit_vector=g̃), 
                                    tracers=:b)
-┌ Warning: The meaning of `gravity_unit_vector` changed in version 0.80.0.
-│ In versions 0.79 and earlier, `gravity_unit_vector` indicated the direction _opposite_ to gravity.
-│ In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration.
-└ @ Oceananigans.BuoyancyModels ~/builds/tartarus-16/clima/oceananigans/src/BuoyancyModels/buoyancy.jl:48
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 ├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper

--- a/src/BuoyancyModels/buoyancy.jl
+++ b/src/BuoyancyModels/buoyancy.jl
@@ -15,7 +15,7 @@ The buoyancy acceleration acts in the direction opposite to gravity.
 Example
 =======
 
-```jldoctest; filter = r"└ @ Oceananigans.BuoyancyModels.*"
+```jldoctest
 
 using Oceananigans
 
@@ -30,10 +30,6 @@ model = NonhydrostaticModel(grid=grid, buoyancy=buoyancy, tracers=:b)
 
 # output
 
-┌ Warning: The meaning of `gravity_unit_vector` changed in version 0.80.0.
-│ In versions 0.79 and earlier, `gravity_unit_vector` indicated the direction _opposite_ to gravity.
-│ In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration.
-└ @ Oceananigans.BuoyancyModels ~/builds/tartarus-16/clima/oceananigans/src/BuoyancyModels/buoyancy.jl:48
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 ├── grid: 1×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper

--- a/src/BuoyancyModels/buoyancy.jl
+++ b/src/BuoyancyModels/buoyancy.jl
@@ -44,10 +44,6 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 ```
 """
 function Buoyancy(; model, gravity_unit_vector=NegativeZDirection())
-    gravity_unit_vector != NegativeZDirection() &&
-        @warn """The meaning of `gravity_unit_vector` changed in version 0.80.0.
-                 In versions 0.79 and earlier, `gravity_unit_vector` indicated the direction _opposite_ to gravity.
-                 In versions 0.80.0 and later, `gravity_unit_vector` indicates the direction of gravitational acceleration."""
     gravity_unit_vector = validate_unit_vector(gravity_unit_vector)
     return Buoyancy(model, gravity_unit_vector)
 end


### PR DESCRIPTION
Since version 0.80 (March 2023) we've had a warning pointing out the change in behavior of `gravity_unit_vector`, which "flipped" directions at that point. I think it's been enough time that we can remove that warning. What do others think?