### PR TITLE
Add validation for array-based coordinates

### DIFF
--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -21,8 +21,8 @@ topological_tuple_length(TX, TY, TZ) = sum(T === Flat ? 0 : 1 for T in (TX, TY, 
 
 """Validate that an argument tuple is the right length and has elements of type `argtype`."""
 function validate_tupled_argument(arg, argtype, argname, len=3; greater_than=0)
-    length(arg) == len      || throw(ArgumentError("length($argname) must be $len."))
-    all(isa.(arg, argtype)) || throw(ArgumentError("$argname=$arg must contain $argtype s."))
+    length(arg) == len        || throw(ArgumentError("length($argname) must be $len."))
+    all(isa.(arg, argtype))   || throw(ArgumentError("$argname=$arg must contain $argtype s."))
     all(arg .> greater_than)  || throw(ArgumentError("Elements of $argname=$arg must be > $(greater_than)!"))
     return nothing
 end
@@ -70,7 +70,7 @@ function validate_dimension_specification(T, ξ, dir, N, FT)
     isnothing(ξ)         && throw(ArgumentError("Must supply extent or $dir keyword when $dir-direction is $T"))
     length(ξ) == 2       || throw(ArgumentError("$dir length($ξ) must be 2."))
     all(isa.(ξ, Number)) || throw(ArgumentError("$dir=$ξ should contain numbers."))
-    ξ[2] >= ξ[1]         || throw(ArgumentError("$dir=$ξ should be an increasing interval."))
+    ξ[2] ≥ ξ[1]          || throw(ArgumentError("$dir=$ξ should be an increasing interval."))
 
     return FT.(ξ)
 end
@@ -105,6 +105,8 @@ end
 
 function validate_dimension_specification(T, ξ::AbstractVector, dir, N, FT)
     ξ = FT.(ξ)
+
+    ξ[end] ≥ ξ[1] || throw(ArgumentError("$dir=$ξ should be a vector with increasing values."))
 
     # Validate the length of ξ: error is ξ is too short, warn if ξ is too long.
     Nξ = length(ξ)

--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -106,7 +106,7 @@ end
 function validate_dimension_specification(T, ξ::AbstractVector, dir, N, FT)
     ξ = FT.(ξ)
 
-    ξ[end] ≥ ξ[1] || throw(ArgumentError("$dir=$ξ should be a vector with increasing values."))
+    ξ[end] ≥ ξ[1] || throw(ArgumentError("$dir=$ξ should have increasing values."))
 
     # Validate the length of ξ: error is ξ is too short, warn if ξ is too long.
     Nξ = length(ξ)
@@ -122,7 +122,10 @@ function validate_dimension_specification(T, ξ::AbstractVector, dir, N, FT)
     return ξ
 end
 
-validate_dimension_specification(T, ξ::Function, dir, N, FT) = ξ
+function validate_dimension_specification(T, ξ::Function, dir, N, FT)
+    ξ(N) ≥ ξ(1) || throw(ArgumentError("$dir should have increasing values."))
+    return ξ
+end
 
 validate_dimension_specification(::Type{Flat}, ξ::AbstractVector, dir, N, FT) = (FT(ξ[1]), FT(ξ[1]))
 validate_dimension_specification(::Type{Flat}, ξ::Function,       dir, N, FT) = (FT(ξ(1)), FT(ξ(1)))


### PR DESCRIPTION
Before this PR, the following would *NOT* error:

```Julia
julia> grid = RectilinearGrid(size=2, z=[0, -0.5, -1], topology=(Flat, Flat, Bounded))
1×1×2 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
├── Flat x
├── Flat y
└── Bounded  z ∈ [0.0, -1.0]      variably spaced with min(Δz)=-0.5, max(Δz)=-0.5
```

After this PR:

```Julia
julia> grid = RectilinearGrid(size=2, z=[0, -0.5, -1], topology=(Flat, Flat, Bounded))
ERROR: ArgumentError: z=[0.0, -0.5, -1.0] should be a vector with increasing values.
Stacktrace:
 [1] validate_dimension_specification(T::Type, ξ::Vector{Float64}, dir::Symbol, N::Int64, FT::Type)
   @ Oceananigans.Grids ~/Research/OC6.jl/src/Grids/input_validation.jl:109
 [2] validate_rectilinear_domain(TX::Type, TY::Type, TZ::Type, FT::Type, size::Tuple{Int64, Int64, Int64}, extent::Nothing, x::Nothing, y::Nothing, z::Vector{Float64})
   @ Oceananigans.Grids ~/Research/OC6.jl/src/Grids/input_validation.jl:100
 [3] validate_rectilinear_grid_args(topology::Tuple{DataType, DataType, DataType}, size::Int64, halo::Nothing, FT::Type, extent::Nothing, x::Nothing, y::Nothing, z::Vector{Float64})
   @ Oceananigans.Grids ~/Research/OC6.jl/src/Grids/rectilinear_grid.jl:293
 [4] RectilinearGrid(architecture::CPU, FT::DataType; size::Int64, x::Nothing, y::Nothing, z::Vector{Float64}, halo::Nothing, extent::Nothing, topology::Tuple{DataType, DataType, DataType})
   @ Oceananigans.Grids ~/Research/OC6.jl/src/Grids/rectilinear_grid.jl:268
 [5] RectilinearGrid
   @ ~/Research/OC6.jl/src/Grids/rectilinear_grid.jl:254 [inlined]
 [6] top-level scope
   @ REPL[13]:1
```

```
julia> grid = LatitudeLongitudeGrid(size=(2, 2, 2), longitude=(-20, 20), latitude=(10, 20), z=[0, -0.5, -1], topology=(Bounded, Bounded, Bounded))

ERROR: ArgumentError: z=[0.0, -0.5, -1.0] should be a vector with increasing values.
Stacktrace:
 [1] validate_dimension_specification(T::Type, ξ::Vector{Float64}, dir::Symbol, N::Int64, FT::Type)
   @ Oceananigans.Grids ~/Research/OC6.jl/src/Grids/input_validation.jl:109
 [2] validate_lat_lon_grid_args(FT::Type, latitude::Tuple{Int64, Int64}, longitude::Tuple{Int64, Int64}, z::Vector{Float64}, size::Tuple{Int64, Int64, Int64}, halo::Nothing, topology::Tuple{DataType, DataType, DataType}, precompute_metrics::Bool)
   @ Oceananigans.Grids ~/Research/OC6.jl/src/Grids/latitude_longitude_grid.jl:272
 [3] LatitudeLongitudeGrid(architecture::CPU, FT::DataType; size::Tuple{Int64, Int64, Int64}, longitude::Tuple{Int64, Int64}, latitude::Tuple{Int64, Int64}, z::Vector{Float64}, radius::Float64, topology::Tuple{DataType, DataType, DataType}, precompute_metrics::Bool, halo::Nothing)
   @ Oceananigans.Grids ~/Research/OC6.jl/src/Grids/latitude_longitude_grid.jl:189
 [4] LatitudeLongitudeGrid
   @ ~/Research/OC6.jl/src/Grids/latitude_longitude_grid.jl:174 [inlined]
 [5] top-level scope
   @ REPL[14]:1
```

Closes #3307 