### PR TITLE
Update climacommon to 2024_04_05

### DIFF
--- a/.buildkite/distributed/pipeline.yml
+++ b/.buildkite/distributed/pipeline.yml
@@ -1,14 +1,13 @@
 agents:
   queue: new-central
   slurm_mem: 8G
-  modules: climacommon/2024_03_18
+  modules: climacommon/2024_04_05
 
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite/distributed"
   OPENBLAS_NUM_THREADS: 1
   OMPI_MCA_opal_warn_on_missing_libcuda: 0
-  JULIA_CPU_TARGET: 'broadwell;skylake'
 
 steps:
   - label: "initialize"


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖 Good news! I found a way to reduce unnecessary precompilations! Have you ever noticed that when you move to a GPU node from a CPU one (or viceversa), everything has to be recompiled again? Or sometimes it seems that you are always precompiling... Well, this is partially because the nodes on the Caltech cluster have different architectures, and Julia compiles for the native one, but when you move to a new architecture, the compiled code has to be invalidated and recompiled again. With the latest version of climacommon, I force Julia to always compile for all the possible targets in our cluster. Buildkite pipelines partially do this with the JULIA_TARGET_CPU, but the strings there are incorrect. This PR fixes that too. 