### PR TITLE
Automatically try to reshape arrays when encountering DimensionMismatch

### DIFF
--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -76,8 +76,7 @@ function set!(u::Field, f::Union{Array, CuArray, OffsetArray})
         u .= f
     catch err
         if err isa DimensionMismatch
-            sz_f = size(f)
-            sz_u = Nx, Ny, Nz = size(u)
+            Nx, Ny, Nz = size(u)
             u .= reshape(f, Nx, Ny, Nz)
 
             msg = string("Reshaped ", summary(f),

--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -71,7 +71,24 @@ end
 
 function set!(u::Field, f::Union{Array, CuArray, OffsetArray})
     f = on_architecture(architecture(u), f)
-    u .= f
+
+    try
+        u .= f
+    catch err
+        if err isa DimensionMismatch
+            sz_f = size(f)
+            sz_u = Nx, Ny, Nz = size(u)
+            u .= reshape(f, Nx, Ny, Nz)
+
+            msg = string("Reshaped ", summary(f),
+                         " to set! its data to ", '\n',
+                         summary(u))
+            @warn msg
+        else
+            throw(err)
+        end
+    end
+
     return u
 end
 


### PR DESCRIPTION
This is a small nicety for friendliness^TM. For safety^TM we throw a warning if we reshaped. Just in case it wasn't intended.

This allows things like

```julia
julia> grid = RectilinearGrid(size=(2, 3, 4), x=(0, 1), y=(0, 1), z=(0, 1))
2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
├── Periodic x ∈ [0.0, 1.0) regularly spaced with Δx=0.5
├── Periodic y ∈ [0.0, 1.0) regularly spaced with Δy=0.333333
└── Bounded  z ∈ [0.0, 1.0] regularly spaced with Δz=0.25

julia> c = Field{Nothing, Nothing, Center}(grid)
1×1×4 Field{Nothing, Nothing, Center} reduced over dims = (1, 2) on RectilinearGrid on CPU
├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
├── boundary conditions: FieldBoundaryConditions
│   └── west: Nothing, east: Nothing, south: Nothing, north: Nothing, bottom: ZeroFlux, top: ZeroFlux, immersed: ZeroFlux
└── data: 1×1×10 OffsetArray(::Array{Float64, 3}, 1:1, 1:1, -2:7) with eltype Float64 with indices 1:1×1:1×-2:7
    └── max=0.0, min=0.0, mean=0.0

julia> set!(c, rand(4))
┌ Warning: Reshaped 4-element Vector{Float64} to set! its data to
│ 1×1×4 Field{Nothing, Nothing, Center} reduced over dims = (1, 2) on RectilinearGrid on CPU
└ @ Oceananigans.Fields ~/Projects/Oceananigans.jl/src/Fields/set!.jl:86
1×1×4 Field{Nothing, Nothing, Center} reduced over dims = (1, 2) on RectilinearGrid on CPU
├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
├── boundary conditions: FieldBoundaryConditions
│   └── west: Nothing, east: Nothing, south: Nothing, north: Nothing, bottom: ZeroFlux, top: ZeroFlux, immersed: ZeroFlux
└── data: 1×1×10 OffsetArray(::Array{Float64, 3}, 1:1, 1:1, -2:7) with eltype Float64 with indices 1:1×1:1×-2:7
    └── max=0.172696, min=0.00231136, mean=0.0906944
```

which is nice when working with 1D data.