### PR TITLE
Propagate eltype through FFT-based implicit free surface solver

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/fft_based_implicit_free_surface_solver.jl
@@ -58,7 +58,7 @@ function FFTImplicitFreeSurfaceSolver(grid, settings=nothing, gravitational_acce
     # Even if the three dimensional grid is vertically stretched, we can only use
     # FFTImplicitFreeSurfaceSolver with grids that are regularly spaced in the
     # horizontal direction.
-    horizontal_grid = RectilinearGrid(architecture(grid);
+    horizontal_grid = RectilinearGrid(architecture(grid), eltype(grid);
                                       topology = (TX, TY, Flat),
                                       size = sz,
                                       halo = halo,


### PR DESCRIPTION
This PR propagates the eltype of the "3D grid" into the horizontal grid that's used by the FFT-based implicit free surface solver.

Should help down the line with one of the issues that cropped up on #3288.

@jagoosw

