### PR TITLE
Add convenience functions for conjuring TimeStepWizards and adding `Callback`s

### DIFF
--- a/examples/baroclinic_adjustment.jl
+++ b/examples/baroclinic_adjustment.jl
@@ -100,8 +100,7 @@ simulation = Simulation(model, Δt=20minutes, stop_time=20days)
 
 # We add a `TimeStepWizard` callback to adapt the simulation's time-step,
 
-wizard = TimeStepWizard(cfl=0.2, max_change=1.1, max_Δt=20minutes)
-simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(20))
+conjure_time_step_wizard!(simulation, IterationInterval(20), cfl=0.2, max_Δt=20minutes)
 
 # Also, we add a callback to print a message about how the simulation is going,
 
@@ -123,7 +122,7 @@ function print_progress(sim)
     return nothing
 end
 
-simulation.callbacks[:print_progress] = Callback(print_progress, IterationInterval(100))
+add_callback!(simulation, print_progress, IterationInterval(100))
 
 # ## Diagnostics/Output
 #

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -161,9 +161,7 @@ simulation = Simulation(model, Δt=2minutes, stop_time=24hours)
 # time-step to 2 minutes, and adapts the time-step such that CFL
 # (Courant-Freidrichs-Lewy) number hovers around `1.0`,
 
-wizard = TimeStepWizard(cfl=1.0, max_change=1.1, max_Δt=2minutes)
-
-simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(10))
+conjure_time_step_wizard!(simulation, cfl=1.0, max_Δt=2minutes)
 
 # We also add a callback that prints the progress of the simulation,
 
@@ -172,7 +170,7 @@ using Printf
 progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
                         iteration(sim), prettytime(sim), prettytime(sim.Δt))
 
-simulation.callbacks[:progress] = Callback(progress, IterationInterval(100))
+add_callback!(simulation, progress, IterationInterval(100))
 
 # and a basic `JLD2OutputWriter` that writes velocities and both
 # the two-dimensional and horizontally-averaged plankton concentration,

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -167,9 +167,7 @@ simulation = Simulation(model, Δt=45.0, stop_time=4hours)
 # We use the `TimeStepWizard` for adaptive time-stepping
 # with a Courant-Freidrichs-Lewy (CFL) number of 1.0,
 
-wizard = TimeStepWizard(cfl=1.0, max_change=1.1, max_Δt=1minute)
-
-simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(10))
+conjure_time_step_wizard!(simulation, cfl=1.0, max_Δt=1minute)
 
 # ### Nice progress messaging
 #

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -198,7 +198,7 @@ progress_message(sim) = @printf("Iteration: %04d, time: %s, Δt: %s, max(|w|) = 
                                 iteration(sim), prettytime(sim), prettytime(sim.Δt),
                                 maximum(abs, sim.model.velocities.w), prettytime(sim.run_wall_time))
 
-simulation.callbacks[:progress] = Callback(progress_message, IterationInterval(20))
+add_callback!(simulation, progress_message, IterationInterval(20))
 
 # We then set up the simulation:
 

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -54,7 +54,7 @@ simulation = Simulation(model, Δt=0.2, stop_time=50)
 # We set up a callback that logs the simulation iteration and time every 100 iterations.
 
 progress(sim) = @info string("Iteration: ", iteration(sim), ", time: ", time(sim))
-simulation.callbacks[:progress] = Callback(progress, IterationInterval(100))
+add_callback!(simulation, progress, IterationInterval(100))
 
 # ## Output
 #

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -90,7 +90,7 @@ export
     PrescribedVelocityFields,
 
     # Time stepping
-    Clock, TimeStepWizard, conjure_wizard!, time_step!,
+    Clock, TimeStepWizard, conjure_time_step_wizard!, time_step!,
 
     # Simulations
     Simulation, run!, Callback, add_callback!, iteration, stopwatch,

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -90,10 +90,10 @@ export
     PrescribedVelocityFields,
 
     # Time stepping
-    Clock, TimeStepWizard, time_step!,
+    Clock, TimeStepWizard, conjure_wizard!, time_step!,
 
     # Simulations
-    Simulation, run!, Callback, iteration, stopwatch,
+    Simulation, run!, Callback, add_callback!, iteration, stopwatch,
     iteration_limit_exceeded, stop_time_exceeded, wall_time_limit_exceeded,
     TimeStepCallsite, TendencyCallsite, UpdateStateCallsite,
 

--- a/src/Simulations/Simulations.jl
+++ b/src/Simulations/Simulations.jl
@@ -1,6 +1,6 @@
 module Simulations
 
-export TimeStepWizard, conjure_wizard!
+export TimeStepWizard, conjure_time_step_wizard!
 export Simulation
 export run!
 export Callback, add_callback!

--- a/src/Simulations/Simulations.jl
+++ b/src/Simulations/Simulations.jl
@@ -1,9 +1,9 @@
 module Simulations
 
-export TimeStepWizard
+export TimeStepWizard, conjure_wizard!
 export Simulation
 export run!
