### PR TITLE
Correction of three-dimensional Stokes drift implementation

### DIFF
--- a/examples/Spatially_varying_stokes_drift.jl
+++ b/examples/Spatially_varying_stokes_drift.jl
@@ -1,0 +1,539 @@
+# # Langmuir turbulence example
+#
+# This example implements a Langmuir turbulence simulation reported in section
+# 4 of
+#
+# > [Wagner et al., "Near-inertial waves and turbulence driven by the growth of swell", Journal of Physical Oceanography (2021)](https://journals.ametsoc.org/view/journals/phoc/51/5/JPO-D-20-0178.1.xml)
+#
+# This example demonstrates
+#
+#   * How to run large eddy simulations with surface wave effects via the
+#     Craik-Leibovich approximation.
+#
+#   * How to specify time- and horizontally-averaged output.
+
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
+
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, CairoMakie"
+# ```
+
+using Oceananigans
+using Oceananigans.Units: minute, minutes, hours
+
+# ## Model set-up
+#
+# To build the model, we specify the grid, Stokes drift, boundary conditions, and
+# Coriolis parameter.
+#
+# ### Domain and numerical grid specification
+#
+# We use a modest resolution and the same total extent as Wagner et al. 2021,
+
+grid = RectilinearGrid(size=(32, 64, 32), extent=(128, 256, 64))
+
+# ### The Stokes Drift profile
+#
+# The surface wave Stokes drift profile prescribed in Wagner et al. 2021,
+# corresponds to a 'monochromatic' (that is, single-frequency) wave field.
+#
+# A monochromatic wave field is characterized by its wavelength and amplitude
+# (half the distance from wave crest to wave trough), which determine the wave
+# frequency and the vertical scale of the Stokes drift profile.
+
+using Oceananigans.BuoyancyModels: g_Earth
+
+ amplitude = 0.8 # m
+wavelength = 60  # m
+wavenumber = 2π / wavelength # m⁻¹
+ frequency = sqrt(g_Earth * wavenumber) # s⁻¹
+
+## The vertical scale over which the Stokes drift of a monochromatic surface wave
+## decays away from the surface is `1/2wavenumber`, or
+const vertical_scale = wavelength / 4π
+
+## Stokes drift velocity at the surface
+const Uˢ = amplitude^2 * wavenumber * frequency # m s⁻¹
+
+stokes_jet_center = 70
+stokes_jet_central_width = 40
+stokes_jet_edge_width = 40
+
+# The `const` declarations ensure that Stokes drift functions compile on the GPU.
+# To run this example on the GPU, include `GPU()` in the
+# constructor for `RectilinearGrid` above.
+#
+# The Stokes drift profile is
+
+#uˢ(x, y, z, t) = Uˢ * exp(z / vertical_scale) * exp( - (y - stokes_jet_center)^2 / (2 * stokes_jet_width^2) )
+
+# Create a Stokes drift field that is a cosine function within a subregion of the domain.
+# This function peaks at `y = stokes_jet_center` with a  value of `2*Uˢ`, reaches zero at a distance of 
+# `stokes_jet_width` either side of the peak, and is zero beyond those regions. 
+# The zeroing of regions outside the jet is achieved through application of a Heaviside function
+#uˢ(x, y, z, t) = Uˢ * exp(z / vertical_scale) * 0.5 * (1 + cos(pi * (y - stokes_jet_center) / stokes_jet_width)) *
+# 0.5 * (sign(y - stokes_jet_center + stokes_jet_width)  -  sign(y - stokes_jet_center - stokes_jet_width) )
+
+uˢ(x, y, z, t) = Uˢ * exp(z / vertical_scale) * 0.5 * (
+    (1 + cos(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width)) * 
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    + (1 + cos(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width)) * 
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) )
+    + (sign(y - stokes_jet_center + stokes_jet_central_width / 2)  -  sign(y - stokes_jet_center - stokes_jet_central_width / 2)) ) *
+    0.5 * ( 1 + 0.1 * cos(2 * pi * (x - grid.Lx/2) / grid.Lx ) )
+
+
+# and its `z`-derivative is
+
+∂z_uˢ(x, y, z, t) = 1 / vertical_scale * Uˢ * exp(z / vertical_scale) * 0.5 * (
+    (1 + cos(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width)) * 
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    + (1 + cos(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width)) * 
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) )
+    + (sign(y - stokes_jet_center + stokes_jet_central_width / 2)  -  sign(y - stokes_jet_center - stokes_jet_central_width / 2)) ) *
+    0.5 * ( 1 + 0.1 * cos(2 * pi * (x - grid.Lx/2) / grid.Lx ) )
+
+∂y_uˢ(x, y, z, t) = - pi / stokes_jet_width * Uˢ * exp(z / vertical_scale) * 0.5 * (
+    sin(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    + sin(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * ( 1 + 0.1 * cos(2 * pi * (x - grid.Lx/2) / grid.Lx ) )
+
+∂x_uˢ(x, y, z, t) = - 2 * pi / grid.Lx * Uˢ * exp(z / vertical_scale) * 0.5 * (
+    sin(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    + sin(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * 0.1 * sin(2 * pi * (x - grid.Lx/2) / grid.Lx )
+
+# Now diagnose the w component of Stokes drift using incompressibility and the surface boundary condition `wˢ(z=0)=0`
+
+wˢ(x, y, z, t) = 2 * pi / grid.Lx *vertical_scale * Uˢ * ( exp(z / vertical_scale) - 1 ) * 0.5 * (
+    sin(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    + sin(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * 0.1 * sin(2 * pi * (x - grid.Lx/2) / grid.Lx )
+
+
+# and its `z`-derivative is
+
+∂z_wˢ(x, y, z, t) = 2 * pi / grid.Lx * Uˢ * exp(z / vertical_scale) * 0.5 * (
+    sin(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    + sin(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * 0.1 * sin(2 * pi * (x - grid.Lx/2) / grid.Lx )
+
+∂y_wˢ(x, y, z, t) = 2 * pi^2 / (grid.Lx * stokes_jet_edge_width) * vertical_scale * Uˢ * ( exp(z / vertical_scale) - 1 ) * 0.5 * (
+    cos(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    + cos(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * 0.1 * sin(2 * pi * (x - grid.Lx/2) / grid.Lx )
+
+∂x_wˢ(x, y, z, t) = - 4 * pi^2 / (grid.Lx)^2 *vertical_scale * Uˢ * ( exp(z / vertical_scale) - 1 ) * 0.5 * (
+    sin(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    + sin(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * 0.1 * cos(2 * pi * (x - grid.Lx/2) / grid.Lx )
+
+#∂z_uˢ(x, y, z, t) = 1 / vertical_scale * Uˢ * exp(z / vertical_scale) * exp( - (y - stokes_jet_center)^2 / (2 * stokes_jet_width^2) )
+
+#∂y_uˢ(x, y, z, t) = - (y - stokes_jet_center) / (2 * stokes_jet_width^2) * Uˢ * exp(z / vertical_scale) * exp( - (y - stokes_jet_center)^2 / (2 * stokes_jet_width^2) )
+
+#∂z_uˢ(x, y, z, t) = 1 / vertical_scale * Uˢ * exp(z / vertical_scale) * (1 + cos(pi * (y - stokes_jet_center) / stokes_jet_width)) *
+# 0.5 * (sign(y - stokes_jet_center + stokes_jet_width)  -  sign(y - stokes_jet_center - stokes_jet_width) )
+
+#∂y_uˢ(x, y, z, t) = - pi / stokes_jet_width * Uˢ * exp(z / vertical_scale) * sin(pi * (y - stokes_jet_center) / stokes_jet_width) *
+# 0.5 * (sign(y - stokes_jet_center + stokes_jet_width)  -  sign(y - stokes_jet_center - stokes_jet_width) )
+
+#
+# !!! info "The Craik-Leibovich equations in Oceananigans"
+#     Oceananigans implements the Craik-Leibovich approximation for surface wave effects
+#     using the _Lagrangian-mean_ velocity field as its prognostic momentum variable.
+#     In other words, `model.velocities.u` is the Lagrangian-mean ``x``-velocity beneath surface
+#     waves. This differs from models that use the _Eulerian-mean_ velocity field
+#     as a prognostic variable, but has the advantage that ``u`` accounts for the total advection
+#     of tracers and momentum, and that ``u = v = w = 0`` is a steady solution even when Coriolis
+#     forces are present. See the
+#     [physics documentation](https://clima.github.io/OceananigansDocumentation/stable/physics/surface_gravity_waves/)
+#     for more information.
+#
+# Finally, we note that the time-derivative of the Stokes drift must be provided
+# if the Stokes drift and surface wave field undergoes _forced_ changes in time.
+# In this example, the Stokes drift is constant
+# and thus the time-derivative of the Stokes drift is 0.
+
+# ### Boundary conditions
+#
+# At the surface at ``z=0``, Wagner et al. 2021 impose
+
+Qᵘ = -3.72e-5 # m² s⁻², surface kinematic momentum flux
+
+u_boundary_conditions = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
+
+# Wagner et al. 2021 impose a linear buoyancy gradient `N²` at the bottom
+# along with a weak, destabilizing flux of buoyancy at the surface to faciliate
+# spin-up from rest.
+
+Qᵇ = 2.307e-8 # m² s⁻³, surface buoyancy flux
+N² = 1.936e-5 # s⁻², initial and bottom buoyancy gradient
+
+b_boundary_conditions = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ),
+                                                bottom = GradientBoundaryCondition(N²))
+
+# !!! info "The flux convention in Oceananigans"
+#     Note that Oceananigans uses "positive upward" conventions for all fluxes. In consequence,
+#     a negative flux at the surface drives positive velocities, and a positive flux of
+#     buoyancy drives cooling.
+
+# ### Coriolis parameter
+#
+# No Coriolis force, to ensure localized "jet" structure of Stokes drift is clear
+
+coriolis = FPlane(f=0) # s⁻¹
+
+# which is typical for mid-latitudes on Earth.
+
+# ## Model instantiation
+#
+# We are ready to build the model. We use a fifth-order Weighted Essentially
+# Non-Oscillatory (WENO) advection scheme and the `AnisotropicMinimumDissipation`
+# model for large eddy simulation. Because our Stokes drift does not vary in ``x, y``,
+# we use `UniformStokesDrift`, which expects Stokes drift functions of ``z, t`` only.
+
+model = NonhydrostaticModel(; grid, coriolis,
+                            advection = WENO(),
+                            timestepper = :RungeKutta3,
+                            tracers = :b,
+                            buoyancy = BuoyancyTracer(),
+                            closure = AnisotropicMinimumDissipation(),
+                            stokes_drift = StokesDrift(∂x_wˢ=∂x_wˢ,∂y_uˢ=∂y_uˢ,∂y_wˢ=∂y_wˢ,∂z_uˢ=∂z_uˢ),
+                            boundary_conditions = (u=u_boundary_conditions, b=b_boundary_conditions))
+
+# ## Initial conditions
+#
+# We make use of random noise concentrated in the upper 4 meters
+# for buoyancy and velocity initial conditions,
+
+Ξ(z) = randn() * exp(z / 4)
+nothing #hide
+
+# Our initial condition for buoyancy consists of a surface mixed layer 33 m deep,
+# a deep linear stratification, plus noise,
+
+initial_mixed_layer_depth = 33 # m
+stratification(z) = z < - initial_mixed_layer_depth ? N² * z : N² * (-initial_mixed_layer_depth)
+
+bᵢ(x, y, z) = stratification(z) + 1e-1 * Ξ(z) * N² * model.grid.Lz
+
+# The simulation we reproduce from Wagner et al. (2021) is zero Lagrangian-mean velocity.
+# This initial condition is consistent with a wavy, quiescent ocean suddenly impacted
+# by winds. To this quiescent state we add noise scaled by the friction velocity to ``u`` and ``w``.
+
+u★ = sqrt(abs(Qᵘ))
+uᵢ(x, y, z) = u★ * 1e-1 * Ξ(z)
+wᵢ(x, y, z) = u★ * 1e-1 * Ξ(z)
+
+set!(model, u=uᵢ, w=wᵢ, b=bᵢ)
+
+# ## Setting up the simulation
+
+simulation = Simulation(model, Δt=45.0, stop_time=12hours)
+
+# We use the `TimeStepWizard` for adaptive time-stepping
+# with a Courant-Freidrichs-Lewy (CFL) number of 1.0,
+
+wizard = TimeStepWizard(cfl=1.0, max_change=1.1, max_Δt=1minute)
+
+simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(10))
+
+# ### Nice progress messaging
+#
+# We define a function that prints a helpful message with
+# maximum absolute value of ``u, v, w`` and the current wall clock time.
+
+using Printf
+
+function progress(simulation)
+    u, v, w = simulation.model.velocities
+
+    ## Print a progress message
+    msg = @sprintf("i: %04d, t: %s, Δt: %s, umax = (%.1e, %.1e, %.1e) ms⁻¹, wall time: %s\n",
+                   iteration(simulation),
+                   prettytime(time(simulation)),
+                   prettytime(simulation.Δt),
+                   maximum(abs, u), maximum(abs, v), maximum(abs, w),
+                   prettytime(simulation.run_wall_time))
+
+    @info msg
+
+    return nothing
+end
+
+simulation.callbacks[:progress] = Callback(progress, IterationInterval(20))
+
+# ## Output
+#
+# ### A field writer
+#
+# We set up an output writer for the simulation that saves all velocity fields,
+# tracer fields, and the subgrid turbulent diffusivity.
+
+output_interval = 5minutes
+
+fields_to_output = merge(model.velocities, model.tracers, (; νₑ=model.diffusivity_fields.νₑ))
+
+simulation.output_writers[:fields] =
+    JLD2OutputWriter(model, fields_to_output,
+                     schedule = TimeInterval(output_interval),
+                     filename = "Stokes_drift_jet_fields.jld2",
+                     overwrite_existing = true)
+
+# ### An "averages" writer
+#
+# We also set up output of time- and horizontally-averaged velocity field and
+# momentum fluxes,
+
+u, v, w = model.velocities
+b = model.tracers.b
+
+ U = Average(u, dims=(1, 2))
+ V = Average(v, dims=(1, 2))
+ B = Average(b, dims=(1, 2))
+wu = Average(w * u, dims=(1, 2))
+wv = Average(w * v, dims=(1, 2))
+
+simulation.output_writers[:averages] =
+    JLD2OutputWriter(model, (; U, V, B, wu, wv),
+                     schedule = AveragedTimeInterval(output_interval, window=2minutes),
+                     filename = "Stokes_drift_jet_averages.jld2",
+                     overwrite_existing = true)
+
+# ## Running the simulation
+#
+# This part is easy,
+
+run!(simulation)
+
+# # Making a neat movie
+#
+# We look at the results by loading data from file with FieldTimeSeries,
+# and plotting vertical slices of ``u`` and ``w``, and a horizontal
+# slice of ``w`` to look for Langmuir cells.
+
+using CairoMakie
+
+time_series = (;
+     w = FieldTimeSeries("Stokes_drift_jet_fields.jld2", "w"),
+     u = FieldTimeSeries("Stokes_drift_jet_fields.jld2", "u"),
+     B = FieldTimeSeries("Stokes_drift_jet_averages.jld2", "B"),
+     U = FieldTimeSeries("Stokes_drift_jet_averages.jld2", "U"),
+     V = FieldTimeSeries("Stokes_drift_jet_averages.jld2", "V"),
+    wu = FieldTimeSeries("Stokes_drift_jet_averages.jld2", "wu"),
+    wv = FieldTimeSeries("Stokes_drift_jet_averages.jld2", "wv"))
+
+times = time_series.w.times
+xw, yw, zw = nodes(time_series.w)
+xu, yu, zu = nodes(time_series.u)
+nothing #hide
+
+# We are now ready to animate using Makie. We use Makie's `Observable` to animate
+# the data. To dive into how `Observable`s work we refer to
+# [Makie.jl's Documentation](https://makie.juliaplots.org/stable/documentation/nodes/index.html).
+
+n = Observable(1)
+
+wxy_title = @lift string("w(x, y, t) at z=-8 m and t = ", prettytime(times[$n]))
+wyz_title = @lift string("w(y, z, t) at x=0 m and t = ", prettytime(times[$n]))
+uyz_title = @lift string("u(y, z, t) at x=0 m and t = ", prettytime(times[$n]))
+
+fig = Figure(resolution = (1.2*850, 1.2*1100))
+
+ax_x_stokes = Axis(fig[2, 4];
+            xlabel = "x (m)",
+            ylabel = string("uˢ(y=", stokes_jet_center + 0.5* (stokes_jet_central_width + stokes_jet_edge_width), "m, z=-2m) terms ([m] s⁻¹)"))
+
+ax_y_stokesu = Axis(fig[1, 1];
+            xlabel = string("uˢ(x=", 3*grid.Lx/8, "m, z=-2m) terms ([m] s⁻¹)"),
+            ylabel = "y (m)")
+
+ax_xy_stokesu = Axis(fig[1, 2];
+            xlabel = "x (m)",
+            ylabel = "y (m)",
+            aspect = AxisAspect(1),
+            limits = ((0, grid.Lx), (0, grid.Ly)),
+            title = "uˢ(z=-2m)")
+
+ax_xy_stokesw = Axis(fig[1, 4];
+            xlabel = "x (m)",
+            ylabel = "y (m)",
+            aspect = AxisAspect(1),
+            limits = ((0, grid.Lx), (0, grid.Ly)),
+            title = "wˢ(z=-2m) x 100")
+
+ax_y_stokesw = Axis(fig[2, 1];
+            xlabel = string("wˢ(x=", 3*grid.Lx/8, "m, z=-2m) terms ([m] s⁻¹)"),
+            ylabel = "y (m)")
+
+#ax_B = Axis(fig[2, 4];
+#            xlabel = "Buoyancy (m s⁻²)",
+#            ylabel = "z (m)")
+
+ax_U = Axis(fig[3, 4];
+            xlabel = "Velocities (m s⁻¹)",
+            ylabel = "z (m)",
+            limits = ((-0.07, 0.07), nothing))
+
+ax_fluxes = Axis(fig[4, 4];
+                 xlabel = "Momentum fluxes (m² s⁻²)",
+                 ylabel = "z (m)",
+                 limits = ((-3.5e-5, 3.5e-5), nothing))
+
+ax_wxy = Axis(fig[2, 2];
+              xlabel = "x (m)",
+              ylabel = "y (m)",
+              aspect = AxisAspect(1),
+              limits = ((0, grid.Lx), (0, grid.Ly)),
+              title = wxy_title)
+
+ax_wyz = Axis(fig[3, 1:2];
+              xlabel = "y (m)",
+              ylabel = "z (m)",
+              aspect = AxisAspect(2),
+              limits = ((0, grid.Ly), (-grid.Lz, 0)),
+              title = wyz_title)
+
+ax_uyz = Axis(fig[4, 1:2];
+              xlabel = "y (m)",
+              ylabel = "z (m)",
+              aspect = AxisAspect(2),
+              limits = ((0, grid.Ly), (-grid.Lz, 0)),
+              title = uyz_title)
+
+nothing #hide
+
+wₙ = @lift time_series.w[$n]
+uₙ = @lift time_series.u[$n]
+Bₙ = @lift time_series.B[$n][1, 1, :]
+Uₙ = @lift time_series.U[$n][1, 1, :]
+Vₙ = @lift time_series.V[$n][1, 1, :]
+wuₙ = @lift time_series.wu[$n][1, 1, :]
+wvₙ = @lift time_series.wv[$n][1, 1, :]
+
+k = searchsortedfirst(grid.zᵃᵃᶠ[:], -8)
+wxyₙ = @lift interior(time_series.w[$n], :, :, k)
+wyzₙ = @lift interior(time_series.w[$n], 1, :, :)
+uyzₙ = @lift interior(time_series.u[$n], 1, :, :)
+
+wlims = (-0.03, 0.03)
+ulims = (-0.05, 0.05)
+stokeslims = (-0.025, 0.025)
+
+global ii = 1
+uˢ_yvariation = Array{Float32}(undef, size(yu,1))
+∂z_uˢ_yvariation = Array{Float32}(undef, size(yu,1))
+∂y_uˢ_yvariation = Array{Float32}(undef, size(yu,1))
+∂x_uˢ_yvariation = Array{Float32}(undef, size(yu,1))
+wˢ_yvariation = Array{Float32}(undef, size(yu,1))
+∂z_wˢ_yvariation = Array{Float32}(undef, size(yu,1))
+∂y_wˢ_yvariation = Array{Float32}(undef, size(yu,1))
+∂x_wˢ_yvariation = Array{Float32}(undef, size(yu,1))
+uˢ_xvariation = Array{Float32}(undef, size(xu,1))
+wˢ_xvariation = Array{Float32}(undef, size(xu,1))
+uˢ_map = Array{Float32}(undef, size(xu,1), size(yu,1))
+wˢ_map = Array{Float32}(undef, size(xu,1), size(yu,1))
+while ii <= size(yu,1) 
+    uˢ_yvariation[ii] = uˢ(3*grid.Lx/8, yu[ii], -2, 0)  
+    ∂z_uˢ_yvariation[ii] = ∂z_uˢ(3*grid.Lx/8, yu[ii], -2, 0) 
+    ∂y_uˢ_yvariation[ii] = ∂y_uˢ(3*grid.Lx/8, yu[ii], -2, 0)
+    ∂x_uˢ_yvariation[ii] = ∂x_uˢ(3*grid.Lx/8, yu[ii], -2, 0)
+    wˢ_yvariation[ii] = wˢ(3*grid.Lx/8, yu[ii], -2, 0)  
+    ∂z_wˢ_yvariation[ii] = ∂z_wˢ(3*grid.Lx/8, yu[ii], -2, 0) 
+    ∂y_wˢ_yvariation[ii] = ∂y_wˢ(3*grid.Lx/8, yu[ii], -2, 0)
+    ∂x_wˢ_yvariation[ii] = ∂x_wˢ(3*grid.Lx/8, yu[ii], -2, 0) 
+    global jj = 1
+    while jj <= size(xu,1) 
+        uˢ_xvariation[jj] = uˢ(xu[jj], stokes_jet_center + 0.5* (stokes_jet_central_width + stokes_jet_edge_width), -2, 0)  
+        wˢ_xvariation[jj] = wˢ(xu[jj], stokes_jet_center + 0.5* (stokes_jet_central_width + stokes_jet_edge_width), -2, 0)   
+        uˢ_map[jj,ii] = uˢ(xu[jj], yu[ii], -2, 0)
+        wˢ_map[jj,ii] = wˢ(xu[jj], yu[ii], -2, 0)
+        global jj += 1
+    end 
+    global ii += 1
+end 
+
+lines!(ax_y_stokesu, uˢ_yvariation, yu; label = L"u^s")
+lines!(ax_y_stokesu, ∂z_uˢ_yvariation, yu; label = L"\partial_z u^s")
+lines!(ax_y_stokesu, ∂y_uˢ_yvariation, yu; label = L"\partial_y u^s")
+lines!(ax_y_stokesu, ∂x_uˢ_yvariation*100, yu; label = L"\partial_x u^s \times 100")
+axislegend(ax_y_stokesu; position = :rt)
+
+lines!(ax_y_stokesw, wˢ_yvariation*100, yu; label = L"w^s \times 100")
+lines!(ax_y_stokesw, ∂z_wˢ_yvariation*100, yu; label = L"\partial_z w^s \times 100")
+lines!(ax_y_stokesw, ∂y_wˢ_yvariation*100, yu; label = L"\partial_y w^s \times 100")
+lines!(ax_y_stokesw, ∂x_wˢ_yvariation*100, yu; label = L"\partial_x w^s \times 100")
+axislegend(ax_y_stokesw; position = :rt)
+
+lines!(ax_x_stokes, uˢ_xvariation, xu; label = L"u^s")
+lines!(ax_x_stokes, wˢ_xvariation*100, xu; label = L"w^s \times 100")
+axislegend(ax_x_stokes; position = :lb)
+
+#lines!(ax_B, Bₙ, zu)
+
+lines!(ax_U, Uₙ, zu; label = L"\bar{u}")
+lines!(ax_U, Vₙ, zu; label = L"\bar{v}")
+axislegend(ax_U; position = :rb)
+
+lines!(ax_fluxes, wuₙ, zw; label = L"mean $wu$")
+lines!(ax_fluxes, wvₙ, zw; label = L"mean $wv$")
+axislegend(ax_fluxes; position = :rb)
+
+hm_xy_stokesu = heatmap!(ax_xy_stokesu, xw, yw, uˢ_map;
+                  colorrange = stokeslims,
+                  colormap = :balance)
+
+Colorbar(fig[1, 3], hm_xy_stokesu; label = "m s⁻¹")
+
+hm_xy_stokesw = heatmap!(ax_xy_stokesw, xw, yw, wˢ_map*100;
+                  colorrange = stokeslims,
+                  colormap = :balance)
+
+hm_wxy = heatmap!(ax_wxy, xw, yw, wxyₙ;
+                  colorrange = wlims,
+                  colormap = :balance)
+
+Colorbar(fig[2, 3], hm_wxy; label = "m s⁻¹")
+
+hm_wyz = heatmap!(ax_wyz, yw, zw, wyzₙ;
+                  colorrange = wlims,
+                  colormap = :balance)
+
+Colorbar(fig[3, 3], hm_wxz; label = "m s⁻¹")
+
+ax_uyz = heatmap!(ax_uyz, yu, zu, uyzₙ;
+                  colorrange = ulims,
+                  colormap = :balance)
+
+Colorbar(fig[4, 3], ax_uyz; label = "m s⁻¹")
+
+current_figure() #hide
+fig
+
+# And, finally, we record a movie.
+
+frames = 1:length(times)
+
+record(fig, "Stokes_drift_jet.mp4", frames, framerate=8) do i
+    n[] = i
+end
+nothing #hide
+
+# ![](langmuir_turbulence.mp4)
+

--- a/examples/Spatially_varying_stokes_drift.jl
+++ b/examples/Spatially_varying_stokes_drift.jl
@@ -79,9 +79,9 @@ stokes_jet_edge_width = 40
 
 uˢ(x, y, z, t) = Uˢ * exp(z / vertical_scale) * 0.5 * (
     (1 + cos(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width)) * 
-    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_edge_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
     + (1 + cos(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width)) * 
-    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) )
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_edge_width) )
     + (sign(y - stokes_jet_center + stokes_jet_central_width / 2)  -  sign(y - stokes_jet_center - stokes_jet_central_width / 2)) ) *
     0.5 * ( 1 + 0.1 * cos(2 * pi * (x - grid.Lx/2) / grid.Lx ) )
 
@@ -90,33 +90,33 @@ uˢ(x, y, z, t) = Uˢ * exp(z / vertical_scale) * 0.5 * (
 
 ∂z_uˢ(x, y, z, t) = 1 / vertical_scale * Uˢ * exp(z / vertical_scale) * 0.5 * (
     (1 + cos(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width)) * 
-    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_edge_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
     + (1 + cos(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width)) * 
-    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) )
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_edge_width) )
     + (sign(y - stokes_jet_center + stokes_jet_central_width / 2)  -  sign(y - stokes_jet_center - stokes_jet_central_width / 2)) ) *
     0.5 * ( 1 + 0.1 * cos(2 * pi * (x - grid.Lx/2) / grid.Lx ) )
 
-∂y_uˢ(x, y, z, t) = - pi / stokes_jet_width * Uˢ * exp(z / vertical_scale) * 0.5 * (
+∂y_uˢ(x, y, z, t) = - pi / stokes_jet_edge_width * Uˢ * exp(z / vertical_scale) * 0.5 * (
     sin(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_edge_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
     + sin(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_edge_width) ) ) *
     0.5 * ( 1 + 0.1 * cos(2 * pi * (x - grid.Lx/2) / grid.Lx ) )
 
 ∂x_uˢ(x, y, z, t) = - 2 * pi / grid.Lx * Uˢ * exp(z / vertical_scale) * 0.5 * (
     sin(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_edge_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
     + sin(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_edge_width) ) ) *
     0.5 * 0.1 * sin(2 * pi * (x - grid.Lx/2) / grid.Lx )
 
 # Now diagnose the w component of Stokes drift using incompressibility and the surface boundary condition `wˢ(z=0)=0`
 
 wˢ(x, y, z, t) = 2 * pi / grid.Lx *vertical_scale * Uˢ * ( exp(z / vertical_scale) - 1 ) * 0.5 * (
     sin(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_edge_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
     + sin(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_edge_width) ) ) *
     0.5 * 0.1 * sin(2 * pi * (x - grid.Lx/2) / grid.Lx )
 
 
@@ -124,34 +124,24 @@ wˢ(x, y, z, t) = 2 * pi / grid.Lx *vertical_scale * Uˢ * ( exp(z / vertical_sc
 
 ∂z_wˢ(x, y, z, t) = 2 * pi / grid.Lx * Uˢ * exp(z / vertical_scale) * 0.5 * (
     sin(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_edge_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
     + sin(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_edge_width) ) ) *
     0.5 * 0.1 * sin(2 * pi * (x - grid.Lx/2) / grid.Lx )
 
 ∂y_wˢ(x, y, z, t) = 2 * pi^2 / (grid.Lx * stokes_jet_edge_width) * vertical_scale * Uˢ * ( exp(z / vertical_scale) - 1 ) * 0.5 * (
     cos(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_edge_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
     + cos(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_edge_width) ) ) *
     0.5 * 0.1 * sin(2 * pi * (x - grid.Lx/2) / grid.Lx )
 
 ∂x_wˢ(x, y, z, t) = - 4 * pi^2 / (grid.Lx)^2 *vertical_scale * Uˢ * ( exp(z / vertical_scale) - 1 ) * 0.5 * (
     sin(pi * (y - stokes_jet_center + stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
+    0.5 * (sign(y - stokes_jet_center + stokes_jet_central_width / 2 + stokes_jet_edge_width)  -  sign(y - stokes_jet_center +stokes_jet_central_width / 2) )
     + sin(pi * (y - stokes_jet_center - stokes_jet_central_width / 2) / stokes_jet_edge_width) * 
-    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_width) ) ) *
+    0.5 * (sign(y - stokes_jet_center - stokes_jet_central_width / 2) - sign(y - stokes_jet_center - stokes_jet_central_width / 2 - stokes_jet_edge_width) ) ) *
     0.5 * 0.1 * cos(2 * pi * (x - grid.Lx/2) / grid.Lx )
-
-#∂z_uˢ(x, y, z, t) = 1 / vertical_scale * Uˢ * exp(z / vertical_scale) * exp( - (y - stokes_jet_center)^2 / (2 * stokes_jet_width^2) )
-
-#∂y_uˢ(x, y, z, t) = - (y - stokes_jet_center) / (2 * stokes_jet_width^2) * Uˢ * exp(z / vertical_scale) * exp( - (y - stokes_jet_center)^2 / (2 * stokes_jet_width^2) )
-
-#∂z_uˢ(x, y, z, t) = 1 / vertical_scale * Uˢ * exp(z / vertical_scale) * (1 + cos(pi * (y - stokes_jet_center) / stokes_jet_width)) *
-# 0.5 * (sign(y - stokes_jet_center + stokes_jet_width)  -  sign(y - stokes_jet_center - stokes_jet_width) )
-
-#∂y_uˢ(x, y, z, t) = - pi / stokes_jet_width * Uˢ * exp(z / vertical_scale) * sin(pi * (y - stokes_jet_center) / stokes_jet_width) *
-# 0.5 * (sign(y - stokes_jet_center + stokes_jet_width)  -  sign(y - stokes_jet_center - stokes_jet_width) )
 
 #
 # !!! info "The Craik-Leibovich equations in Oceananigans"
@@ -245,7 +235,7 @@ set!(model, u=uᵢ, w=wᵢ, b=bᵢ)
 
 # ## Setting up the simulation
 
-simulation = Simulation(model, Δt=45.0, stop_time=12hours)
+simulation = Simulation(model, Δt=45.0, stop_time=4hours)
 
 # We use the `TimeStepWizard` for adaptive time-stepping
 # with a Courant-Freidrichs-Lewy (CFL) number of 1.0,
@@ -515,7 +505,7 @@ hm_wyz = heatmap!(ax_wyz, yw, zw, wyzₙ;
                   colorrange = wlims,
                   colormap = :balance)
 
-Colorbar(fig[3, 3], hm_wxz; label = "m s⁻¹")
+Colorbar(fig[3, 3], hm_wyz; label = "m s⁻¹")
 
 ax_uyz = heatmap!(ax_uyz, yu, zu, uyzₙ;
                   colorrange = ulims,

--- a/src/StokesDrifts.jl
+++ b/src/StokesDrifts.jl
@@ -74,23 +74,37 @@ const c = Center()
 @inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::USDnoP, U, time) = @inbounds (- ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(znode(k, grid, f), time)
                                                                            - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(znode(k, grid, f), time))
 
-struct StokesDrift{P, UZ, VZ, UT, VT, WT}
+struct StokesDrift{P, UX, VX, WX, UY, VY, WY, UZ, VZ, WZ, UT, VT, WT}
+    ∂x_uˢ :: UX
+    ∂x_vˢ :: VX
+    ∂x_wˢ :: WX
+    ∂y_uˢ :: UY
+    ∂y_vˢ :: VY
+    ∂y_wˢ :: WY
     ∂z_uˢ :: UZ
     ∂z_vˢ :: VZ
+    ∂z_wˢ :: WZ
     ∂t_uˢ :: UT
     ∂t_vˢ :: VT
     ∂t_wˢ :: WT
     parameters :: P
 end
 
-function StokesDrift(; ∂z_uˢ = addzero,
+function StokesDrift(; ∂x_uˢ = addzero,
+                       ∂x_vˢ = addzero,
+                       ∂x_wˢ = addzero,
+                       ∂y_uˢ = addzero,
+                       ∂y_vˢ = addzero,
+                       ∂y_wˢ = addzero,
+                       ∂z_uˢ = addzero,
                        ∂z_vˢ = addzero,
+                       ∂z_wˢ = addzero,
                        ∂t_uˢ = addzero,
                        ∂t_vˢ = addzero,
                        ∂t_wˢ = addzero,
                        parameters = nothing)
 
-    return StokesDrift(∂z_uˢ, ∂z_vˢ, ∂t_uˢ, ∂t_vˢ, ∂t_wˢ, parameters)
+    return StokesDrift(∂x_uˢ, ∂x_vˢ, ∂x_wˢ, ∂y_uˢ, ∂y_vˢ, ∂y_wˢ, ∂z_uˢ, ∂z_vˢ, ∂z_wˢ, ∂t_uˢ, ∂t_vˢ, ∂t_wˢ, parameters)
 end
 
 const SD = StokesDrift
@@ -100,10 +114,19 @@ const SDnoP = StokesDrift{<:Nothing}
 @inline ∂t_vˢ(i, j, k, grid, sw::SD, time) = sw.∂t_vˢ(node(i, j, k, grid, c, f, c)..., time, sw.parameters)
 @inline ∂t_wˢ(i, j, k, grid, sw::SD, time) = sw.∂t_wˢ(node(i, j, k, grid, c, c, f)..., time, sw.parameters)
 
-@inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::SD, U, time) = ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂z_uˢ(node(i, j, k, grid, f, c, c)..., time, sw.parameters)
-@inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::SD, U, time) = ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(node(i, j, k, grid, c, f, c)..., time, sw.parameters)
+@inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::SD, U, time) = (  ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂z_uˢ(node(i, j, k, grid, f, c, c)..., time, sw.parameters)
+                                                             + ℑxyᶠᶜᵃ(i, j, k, grid, U.v) * sw.∂y_uˢ(node(i, j, k, grid, f, c, c)..., time, sw.parameters)
+                                                             - ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂x_wˢ(node(i, j, k, grid, f, c, c)..., time, sw.parameters)
+                                                             - ℑxyᶠᶜᵃ(i, j, k, grid, U.v) * sw.∂x_vˢ(node(i, j, k, grid, f, c, c)..., time, sw.parameters))
 
-@inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::SD, U, time) = (- ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(node(i, j, k, grid, c, c, f)..., time, sw.parameters)
+@inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::SD, U, time) = (  ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(node(i, j, k, grid, c, f, c)..., time, sw.parameters)
+                                                             + ℑxyᶜᶠᵃ(i, j, k, grid, U.u) * sw.∂x_vˢ(node(i, j, k, grid, c, f, c)..., time, sw.parameters)
+                                                             - ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂y_wˢ(node(i, j, k, grid, c, f, c)..., time, sw.parameters)
+                                                             - ℑxyᶜᶠᵃ(i, j, k, grid, U.u) * sw.∂y_uˢ(node(i, j, k, grid, c, f, c)..., time, sw.parameters))
+
+@inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::SD, U, time) = (  ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂x_wˢ(node(i, j, k, grid, c, c, f)..., time, sw.parameters)
+                                                             + ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂y_wˢ(node(i, j, k, grid, c, c, f)..., time, sw.parameters)
+                                                             - ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(node(i, j, k, grid, c, c, f)..., time, sw.parameters)
                                                              - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(node(i, j, k, grid, c, c, f)..., time, sw.parameters))
 
 
@@ -111,10 +134,19 @@ const SDnoP = StokesDrift{<:Nothing}
 @inline ∂t_vˢ(i, j, k, grid, sw::SDnoP, time) = sw.∂t_vˢ(node(i, j, k, grid, c, f, c)..., time)
 @inline ∂t_wˢ(i, j, k, grid, sw::SDnoP, time) = sw.∂t_wˢ(node(i, j, k, grid, c, c, f)..., time)
 
-@inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::SDnoP, U, time) = ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂z_uˢ(node(i, j, k, grid, f, c, c)..., time)
-@inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::SDnoP, U, time) = ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(node(i, j, k, grid, c, f, c)..., time)
+@inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::SDnoP, U, time) = (  ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂z_uˢ(node(i, j, k, grid, f, c, c)..., time)
+                                                                + ℑxyᶠᶜᵃ(i, j, k, grid, U.v) * sw.∂y_uˢ(node(i, j, k, grid, f, c, c)..., time)
+                                                                - ℑxzᶠᵃᶜ(i, j, k, grid, U.w) * sw.∂x_wˢ(node(i, j, k, grid, f, c, c)..., time)
+                                                                - ℑxyᶠᶜᵃ(i, j, k, grid, U.v) * sw.∂x_vˢ(node(i, j, k, grid, f, c, c)..., time))
 
-@inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::SDnoP, U, time) = (- ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(node(i, j, k, grid, c, c, f)..., time)
+@inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::SDnoP, U, time) = (  ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(node(i, j, k, grid, c, f, c)..., time)
+                                                                + ℑxyᶜᶠᵃ(i, j, k, grid, U.u) * sw.∂x_vˢ(node(i, j, k, grid, c, f, c)..., time)
+                                                                - ℑyzᵃᶠᶜ(i, j, k, grid, U.w) * sw.∂y_wˢ(node(i, j, k, grid, c, f, c)..., time)
+                                                                - ℑxyᶜᶠᵃ(i, j, k, grid, U.u) * sw.∂y_uˢ(node(i, j, k, grid, c, f, c)..., time))
+
+@inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::SDnoP, U, time) = (  ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂x_wˢ(node(i, j, k, grid, c, c, f)..., time)
+                                                                + ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂y_wˢ(node(i, j, k, grid, c, c, f)..., time)
+                                                                - ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(node(i, j, k, grid, c, c, f)..., time)
                                                                 - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(node(i, j, k, grid, c, c, f)..., time))
 
 end # module

--- a/src/StokesDrifts.jl
+++ b/src/StokesDrifts.jl
@@ -74,37 +74,31 @@ const c = Center()
 @inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::USDnoP, U, time) = @inbounds (- ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(znode(k, grid, f), time)
                                                                            - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(znode(k, grid, f), time))
 
