### PR TITLE
Added adapt method for scalar and scalar biharmonic diffusvity + test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.90.1"
+version = "0.90.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_biharmonic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_biharmonic_diffusivity.jl
@@ -102,3 +102,6 @@ function Base.summary(closure::ScalarBiharmonicDiffusivity)
 end
 
 Base.show(io::IO, closure::ScalarBiharmonicDiffusivity) = print(io, summary(closure))
+
+adapt_structure(to, closure::ScalarBiharmonicDiffusivity) = ScalarBiharmonicDiffusivity(adapt(closure.ν),
+                                                                                        adapt(closure.κ))

--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
@@ -1,3 +1,4 @@
+import Adapt: adapt_structure
 import Oceananigans.Grids: required_halo_size
 using Oceananigans.Utils: prettysummary
 
@@ -196,3 +197,6 @@ function Base.summary(closure::ScalarDiffusivity)
 end
 
 Base.show(io::IO, closure::ScalarDiffusivity) = print(io, summary(closure))
+
+adapt_structure(to, closure::ScalarDiffusivity) = ScalarDiffusivity(adapt(closure.ν),
+                                                                    adapt(closure.κ))

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -108,6 +108,20 @@ function time_step_with_variable_isotropic_diffusivity(arch)
     return true
 end
 
+function time_step_with_field_isotropic_diffusivity(arch)
+    grid = RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 2, 3))
+
+    ν = CenterField(grid)
+    κ = CenterField(grid)
+
+    closure = ScalarDiffusivity(; ν, κ)
+
+    model = NonhydrostaticModel(; grid, closure)
+
+    time_step!(model, 1, euler=true)
+    return true
+end
+
 function time_step_with_variable_anisotropic_diffusivity(arch)
     clov = VerticalScalarDiffusivity(ν = (x, y, z, t) -> exp(z) * cos(x) * cos(y) * cos(t),
                                      κ = (x, y, z, t) -> exp(z) * cos(x) * cos(y) * cos(t))
@@ -249,6 +263,7 @@ end
         @info "  Testing time-stepping with presribed variable diffusivities..."
         for arch in archs
             @test time_step_with_variable_isotropic_diffusivity(arch)
+            @test time_step_with_field_isotropic_diffusivity(arch)
             @test time_step_with_variable_anisotropic_diffusivity(arch)
             @test time_step_with_variable_discrete_diffusivity(arch)
         end


### PR DESCRIPTION
Scalar diffusivity fails on GPU if you use fields for the viscosity/diffusivity since there is no adapt method. 

I've added them in this PR along with a test, feel free to remove the test if its too much.