### PR TITLE
Fixes bug in free surface build for `HydrostaticFreeSurfaceModel`s on a `ConformalCubedSphereGrid`

### DIFF
--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -1062,8 +1062,8 @@ function with_halo(new_halo, old_grid::OrthogonalSphericalShellGrid; rotation=no
     size = (old_grid.Nx, old_grid.Ny, old_grid.Nz)
     topo = topology(old_grid)
 
-    ξ = (old_grid.ξₗ, old_grid.ξᵣ)
-    η = (old_grid.ηₗ, old_grid.ηᵣ)
+    ξ = old_grid.conformal_mapping.ξ
+    η = old_grid.conformal_mapping.η
 
     z = cpu_face_constructor_z(old_grid)
 

--- a/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl
@@ -127,7 +127,7 @@ function implicit_free_surface_step!(free_surface::ImplicitFreeSurface, model, �
     ∫ᶻQ    = free_surface.barotropic_volume_flux
     solver = free_surface.implicit_step_solver
     arch   = model.architecture
- 
+
     fill_halo_regions!(model.velocities)
 
     # Compute right hand side of implicit free surface equation
@@ -144,17 +144,16 @@ function implicit_free_surface_step!(free_surface::ImplicitFreeSurface, model, �
     @debug "Implicit step solve took $(prettytime((time_ns() - start_time) * 1e-9))."
 
     fill_halo_regions!(η)
-    
+
     return nothing
 end
 
 function local_compute_integrated_volume_flux!(∫ᶻQ, velocities, arch)
     
     foreach(mask_immersed_field!, velocities)
-    
+
     # Compute barotropic volume flux. Blocking.
     compute_vertically_integrated_volume_flux!(∫ᶻQ, velocities)
 
     return nothing
 end
-

--- a/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
@@ -83,10 +83,10 @@ function solve!(η, implicit_free_surface_solver::PCGImplicitFreeSurfaceSolver, 
     # Take explicit step first? We haven't found improvement from this yet, but perhaps it will
     # help eventually.
     #explicit_ab2_step_free_surface!(free_surface, model, Δt, χ)
-    
+
     ∫ᶻA = implicit_free_surface_solver.vertically_integrated_lateral_areas
     solver = implicit_free_surface_solver.preconditioned_conjugate_gradient_solver
-    
+
     # solve!(x, solver, b, args...) solves A*x = b for x.
     solve!(η, solver, rhs, ∫ᶻA.xᶠᶜᶜ, ∫ᶻA.yᶜᶠᶜ, g, Δt)
 

--- a/src/MultiRegion/multi_region_cubed_sphere_grid.jl
+++ b/src/MultiRegion/multi_region_cubed_sphere_grid.jl
@@ -151,7 +151,7 @@ for region in 1:length(grid); println("panel ", region, ": ", getregion(grid.con
 function ConformalCubedSphereGrid(arch::AbstractArchitecture=CPU(), FT=Float64;
                                   panel_size,
                                   z,
-                                  horizontal_direction_halo = 1,
+                                  horizontal_direction_halo = 3,
                                   z_halo = horizontal_direction_halo,
                                   horizontal_topology = FullyConnected,
                                   z_topology = Bounded,
@@ -424,11 +424,11 @@ function ConformalCubedSphereGrid(filepath::AbstractString, arch::AbstractArchit
     return MultiRegionGrid{FT, panel_topology[1], panel_topology[2], panel_topology[3]}(arch, partition, connectivity, region_grids, devices)
 end
 
-function with_halo(new_halo, csg::ConformalCubedSphereGrid) 
+function with_halo(new_halo, csg::ConformalCubedSphereGrid)
     region_rotation = []
 
-    for r in 1:length(csg.partition)
-        push!(region_rotation, rotation_from_panel_index(panel_index(r, csg.partition)))
+    for region in 1:length(csg.partition)
+        push!(region_rotation, csg[region].conformal_mapping.rotation)
     end
 
     apply_regionally!(with_halo, new_halo, csg; rotation = Iterate(region_rotation))

--- a/test/test_multi_region_cubed_sphere.jl
+++ b/test/test_multi_region_cubed_sphere.jl
@@ -139,10 +139,12 @@ end
         grid_cs32 = ConformalCubedSphereGrid(cs32_filepath, arch; Nz, z)
 
         Nx, Ny, Nz = size(grid_cs32)
+        Hx, Hy, Hz = halo_size(grid_cs32)
         radius = getregion(grid_cs32, 1).radius
 
         # construct a ConformalCubedSphereGrid similar to cs32
-        grid = ConformalCubedSphereGrid(arch; z, panel_size=(Nx, Ny, Nz), radius)
+        grid = ConformalCubedSphereGrid(arch; z, panel_size=(Nx, Ny, Nz), radius,
+                                        horizontal_direction_halo = Hx, z_halo = Hz)
 
         for panel in 1:6
 

--- a/test/test_multi_region_cubed_sphere.jl
+++ b/test/test_multi_region_cubed_sphere.jl
@@ -138,9 +138,10 @@ end
         # read cs32 grid from file
         grid_cs32 = ConformalCubedSphereGrid(cs32_filepath, arch; Nz, z)
 
+        radius = first(grid_cs32).radius
         Nx, Ny, Nz = size(grid_cs32)
         Hx, Hy, Hz = halo_size(grid_cs32)
-        radius = getregion(grid_cs32, 1).radius
+        Hx !== Hy && error("Hx must be same as Hy")
 
         # construct a ConformalCubedSphereGrid similar to cs32
         grid = ConformalCubedSphereGrid(arch; z, panel_size=(Nx, Ny, Nz), radius,


### PR DESCRIPTION
Closes  #3295

Before this PR:

```Julia
julia> using Oceananigans

julia> grid = ConformalCubedSphereGrid(; panel_size = (3, 3, 3), z = (-1, 0));

julia> model = HydrostaticFreeSurfaceModel(; grid, momentum_advection = VectorInvariant())
ERROR: UndefVarError: `rotation_from_panel_index` not defined
Stacktrace:
 [1] with_halo(new_halo::Tuple{Int64, Int64, Int64}, csg::ConformalCubedSphereGrid{Float64, FullyConnected, ....
   @ Oceananigans.MultiRegion ~/Research/OC8.jl/src/MultiRegion/multi_region_cubed_sphere_grid.jl:431
 [2] Oceananigans.Models.HydrostaticFreeSurfaceModels.PCGImplicitFreeSurfaceSolver(grid::ConformalCubedSphereGrid{Float64, ...
   @ Oceananigans.Models.HydrostaticFreeSurfaceModels ~/Research/OC8.jl/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl:47
 [3] build_implicit_step_solver(#unused#::Val{:Default}, grid::ConformalCubedSphereGrid{Float64, ...
   @ Oceananigans.MultiRegion ~/Research/OC8.jl/src/MultiRegion/unified_implicit_free_surface_solver.jl:67
 [4] FreeSurface(free_surface::ImplicitFreeSurface{Nothing, Float64, Nothing, Nothing, Symbol, ...
   @ Oceananigans.Models.HydrostaticFreeSurfaceModels ~/Research/OC8.jl/src/Models/HydrostaticFreeSurfaceModels/implicit_free_surface.jl:95
 [5] HydrostaticFreeSurfaceModel(; grid::ConformalCubedSphereGrid{Float64, ...
   @ Oceananigans.Models.HydrostaticFreeSurfaceModels ~/Research/OC8.jl/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl:169
 [6] top-level scope
   @ REPL[63]:1
```

With this PR:

```Julia
julia> using Oceananigans

julia> grid = ConformalCubedSphereGrid(; panel_size = (3, 3, 3), z = (-1, 0));

julia> model = HydrostaticFreeSurfaceModel(; grid, momentum_advection = VectorInvariant())
HydrostaticFreeSurfaceModel{CPU, MultiRegionGrid}(time = 0 seconds, iteration = 0)
├── grid: 3×3×3 ConformalCubedSphereGrid{Float64, FullyConnected, FullyConnected, Bounded} on CPU with 6×6×6 halo
├── timestepper: QuasiAdamsBashforth2TimeStepper
├── tracers: (T, S)
├── closure: Nothing
├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with ĝ = NegativeZDirection()
├── free surface: ImplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
│   └── solver: PCGImplicitFreeSurfaceSolver
└── coriolis: Nothing
```