### PR TITLE
Fix bug when using Lagrangian particles on Flat topologies

### DIFF
--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -15,7 +15,7 @@ using Oceananigans.Architectures: child_architecture
 """
     index_binary_search(val, vec, N)
 
-Return indices `low, high` of `vec`tor for which 
+Return indices `low, high` of `vec`tor for which
 
 ```julia
 vec[low] ≤ val && vec[high] ≥ val
@@ -29,9 +29,9 @@ Code credit: https://gist.github.com/cuongld2/8e4fed9ba44ea2b4598f90e7d5b6c612/1
     low = 0
     high = N - 1
 
-    while low + 1 < high 
+    while low + 1 < high
         mid = middle_point(low, high)
-        if @inbounds vec[mid + 1] == val 
+        if @inbounds vec[mid + 1] == val
             return (mid + 1, mid + 1)
         elseif @inbounds vec[mid + 1] < val
             low = mid
@@ -212,6 +212,23 @@ end
 end
 
 """
+    truncate_fractional_indices(fi, fj, fk)
+
+Truncate _fractional_ indices output from `fractional_indices` to integer indices, dealing
+with `nothing` indices for `Flat` domains.
+"""
+@inline function truncate_fractional_indices(fi, fj, fk)
+    i = _truncate_fractional_index(fi)
+    j = _truncate_fractional_index(fj)
+    k = _truncate_fractional_index(fk)
+    return (i, j, k)
+end
+
+@inline _truncate_fractional_index(::Nothing) = 1
+@inline _truncate_fractional_index(fi) = Base.unsafe_trunc(Int, fi)
+
+
+"""
     interpolate(at_node, from_field, from_loc, from_grid)
 
 Interpolate `from_field`, `at_node`, on `from_grid` and at `from_loc`ation,
@@ -277,7 +294,7 @@ end
     k⁻, k⁺, ζ = iz
 
     return @inbounds ϕ₁(ξ, η, ζ) * getindex(data, i⁻, j⁻, k⁻, in...) +
-                     ϕ₂(ξ, η, ζ) * getindex(data, i⁻, j⁻, k⁺, in...) +  
+                     ϕ₂(ξ, η, ζ) * getindex(data, i⁻, j⁻, k⁺, in...) +
                      ϕ₃(ξ, η, ζ) * getindex(data, i⁻, j⁺, k⁻, in...) +
                      ϕ₄(ξ, η, ζ) * getindex(data, i⁻, j⁺, k⁺, in...) +
                      ϕ₅(ξ, η, ζ) * getindex(data, i⁺, j⁻, k⁻, in...) +
@@ -316,7 +333,7 @@ function interpolate!(to_field::Field, from_field::AbstractField)
     to_arch   = architecture(to_field)
     from_arch = architecture(from_field)
 
-    # In case architectures are `Distributed` we 
+    # In case architectures are `Distributed` we
     # verify that the fields are on the same child architecture
     to_arch   = child_architecture(to_arch)
     from_arch = child_architecture(from_arch)
@@ -338,4 +355,3 @@ function interpolate!(to_field::Field, from_field::AbstractField)
 
     return nothing
 end
-

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -218,14 +218,14 @@ Truncate _fractional_ indices output from fractional indices `fi, fj, fk` to int
 with `nothing` indices for `Flat` domains.
 """
 @inline function truncate_fractional_indices(fi, fj, fk)
-    i = _truncate_fractional_index(fi)
-    j = _truncate_fractional_index(fj)
-    k = _truncate_fractional_index(fk)
+    i = truncate_fractional_index(fi)
+    j = truncate_fractional_index(fj)
+    k = truncate_fractional_index(fk)
     return (i, j, k)
 end
 
-@inline _truncate_fractional_index(::Nothing) = 1
-@inline _truncate_fractional_index(fi) = Base.unsafe_trunc(Int, fi)
+@inline truncate_fractional_index(::Nothing) = 1
+@inline truncate_fractional_index(fi) = Base.unsafe_trunc(Int, fi)
 
 
 """

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -214,7 +214,7 @@ end
 """
     truncate_fractional_indices(fi, fj, fk)
 
-Truncate _fractional_ indices output from `fractional_indices` to integer indices, dealing
+Truncate _fractional_ indices output from fractional indices `fi, fj, fk` to integer indices, dealing
 with `nothing` indices for `Flat` domains.
 """
 @inline function truncate_fractional_indices(fi, fj, fk)

--- a/src/Models/LagrangianParticleTracking/LagrangianParticleTracking.jl
+++ b/src/Models/LagrangianParticleTracking/LagrangianParticleTracking.jl
@@ -17,7 +17,7 @@ using Oceananigans.Grids: XYFlatGrid, YZFlatGrid, XZFlatGrid
 using Oceananigans.ImmersedBoundaries: immersed_cell
 using Oceananigans.Architectures: device, architecture
 using Oceananigans.Fields: interpolate, datatuple, compute!, location
