### PR TITLE
Update quick_start.md

### DIFF
--- a/docs/src/quick_start.md
+++ b/docs/src/quick_start.md
@@ -8,7 +8,7 @@ using Oceananigans
 grid = RectilinearGrid(size=(128, 128), x=(0, 2π), y=(0, 2π), topology=(Periodic, Periodic, Flat))
 model = NonhydrostaticModel(; grid, advection=WENO())
 
-ϵ(x, y) = 2rand() - 1
+ϵ(x, y, z) = 2rand() - 1
 set!(model, u=ϵ, v=ϵ)
 
 simulation = Simulation(model; Δt=0.01, stop_iteration=100)


### PR DESCRIPTION
Fixing an error in the quick start code: set!(model, u=\epsilon, v=\epsilon) fails if the function \epsilon only has two arguments. Code runs if a third argument is added to the \epsilon definition.

