### PR TITLE
Introduce closure_constant interface for AMD and SmagorinskyLilly

### DIFF
--- a/src/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/TurbulenceClosures/TurbulenceClosures.jl
@@ -161,8 +161,15 @@ include("turbulence_closure_implementations/nothing_closure.jl")
 # AbstractScalarDiffusivity closures:
 include("turbulence_closure_implementations/scalar_diffusivity.jl")
 include("turbulence_closure_implementations/scalar_biharmonic_diffusivity.jl")
+
+# Dispatch on the type of the user-provided AMD model constant.
+# Only numbers, arrays, and functions supported now.
+@inline closure_constant(i, j, k, grid, C::Number) = C
+@inline closure_constant(i, j, k, grid, C::AbstractArray) = @inbounds C[i, j, k]
+
 include("turbulence_closure_implementations/smagorinsky_lilly.jl")
 include("turbulence_closure_implementations/anisotropic_minimum_dissipation.jl")
+
 include("turbulence_closure_implementations/convective_adjustment_vertical_diffusivity.jl")
 include("turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl")
 include("turbulence_closure_implementations/ri_based_vertical_diffusivity.jl")

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
@@ -137,11 +137,6 @@ end
 ##### Kernel functions
 #####
 
-# Dispatch on the type of the user-provided AMD model constant.
-# Only numbers, arrays, and functions supported now.
-@inline Cᴾᵒⁱⁿ(i, j, k, grid, C::Number) = C
-@inline Cᴾᵒⁱⁿ(i, j, k, grid, C::AbstractArray) = @inbounds C[i, j, k]
-@inline Cᴾᵒⁱⁿ(i, j, k, grid, C::Function) = C(xnode(i, grid, Center()), ynode(j, grid, Center()), znode(k, grid, Center()))
 
 @kernel function _compute_AMD_viscosity!(νₑ, grid, closure::AMD, buoyancy, velocities, tracers)
     i, j, k = @index(Global, NTuple)
@@ -161,7 +156,7 @@ end
 
         δ² = 3 / (1 / Δᶠxᶜᶜᶜ(ijk...)^2 + 1 / Δᶠyᶜᶜᶜ(ijk...)^2 + 1 / Δᶠzᶜᶜᶜ(ijk...)^2)
 
-        νˢᵍˢ = - Cᴾᵒⁱⁿ(i, j, k, grid, closure.Cν) * δ² * (r - Cb_ζ) / q
+        νˢᵍˢ = - closure_constant(i, j, k, grid, closure.Cν) * δ² * (r - Cb_ζ) / q
     end
 
     @inbounds νₑ[i, j, k] = max(zero(FT), νˢᵍˢ)
@@ -182,7 +177,7 @@ end
     else
         ϑ =  norm_uᵢⱼ_cⱼ_cᵢᶜᶜᶜ(ijk..., closure, velocities.u, velocities.v, velocities.w, tracer)
         δ² = 3 / (1 / Δᶠxᶜᶜᶜ(ijk...)^2 + 1 / Δᶠyᶜᶜᶜ(ijk...)^2 + 1 / Δᶠzᶜᶜᶜ(ijk...)^2)
-        κˢᵍˢ = - Cᴾᵒⁱⁿ(i, j, k, grid, Cκ) * δ² * ϑ / σ
+        κˢᵍˢ = - closure_constant(i, j, k, grid, Cκ) * δ² * ϑ / σ
     end
 
     @inbounds κₑ[i, j, k] = max(zero(FT), κˢᵍˢ)


### PR DESCRIPTION
This PR adds support for variable "closure constants" in `SmagorinskyLilly`, and refactors the `AnisotropicMinimumDissipation` to share it. It discontinues support for `Function` closure constants in AMD.

As an example, the "Van Driest" damping function (discussed in #3369) would be implemented in a simple channel simulation as follows:

```julia
using Oceananigans

grid = RectilinearGrid(size=(64, 64, 64), x=(0, 1), y=(0, 1), z=(0, 1),
                       topology = (Periodic, Bounded, Bounded))

molecular_diffusivity = ScalarDiffusivity(ν=1.05e-6)

@inline function van_driest_damping_function(x, y, z, p)
    y⁺ = y / p.δ⁺
    A⁺ = p.A⁺
    C = p.C
    return C * (1 - exp(y⁺ / A⁺))
end

parameters = (C = 0.16,
              A⁺ = 26,  # :-D
              δ⁺ = 1)   # function of molecular_diffusivity.ν

van_driest_damping = FunctionField(van_driest_damping_function, grid; parameters)

smagorinsky_lilly = SmagorinskyLilly(C=van_driest_damping)

model = NonhydrostaticModel(; grid,
                            timestepper = :RungeKutta3,
                            closure = (molecular_diffusivity, smagorinsky_lilly))

# Re = U * L / ν → U = ν * Re
# U = ν * Re
U = ν * 1000
ϵ(x, y, z) = U * randn()
set!(model, u=ϵ, v=ϵ, w=ϵ)

# Δt = 0.1 * Δx / U
Δx = 1 / size(grid, 1)
Δt = 0.1 * Δx / U
simulation = Simulation(model; Δt, stop_iteration=100)
run!(simulation)
```