-using Oceananigans.Fields: fractional_indices
+using Oceananigans.Fields: fractional_indices, truncate_fractional_indices
 using Oceananigans.TimeSteppers: AbstractLagrangianParticles
 using Oceananigans.Utils: prettysummary, launch!, SumOfArrays
 
@@ -135,7 +135,7 @@ step_lagrangian_particles!(::Nothing, model, Δt) = nothing
 function step_lagrangian_particles!(particles::LagrangianParticles, model, Δt)
     # Update the properties of the Lagrangian particles
     update_lagrangian_particle_properties!(particles, model, Δt)
-    
+
     # Compute dynamics
     particles.dynamics(particles, model, Δt)
 

--- a/src/Models/LagrangianParticleTracking/lagrangian_particle_advection.jl
+++ b/src/Models/LagrangianParticleTracking/lagrangian_particle_advection.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Utils: instantiate 
+using Oceananigans.Utils: instantiate
 using Oceananigans.Models: total_velocities
 
 #####
@@ -41,23 +41,23 @@ bouncing the particle off the immersed boundary with a coefficient or `restituti
     X = flattened_node((x, y, z), ibg)
 
     # Determine current particle cell
-    i, j, k = fractional_indices(X, ibg.underlying_grid, (c, c, c))
-    i = Base.unsafe_trunc(Int, i)
-    j = Base.unsafe_trunc(Int, j)
-    k = Base.unsafe_trunc(Int, k)
-   
+    fi, fj, fk = fractional_indices(X, ibg.underlying_grid, (c, c, c))
+    i = Base.unsafe_trunc(Int, fi)
+    j = Base.unsafe_trunc(Int, fj)
+    k = Base.unsafe_trunc(Int, fk)
+
     if immersed_cell(i, j, k, ibg)
         # Determine whether particle was _previously_ in a non-immersed cell
         i⁻, j⁻, k⁻ = previous_particle_indices
-       
+
         if !immersed_cell(i⁻, j⁻, k⁻, ibg)
             # Left-right bounds of the previous, non-immersed cell
             xᴿ, yᴿ, zᴿ = node(i⁻+1, j⁻+1, k⁻+1, ibg, f, f, f)
             xᴸ, yᴸ, zᴸ = node(i⁻,   j⁻,   k⁻,   ibg, f, f, f)
 
             Cʳ = restitution
-            x⁺ = enforce_boundary_conditions(Bounded(), x, xᴸ, xᴿ, Cʳ)    
-            y⁺ = enforce_boundary_conditions(Bounded(), y, yᴸ, yᴿ, Cʳ)    
+            x⁺ = enforce_boundary_conditions(Bounded(), x, xᴸ, xᴿ, Cʳ)
+            y⁺ = enforce_boundary_conditions(Bounded(), y, yᴸ, yᴿ, Cʳ)
             z⁺ = enforce_boundary_conditions(Bounded(), z, zᴸ, zᴿ, Cʳ)
 
         end
@@ -76,10 +76,10 @@ given `velocities`, time-step `Δt, and coefficient of `restitution`.
     X = flattened_node((x, y, z), grid)
 
     # Obtain current particle indices
-    i, j, k = fractional_indices(X, grid, c, c, c)
-    i = Base.unsafe_trunc(Int, i)
-    j = Base.unsafe_trunc(Int, j)
-    k = Base.unsafe_trunc(Int, k)
+    fi, fj, fk = fractional_indices(X, grid, c, c, c)
+    i = Base.unsafe_trunc(Int, fi)
+    j = Base.unsafe_trunc(Int, fj)
+    k = Base.unsafe_trunc(Int, fk)
 
     current_particle_indices = (i, j, k)
 
