### PR TITLE
Modify `NonhydrostaticModel` to include different advection schemes for velocities and tracers

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -32,7 +32,7 @@ mutable struct HydrostaticFreeSurfaceModel{TS, E, A<:AbstractArchitecture, S,
           architecture :: A        # Computer `Architecture` on which `Model` is run
                   grid :: G        # Grid of physical points on which `Model` is solved
                  clock :: Clock{T} # Tracks iteration number and simulation time of `Model`
-             advection :: V        # Advection scheme for tracers
+             advection :: V        # Advection scheme for velocities and tracers
               buoyancy :: B        # Set of parameters for buoyancy model
               coriolis :: R        # Set of parameters for the background rotation rate of `Model`
           free_surface :: S        # Free surface parameters and fields

--- a/src/Models/NonhydrostaticModels/compute_nonhydrostatic_tendencies.jl
+++ b/src/Models/NonhydrostaticModels/compute_nonhydrostatic_tendencies.jl
@@ -73,7 +73,7 @@ function compute_interior_tendency_contributions!(model, kernel_parameters; only
     v_immersed_bc        = velocities.v.boundary_conditions.immersed
     w_immersed_bc        = velocities.w.boundary_conditions.immersed
 
-    start_momentum_kernel_args = (advection,
+    start_momentum_kernel_args = (advection.momentum,
                                   coriolis,
                                   stokes_drift,
                                   closure)
@@ -103,10 +103,11 @@ function compute_interior_tendency_contributions!(model, kernel_parameters; only
                 only_active_cells)
     end
 
-    start_tracer_kernel_args = (advection, closure)
     end_tracer_kernel_args   = (buoyancy, biogeochemistry, background_fields, velocities, tracers, auxiliary_fields, diffusivities)
 
-    for tracer_index in 1:length(tracers)
+    for (tracer_index, tracer_name) in enumerate(propertynames(tracers))
+        start_tracer_kernel_args = (advection[tracer_name], closure)
+
         @inbounds c_tendency = tendencies[tracer_index + 3]
         @inbounds forcing = forcings[tracer_index + 3]
         @inbounds c_immersed_bc = tracers[tracer_index].boundary_conditions.immersed


### PR DESCRIPTION
This PR would allow the user to choose the advection schemes they wish to use for velocities and tracers separately. 
This improves customizability as well as allowing the user to run other arbitrary sets of equations that requires timestepping.