### PR TITLE
Show method for `HydrostaticFreeSurfaceModel` summarizes advection schemes

### DIFF
--- a/docs/src/model_setup/buoyancy_and_equation_of_state.md
+++ b/docs/src/model_setup/buoyancy_and_equation_of_state.md
@@ -63,6 +63,8 @@ HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 
 ├── buoyancy: Nothing
 ├── free surface: ImplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 │   └── solver: FFTImplicitFreeSurfaceSolver
+├── advection scheme: 
+│   └── momentum: Centered reconstruction order 2
 └── coriolis: Nothing
 ```
 
@@ -94,6 +96,9 @@ HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 
 ├── buoyancy: BuoyancyTracer with ĝ = NegativeZDirection()
 ├── free surface: ImplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 │   └── solver: FFTImplicitFreeSurfaceSolver
+├── advection scheme: 
+│   ├── momentum: Centered reconstruction order 2
+│   └── b: Centered reconstruction order 2
 └── coriolis: Nothing
 ```
 
@@ -131,6 +136,10 @@ HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 
 ├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with ĝ = NegativeZDirection()
 ├── free surface: ImplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 │   └── solver: FFTImplicitFreeSurfaceSolver
+├── advection scheme: 
+│   ├── momentum: Centered reconstruction order 2
+│   ├── T: Centered reconstruction order 2
+│   └── S: Centered reconstruction order 2
 └── coriolis: Nothing
 ```
 
@@ -146,6 +155,10 @@ HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 
 ├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with ĝ = NegativeZDirection()
 ├── free surface: ImplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
 │   └── solver: FFTImplicitFreeSurfaceSolver
+├── advection scheme: 
+│   ├── momentum: Centered reconstruction order 2
+│   ├── T: Centered reconstruction order 2
+│   └── S: Centered reconstruction order 2
 └── coriolis: Nothing
 ```
 

--- a/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
@@ -31,6 +31,16 @@ function Base.show(io::IO, model::HydrostaticFreeSurfaceModel)
         end
     end
 
+    if model.advection !== nothing
+        print(io, "├── advection scheme: ", "\n")
+        names = keys(model.advection)
+        for name in names[1:end-1]
+            print(io, "│   ├── " * string(name) * ": " * summary(model.advection[name]), "\n")
+        end
+        name = names[end]
+        print(io, "│   └── " * string(name) * ": " * summary(model.advection[name]), "\n")
+    end
+
     if isnothing(model.particles)
         print(io, "└── coriolis: $(typeof(model.coriolis))")
     else


### PR DESCRIPTION
Closes #3197

```Julia
julia> using Oceananigans

julia> grid = RectilinearGrid(size=(2, 2, 2), extent=(1, 1, 1))
2×2×2 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
├── Periodic x ∈ [0.0, 1.0)  regularly spaced with Δx=0.5
├── Periodic y ∈ [0.0, 1.0)  regularly spaced with Δy=0.5
└── Bounded  z ∈ [-1.0, 0.0] regularly spaced with Δz=0.5

julia> model = HydrostaticFreeSurfaceModel(; grid, momentum_advection=nothing, tracer_advection=nothing, tracers=nothing, buoyancy=nothing)
HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
├── grid: 2×2×2 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
├── timestepper: QuasiAdamsBashforth2TimeStepper
├── tracers: ()
├── closure: Nothing
├── buoyancy: Nothing
├── free surface: ImplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
│   └── solver: FFTImplicitFreeSurfaceSolver
├── advection scheme:
│   └── momentum: Nothing
└── coriolis: Nothing

julia> model = HydrostaticFreeSurfaceModel(; grid)
HydrostaticFreeSurfaceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
├── grid: 2×2×2 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
├── timestepper: QuasiAdamsBashforth2TimeStepper
├── tracers: (T, S)
├── closure: Nothing
├── buoyancy: SeawaterBuoyancy with g=9.80665 and LinearEquationOfState(thermal_expansion=0.000167, haline_contraction=0.00078) with ĝ = NegativeZDirection()
├── free surface: ImplicitFreeSurface with gravitational acceleration 9.80665 m s⁻²
│   └── solver: FFTImplicitFreeSurfaceSolver
├── advection scheme:
│   ├── momentum: Centered reconstruction order 2
│   ├── T: Centered reconstruction order 2
│   └── S: Centered reconstruction order 2
└── coriolis: Nothing
```