### PR TITLE
Enhance docstring for `Integral`

### DIFF
--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -76,7 +76,8 @@ Example
 =======
 
 Compute the integral of ``f(x, y, z) = x y z`` over the domain
-``(x, y, z) ∈ [0, 1] × [0, 1] × [0, 1]``.
+``(x, y, z) ∈ [0, 1] × [0, 1] × [0, 1]``. The analytical answer
+is ``\iiint x y z \\, dx \\, dy \\, dz = 1/8``.
 
 ```jldoctest
 julia> using Oceananigans

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -81,7 +81,7 @@ Compute the integral of ``f(x, y, z) = x y z`` over the domain
 ```jldoctest
 julia> using Oceananigans
 
-julia> grid = RectilinearGrid(size=(18, 18, 8), x=(0, 1), y=(0, 1), z=(0, 1), topology = (Periodic, Periodic, Periodic));
+julia> grid = RectilinearGrid(size=(8, 8, 8), x=(0, 1), y=(0, 1), z=(0, 1), topology = (Periodic, Periodic, Periodic));
 
 julia> f = CenterField(grid);
 

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -84,15 +84,15 @@ julia> using Oceananigans
 
 julia> grid = RectilinearGrid(size=(8, 8, 8), x=(0, 1), y=(0, 1), z=(0, 1));
 
-julia> f = CenterField(grid)
+julia> f = CenterField(grid);
 
-julia> set!(f, (x, y, z) -> x * y * z);
+julia> set!(f, (x, y, z) -> x * y * z)
 8×8×8 Field{Center, Center, Center} on RectilinearGrid on CPU
 ├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── boundary conditions: FieldBoundaryConditions
 │   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: ZeroFlux, top: ZeroFlux, immersed: ZeroFlux
 └── data: 14×14×14 OffsetArray(::Array{Float64, 3}, -2:11, -2:11, -2:11) with eltype Float64 with indices -2:11×-2:11×-2:11
-    └── max=0.0, min=0.0, mean=0.0
+    └── max=0.823975, min=0.000244141, mean=0.125
 
 julia> ∫f = Integral(f)
 sum! over dims (1, 2, 3) of BinaryOperation at (Center, Center, Center)

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -67,7 +67,8 @@ function Reduction(int::Integral, field::AbstractField; condition = nothing, mas
 end
 
 """
-    Integral(field; dims=:)
+    Integral(field::AbstractField; condition = nothing, mask = 0, dims=:)
+
 
 Return a `Reduction` representing a spatial integral of `field` over `dims`.
 """

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -84,9 +84,20 @@ julia> using Oceananigans
 
 julia> grid = RectilinearGrid(size=(8, 8, 8), x=(0, 1), y=(0, 1), z=(0, 1));
 
-julia> f = CenterField(grid);
+julia> f = CenterField(grid)
 
 julia> set!(f, (x, y, z) -> x * y * z);
+8×8×8 Field{Center, Center, Center} on RectilinearGrid on CPU
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── boundary conditions: FieldBoundaryConditions
+│   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: ZeroFlux, top: ZeroFlux, immersed: ZeroFlux
+└── data: 14×14×14 OffsetArray(::Array{Float64, 3}, -2:11, -2:11, -2:11) with eltype Float64 with indices -2:11×-2:11×-2:11
+    └── max=0.0, min=0.0, mean=0.0
+
+julia> ∫f = Integral(f)
+sum! over dims (1, 2, 3) of BinaryOperation at (Center, Center, Center)
+└── operand: BinaryOperation at (Center, Center, Center)
+    └── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halojulia> compute!(∫f);
 
 julia> ∫f = Field(Integral(f));
 

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -107,7 +107,8 @@ julia> ∫f[1, 1, 1]
 0.125
 ```
 """
-Integral(field::AbstractField; condition = nothing, mask = 0, dims=:) = Reduction(Integral(), condition_operand(field, condition, mask); dims)
+Integral(field::AbstractField; condition = nothing, mask = 0, dims=:) =
+    Reduction(Integral(), condition_operand(field, condition, mask); dims)
 
 #####
 ##### show

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -76,12 +76,12 @@ Example
 =======
 
 Compute the integral of ``f(x, y, z) = x y z`` over the domain
-``(x, y, z) ∈ [0, 1] \times [0, 1] \times [0, 1]``.
+``(x, y, z) ∈ [0, 1] × [0, 1] × [0, 1]``.
 
 ```jldoctest
 julia> using Oceananigans
 
-julia> grid = RectilinearGrid(size=(8, 8, 8), x=(0, 1), y=(0, 1), z=(0, 1));
+julia> grid = RectilinearGrid(size=(18, 18, 8), x=(0, 1), y=(0, 1), z=(0, 1), topology = (Periodic, Periodic, Periodic));
 
 julia> f = CenterField(grid);
 

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -82,7 +82,7 @@ is ``∭ x y z \\, dx \\, dy \\, dz = 1/8``.
 ```jldoctest
 julia> using Oceananigans
 
-julia> grid = RectilinearGrid(size=(8, 8, 8), x=(0, 1), y=(0, 1), z=(0, 1), topology = (Periodic, Periodic, Periodic));
+julia> grid = RectilinearGrid(size=(8, 8, 8), x=(0, 1), y=(0, 1), z=(0, 1));
 
 julia> f = CenterField(grid);
 

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -77,7 +77,7 @@ Example
 
 Compute the integral of ``f(x, y, z) = x y z`` over the domain
 ``(x, y, z) ∈ [0, 1] × [0, 1] × [0, 1]``. The analytical answer
-is ``\iiint x y z \\, dx \\, dy \\, dz = 1/8``.
+is ``∭ x y z \\, dx \\, dy \\, dz = 1/8``.
 
 ```jldoctest
 julia> using Oceananigans

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -71,6 +71,29 @@ end
 
 
 Return a `Reduction` representing a spatial integral of `field` over `dims`.
+
+Example
+=======
+
+Compute the integral of ``f(x, y, z) = x y z`` over the domain
+``(x, y, z) ∈ [0, 1] \times [0, 1] \times [0, 1]``.
+
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = RectilinearGrid(size=(8, 8, 8), x=(0, 1), y=(0, 1), z=(0, 1));
+
+julia> f = CenterField(grid);
+
+julia> set!(f, (x, y, z) -> x * y * z);
+
+julia> ∫f = Field(Integral(f));
+
+julia> compute!(∫f);
+
+julia> ∫f[1, 1, 1]
+0.125
+```
 """
 Integral(field::AbstractField; condition = nothing, mask = 0, dims=:) = Reduction(Integral(), condition_operand(field, condition, mask); dims)
 

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -97,7 +97,7 @@ julia> set!(f, (x, y, z) -> x * y * z)
 julia> ∫f = Integral(f)
 sum! over dims (1, 2, 3) of BinaryOperation at (Center, Center, Center)
 └── operand: BinaryOperation at (Center, Center, Center)
-    └── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halojulia> compute!(∫f);
+    └── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 
 julia> ∫f = Field(Integral(f));
 


### PR DESCRIPTION
This PR fixes the current signature on the docstring for `Average`, which isn't accurate on `main`.