### PR TITLE
(0.90.9) Fix a sign error in CATKE's implicit dissipative buoyancy flux

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.90.8"
+version = "0.90.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/CATKEVerticalDiffusivities/CATKEVerticalDiffusivities.jl
@@ -353,7 +353,7 @@ end
         #
         # where ω = ϵ / e ∼ √e / ℓ.
         
-        diffusivities.Lᵉ[i, j, k] = - wb_e - ω + div_Jᵉ_e
+        diffusivities.Lᵉ[i, j, k] = wb_e - ω + div_Jᵉ_e
     end
 end
 


### PR DESCRIPTION
This PR fixes a sign error in the implicit dissipative buoyancy flux. We're also recalibrating parameters and will update them here before merging the PR.