### PR TITLE
Allow testing of just a single file

### DIFF
--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -36,11 +36,11 @@ Discussions are recommended for asking questions about (for example) the user in
 
 * Note: for small or minor changes (such as fixing a typo in documentation), the [GitHub editor](https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/editing-files-in-your-repository) is super useful for forking and opening a pull request with a single click.
 
-* Write your code with love and care. In particular, conform to existing Oceananigans style and formatting conventions. For example, we love verbose and explicit variable names, use `TitleCase` for types, `snake_case` for objects, and always.put.spaces.after.commas. For formatting decisions we loosely follow the [YASGuide](https://github.com/jrevels/YASGuide). It's worth few extra minutes of our time to leave future generations with well-written, readable code.
+* Write your code with love and care. In particular, conform to existing Oceananigans style and formatting conventions. For example, we love verbose and explicit variable names, use `TitleCase` for types, `snake_case` for objects, and always,put,spaces.after.commas,or.periods. For formatting decisions we loosely follow the [YASGuide](https://github.com/jrevels/YASGuide). It's worth few extra minutes of our time to leave future generations with well-written, readable code.
 
 ## What is a "collaborator" and how can I become one?
 
-* Collaborators have permissions to review pull requests and  status allows a contributor to review pull requests in addition to opening them. Collaborators can also create branches in the main Oceananigans repository.
+* Collaborators have permissions to review pull requests and status allows a contributor to review pull requests in addition to opening them. Collaborators can also create branches in the main Oceananigans repository.
 
 * We ask that new contributors try their hand at forking Oceananigans, and opening and merging a pull request before requesting collaborator status.
 
@@ -122,12 +122,17 @@ Oceananigans or by requesting something you think is missing.
 
 * Create the development environment by opening Julia via `julia --project` then
   typing in `] instantiate`. This will install all the dependencies in the Project.toml
-  file.
+  file. Your development environment is now ready!
 
-* You can test to make sure Oceananigans works by typing in `] test`. Doing so will run all
-  the tests (and this can take a while).
+* You can test to make sure Oceananigans works by typing in `] test`. (This is equivalent to
+  `using Pkg; Pkg.test()`.) Doing so will run all the tests (and this can take a while).
+  Alternatively, you can run only one test script file by providing its name as an environment
+  variable. For example, to run the tests only from the `test_coriolis.jl` file we call:
 
-Your development environment is now ready!
+  ```
+  $ TEST_FILE=test_coriolis.jl julia --project -e"using Pkg; Pkg.test()"
+  ```
+
 
 ## Pull Requests
 

--- a/test/dependencies_for_runtests.jl
+++ b/test/dependencies_for_runtests.jl
@@ -57,8 +57,6 @@ Logging.global_logger(OceananigansLogger())
 ##### Testing parameters
 #####
 
-float_types = (Float32, Float64)
-
 closures = (
     :ScalarDiffusivity,
     :ScalarBiharmonicDiffusivity,
@@ -68,15 +66,5 @@ closures = (
     :ConvectiveAdjustmentVerticalDiffusivity,
 )
 
-#####
-##### Run tests!
-#####
-
-float_types = (Float32, Float64)
-
 include("utils_for_runtests.jl")
 
-archs = test_architectures()
-
-group     = get(ENV, "TEST_GROUP", :all) |> Symbol
-test_file = get(ENV, "TEST_FILE", :none) |> Symbol

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,6 @@ CUDA.allowscalar() do
     end
 
     # Core Oceananigans
-    @show group
     if group == :unit || group == :all
         @testset "Unit tests" begin
             include("test_grids.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,8 +24,6 @@ CUDA.allowscalar() do
     # Core Oceananigans
     @show group
     if group == :unit || group == :all
-        @info "hi from CI"
-        @show group
         @testset "Unit tests" begin
             include("test_grids.jl")
             include("test_operators.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,11 @@ if test_file != :none
     group = :none
 end
 
+
+#####
+##### Run tests!
+#####
+
 CUDA.allowscalar() do
 
 @testset "Oceananigans" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,188 +1,197 @@
 include("dependencies_for_runtests.jl")
 
+float_types = (Float32, Float64)
+archs = test_architectures()
+
+group     = get(ENV, "TEST_GROUP", :all) |> Symbol
+test_file = get(ENV, "TEST_FILE", :none) |> Symbol
+
+# if we are testing just a single file then group = :none
+# to skip the full test suite
+if test_file != :none
+    group = :none
+end
+
 CUDA.allowscalar() do
 
 @testset "Oceananigans" begin
-
     if test_file != :none
-
-        # just testing a single file
         @testset "Single file test" begin
             include(String(test_file))
         end
+    end
 
-    else
-
-        # Core Oceananigans
-        if group == :unit || group == :all
-            @testset "Unit tests" begin
-                include("test_grids.jl")
-                include("test_operators.jl")
-                include("test_boundary_conditions.jl")
-                include("test_field.jl")
-                include("test_regrid.jl")
-                include("test_field_reductions.jl")
-                include("test_halo_regions.jl")
-                include("test_coriolis.jl")
-                include("test_buoyancy.jl")
-                include("test_stokes_drift.jl")
-                include("test_utils.jl")
-                include("test_schedules.jl")
-            end
+    # Core Oceananigans
+    @show group
+    if group == :unit || group == :all
+        @info "hi from CI"
+        @show group
+        @testset "Unit tests" begin
+            include("test_grids.jl")
+            include("test_operators.jl")
+            include("test_boundary_conditions.jl")
+            include("test_field.jl")
+            include("test_regrid.jl")
+            include("test_field_reductions.jl")
+            include("test_halo_regions.jl")
+            include("test_coriolis.jl")
+            include("test_buoyancy.jl")
+            include("test_stokes_drift.jl")
+            include("test_utils.jl")
+            include("test_schedules.jl")
         end
+    end
 
-        if group == :abstract_operations || group == :all
-            @testset "AbstractOperations and broadcasting tests" begin
-                include("test_abstract_operations.jl")
-                include("test_conditional_reductions.jl")
-                include("test_computed_field.jl")
-                include("test_broadcasting.jl")
-            end
+    if group == :abstract_operations || group == :all
+        @testset "AbstractOperations and broadcasting tests" begin
+            include("test_abstract_operations.jl")
+            include("test_conditional_reductions.jl")
+            include("test_computed_field.jl")
+            include("test_broadcasting.jl")
         end
+    end
 
-        if group == :poisson_solvers_1 || group == :all
-            @testset "Poisson Solvers 1" begin
-                include("test_poisson_solvers.jl")
-            end
+    if group == :poisson_solvers_1 || group == :all
+        @testset "Poisson Solvers 1" begin
+            include("test_poisson_solvers.jl")
         end
+    end
 
-        if group == :poisson_solvers_2 || group == :all
-            @testset "Poisson Solvers 2" begin
-                include("test_poisson_solvers_stretched_grids.jl")
-            end
+    if group == :poisson_solvers_2 || group == :all
+        @testset "Poisson Solvers 2" begin
+            include("test_poisson_solvers_stretched_grids.jl")
         end
+    end
 
-        if group == :matrix_poisson_solvers || group == :all
-            @testset "Matrix Poisson Solvers" begin
-                include("test_matrix_poisson_solver.jl")
-            end
+    if group == :matrix_poisson_solvers || group == :all
+        @testset "Matrix Poisson Solvers" begin
+            include("test_matrix_poisson_solver.jl")
         end
+    end
 
-        if group == :general_solvers || group == :all
-            @testset "General Solvers" begin
-                include("test_batched_tridiagonal_solver.jl")
-                include("test_preconditioned_conjugate_gradient_solver.jl")
-            end
+    if group == :general_solvers || group == :all
+        @testset "General Solvers" begin
+            include("test_batched_tridiagonal_solver.jl")
+            include("test_preconditioned_conjugate_gradient_solver.jl")
         end
+    end
 
-        # Simulations
-        if group == :simulation || group == :all
-            @testset "Simulation tests" begin
-                include("test_simulations.jl")
-                include("test_diagnostics.jl")
-                include("test_output_writers.jl")
-                include("test_netcdf_output_writer.jl")
-                include("test_output_readers.jl")
-            end
+    # Simulations
+    if group == :simulation || group == :all
+        @testset "Simulation tests" begin
+            include("test_simulations.jl")
+            include("test_diagnostics.jl")
+            include("test_output_writers.jl")
+            include("test_netcdf_output_writer.jl")
+            include("test_output_readers.jl")
         end
+    end
 
-        # Lagrangian particle tracking
-        if group == :lagrangian || group == :all
-            @testset "Lagrangian particle tracking tests" begin
-                include("test_lagrangian_particle_tracking.jl")
-            end
+    # Lagrangian particle tracking
+    if group == :lagrangian || group == :all
+        @testset "Lagrangian particle tracking tests" begin
+            include("test_lagrangian_particle_tracking.jl")
         end
+    end
 
-        # Models
-        if group == :time_stepping_1 || group == :all
-            @testset "Model and time stepping tests (part 1)" begin
-                include("test_nonhydrostatic_models.jl")
-                include("test_time_stepping.jl")
-            end
+    # Models
+    if group == :time_stepping_1 || group == :all
+        @testset "Model and time stepping tests (part 1)" begin
+            include("test_nonhydrostatic_models.jl")
+            include("test_time_stepping.jl")
         end
+    end
 
-        if group == :time_stepping_2 || group == :all
-            @testset "Model and time stepping tests (part 2)" begin
-                include("test_boundary_conditions_integration.jl")
-                include("test_forcings.jl")
-                include("test_immersed_advection.jl")
-            end
+    if group == :time_stepping_2 || group == :all
+        @testset "Model and time stepping tests (part 2)" begin
+            include("test_boundary_conditions_integration.jl")
+            include("test_forcings.jl")
+            include("test_immersed_advection.jl")
         end
+    end
 
-        if group == :time_stepping_3 || group == :all
-            @testset "Model and time stepping tests (part 3)" begin
-                include("test_dynamics.jl")
-                include("test_biogeochemistry.jl")
-                include("test_sewater_density.jl")
-            end
+    if group == :time_stepping_3 || group == :all
+        @testset "Model and time stepping tests (part 3)" begin
+            include("test_dynamics.jl")
+            include("test_biogeochemistry.jl")
+            include("test_sewater_density.jl")
         end
+    end
 
-        if group == :turbulence_closures || group == :all
-            @testset "Turbulence closures tests" begin
-                include("test_turbulence_closures.jl")
-            end
+    if group == :turbulence_closures || group == :all
+        @testset "Turbulence closures tests" begin
+            include("test_turbulence_closures.jl")
         end
+    end
 
-        if group == :shallow_water || group == :all
-            include("test_shallow_water_models.jl")
+    if group == :shallow_water || group == :all
+        include("test_shallow_water_models.jl")
+    end
+
+    if group == :hydrostatic_free_surface || group == :all
+        @testset "HydrostaticFreeSurfaceModel tests" begin
+            include("test_hydrostatic_free_surface_models.jl")
+            include("test_ensemble_hydrostatic_free_surface_models.jl")
+            include("test_hydrostatic_free_surface_immersed_boundaries.jl")
+            include("test_vertical_vorticity_field.jl")
+            include("test_implicit_free_surface_solver.jl")
+            include("test_split_explicit_free_surface_solver.jl")
+            include("test_split_explicit_vertical_integrals.jl")
+            include("test_hydrostatic_free_surface_immersed_boundaries_implicit_solve.jl")
         end
+    end
 
-        if group == :hydrostatic_free_surface || group == :all
-            @testset "HydrostaticFreeSurfaceModel tests" begin
-                include("test_hydrostatic_free_surface_models.jl")
-                include("test_ensemble_hydrostatic_free_surface_models.jl")
-                include("test_hydrostatic_free_surface_immersed_boundaries.jl")
-                include("test_vertical_vorticity_field.jl")
-                include("test_implicit_free_surface_solver.jl")
-                include("test_split_explicit_free_surface_solver.jl")
-                include("test_split_explicit_vertical_integrals.jl")
-                include("test_hydrostatic_free_surface_immersed_boundaries_implicit_solve.jl")
-            end
+    # Model enhancements: cubed sphere, distributed, etc
+    if group == :multi_region || group == :all
+        @testset "Multi Region tests" begin
+            include("test_multi_region_unit.jl")
+            include("test_multi_region_advection_diffusion.jl")
+            include("test_multi_region_implicit_solver.jl")
+            include("test_multi_region_cubed_sphere.jl")
         end
+    end
 
-        # Model enhancements: cubed sphere, distributed, etc
-        if group == :multi_region || group == :all
-            @testset "Multi Region tests" begin
-                include("test_multi_region_unit.jl")
-                include("test_multi_region_advection_diffusion.jl")
-                include("test_multi_region_implicit_solver.jl")
-                include("test_multi_region_cubed_sphere.jl")
-            end
+    if group == :distributed || group == :all
+        MPI.Initialized() || MPI.Init()
+        include("test_distributed_models.jl")
+    end
+
+    if group == :distributed_solvers || group == :all
+        MPI.Initialized() || MPI.Init()
+        include("test_distributed_poisson_solvers.jl")
+    end
+
+    if group == :distributed_hydrostatic_model || group == :all
+        MPI.Initialized() || MPI.Init()
+        archs = test_architectures() 
+        include("test_hydrostatic_regression.jl")
+        include("test_distributed_hydrostatic_model.jl")
+    end
+
+    if group == :nonhydrostatic_regression || group == :all
+        include("test_nonhydrostatic_regression.jl")
+    end
+
+    if group == :hydrostatic_regression || group == :all
+        include("test_hydrostatic_regression.jl")
+    end
+
+    if group == :scripts || group == :all
+        @testset "Scripts" begin
+            include("test_validation.jl")
         end
+    end
 
-        if group == :distributed || group == :all
-            MPI.Initialized() || MPI.Init()
-            include("test_distributed_models.jl")
+    # Tests for Enzyme extension
+    if group == :enzyme || group == :all
+        @testset "Enzyme extension tests" begin
+            include("test_enzyme.jl")
         end
+    end
 
-        if group == :distributed_solvers || group == :all
-            MPI.Initialized() || MPI.Init()
-            include("test_distributed_poisson_solvers.jl")
-        end
-
-        if group == :distributed_hydrostatic_model || group == :all
-            MPI.Initialized() || MPI.Init()
-            archs = test_architectures() 
-            include("test_hydrostatic_regression.jl")
-            include("test_distributed_hydrostatic_model.jl")
-        end
-
-        if group == :nonhydrostatic_regression || group == :all
-            include("test_nonhydrostatic_regression.jl")
-        end
-
-        if group == :hydrostatic_regression || group == :all
-            include("test_hydrostatic_regression.jl")
-        end
-
-        if group == :scripts || group == :all
-            @testset "Scripts" begin
-                include("test_validation.jl")
-            end
-        end
-
-        # Tests for Enzyme extension
-        if group == :enzyme || group == :all
-            @testset "Enzyme extension tests" begin
-                include("test_enzyme.jl")
-            end
-        end
-
-        if group == :convergence
-            include("test_convergence.jl")
-        end
-
-    end # if test_file
+    if group == :convergence
+        include("test_convergence.jl")
+    end
 end
 
 end #CUDA.allowscalar()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,180 +3,186 @@ include("dependencies_for_runtests.jl")
 CUDA.allowscalar() do
 
 @testset "Oceananigans" begin
+
     if test_file != :none
+
+        # just testing a single file
         @testset "Single file test" begin
             include(String(test_file))
         end
-    end
 
-    # Core Oceananigans
-    if group == :unit || group == :all
-        @testset "Unit tests" begin
-            include("test_grids.jl")
-            include("test_operators.jl")
-            include("test_boundary_conditions.jl")
-            include("test_field.jl")
-            include("test_regrid.jl")
-            include("test_field_reductions.jl")
-            include("test_halo_regions.jl")
-            include("test_coriolis.jl")
-            include("test_buoyancy.jl")
-            include("test_stokes_drift.jl")
-            include("test_utils.jl")
-            include("test_schedules.jl")
+    else
+
+        # Core Oceananigans
+        if group == :unit || group == :all
+            @testset "Unit tests" begin
+                include("test_grids.jl")
+                include("test_operators.jl")
+                include("test_boundary_conditions.jl")
+                include("test_field.jl")
+                include("test_regrid.jl")
+                include("test_field_reductions.jl")
+                include("test_halo_regions.jl")
+                include("test_coriolis.jl")
+                include("test_buoyancy.jl")
+                include("test_stokes_drift.jl")
+                include("test_utils.jl")
+                include("test_schedules.jl")
+            end
         end
-    end
 
-    if group == :abstract_operations || group == :all
-        @testset "AbstractOperations and broadcasting tests" begin
-            include("test_abstract_operations.jl")
-            include("test_conditional_reductions.jl")
-            include("test_computed_field.jl")
-            include("test_broadcasting.jl")
+        if group == :abstract_operations || group == :all
+            @testset "AbstractOperations and broadcasting tests" begin
+                include("test_abstract_operations.jl")
+                include("test_conditional_reductions.jl")
+                include("test_computed_field.jl")
+                include("test_broadcasting.jl")
+            end
         end
-    end
 
-    if group == :poisson_solvers_1 || group == :all
-        @testset "Poisson Solvers 1" begin
-            include("test_poisson_solvers.jl")
+        if group == :poisson_solvers_1 || group == :all
+            @testset "Poisson Solvers 1" begin
+                include("test_poisson_solvers.jl")
+            end
         end
-    end
 
-    if group == :poisson_solvers_2 || group == :all
-        @testset "Poisson Solvers 2" begin
-            include("test_poisson_solvers_stretched_grids.jl")
+        if group == :poisson_solvers_2 || group == :all
+            @testset "Poisson Solvers 2" begin
+                include("test_poisson_solvers_stretched_grids.jl")
+            end
         end
-    end
 
-    if group == :matrix_poisson_solvers || group == :all
-        @testset "Matrix Poisson Solvers" begin
-            include("test_matrix_poisson_solver.jl")
+        if group == :matrix_poisson_solvers || group == :all
+            @testset "Matrix Poisson Solvers" begin
+                include("test_matrix_poisson_solver.jl")
+            end
         end
-    end
 
-    if group == :general_solvers || group == :all
-        @testset "General Solvers" begin
-            include("test_batched_tridiagonal_solver.jl")
-            include("test_preconditioned_conjugate_gradient_solver.jl")
+        if group == :general_solvers || group == :all
+            @testset "General Solvers" begin
+                include("test_batched_tridiagonal_solver.jl")
+                include("test_preconditioned_conjugate_gradient_solver.jl")
+            end
         end
-    end
 
-    # Simulations
-    if group == :simulation || group == :all
-        @testset "Simulation tests" begin
-            include("test_simulations.jl")
-            include("test_diagnostics.jl")
-            include("test_output_writers.jl")
-            include("test_netcdf_output_writer.jl")
-            include("test_output_readers.jl")
+        # Simulations
+        if group == :simulation || group == :all
+            @testset "Simulation tests" begin
+                include("test_simulations.jl")
+                include("test_diagnostics.jl")
+                include("test_output_writers.jl")
+                include("test_netcdf_output_writer.jl")
+                include("test_output_readers.jl")
+            end
         end
-    end
 
-    # Lagrangian particle tracking
-    if group == :lagrangian || group == :all
-        @testset "Lagrangian particle tracking tests" begin
-            include("test_lagrangian_particle_tracking.jl")
+        # Lagrangian particle tracking
+        if group == :lagrangian || group == :all
+            @testset "Lagrangian particle tracking tests" begin
+                include("test_lagrangian_particle_tracking.jl")
+            end
         end
-    end
 
-    # Models
-    if group == :time_stepping_1 || group == :all
-        @testset "Model and time stepping tests (part 1)" begin
-            include("test_nonhydrostatic_models.jl")
-            include("test_time_stepping.jl")
+        # Models
+        if group == :time_stepping_1 || group == :all
+            @testset "Model and time stepping tests (part 1)" begin
+                include("test_nonhydrostatic_models.jl")
+                include("test_time_stepping.jl")
+            end
         end
-    end
 
-    if group == :time_stepping_2 || group == :all
-        @testset "Model and time stepping tests (part 2)" begin
-            include("test_boundary_conditions_integration.jl")
-            include("test_forcings.jl")
-            include("test_immersed_advection.jl")
+        if group == :time_stepping_2 || group == :all
+            @testset "Model and time stepping tests (part 2)" begin
+                include("test_boundary_conditions_integration.jl")
+                include("test_forcings.jl")
+                include("test_immersed_advection.jl")
+            end
         end
-    end
 
-    if group == :time_stepping_3 || group == :all
-        @testset "Model and time stepping tests (part 3)" begin
-            include("test_dynamics.jl")
-            include("test_biogeochemistry.jl")
-            include("test_sewater_density.jl")
+        if group == :time_stepping_3 || group == :all
+            @testset "Model and time stepping tests (part 3)" begin
+                include("test_dynamics.jl")
+                include("test_biogeochemistry.jl")
+                include("test_sewater_density.jl")
+            end
         end
-    end
 
-    if group == :turbulence_closures || group == :all
-        @testset "Turbulence closures tests" begin
-            include("test_turbulence_closures.jl")
+        if group == :turbulence_closures || group == :all
+            @testset "Turbulence closures tests" begin
+                include("test_turbulence_closures.jl")
+            end
         end
-    end
 
-    if group == :shallow_water || group == :all
-        include("test_shallow_water_models.jl")
-    end
-
-    if group == :hydrostatic_free_surface || group == :all
-        @testset "HydrostaticFreeSurfaceModel tests" begin
-            include("test_hydrostatic_free_surface_models.jl")
-            include("test_ensemble_hydrostatic_free_surface_models.jl")
-            include("test_hydrostatic_free_surface_immersed_boundaries.jl")
-            include("test_vertical_vorticity_field.jl")
-            include("test_implicit_free_surface_solver.jl")
-            include("test_split_explicit_free_surface_solver.jl")
-            include("test_split_explicit_vertical_integrals.jl")
-            include("test_hydrostatic_free_surface_immersed_boundaries_implicit_solve.jl")
+        if group == :shallow_water || group == :all
+            include("test_shallow_water_models.jl")
         end
-    end
 
-    # Model enhancements: cubed sphere, distributed, etc
-    if group == :multi_region || group == :all
-        @testset "Multi Region tests" begin
-            include("test_multi_region_unit.jl")
-            include("test_multi_region_advection_diffusion.jl")
-            include("test_multi_region_implicit_solver.jl")
-            include("test_multi_region_cubed_sphere.jl")
+        if group == :hydrostatic_free_surface || group == :all
+            @testset "HydrostaticFreeSurfaceModel tests" begin
+                include("test_hydrostatic_free_surface_models.jl")
+                include("test_ensemble_hydrostatic_free_surface_models.jl")
+                include("test_hydrostatic_free_surface_immersed_boundaries.jl")
+                include("test_vertical_vorticity_field.jl")
+                include("test_implicit_free_surface_solver.jl")
+                include("test_split_explicit_free_surface_solver.jl")
+                include("test_split_explicit_vertical_integrals.jl")
+                include("test_hydrostatic_free_surface_immersed_boundaries_implicit_solve.jl")
+            end
         end
-    end
 
-    if group == :distributed || group == :all
-        MPI.Initialized() || MPI.Init()
-        include("test_distributed_models.jl")
-    end
-
-    if group == :distributed_solvers || group == :all
-        MPI.Initialized() || MPI.Init()
-        include("test_distributed_poisson_solvers.jl")
-    end
-
-    if group == :distributed_hydrostatic_model || group == :all
-        MPI.Initialized() || MPI.Init()
-        archs = test_architectures() 
-        include("test_hydrostatic_regression.jl")
-        include("test_distributed_hydrostatic_model.jl")
-    end
-
-    if group == :nonhydrostatic_regression || group == :all
-        include("test_nonhydrostatic_regression.jl")
-    end
-
-    if group == :hydrostatic_regression || group == :all
-        include("test_hydrostatic_regression.jl")
-    end
-
-    if group == :scripts || group == :all
-        @testset "Scripts" begin
-            include("test_validation.jl")
+        # Model enhancements: cubed sphere, distributed, etc
+        if group == :multi_region || group == :all
+            @testset "Multi Region tests" begin
+                include("test_multi_region_unit.jl")
+                include("test_multi_region_advection_diffusion.jl")
+                include("test_multi_region_implicit_solver.jl")
+                include("test_multi_region_cubed_sphere.jl")
+            end
         end
-    end
 
-    # Tests for Enzyme extension
-    if group == :enzyme || group == :all
-        @testset "Enzyme extension tests" begin
-            include("test_enzyme.jl")
+        if group == :distributed || group == :all
+            MPI.Initialized() || MPI.Init()
+            include("test_distributed_models.jl")
         end
-    end
 
-    if group == :convergence
-        include("test_convergence.jl")
-    end
+        if group == :distributed_solvers || group == :all
+            MPI.Initialized() || MPI.Init()
+            include("test_distributed_poisson_solvers.jl")
+        end
+
+        if group == :distributed_hydrostatic_model || group == :all
+            MPI.Initialized() || MPI.Init()
+            archs = test_architectures() 
+            include("test_hydrostatic_regression.jl")
+            include("test_distributed_hydrostatic_model.jl")
+        end
+
+        if group == :nonhydrostatic_regression || group == :all
+            include("test_nonhydrostatic_regression.jl")
+        end
+
+        if group == :hydrostatic_regression || group == :all
+            include("test_hydrostatic_regression.jl")
+        end
+
+        if group == :scripts || group == :all
+            @testset "Scripts" begin
+                include("test_validation.jl")
+            end
+        end
+
+        # Tests for Enzyme extension
+        if group == :enzyme || group == :all
+            @testset "Enzyme extension tests" begin
+                include("test_enzyme.jl")
+            end
+        end
+
+        if group == :convergence
+            include("test_convergence.jl")
+        end
+
+    end # if test_file
 end
 
 end #CUDA.allowscalar()


### PR DESCRIPTION
This PR removes the definition of `group` and `test_file` from the `dependencies_for_runtests.lj` otherwise these were redefined with every test file. Now, we are able to set their values and they remain constant for the whole test suite.

Also, now if the test find that `test_file != :none` then they set `group = :none` so that the test suite exits after the `@testset "Single file test"`.

With the current PR we can run a single file test-suite by providing it as an ENV variable. For example:

```Julia
$ TEST_FILE=test_coriolis.jl julia --project -e"using Pkg; Pkg.test()"
     Testing Oceananigans
      Status `/private/tmp/jl_p57glG/Project.toml`
⌃ [79e6a3ab] Adapt v4.0.2
  [6e4b80f9] BenchmarkTools v1.5.0
  [052768ef] CUDA v5.2.0
  [a2441757] Coverage v1.6.0
  [a8cc5b0e] Crayons v4.1.1
  [7445602f] CubedSphere v0.2.5
  [124859b0] DataDeps v0.7.13
  [b4f34e82] Distances v0.10.11
  [ffbed154] DocStringExtensions v0.9.3
  [7da242da] Enzyme v0.11.19
  [7a1cc6ca] FFTW v1.8.0
  [c27321d9] Glob v1.3.1
  [40713840] IncompleteLU v0.2.1
  [42fd0dbc] IterativeSolvers v0.9.4
  [033835bb] JLD2 v0.4.46
  [63c18a36] KernelAbstractions v0.9.18
  [da04e1cc] MPI v0.20.19
  [3da0fdf6] MPIPreferences v0.1.10
  [85f8d34a] NCDatasets v0.14.3
  [9e8cae18] Oceananigans v0.90.11 `~/Research/OC11.jl`
  [6fe1bfb0] OffsetArrays v1.13.0
  [bac558e1] OrderedCollections v1.6.3
  [0e08944d] PencilArrays v0.19.3
  [4a48f351] PencilFFTs v0.15.1
  [91a5bcdd] Plots v1.40.2
  [6038ab10] Rotations v1.7.0
  [1bc83da4] SafeTestsets v0.1.0
  [d496a93d] SeawaterPolynomials v0.3.4
  [09ab397b] StructArrays v0.6.18
  [a759f4b9] TimerOutputs v0.5.23
  [bdfc003b] TimesDates v0.3.1
⌅ [76a88914] CUDA_Runtime_jll v0.11.1+0
⌅ [fe0851c0] OpenMPI_jll v4.1.6+0
  [ade2ca70] Dates
  [b77e0a4c] InteractiveUtils
  [37e2e46d] LinearAlgebra
  [56ddb016] Logging
  [44cfe95a] Pkg v1.10.0
  [de0858da] Printf
  [9a3f8284] Random
  [2f01184e] SparseArrays v1.10.0
  [10745b16] Statistics v1.10.0
  [8dfed614] Test
      Status `/private/tmp/jl_p57glG/Manifest.toml`
  [621f4979] AbstractFFTs v1.5.0
⌃ [79e6a3ab] Adapt v4.0.2
⌃ [4fba245c] ArrayInterface v7.8.0
  [a9b6321e] Atomix v0.1.0
⌃ [ab4f0b2a] BFloat16s v0.4.2
  [6e4b80f9] BenchmarkTools v1.5.0
  [d1d4a3ce] BitFlags v0.1.8
  [fa961155] CEnum v0.5.0
  [179af706] CFTime v0.1.3
  [052768ef] CUDA v5.2.0
  [1af6417a] CUDA_Runtime_Discovery v0.2.3
  [944b1d66] CodecZlib v0.7.4
  [35d6a980] ColorSchemes v3.24.0
  [3da002f7] ColorTypes v0.11.4
  [c3611d14] ColorVectorSpace v0.10.0
  [5ae59095] Colors v0.12.10
  [1fbeeb36] CommonDataModel v0.3.5
  [34da2185] Compat v4.14.0
  [a216cea6] CompoundPeriods v0.5.1
  [f0e56b4a] ConcurrentUtilities v2.4.0
  [187b0558] ConstructionBase v1.5.4
  [d38c429a] Contour v0.6.2
  [a2441757] Coverage v1.6.0
  [c36e975a] CoverageTools v1.3.0
  [a8cc5b0e] Crayons v4.1.1
  [7445602f] CubedSphere v0.2.5
  [9a962f9c] DataAPI v1.16.0
  [124859b0] DataDeps v0.7.13
  [a93c6f00] DataFrames v1.6.1
  [864edb3b] DataStructures v0.18.18
  [e2d170a0] DataValueInterfaces v1.0.0
  [8bb1440f] DelimitedFiles v1.9.1
⌅ [3c3547ce] DiskArrays v0.3.23
  [b4f34e82] Distances v0.10.11
  [ffbed154] DocStringExtensions v0.9.3
  [b305315f] Elliptic v1.0.1
  [7da242da] Enzyme v0.11.19
⌅ [f151be2c] EnzymeCore v0.6.5
  [460bff9d] ExceptionUnwrapping v0.1.10
  [e2ba6199] ExprTools v0.1.10
  [c87230d0] FFMPEG v0.4.1
  [7a1cc6ca] FFTW v1.8.0
  [5789e2e9] FileIO v1.16.2
  [53c48c17] FixedPointNumbers v0.8.4
  [1fa38f19] Format v1.3.6
  [0c68f7d7] GPUArrays v10.0.2
  [46192b85] GPUArraysCore v0.1.6
⌅ [61eb1bfa] GPUCompiler v0.25.0
  [28b8d3ca] GR v0.73.3
  [c27321d9] Glob v1.3.1
  [42e2da0e] Grisu v1.0.2
  [cd3eb016] HTTP v1.10.3
  [615f187c] IfElse v0.1.1
  [40713840] IncompleteLU v0.2.1
  [842dd82b] InlineStrings v1.4.0
  [41ab1584] InvertedIndices v1.3.0
  [92d709cd] IrrationalConstants v0.2.2
  [42fd0dbc] IterativeSolvers v0.9.4
  [82899510] IteratorInterfaceExtensions v1.0.0
  [033835bb] JLD2 v0.4.46
  [1019f520] JLFzf v0.1.7
  [692b3bcd] JLLWrappers v1.5.0
  [682c06a0] JSON v0.21.4
  [0f8b85d8] JSON3 v1.14.0
  [63c18a36] KernelAbstractions v0.9.18
  [929cbde3] LLVM v6.6.0
  [8b046642] LLVMLoopInfo v1.0.0
  [8ac3fa9e] LRUCache v1.6.1
  [b964fa9f] LaTeXStrings v1.3.1
  [23fbe1c1] Latexify v0.16.2
  [2ab3a3ac] LogExpFunctions v0.3.27
  [e6f89c97] LoggingExtras v1.0.3
  [da04e1cc] MPI v0.20.19
  [3da0fdf6] MPIPreferences v0.1.10
  [1914dd2f] MacroTools v0.5.13
  [739be429] MbedTLS v1.1.9
  [442fdcdd] Measures v0.3.2
  [e1d29d7a] Missings v1.1.0
  [78c3b35d] Mocking v0.7.7
  [85f8d34a] NCDatasets v0.14.3
  [5da4648a] NVTX v0.3.4
  [77ba4419] NaNMath v1.0.2
  [d8793406] ObjectFile v0.4.1
  [9e8cae18] Oceananigans v0.90.11 `~/Research/OC11.jl`
  [6fe1bfb0] OffsetArrays v1.13.0
  [4d8831e6] OpenSSL v1.4.2
  [bac558e1] OrderedCollections v1.6.3
  [65ce6f38] PackageExtensionCompat v1.0.2
  [69de0a69] Parsers v2.8.1
  [0e08944d] PencilArrays v0.19.3
  [4a48f351] PencilFFTs v0.15.1
  [b98c9c47] Pipe v1.3.0
  [eebad327] PkgVersion v0.3.3
  [ccf2f8ad] PlotThemes v3.1.0
  [995b91a9] PlotUtils v1.4.1
  [91a5bcdd] Plots v1.40.2
  [2dfb63ee] PooledArrays v1.4.3
⌃ [aea7be01] PrecompileTools v1.2.0
  [21216c6a] Preferences v1.4.3
  [08abe8d2] PrettyTables v2.3.1
  [49802e3a] ProgressBars v1.5.1
  [94ee1d12] Quaternions v0.7.6
  [74087812] Random123 v1.7.0
  [e6cf234a] RandomNumbers v1.5.3
  [c1ae055f] RealDot v0.1.0
  [3cdcf5f2] RecipesBase v1.3.4
  [01d81517] RecipesPipeline v0.6.12
  [189a3867] Reexport v1.2.2
  [05181044] RelocatableFolders v1.0.1
  [ae029012] Requires v1.3.0
  [6038ab10] Rotations v1.7.0
  [1bc83da4] SafeTestsets v0.1.0
  [6c6a2e73] Scratch v1.2.1
  [d496a93d] SeawaterPolynomials v0.3.4
  [91c51154] SentinelArrays v1.4.1
  [992d4aef] Showoff v1.0.3
  [777ac1f9] SimpleBufferStream v1.1.0
  [a2af1166] SortingAlgorithms v1.2.1
  [276daf66] SpecialFunctions v2.3.1
  [aedffcd0] Static v0.8.10
  [0d7ed370] StaticArrayInterface v1.5.0
  [90137ffa] StaticArrays v1.9.3
  [1e83bf80] StaticArraysCore v1.4.2
  [15972242] StaticPermutations v0.3.0
  [82ae8749] StatsAPI v1.7.0
  [2913bbd2] StatsBase v0.34.2
  [5e0ebb24] Strided v2.0.4
  [4db3bf67] StridedViews v0.2.2
  [892a3eda] StringManipulation v0.3.4
  [09ab397b] StructArrays v0.6.18
  [53d494c1] StructIO v0.3.0
  [856f2bd8] StructTypes v1.10.0
  [dc5dba14] TZJData v1.1.0+2023d
  [3783bdb8] TableTraits v1.0.1
  [bd369af6] Tables v1.11.1
⌅ [6aa5eb33] TaylorSeries v0.16.0
  [62fd8b95] TensorCore v0.1.1
  [f269a46b] TimeZones v1.13.0
  [a759f4b9] TimerOutputs v0.5.23
  [bdfc003b] TimesDates v0.3.1
  [3bb67fe8] TranscodingStreams v0.10.4
  [9d95972d] TupleTools v1.5.0
  [5c2747f8] URIs v1.5.1
  [1cfade01] UnicodeFun v0.4.1
  [1986cc42] Unitful v1.19.0
  [45397f5d] UnitfulLatexify v1.6.3
  [013be700] UnsafeAtomics v0.2.1
  [d80eeb9a] UnsafeAtomicsLLVM v0.1.3
  [41fe7b60] Unzip v0.2.0
  [81def892] VersionParsing v1.3.0
  [0b7ba130] Blosc_jll v1.21.5+0
  [6e34b625] Bzip2_jll v1.0.8+1
⌅ [4ee394cb] CUDA_Driver_jll v0.7.0+1
⌅ [76a88914] CUDA_Runtime_jll v0.11.1+0
  [83423d85] Cairo_jll v1.18.0+1
  [7cc45869] Enzyme_jll v0.0.102+0
  [2702e6a9] EpollShim_jll v0.0.20230411+0
  [2e619515] Expat_jll v2.5.0+0
⌅ [b22a6f82] FFMPEG_jll v4.4.4+1
  [f5851436] FFTW_jll v3.3.10+0
  [a3f928ae] Fontconfig_jll v2.13.93+0
  [d7e528f0] FreeType2_jll v2.13.1+0
  [559328eb] FriBidi_jll v1.0.10+0
  [0656b61e] GLFW_jll v3.3.9+0
  [d2c73de3] GR_jll v0.73.3+0
  [78b55507] Gettext_jll v0.21.0+0
  [7746bdde] Glib_jll v2.80.0+0
  [0951126a] GnuTLS_jll v3.8.3+0
  [3b182d85] Graphite2_jll v1.3.14+0
  [0234f1f7] HDF5_jll v1.14.3+1
  [2e76f6c2] HarfBuzz_jll v2.8.1+1
  [e33a78d0] Hwloc_jll v2.10.0+0
  [1d5cc7b8] IntelOpenMP_jll v2024.0.2+0
  [aacddb02] JpegTurbo_jll v3.0.2+0
  [9c1d0b0a] JuliaNVTXCallbacks_jll v0.2.1+0
  [c1c5ebd0] LAME_jll v3.100.1+0
  [88015f11] LERC_jll v3.0.0+1
  [dad2f222] LLVMExtra_jll v0.0.29+0
  [1d63c593] LLVMOpenMP_jll v15.0.7+0
  [dd4b983a] LZO_jll v2.10.1+0
⌅ [e9f186c6] Libffi_jll v3.2.2+1
  [d4300ac3] Libgcrypt_jll v1.8.7+0
  [7e76a0d4] Libglvnd_jll v1.6.0+0
  [7add5ba3] Libgpg_error_jll v1.42.0+0
  [94ce4f54] Libiconv_jll v1.17.0+0
  [4b2f31a3] Libmount_jll v2.39.3+0
⌅ [89763e89] Libtiff_jll v4.5.1+1
  [38a345b3] Libuuid_jll v2.39.3+1
  [5ced341a] Lz4_jll v1.9.4+0
  [856f044c] MKL_jll v2024.0.0+0
  [7cb0a576] MPICH_jll v4.2.0+0
  [f1f71cc9] MPItrampoline_jll v5.3.2+0
  [9237b28f] MicrosoftMPI_jll v10.1.4+2
  [e98f9f5b] NVTX_jll v3.1.0+2
  [7243133f] NetCDF_jll v400.902.209+0
  [4c82536e] Nettle_jll v3.7.2+0
  [e7412a2a] Ogg_jll v1.3.5+1
⌅ [fe0851c0] OpenMPI_jll v4.1.6+0
  [458c3c95] OpenSSL_jll v3.0.13+0
  [efe28fd5] OpenSpecFun_jll v0.5.5+0
  [91d4177d] Opus_jll v1.3.2+0
  [c2071276] P11Kit_jll v0.24.1+0
  [30392449] Pixman_jll v0.42.2+0
  [c0090381] Qt6Base_jll v6.5.3+1
  [a44049a8] Vulkan_Loader_jll v1.3.243+0
  [a2964d1f] Wayland_jll v1.21.0+1
  [2381bf8a] Wayland_protocols_jll v1.31.0+0
  [02c8fc9c] XML2_jll v2.12.5+0
  [aed1982a] XSLT_jll v1.1.34+0
⌃ [ffd25f8a] XZ_jll v5.6.0+0
  [f67eecfb] Xorg_libICE_jll v1.0.10+1
  [c834827a] Xorg_libSM_jll v1.2.3+0
  [4f6342f7] Xorg_libX11_jll v1.8.6+0
  [0c0b7dd1] Xorg_libXau_jll v1.0.11+0
  [935fb764] Xorg_libXcursor_jll v1.2.0+4
  [a3789734] Xorg_libXdmcp_jll v1.1.4+0
  [1082639a] Xorg_libXext_jll v1.3.4+4
  [d091e8ba] Xorg_libXfixes_jll v5.0.3+4
  [a51aa0fd] Xorg_libXi_jll v1.7.10+4
  [d1454406] Xorg_libXinerama_jll v1.1.4+4
  [ec84b674] Xorg_libXrandr_jll v1.5.2+4
  [ea2f1a96] Xorg_libXrender_jll v0.9.10+4
  [14d82f49] Xorg_libpthread_stubs_jll v0.1.1+0
  [c7cfdc94] Xorg_libxcb_jll v1.15.0+0
  [cc61e674] Xorg_libxkbfile_jll v1.1.2+0
  [e920d4aa] Xorg_xcb_util_cursor_jll v0.1.4+0
  [12413925] Xorg_xcb_util_image_jll v0.4.0+1
  [2def613f] Xorg_xcb_util_jll v0.4.0+1
  [975044d2] Xorg_xcb_util_keysyms_jll v0.4.0+1
  [0d47668e] Xorg_xcb_util_renderutil_jll v0.3.9+1
  [c22f9ab0] Xorg_xcb_util_wm_jll v0.4.1+1
  [35661453] Xorg_xkbcomp_jll v1.4.6+0
  [33bec58e] Xorg_xkeyboard_config_jll v2.39.0+0
  [c5fb5394] Xorg_xtrans_jll v1.5.0+0
  [3161d3a3] Zstd_jll v1.5.5+0
  [35ca27e7] eudev_jll v3.2.9+0
  [214eeab7] fzf_jll v0.43.0+0
  [1a1c6b14] gperf_jll v3.1.1+0
  [477f73a3] libaec_jll v1.1.2+0
  [a4ae2306] libaom_jll v3.4.0+0
  [0ac62f75] libass_jll v0.15.1+0
  [2db6ffa8] libevdev_jll v1.11.0+0
  [f638f0a6] libfdk_aac_jll v2.0.2+0
  [36db933b] libinput_jll v1.18.0+0
  [b53b4c65] libpng_jll v1.6.43+1
  [f27f6e37] libvorbis_jll v1.3.7+1
  [337d8026] libzip_jll v1.10.1+0
  [009596ad] mtdev_jll v1.1.6+0
  [1270edf5] x264_jll v2021.5.5+0
  [dfaa095f] x265_jll v3.5.0+0
  [d8fb68d0] xkbcommon_jll v1.4.1+1
  [0dad84c5] ArgTools v1.1.1
  [56f22d72] Artifacts
  [2a0f44e3] Base64
  [ade2ca70] Dates
  [8ba89e20] Distributed
  [f43a241f] Downloads v1.6.0
  [7b1f6079] FileWatching
  [9fa8497b] Future
  [b77e0a4c] InteractiveUtils
  [4af54fe1] LazyArtifacts
  [b27032c2] LibCURL v0.6.4
  [76f85450] LibGit2
  [8f399da3] Libdl
  [37e2e46d] LinearAlgebra
  [56ddb016] Logging
  [d6f4376e] Markdown
  [a63ad114] Mmap
  [ca575930] NetworkOptions v1.2.0
  [44cfe95a] Pkg v1.10.0
  [de0858da] Printf
  [9abbd945] Profile
  [3fa0cd96] REPL
  [9a3f8284] Random
  [ea8e919c] SHA v0.7.0
  [9e88b42a] Serialization
  [6462fe0b] Sockets
  [2f01184e] SparseArrays v1.10.0
  [10745b16] Statistics v1.10.0
  [4607b0f0] SuiteSparse
  [fa267f1f] TOML v1.0.3
  [a4e569a6] Tar v1.10.0
  [8dfed614] Test
  [cf7118a7] UUIDs
  [4ec0a83e] Unicode
  [e66e0078] CompilerSupportLibraries_jll v1.1.0+0
  [781609d7] GMP_jll v6.2.1+6
  [deac9b47] LibCURL_jll v8.4.0+0
  [e37daf67] LibGit2_jll v1.6.4+0
  [29816b5a] LibSSH2_jll v1.11.0+1
  [c8ffd9c3] MbedTLS_jll v2.28.2+1
  [14a3606d] MozillaCACerts_jll v2023.1.10
  [4536629a] OpenBLAS_jll v0.3.23+4
  [05823500] OpenLibm_jll v0.8.1+2
  [efcefdf7] PCRE2_jll v10.42.0+1
  [bea87d4a] SuiteSparse_jll v7.2.1+1
  [83775a58] Zlib_jll v1.2.13+1
  [8e850b90] libblastrampoline_jll v5.8.0+1
  [8e850ede] nghttp2_jll v1.52.0+1
  [3f19e933] p7zip_jll v17.4.0+2
        Info Packages marked with ⌃ and ⌅ have new versions available. Those with ⌃ may be upgradable, but those with ⌅ are restricted by compatibility constraints from upgrading.
     Testing Running tests...
MPIPreferences:
  binary:  MPICH_jll
  abi:     MPICH

Package versions
  MPI.jl:             0.20.19
  MPIPreferences.jl:  0.1.10
  MPICH_jll:          4.2.0+0

Library information:
  libmpi:  /Users/navid/.julia/artifacts/5c81ad3c4ead80006fae560b5e6f06fa265aefb1/lib/libmpi.12.dylib
  libmpi dlpath:  /Users/navid/.julia/artifacts/5c81ad3c4ead80006fae560b5e6f06fa265aefb1/lib/libmpi.12.dylib
  MPI version:  4.1.0
  Library version:  
    MPICH Version:      4.2.0
    MPICH Release date: Fri Feb  9 12:29:21 CST 2024
    MPICH ABI:          16:0:4
    MPICH Device:       ch3:nemesis
    MPICH configure:    --prefix=/workspace/destdir --build=x86_64-linux-musl --host=aarch64-apple-darwin20 --disable-dependency-tracking --docdir=/tmp --enable-fast=all,O3 --enable-static=no --mandir=/tmp --with-device=ch3 --with-hwloc=/workspace/destdir FFLAGS=-fallow-argument-mismatch FCFLAGS=-fallow-argument-mismatch
    MPICH CC:           cc   -fno-common  -DNDEBUG -DNVALGRIND -O3
    MPICH CXX:          c++   -DNDEBUG -DNVALGRIND -O3
    MPICH F77:          gfortran -fallow-argument-mismatch  -O3
    MPICH FC:           gfortran -fallow-argument-mismatch  -O3
    MPICH features:     
    
[ Info: Oceananigans will use 8 threads
MPIPreferences:
  binary:  MPICH_jll
  abi:     MPICH

Package versions
  MPI.jl:             0.20.19
  MPIPreferences.jl:  0.1.10
  MPICH_jll:          4.2.0+0

Library information:
  libmpi:  /Users/navid/.julia/artifacts/5c81ad3c4ead80006fae560b5e6f06fa265aefb1/lib/libmpi.12.dylib
  libmpi dlpath:  /Users/navid/.julia/artifacts/5c81ad3c4ead80006fae560b5e6f06fa265aefb1/lib/libmpi.12.dylib
  MPI version:  4.1.0
  Library version:  
    MPICH Version:      4.2.0
    MPICH Release date: Fri Feb  9 12:29:21 CST 2024
    MPICH ABI:          16:0:4
    MPICH Device:       ch3:nemesis
    MPICH configure:    --prefix=/workspace/destdir --build=x86_64-linux-musl --host=aarch64-apple-darwin20 --disable-dependency-tracking --docdir=/tmp --enable-fast=all,O3 --enable-static=no --mandir=/tmp --with-device=ch3 --with-hwloc=/workspace/destdir FFLAGS=-fallow-argument-mismatch FCFLAGS=-fallow-argument-mismatch
    MPICH CC:           cc   -fno-common  -DNDEBUG -DNVALGRIND -O3
    MPICH CXX:          c++   -DNDEBUG -DNVALGRIND -O3
    MPICH F77:          gfortran -fallow-argument-mismatch  -O3
    MPICH FC:           gfortran -fallow-argument-mismatch  -O3
    MPICH features:     
    
WARNING: Method definition test_architectures() in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:14 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition summarize_regression_test(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:32 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition center_clustered_coord(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:53 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition boundary_clustered_coord(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:64 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition cpu_∇²!(Any, Any, Any, Any) in module Main overwritten.
WARNING: Method definition gpu_∇²!(Any, Any, Any, Any) in module Main overwritten.
WARNING: Method definition cpu_divergence!(Any, Any, Any, Any, Any, Any) in module Main overwritten.
WARNING: Method definition gpu_divergence!(Any, Any, Any, Any, Any, Any) in module Main overwritten.
WARNING: Method definition compute_∇²!(Any, Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:88 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition interior(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:100 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition datatuple(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:104 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition datatuple(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:105 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition get_output_tuple(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:107 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition run_script(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:114 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition run_script(Any, Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:114 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition discrete_func(Any, Any, Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:162 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_discrete_func(Any, Any, Any, Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:163 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_fun(Any, Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:165 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition field_dependent_fun(Any, Any, Any, Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:166 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition exploding_fun(Any, Any, Any, Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:167 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition integer_bc(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:170 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition integer_bc(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:170 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition integer_bc(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:170 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition float_bc(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:171 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition float_bc(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:171 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition float_bc(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:171 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition irrational_bc(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:172 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition irrational_bc(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:172 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition irrational_bc(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:172 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition array_bc(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:173 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition array_bc(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:173 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition array_bc(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:173 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition simple_function_bc(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:174 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition simple_function_bc(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:174 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition simple_function_bc(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:174 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_function_bc(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:175 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_function_bc(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:175 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_function_bc(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:175 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition field_dependent_function_bc(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:176 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition field_dependent_function_bc(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:176 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition field_dependent_function_bc(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:176 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition discrete_function_bc(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:177 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition discrete_function_bc(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:177 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition discrete_function_bc(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:177 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_discrete_function_bc(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:179 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_discrete_function_bc(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:179 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_discrete_function_bc(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:179 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_field_dependent_function_bc(Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:180 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_field_dependent_function_bc(Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:180 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition parameterized_field_dependent_function_bc(Any, Any, Any) in module Main at /Users/navid/Research/OC11.jl/test/utils_for_runtests.jl:180 overwritten on the same line (check for duplicate calls to `include`).
[2024/03/15 16:21:27.055] INFO  Testing Coriolis...
FPlane{Float32}(f=0.000103126)
ConstantCartesianCoriolis{Float32}: fx = 0.00e+00, fy = 0.00e+00, fz = 1.00e-04
BetaPlane{Float32}(f₀=0.000103126, β=1.61868e-11)
NonTraditionalBetaPlane{Float32}(fz = 1.03e-04, fy = 1.03e-04, β = 1.62e-11, γ = -3.24e-11, R = 6.37e+06)
FPlane{Float64}(f=0.000103126)
ConstantCartesianCoriolis{Float64}: fx = 0.00e+00, fy = 0.00e+00, fz = 1.00e-04
BetaPlane{Float64}(f₀=0.000103126, β=1.61868e-11)
NonTraditionalBetaPlane{Float64}(fz = 1.03e-04, fy = 1.03e-04, β = 1.62e-11, γ = -3.24e-11, R = 6.37e+06)
Test Summary: | Pass  Total  Time
Oceananigans  |   90     90  1.8s
     Testing Oceananigans tests passed 
```

Closes #3507