@@ -91,7 +91,7 @@ given `velocities`, time-step `Δt, and coefficient of `restitution`.
     # Advect particles, calculating the advection metric for a curvilinear grid.
     # Note that all supported grids use length coordinates in the vertical, so we do not
     # transform the vertical velocity nor invoke the k-index.
-    ξ = x_metric(i, j, grid) 
+    ξ = x_metric(i, j, grid)
     η = y_metric(i, j, grid)
 
     x⁺ = x + ξ * u * Δt
@@ -137,7 +137,7 @@ end
 @inline y_metric(i, j, grid::RectilinearGrid) = 1
 @inline y_metric(i, j, grid::LatitudeLongitudeGrid{FT}) where FT = 1 / grid.radius * FT(360 / 2π)
 
-@kernel function _advect_particles!(particles, restitution, grid::AbstractUnderlyingGrid, Δt, velocities) 
+@kernel function _advect_particles!(particles, restitution, grid::AbstractUnderlyingGrid, Δt, velocities)
     p = @index(Global)
 
     @inbounds begin
@@ -146,12 +146,12 @@ end
         z = particles.z[p]
     end
 
-    x⁺, y⁺, z⁺ = advect_particle((x, y, z), p, restitution, grid, Δt, velocities) 
+    x⁺, y⁺, z⁺ = advect_particle((x, y, z), p, restitution, grid, Δt, velocities)
 
     @inbounds begin
-        particles.x[p] = x⁺ 
-        particles.y[p] = y⁺ 
-        particles.z[p] = z⁺ 
+        particles.x[p] = x⁺
+        particles.y[p] = y⁺
+        particles.z[p] = z⁺
     end
 end
 
@@ -166,4 +166,3 @@ function advect_lagrangian_particles!(particles, model, Δt)
 
     return nothing
 end
-

--- a/src/Models/LagrangianParticleTracking/lagrangian_particle_advection.jl
+++ b/src/Models/LagrangianParticleTracking/lagrangian_particle_advection.jl
@@ -28,6 +28,13 @@ is outside the Periodic interval `(xᴸ, xᴿ)`.
 @inline enforce_boundary_conditions(::Periodic, x, xᴸ, xᴿ, Cʳ) = ifelse(x > xᴿ, xᴸ + (x - xᴿ),
                                                                  ifelse(x < xᴸ, xᴿ - (xᴸ - x), x))
 
+"""
+    enforce_boundary_conditions(::Flat, x, xᴸ, xᴿ, Cʳ)
+
+Do nothing on Flat dimensions.
+"""
+@inline enforce_boundary_conditions(::Flat, x, xᴸ, xᴿ, Cʳ) = x
+
 const f = Face()
 const c = Center()
 

--- a/src/Models/LagrangianParticleTracking/lagrangian_particle_advection.jl
+++ b/src/Models/LagrangianParticleTracking/lagrangian_particle_advection.jl
@@ -42,9 +42,7 @@ bouncing the particle off the immersed boundary with a coefficient or `restituti
 
     # Determine current particle cell
     fi, fj, fk = fractional_indices(X, ibg.underlying_grid, (c, c, c))
-    i = Base.unsafe_trunc(Int, fi)
-    j = Base.unsafe_trunc(Int, fj)
-    k = Base.unsafe_trunc(Int, fk)
+    i, j, k = truncate_fractional_indices(fi, fj, fk)
 
     if immersed_cell(i, j, k, ibg)
         # Determine whether particle was _previously_ in a non-immersed cell
@@ -77,9 +75,7 @@ given `velocities`, time-step `Δt, and coefficient of `restitution`.
 
     # Obtain current particle indices
     fi, fj, fk = fractional_indices(X, grid, c, c, c)
-    i = Base.unsafe_trunc(Int, fi)
-    j = Base.unsafe_trunc(Int, fj)
-    k = Base.unsafe_trunc(Int, fk)
+    i, j, k = truncate_fractional_indices(fi, fj, fk)
 
     current_particle_indices = (i, j, k)
 

--- a/test/test_lagrangian_particle_tracking.jl
+++ b/test/test_lagrangian_particle_tracking.jl
@@ -29,7 +29,7 @@ function particle_tracking_simulation(; grid, particles, timestepper=:RungeKutta
         NetCDFOutputWriter(model, model.particles, filename=nc_filepath, schedule=IterationInterval(1))
 
     sim.output_writers[:checkpointer] = Checkpointer(model, schedule=IterationInterval(1),
-        dir=".", prefix="particles_checkpoint")
+                                                     dir=".", prefix="particles_checkpoint")
 
     return sim, jld2_filepath, nc_filepath
 end
@@ -114,8 +114,8 @@ function run_simple_particle_tracking_tests(arch, grid, timestepper)
     @test lagrangian_particles isa LagrangianParticles
 
     model = NonhydrostaticModel(; grid, timestepper,
-        velocities, particles=lagrangian_particles,
-        background_fields=(v=background_v,))
+                                  velocities, particles=lagrangian_particles,
+                                  background_fields=(v=background_v,))
 
     set!(model, u=1)
 
@@ -124,14 +124,14 @@ function run_simple_particle_tracking_tests(arch, grid, timestepper)
     jld2_filepath = "test_particles.jld2"
     sim.output_writers[:particles_jld2] =
         JLD2OutputWriter(model, (; particles=model.particles),
-            filename=jld2_filepath, schedule=IterationInterval(1))
+                         filename=jld2_filepath, schedule=IterationInterval(1))
 
     nc_filepath = "test_particles.nc"
     sim.output_writers[:particles_nc] =
         NetCDFOutputWriter(model, model.particles, filename=nc_filepath, schedule=IterationInterval(1))
 
     sim.output_writers[:checkpointer] = Checkpointer(model, schedule=IterationInterval(1),
-        dir=".", prefix="particles_checkpoint")
+                                                    dir=".", prefix="particles_checkpoint")
 
     rm(jld2_filepath)
     rm(nc_filepath)


### PR DESCRIPTION
Fixes #3545 

- Add `truncate_fractional_indices` to handle the truncation of `nothing` indices returned by `fractional_indices` for `Flat` dimensions. `nothing` indices are "truncated" to 1.
- `truncate_fractional_indices` used in `advect_particle` and `bounce_immersed_particle`.
- Add method of `enforce_boundary_conditions` for `Flat` boundaries. This method does not modify the particle position.
