### PR TITLE
Fix various bugs in auto adding bgc tracers and setting up field dependant forcing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.89.1"
+version = "0.89.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Biogeochemistry.jl
+++ b/src/Biogeochemistry.jl
@@ -126,7 +126,8 @@ tracernames(tracers) = keys(tracers)
 tracernames(tracers::Tuple) = tracers
 
 add_biogeochemical_tracer(tracers::Tuple, name, grid) = tuple(tracers..., name)
-add_biogeochemical_tracer(tracers::NamedTuple, name, grid) = merge(tracers, NamedTuple((name => CenterField(grid), )))
+add_biogeochemical_tracer(tracers::NamedTuple, name, grid) = merge(tracers, 
+                                                                   NamedTuple{(name, )}((CenterField(grid), )))
 
 @inline function has_biogeochemical_tracers(fields, required_fields, grid)
     user_specified_tracers = [name in tracernames(fields) for name in required_fields]

--- a/src/Biogeochemistry.jl
+++ b/src/Biogeochemistry.jl
@@ -126,8 +126,7 @@ tracernames(tracers) = keys(tracers)
 tracernames(tracers::Tuple) = tracers
 
 add_biogeochemical_tracer(tracers::Tuple, name, grid) = tuple(tracers..., name)
-add_biogeochemical_tracer(tracers::NamedTuple, name, grid) = merge(tracers, 
-                                                                   NamedTuple{(name, )}((CenterField(grid), )))
+add_biogeochemical_tracer(tracers::NamedTuple, name, grid) = merge(tracers, (; name => CenterField(grid)))
 
 @inline function has_biogeochemical_tracers(fields, required_fields, grid)
     user_specified_tracers = [name in tracernames(fields) for name in required_fields]

--- a/src/Biogeochemistry.jl
+++ b/src/Biogeochemistry.jl
@@ -126,7 +126,7 @@ tracernames(tracers) = keys(tracers)
 tracernames(tracers::Tuple) = tracers
 
 add_biogeochemical_tracer(tracers::Tuple, name, grid) = tuple(tracers..., name)
-add_biogeochemical_tracer(tracers::NamedTuple, name, grid) = merge(tracers, NamedTuple(name => CenterField(grid)))
+add_biogeochemical_tracer(tracers::NamedTuple, name, grid) = merge(tracers, NamedTuple((name => CenterField(grid), )))
 
 @inline function has_biogeochemical_tracers(fields, required_fields, grid)
     user_specified_tracers = [name in tracernames(fields) for name in required_fields]

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -138,7 +138,7 @@ function HydrostaticFreeSurfaceModel(; grid,
                                          extract_boundary_conditions(diffusivity_fields))
 
     # Next, we form a list of default boundary conditions:
-    prognostic_field_names = (:u, :v, :η, tracernames(tracers)...)
+    prognostic_field_names = (:u, :v, :w, tracernames(tracers)..., :η, keys(auxiliary_fields)...)
     default_boundary_conditions = NamedTuple{prognostic_field_names}(Tuple(FieldBoundaryConditions() for name in prognostic_field_names))
 
     # Then we merge specified, embedded, and default boundary conditions. Specified boundary conditions
@@ -175,7 +175,7 @@ function HydrostaticFreeSurfaceModel(; grid,
                               G⁻ = HydrostaticFreeSurfaceTendencyFields(velocities, free_surface, grid, tracernames(tracers)))
 
     # Regularize forcing for model tracer and velocity fields.
-    model_fields = (hydrostatic_prognostic_fields(velocities, free_surface, tracers)..., keys(auxiliary_fields)...)
+    model_fields = merge(hydrostatic_prognostic_fields(velocities, free_surface, tracers), auxiliary_fields)
     forcing = model_forcing(model_fields; forcing...)
 
     default_tracer_advection, tracer_advection = validate_tracer_advection(tracer_advection, grid)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -175,7 +175,7 @@ function HydrostaticFreeSurfaceModel(; grid,
                               G⁻ = HydrostaticFreeSurfaceTendencyFields(velocities, free_surface, grid, tracernames(tracers)))
 
     # Regularize forcing for model tracer and velocity fields.
