### PR TITLE
Fix typo in doc @ref in one_dimensional_diffusion.jl

### DIFF
--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -1,4 +1,4 @@
-# # [Simple diffusion example]](@id one_dimensional_diffusion_example)
+# # [Simple diffusion example](@id one_dimensional_diffusion_example)
 #
 # This is Oceananigans.jl's simplest example:
 # the diffusion of a one-dimensional Gaussian. This example demonstrates


### PR DESCRIPTION
Fix typo in header for simple diffusion example.
It also fixes crosslinks from quickstart not working.