-struct StokesDrift{P, UX, VX, WX, UY, VY, WY, UZ, VZ, WZ, UT, VT, WT}
-    ∂x_uˢ :: UX
+struct StokesDrift{P, VX, WX, UY, WY, UZ, VZ, UT, VT, WT}
     ∂x_vˢ :: VX
     ∂x_wˢ :: WX
     ∂y_uˢ :: UY
-    ∂y_vˢ :: VY
     ∂y_wˢ :: WY
     ∂z_uˢ :: UZ
     ∂z_vˢ :: VZ
-    ∂z_wˢ :: WZ
     ∂t_uˢ :: UT
     ∂t_vˢ :: VT
     ∂t_wˢ :: WT
     parameters :: P
 end
 
-function StokesDrift(; ∂x_uˢ = addzero,
-                       ∂x_vˢ = addzero,
+function StokesDrift(; ∂x_vˢ = addzero,
                        ∂x_wˢ = addzero,
                        ∂y_uˢ = addzero,
-                       ∂y_vˢ = addzero,
                        ∂y_wˢ = addzero,
                        ∂z_uˢ = addzero,
                        ∂z_vˢ = addzero,
-                       ∂z_wˢ = addzero,
                        ∂t_uˢ = addzero,
                        ∂t_vˢ = addzero,
                        ∂t_wˢ = addzero,
                        parameters = nothing)
 
-    return StokesDrift(∂x_uˢ, ∂x_vˢ, ∂x_wˢ, ∂y_uˢ, ∂y_vˢ, ∂y_wˢ, ∂z_uˢ, ∂z_vˢ, ∂z_wˢ, ∂t_uˢ, ∂t_vˢ, ∂t_wˢ, parameters)
+    return StokesDrift(∂x_vˢ, ∂x_wˢ, ∂y_uˢ, ∂y_wˢ, ∂z_uˢ, ∂z_vˢ, ∂t_uˢ, ∂t_vˢ, ∂t_wˢ, parameters)
 end
 
 const SD = StokesDrift


### PR DESCRIPTION
@glwagner This PR completes (hopefully!) the implementation of three-dimensional Stokes drift implementation within non-hydrostatic simulations by adding the momentum forcing terms that arise from horizontal gradients of the Stokes drift via $(\nabla \times \mathbf{u^s}) \times \mathbf{v}$. 

I also added an example code that utilizes the new `StokesDrift` function (and retains the previous `UniformStokesDrift` function). It is a little convoluted because I wanted to implement a Stokes drift that varied in all 3 dimensions to ensure that the code was well-behaved. The example is as follows:

- Is based on the Langmuir turbulence example
- The new example imposes a spatially-varying x-aligned Stokes drift that is a separable function of the three spatial dimensions

```math
u^s(x, y, z) = f(x)g'(y)h(z)
```
- The vertical variation is a classic exponential decay with depth over a vertical length scale $\delta$. Note this function is defined as the z-derivative of another function $h(z)$ to make the description of the vertical Stokes drift easier below.

```math
h'(z) = U^s e^{(z/\delta)}
```

- The x-variation is sinusoidal modulation on top of a background that peaks in the middle of the x-domain.

```math
f(x) = \frac{1}{2}\left( 1 + 0.1cos\left(\frac{\pi(2x-L_x)}{L_x}\right)\right)
```

- The y-variation represents a piece-wise function consisting of a _jet_ region of width $L_{jet}$ centered at $y_{jet}$ where $u^s$ is constant, transition regions of width $L_{transition}$ on either side of the jet where Stokes drift follows a sinusoidal decay from its jet value to zero, and a _no wave_ region where there is no Stokes drift outside of the jet and transition zones.
```math
 g(y) =    1 + cos\left(\pi \frac{y - y_{jet} + L_{jet}/2 }{L_{transition}} \right)       \quad \text{if } y_{jet} - L_{jet}/2  > y >  y_{jet} - L_{jet}/2 - L_{transition} 
```

```math
 g(y) = 1 + cos\left(\pi \frac{y - y_{jet} - L_{jet}/2 }{L_{transition}} \right)       \quad \text{if } y_{jet} + L_{jet}/2 + L_{transition}  > y >  y_{jet} + L_{jet}/2
```

```math
  g(y) = 0  \quad \text{at all other } y
```

- This x-aligned Stokes drift has $\partial_x u^s\neq0$ so incompressibility ($\nabla \cdot \mathbf{u^s}$) requires another Stokes drift component. Since we do not impose a y-oriented wave field, we achieve this through a vertical Stokes drift component $w^s(x,y,z)$. We diagnose this from the $u^s$ field and by imposing a surface boundary condition of no vertical motion: $w^s(x,y,0)=0$ . It then follows that:

```math
w^s(x, y, z) = f'(x)g(y)\left[h(z)-h(0)\right]
```