-    model_fields = hydrostatic_prognostic_fields(velocities, free_surface, tracers)
+    model_fields = (hydrostatic_prognostic_fields(velocities, free_surface, tracers)..., keys(auxiliary_fields)...)
     forcing = model_forcing(model_fields; forcing...)
 
     default_tracer_advection, tracer_advection = validate_tracer_advection(tracer_advection, grid)

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -158,7 +158,9 @@ function NonhydrostaticModel(;    grid,
                                          extract_boundary_conditions(diffusivity_fields))
 
     # Next, we form a list of default boundary conditions:
-    prognostic_field_names = (:u, :v, :w, tracernames(tracers)...)
+    
+    # Next, we form a list of default boundary conditions:
+    prognostic_field_names = (:u, :v, :w, tracernames(tracers)..., names(auxiliary_fields)..., names(biogeochemical_auxiliary_fields(biogeochemistry))...)
     default_boundary_conditions = NamedTuple{prognostic_field_names}(FieldBoundaryConditions() for name in prognostic_field_names)
 
     # Finally, we merge specified, embedded, and default boundary conditions. Specified boundary conditions

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -160,7 +160,7 @@ function NonhydrostaticModel(;    grid,
     # Next, we form a list of default boundary conditions:
     
     # Next, we form a list of default boundary conditions:
-    prognostic_field_names = (:u, :v, :w, tracernames(tracers)..., names(auxiliary_fields)..., names(biogeochemical_auxiliary_fields(biogeochemistry))...)
+    prognostic_field_names = (:u, :v, :w, tracernames(tracers)..., keys(auxiliary_fields)..., keys(biogeochemical_auxiliary_fields(biogeochemistry))...)
     default_boundary_conditions = NamedTuple{prognostic_field_names}(FieldBoundaryConditions() for name in prognostic_field_names)
 
     # Finally, we merge specified, embedded, and default boundary conditions. Specified boundary conditions

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -160,7 +160,7 @@ function NonhydrostaticModel(;    grid,
     # Next, we form a list of default boundary conditions:
     
     # Next, we form a list of default boundary conditions:
-    prognostic_field_names = (:u, :v, :w, tracernames(tracers)..., keys(auxiliary_fields)..., keys(biogeochemical_auxiliary_fields(biogeochemistry))...)
+    prognostic_field_names = (:u, :v, :w, tracernames(tracers)..., keys(auxiliary_fields)...)
     default_boundary_conditions = NamedTuple{prognostic_field_names}(FieldBoundaryConditions() for name in prognostic_field_names)
 
     # Finally, we merge specified, embedded, and default boundary conditions. Specified boundary conditions

--- a/src/Operators/interpolation_utils.jl
+++ b/src/Operators/interpolation_utils.jl
@@ -106,6 +106,8 @@ function index_and_interp_dependencies(X, Y, Z, dependencies, model_field_names)
         findfirst(isequal(name), model_field_names)
     end
 
+    !any(isnothing.(indices)) || error("$dependencies are required to be model fields but only $model_field_names are present")
+
     return indices, interps
 end
 


### PR DESCRIPTION
There is a bug when trying to auto add bgc tracers when a user has specified a namedtuple of tracers.

@glwagner I recall discussing dropping support for auto adding tracers, I find it quite useful but can't remember where we landed. 

This PR:
- fixes an issue with auto adding bgc tracers
- fixes an issue with auxiliary field dependant forcing in hydrostatic free surface models and boundary conditions
- adds an error when a user tries to define a forcing or functional boundary condition which depends on a field not found in the model, previously this would just raise a mysterious error like the one in https://github.com/OceanBioME/OceanBioME.jl/pull/146#issuecomment-1755771558