-export Callback
+export Callback, add_callback!
 export iteration
 export stopwatch
 
@@ -21,8 +21,8 @@ using OrderedCollections: OrderedDict
 import Base: show
 
 include("callback.jl")
-include("time_step_wizard.jl")
 include("simulation.jl")
 include("run.jl")
+include("time_step_wizard.jl")
 
 end # module

--- a/src/Simulations/callback.jl
+++ b/src/Simulations/callback.jl
@@ -51,3 +51,41 @@ Callback(wta::WindowedTimeAverage, schedule; kw...) =
     throw(ArgumentError("Schedule must be inferred from WindowedTimeAverage. 
                         Use Callback(windowed_time_average)"))
 
+struct GenericName end
+
+function unique_callback_name(name, existing_names)
+    if name ∈ existing_names
+        return Symbol(:another_, name)
+    else
+        return name
+    end
+end
+
+function unique_callback_name(::GenericName, existing_names)
+    prefix = :callback # yeah, that's generic
+
+    # Find a unique one
+    n = 1
+    while Symbol(prefix, n) ∈ existing_names
+        n += 1
+    end
+
+    return Symbol(prefix, n)
+end
+
+"""
+    add_callback!(simulation, callback, name=GenericName())
+
+Add `callback` to `simulation.callbacks` under `name`. The default
+`GenericName()` generates a name of the form `:callbackN`, where `N`
+is big enough for the name to be unique.
+
+If `name` is supplied, it may be modified if `simulation.callbacks[name]`
+already exists.
+"""
+function add_callback!(simulation, callback, name=GenericName())
+    name = unique_callback_name(name, keys(simulation.callbacks))
+    simulation.callbacks[name] = callback
+    return nothing
+end
+

--- a/src/Simulations/callback.jl
+++ b/src/Simulations/callback.jl
@@ -74,18 +74,28 @@ function unique_callback_name(::GenericName, existing_names)
 end
 
 """
-    add_callback!(simulation, callback, name=GenericName())
+    add_callback!(simulation, callback::Callback; name = GenericName())
+                  
+    add_callback!(simulation, func; schedule=IterationInterval(1), name = GenericName())
 
-Add `callback` to `simulation.callbacks` under `name`. The default
+Add `Callback(func, schedule)` to `simulation.callbacks` under `name`. The default
 `GenericName()` generates a name of the form `:callbackN`, where `N`
 is big enough for the name to be unique.
 
 If `name` is supplied, it may be modified if `simulation.callbacks[name]`
 already exists.
+
+The `callback` (which contains a schedule) can also be supplied directly.
 """
-function add_callback!(simulation, callback, name=GenericName())
+function add_callback!(simulation, callback::Callback; name = GenericName())
     name = unique_callback_name(name, keys(simulation.callbacks))
     simulation.callbacks[name] = callback
     return nothing
+end
+
+function add_callback!(simulation, func; schedule = IterationInterval(1),
+                                             name = GenericName())
+    callback = Callback(func, schedule)
+    return add_callback!(simulation, callback; name)
 end
 

--- a/src/Simulations/callback.jl
+++ b/src/Simulations/callback.jl
@@ -29,8 +29,12 @@ with optional `parameters`. `schedule = IterationInterval(1)` by default.
 If `isnothing(parameters)`, `func(sim::Simulation)` is called.
 Otherwise, `func` is called via `func(sim::Simulation, parameters)`.
 """
-Callback(func, schedule=IterationInterval(1); parameters=nothing, callsite = TimeStepCallsite()) =
-    Callback(func, schedule, parameters, callsite)
+function Callback(func, schedule=IterationInterval(1);
+                  parameters = nothing,
+                  callsite = TimeStepCallsite())
+
+    return Callback(func, schedule, parameters, callsite)
+end
 
 Base.summary(cb::Callback{Nothing}) = string("Callback of ", prettysummary(cb.func, false), " on ", summary(cb.schedule))
 Base.summary(cb::Callback) = string("Callback of ", prettysummary(cb.func, false), " on ", summary(cb.schedule),
@@ -74,8 +78,9 @@ function unique_callback_name(::GenericName, existing_names)
 end
 
 """
-    add_callback!(simulation, callback::Callback; name = GenericName())
-    add_callback!(simulation, func; schedule=IterationInterval(1), name = GenericName())
+    add_callback!(simulation, callback::Callback; name = GenericName(), callback_kw...)
+
+    add_callback!(simulation, func, schedule=IterationInterval(1); name = GenericName(), callback_kw...)
 
 Add `Callback(func, schedule)` to `simulation.callbacks` under `name`. The default
 `GenericName()` generates a name of the form `:callbackN`, where `N`
@@ -92,9 +97,10 @@ function add_callback!(simulation, callback::Callback; name = GenericName())
     return nothing
 end
 
-function add_callback!(simulation, func; schedule = IterationInterval(1),
-                                             name = GenericName())
-    callback = Callback(func, schedule)
+function add_callback!(simulation, func, schedule = IterationInterval(1);
+                       name = GenericName(), callback_kw...)
+
+    callback = Callback(func, schedule; callback_kw...)
     return add_callback!(simulation, callback; name)
 end
 

--- a/src/Simulations/callback.jl
+++ b/src/Simulations/callback.jl
@@ -75,7 +75,6 @@ end
 
 """
     add_callback!(simulation, callback::Callback; name = GenericName())
-                  
     add_callback!(simulation, func; schedule=IterationInterval(1), name = GenericName())
 
 Add `Callback(func, schedule)` to `simulation.callbacks` under `name`. The default

--- a/src/Simulations/callback.jl
+++ b/src/Simulations/callback.jl
@@ -21,13 +21,27 @@ function initialize!(callback::Callback, sim)
 end
 
 """
-    Callback(func, schedule=IterationInterval(1); parameters=nothing)
+    Callback(func, schedule=IterationInterval(1);
+             parameters=nothing, callsite=TimeStepCallsite())
 
 Return `Callback` that executes `func` on `schedule`
-with optional `parameters`. `schedule = IterationInterval(1)` by default.
+at the `callsite` with optional `parameters`. By default,
+`schedule = IterationInterval(1)` and `callsite = TimeStepCallsite()`.
 
 If `isnothing(parameters)`, `func(sim::Simulation)` is called.
 Otherwise, `func` is called via `func(sim::Simulation, parameters)`.
+
+The `callsite` determines where `Callback` is executed. The possible values for 
+`callsite` are
+
+ * `TimeStepCallsite()`: after a time-step.
+
+ * `TendencyCallsite()`: after tendencies are calculated, but before taking
+    a time-step (useful for modifying tendency calculations).
+
+ * `UpdateStateCallsite()`: within `update_state!`, after auxiliary variables have
+    been computed (for multi-stage time-steppers, `update_state!` may be called multiple
+    times per time-step).
 """
 function Callback(func, schedule=IterationInterval(1);
                   parameters = nothing,
@@ -88,6 +102,8 @@ is big enough for the name to be unique.
 
 If `name` is supplied, it may be modified if `simulation.callbacks[name]`
 already exists.
+
+`callback_kw` are passed to the constructor for [`Callback`](@ref).
 
 The `callback` (which contains a schedule) can also be supplied directly.
 """

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -117,12 +117,12 @@ end
     simulation.Δt = new_time_step(simulation.Δt, wizard, simulation.model)
 
 """
-    conjure_wizard!(simulation; interval=5, wizard_kw...)
+    conjure_time_step_wizard!(simulation; interval=5, wizard_kw...)
 
 Add a `TimeStepWizard` built with `wizard_kw` as a `Callback` to `simulation`
 using the schedule `IterationInterval(interval)`.
 """
-function conjure_wizard!(simulation; interval=5, wizard_kw...)
+function conjure_time_step_wizard!(simulation; interval=5, wizard_kw...)
     wizard = TimeStepWizard(; wizard_kw...)
     simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(interval))
     return nothing

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -117,14 +117,14 @@ end
     simulation.Δt = new_time_step(simulation.Δt, wizard, simulation.model)
 
 """
-    conjure_time_step_wizard!(simulation; interval=5, wizard_kw...)
+    conjure_time_step_wizard!(simulation, schedule=IterationInterval(5), wizard_kw...)
 
-Add a `TimeStepWizard` built with `wizard_kw` as a `Callback` to `simulation`
-using the schedule `IterationInterval(interval)`.
+Add a `TimeStepWizard` built with `wizard_kw` as a `Callback` to `simulation`,
+called on `schedule` which is `IterationInterval(5)` by default.
 """
-function conjure_time_step_wizard!(simulation; interval=5, wizard_kw...)
+function conjure_time_step_wizard!(simulation, schedule=IterationInterval(10); wizard_kw...)
     wizard = TimeStepWizard(; wizard_kw...)
-    simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(interval))
+    simulation.callbacks[:time_step_wizard] = Callback(wizard, schedule)
     return nothing
 end
 

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -116,3 +116,15 @@ end
 (wizard::TimeStepWizard)(simulation) =
     simulation.Δt = new_time_step(simulation.Δt, wizard, simulation.model)
 
+"""
+    conjure_wizard!(simulation; interval=5, wizard_kw...)
+
+Add a `TimeStepWizard` built with `wizard_kw` as a `Callback` to `simulation`
+using the schedule `IterationInterval(interval)`.
+"""
+function conjure_wizard!(simulation; interval=5, wizard_kw...)
+    wizard = TimeStepWizard(; wizard_kw...)
+    simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(interval))
+    return nothing
+end
+


### PR DESCRIPTION
This PR implements two convenience functions that eliminate a line of boilerplate associated with `TimeStepWizard` and `Callback`:

* `conjure_wizard!`
* `add_callback!`

If we like it, I'll modify an example or two to use the convenience functions.

Usage:

```julia
conjure_time_step_wizard!(simulation, IterationInterval(5), cfl=0.5)
```

```julia
progress(sim) = @info string("Iteration ", iteration(sim))
add_callback!(simulation, progress, IterationInterval(10))
```
