### PR TITLE
Extract major source code modifications from PR 3306

### DIFF
--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -122,10 +122,10 @@ julia> grid = RectilinearGrid(size=(2, 3, 4), extent=(1, 1, 1));
 
 julia> ω = Field{Face, Face, Center}(grid)
 2×3×4 Field{Face, Face, Center} on RectilinearGrid on CPU
-├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
+├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── boundary conditions: FieldBoundaryConditions
 │   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: ZeroFlux, top: ZeroFlux, immersed: ZeroFlux
-└── data: 6×9×10 OffsetArray(::Array{Float64, 3}, -1:4, -2:6, -2:7) with eltype Float64 with indices -1:4×-2:6×-2:7
+└── data: 8×9×10 OffsetArray(::Array{Float64, 3}, -2:5, -2:6, -2:7) with eltype Float64 with indices -2:5×-2:6×-2:7
     └── max=0.0, min=0.0, mean=0.0
 ```
 
@@ -138,24 +138,24 @@ julia> u = XFaceField(grid); v = YFaceField(grid);
 
 julia> ωₛ = Field(∂x(v) - ∂y(u), indices=(:, :, grid.Nz))
 2×3×1 Field{Face, Face, Center} on RectilinearGrid on CPU
-├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
+├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── boundary conditions: FieldBoundaryConditions
 │   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: Nothing, top: Nothing, immersed: ZeroFlux
 ├── indices: (:, :, 4:4)
 ├── operand: BinaryOperation at (Face, Face, Center)
 ├── status: time=0.0
-└── data: 6×9×1 OffsetArray(::Array{Float64, 3}, -1:4, -2:6, 4:4) with eltype Float64 with indices -1:4×-2:6×4:4
+└── data: 8×9×1 OffsetArray(::Array{Float64, 3}, -2:5, -2:6, 4:4) with eltype Float64 with indices -2:5×-2:6×4:4
     └── max=0.0, min=0.0, mean=0.0
 
 julia> compute!(ωₛ)
 2×3×1 Field{Face, Face, Center} on RectilinearGrid on CPU
-├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
+├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── boundary conditions: FieldBoundaryConditions
 │   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: Nothing, top: Nothing, immersed: ZeroFlux
 ├── indices: (:, :, 4:4)
 ├── operand: BinaryOperation at (Face, Face, Center)
 ├── status: time=0.0
-└── data: 6×9×1 OffsetArray(::Array{Float64, 3}, -1:4, -2:6, 4:4) with eltype Float64 with indices -1:4×-2:6×4:4
+└── data: 8×9×1 OffsetArray(::Array{Float64, 3}, -2:5, -2:6, 4:4) with eltype Float64 with indices -2:5×-2:6×4:4
     └── max=0.0, min=0.0, mean=0.0
 ```
 """
@@ -245,6 +245,10 @@ function offset_windowed_data(data, Loc, grid, indices)
         windowed_parent = parent(data)
     else
         parent_indices = map(parent_index_range, indices, loc, topo, halo)
+        if size(data)[3] == 1 && first.(axes(data))[3] == grid.Nz + 1 # take ssh into consideration
+            parent_indices = collect(parent_indices)
+            parent_indices[3] = 1:1
+        end
         windowed_parent = view(parent(data), parent_indices...)
     end
 
@@ -276,21 +280,21 @@ julia> grid = RectilinearGrid(size=(2, 3, 4), x=(0, 1), y=(0, 1), z=(0, 1));
 
 julia> c = CenterField(grid)
 2×3×4 Field{Center, Center, Center} on RectilinearGrid on CPU
-├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
+├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── boundary conditions: FieldBoundaryConditions
 │   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: ZeroFlux, top: ZeroFlux, immersed: ZeroFlux
-└── data: 6×9×10 OffsetArray(::Array{Float64, 3}, -1:4, -2:6, -2:7) with eltype Float64 with indices -1:4×-2:6×-2:7
+└── data: 8×9×10 OffsetArray(::Array{Float64, 3}, -2:5, -2:6, -2:7) with eltype Float64 with indices -2:5×-2:6×-2:7
     └── max=0.0, min=0.0, mean=0.0
 
 julia> c .= rand(size(c)...);
 
 julia> v = view(c, :, 2:3, 1:2)
 2×2×2 Field{Center, Center, Center} on RectilinearGrid on CPU
-├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
+├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── boundary conditions: FieldBoundaryConditions
 │   └── west: Periodic, east: Periodic, south: Nothing, north: Nothing, bottom: Nothing, top: Nothing, immersed: ZeroFlux
 ├── indices: (:, 2:3, 1:2)
-└── data: 6×2×2 OffsetArray(view(::Array{Float64, 3}, :, 5:6, 4:5), -1:4, 2:3, 1:2) with eltype Float64 with indices -1:4×2:3×1:2
+└── data: 8×2×2 OffsetArray(view(::Array{Float64, 3}, :, 5:6, 4:5), -2:5, 2:3, 1:2) with eltype Float64 with indices -2:5×2:3×1:2
     └── max=0.972136, min=0.0149088, mean=0.59198
 
 julia> size(v)

--- a/src/Fields/field_boundary_buffers.jl
+++ b/src/Fields/field_boundary_buffers.jl
@@ -306,6 +306,3 @@ _recv_from_southwest_buffer!(c, b, buff, Hx, Hy, Nx, Ny) = view(c, 1:Hx,        
 _recv_from_southeast_buffer!(c, b, buff, Hx, Hy, Nx, Ny) = view(c, 1+Nx+Hx:Nx+2Hx, 1:Hy,           :) .= buff.recv
 _recv_from_northwest_buffer!(c, b, buff, Hx, Hy, Nx, Ny) = view(c, 1:Hx,           1+Ny+Hy:Ny+2Hy, :) .= buff.recv
 _recv_from_northeast_buffer!(c, b, buff, Hx, Hy, Nx, Ny) = view(c, 1+Nx+Hx:Nx+2Hx, 1+Ny+Hy:Ny+2Hy, :) .= buff.recv
-
-# Switch around halos for cubed sphere by exchanging buffer informations
-replace_horizontal_vector_halos!(vel, grid::AbstractGrid; signed=true) = nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
@@ -5,8 +5,8 @@ using Oceananigans.Architectures
 using Oceananigans.Grids: with_halo, isrectilinear, halo_size
 using Oceananigans.Architectures: device
 
-import Oceananigans.Solvers: solve!, precondition!
 import Oceananigans.Architectures: architecture
+import Oceananigans.Solvers: solve!, precondition!, auxiliary_actions!
 
 """
     struct PCGImplicitFreeSurfaceSolver{V, S, R}
@@ -50,7 +50,12 @@ function PCGImplicitFreeSurfaceSolver(grid::AbstractGrid, settings, gravitationa
     vertically_integrated_lateral_areas = (xᶠᶜᶜ = ∫ᶻ_Axᶠᶜᶜ, yᶜᶠᶜ = ∫ᶻ_Ayᶜᶠᶜ)
 
     @apply_regionally compute_vertically_integrated_lateral_areas!(vertically_integrated_lateral_areas)
-    fill_halo_regions!(vertically_integrated_lateral_areas)
+    
+    u = vertically_integrated_lateral_areas.xᶠᶜᶜ
+    v = vertically_integrated_lateral_areas.yᶜᶠᶜ
+    
+    grid isa ConformalCubedSphereGrid ? fill_halo_regions!((u, v); signed=false) :
+                                        fill_halo_regions!(vertically_integrated_lateral_areas)
 
     # Set some defaults
     settings = Dict{Symbol, Any}(settings)
@@ -136,13 +141,16 @@ function implicit_free_surface_linear_operation!(L_ηⁿ⁺¹, ηⁿ⁺¹, ∫�
 
     # Note: because of `fill_halo_regions!` below, we cannot use `PCGImplicitFreeSurface` on a
     # multi-region grid; `fill_halo_regions!` cannot be used within `@apply_regionally`
-    fill_halo_regions!(ηⁿ⁺¹)
 
     launch!(arch, grid, :xy, _implicit_free_surface_linear_operation!,
             L_ηⁿ⁺¹, grid,  ηⁿ⁺¹, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, g, Δt)
 
     return nothing
 end
+
+ImplicitFreeSurfaceOperation = typeof(implicit_free_surface_linear_operation!)
+
+auxiliary_actions!(::ImplicitFreeSurfaceOperation, L_ηⁿ⁺¹, ηⁿ⁺¹, args...) = fill_halo_regions!(ηⁿ⁺¹)
 
 # Kernels that act on vertically integrated / surface quantities
 @inline ∫ᶻ_Ax_∂x_ηᶠᶜᶜ(i, j, k, grid, ∫ᶻ_Axᶠᶜᶜ, η) = @inbounds ∫ᶻ_Axᶠᶜᶜ[i, j, k] * ∂xᶠᶜᶠ(i, j, k, grid, η)

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -63,11 +63,8 @@ function HydrostaticFreeSurfaceVelocityFields(velocities::PrescribedVelocityFiel
     v = wrap_prescribed_field(Center, Face, Center, velocities.v, grid; clock, parameters)
     w = wrap_prescribed_field(Center, Center, Face, velocities.w, grid; clock, parameters)
 
-    fill_halo_regions!(u)
-    fill_halo_regions!(v)
+    fill_halo_regions!((u, v))
     fill_halo_regions!(w)
-    prescribed_velocities = (; u, v, w)
-    @apply_regionally replace_horizontal_vector_halos!(prescribed_velocities, grid)
 
     return PrescribedVelocityFields(u, v, w, parameters)
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/update_hydrostatic_free_surface_model_state.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/update_hydrostatic_free_surface_model_state.jl
@@ -7,7 +7,6 @@ using Oceananigans.TurbulenceClosures: compute_diffusivities!
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!, mask_immersed_field_xy!, inactive_node
 using Oceananigans.Models: update_model_field_time_series!
 using Oceananigans.Models.NonhydrostaticModels: update_hydrostatic_pressure!, p_kernel_parameters
-using Oceananigans.Fields: replace_horizontal_vector_halos!
 
 import Oceananigans.Models.NonhydrostaticModels: compute_auxiliaries!
 import Oceananigans.TimeSteppers: update_state!
@@ -34,7 +33,7 @@ function update_state!(model::HydrostaticFreeSurfaceModel, grid, callbacks; comp
     @apply_regionally update_model_field_time_series!(model, model.clock)
 
     fill_halo_regions!(prognostic_fields(model), model.clock, fields(model); async = true)
-    @apply_regionally replace_horizontal_vector_halos!(model.velocities, model.grid)
+    grid isa ConformalCubedSphereGrid ? fill_halo_regions!((model.velocities.u, model.velocities.v)) : nothing
     @apply_regionally compute_auxiliaries!(model)
 
     fill_halo_regions!(model.diffusivity_fields; only_local_halos = true)

--- a/src/MultiRegion/cubed_sphere_boundary_conditions.jl
+++ b/src/MultiRegion/cubed_sphere_boundary_conditions.jl
@@ -23,7 +23,7 @@ end
 function fill_halo_regions!(field::CubedSphereField{<:Center, <:Center})
     grid = field.grid
 
-    Nx, Ny, Nz = size(grid)
+    Nx, Ny, Nz = size(field)
     Hx, Hy, Hz = halo_size(grid)
 
     Nx == Ny || error("horizontal grid size Nx and Ny must be the same")
@@ -32,6 +32,12 @@ function fill_halo_regions!(field::CubedSphereField{<:Center, <:Center})
     Hx == Hy || error("horizontal halo size Hx and Hy must be the same")
     Hc = Hx
 
+    if size(field[1].data)[3] == 1 && first.(axes(field[1].data))[3] == grid.Nz + 1 # take ssh into consideration
+        k_min, k_max = Nz+1, Nz+1
+    else
+        k_min, k_max = 1, Nz
+    end
+
     #-- one pass: only use interior-point values:
     for region in 1:6
 
@@ -39,7 +45,7 @@ function fill_halo_regions!(field::CubedSphereField{<:Center, <:Center})
 
         if isodd(region)
             #- odd face number (1, 3, 5):
-            for k in -Hz+1:Nz+Hz
+            for k in k_min:k_max
                 #- E + W Halo for field:
                 field[region][Nc+1:Nc+Hc, 1:Nc, k] .=         field[region_E][1:Hc, 1:Nc, k]
                 field[region][1-Hc:0, 1:Nc, k]     .= reverse(field[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)'
@@ -49,7 +55,7 @@ function fill_halo_regions!(field::CubedSphereField{<:Center, <:Center})
             end
         elseif iseven(region)
             #- even face number (2, 4, 6):
-            for k in -Hz+1:Nz+Hz
+            for k in k_min:k_max
                 #- E + W Halo for field:
                 field[region][Nc+1:Nc+Hc, 1:Nc, k] .= reverse(field[region_E][1:Nc, 1:Hc, k], dims=1)'
                 field[region][1-Hc:0, 1:Nc, k]     .=         field[region_W][Nc+1-Hc:Nc, 1:Nc, k]
@@ -63,10 +69,16 @@ function fill_halo_regions!(field::CubedSphereField{<:Center, <:Center})
     return nothing
 end
 
+# Halos have to be filled concurrently for pairs of XFaced and YFaced Fields, like `u` and `v`.
+# Therefore, e.g., fill_halo_regions!(u) should do nothing and the halos for `u` and `v` are filed
+# via fill_halo_regions!((u, v))
+fill_halo_regions!(field::CubedSphereField{<:Face, <:Center}) = nothing
+fill_halo_regions!(field::CubedSphereField{<:Center, <:Face}) = nothing
+
 function fill_halo_regions!(field::CubedSphereField{<:Face, <:Face})
     grid = field.grid
 
-    Nx, Ny, Nz = size(grid)
+    Nx, Ny, Nz = size(field)
     Hx, Hy, Hz = halo_size(grid)
 
     Nx == Ny || error("horizontal grid size Nx and Ny must be the same")
@@ -82,7 +94,7 @@ function fill_halo_regions!(field::CubedSphereField{<:Face, <:Face})
 
         if isodd(region)
             #- odd face number (1, 3, 5):
-            for k in -Hz+1:Nz+Hz
+            for k in 1:Nz
                 #- E + W Halo for field:
                 field[region][Nc+1:Nc+Hc, 1:Nc, k]   .=         field[region_E][1:Hc, 1:Nc, k]
                 field[region][1-Hc:0, 2:Nc+1, k]     .= reverse(field[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)'
@@ -99,7 +111,7 @@ function fill_halo_regions!(field::CubedSphereField{<:Face, <:Face})
             end
         elseif iseven(region)
             #- even face number (2, 4, 6):
-            for k in -Hz+1:Nz+Hz
+            for k in 1:Nz
                 #- E + W Halo for field:
                 field[region][Nc+1:Nc+Hc, 2:Nc, k]   .= reverse(field[region_E][2:Nc, 1:Hc, k], dims=1)'
                 if Hc > 1
@@ -128,7 +140,7 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Center, <:Center},
     field_1.grid == field_2.grid || error("fields must be on the same grid")
     grid = field_1.grid
 
-    Nx, Ny, Nz = size(grid)
+    Nx, Ny, Nz = size(field_1)
     Hx, Hy, Hz = halo_size(grid)
     signed ? plmn = -1 : plmn = 1
 
@@ -145,7 +157,7 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Center, <:Center},
 
         if isodd(region)
             #- odd face number (1, 3, 5):
-            for k in -Hz+1:Nz+Hz
+            for k in 1:Nz
                 #- E Halo:
                 field_1[region][Nc+1:Nc+Hc, 1:Nc, k] .=         field_1[region_E][1:Hc, 1:Nc, k]
                 field_2[region][Nc+1:Nc+Hc, 1:Nc, k] .=         field_2[region_E][1:Hc, 1:Nc, k]
@@ -161,7 +173,7 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Center, <:Center},
             end
         elseif iseven(region)
             #- even face number (2, 4, 6):
-            for k in -Hz+1:Nz+Hz
+            for k in 1:Nz
                 #- E Halo:
                 field_1[region][Nc+1:Nc+Hc, 1:Nc, k] .= reverse(field_2[region_E][1:Nc, 1:Hc, k], dims=1)'
                 field_2[region][Nc+1:Nc+Hc, 1:Nc, k] .= reverse(field_1[region_E][1:Nc, 1:Hc, k], dims=1)' * plmn
@@ -187,7 +199,7 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Center},
     field_1.grid == field_2.grid || error("fields must be on the same grid")
     grid = field_1.grid
 
-    Nx, Ny, Nz = size(grid)
+    Nx, Ny, Nz = size(field_1)
     Hx, Hy, Hz = halo_size(grid)
     signed ? plmn = -1 : plmn = 1
 
@@ -204,7 +216,7 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Center},
 
         if isodd(region)
             #- odd face number (1, 3, 5):
-            for k in -Hz+1:Nz+Hz
+            for k in 1:Nz
                 #- E + W Halo for field_1:
                 field_1[region][Nc+1:Nc+Hc, 1:Nc, k]   .=         field_1[region_E][1:Hc, 1:Nc, k]
                 field_1[region][1-Hc:0, 1:Nc, k]       .= reverse(field_2[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)'
@@ -224,7 +236,7 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Center},
             end
         elseif iseven(region)
             #- even face number (2, 4, 6):
-            for k in -Hz+1:Nz+Hz
+            for k in 1:Nz
                 #- E + W Halo for field_1:
                 field_1[region][Nc+1:Nc+Hc, 1:Nc, k]   .= reverse(field_2[region_E][1:Nc, 1:Hc, k], dims=1)'
                 field_1[region][1-Hc:0, 1:Nc, k]       .=         field_1[region_W][Nc+1-Hc:Nc, 1:Nc, k]
@@ -249,7 +261,7 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Center},
     # (e.g., vort3(0,1) & (1,0)).
     if Hc > 1
         for region in 1:6
-            for k in -Hz+1:Nz+Hz
+            for k in 1:Nz
                 #- SW corner:
                 field_1[region][1-Hc:0, 0, k] .= field_2[region][1, 1-Hc:0, k]
                 field_2[region][0, 1-Hc:0, k] .= field_1[region][1-Hc:0, 1, k]'
@@ -275,7 +287,7 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Face},
     field_1.grid == field_2.grid || error("fields must be on the same grid")
     grid = field_1.grid
 
-    Nx, Ny, Nz = size(grid)
+    Nx, Ny, Nz = size(field_1)
     Hx, Hy, Hz = halo_size(grid)
     signed ? plmn = -1 : plmn = 1
 
@@ -292,7 +304,7 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Face},
 
         if isodd(region)
             #- odd face number (1, 3, 5):
-            for k in -Hz+1:Nz+Hz
+            for k in 1:Nz
                 #- E Halo:
                 field_1[region][Nc+1:Nc+Hc, 1:Nc, k]   .=         field_1[region_E][1:Hc, 1:Nc, k]
                 field_2[region][Nc+1:Nc+Hc, 1:Nc, k]   .=         field_2[region_E][1:Hc, 1:Nc, k]
@@ -318,7 +330,7 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Face},
             end
         else
             #- even face number (2, 4, 6):
-            for k in -Hz+1:Nz+Hz
+            for k in 1:Nz
                 #- E Halo:
                 field_1[region][Nc+1:Nc+Hc, 2:Nc, k]   .= reverse(field_2[region_E][2:Nc, 1:Hc, k], dims=1)'
                 field_2[region][Nc+1:Nc+Hc, 2:Nc+1, k] .= reverse(field_1[region_E][1:Nc, 1:Hc, k], dims=1)' * plmn

--- a/src/MultiRegion/cubed_sphere_partitions.jl
+++ b/src/MultiRegion/cubed_sphere_partitions.jl
@@ -2,8 +2,6 @@ using Oceananigans.Grids: cpu_face_constructor_x, cpu_face_constructor_y, cpu_fa
 
 using DocStringExtensions
 
-import Oceananigans.Fields: replace_horizontal_vector_halos!
-
 struct CubedSpherePartition{M, P} <: AbstractPartition
     div :: Int
     Rx :: M
@@ -88,37 +86,6 @@ end
 
 # A cubed sphere panel grid is an OSSG grid that is fully connected in xy
 const SpherePanelGrid = OrthogonalSphericalShellGrid{<:Any, FullyConnected, FullyConnected}
-
-# TODO: move prescribed velocity field stuff to Model/HydrostaticFreeSurfaceModels/prescribed_velocity_fields.jl
-replace_horizontal_vector_halos!(::PrescribedVelocityFields, ::AbstractGrid; kw...) = nothing
-replace_horizontal_vector_halos!(::PrescribedVelocityFields, ::SpherePanelGrid; kw...) = nothing
-
-function replace_horizontal_vector_halos!(velocities, grid::SpherePanelGrid; signed=true)
-    u, v, _ = velocities
-
-    ubuff = u.boundary_buffers
-    vbuff = v.boundary_buffers
-
-    conn_west  = u.boundary_conditions.west.condition.from_side
-    conn_east  = u.boundary_conditions.east.condition.from_side
-    conn_south = u.boundary_conditions.south.condition.from_side
-    conn_north = u.boundary_conditions.north.condition.from_side
-
-    Hx, Hy, _ = halo_size(u.grid)
-    Nx, Ny, _ = size(grid)
-
-     replace_west_u_halos!(parent(u), vbuff, Nx, Hx, conn_west; signed)
-     replace_east_u_halos!(parent(u), vbuff, Nx, Hx, conn_east; signed)
-    replace_south_u_halos!(parent(u), vbuff, Ny, Hy, conn_south; signed)
-    replace_north_u_halos!(parent(u), vbuff, Ny, Hy, conn_north; signed)
-
-     replace_west_v_halos!(parent(v), ubuff, Nx, Hx, conn_west; signed)
-     replace_east_v_halos!(parent(v), ubuff, Nx, Hx, conn_east; signed)
-    replace_south_v_halos!(parent(v), ubuff, Ny, Hy, conn_south; signed)
-    replace_north_v_halos!(parent(v), ubuff, Ny, Hy, conn_north; signed)
-
-    return nothing
-end
 
 for vel in (:u, :v), dir in (:east, :west, :north, :south)
     @eval $(Symbol(:replace_, dir, :_, vel, :_halos!))(u, buff, N, H, conn; signed=true) = nothing

--- a/src/MultiRegion/multi_region_field.jl
+++ b/src/MultiRegion/multi_region_field.jl
@@ -24,7 +24,7 @@ const GriddedMultiRegionFieldTuple{N, T} = NTuple{N, T} where {N, T<:GriddedMult
 const GriddedMultiRegionFieldNamedTuple{S, N} = NamedTuple{S, N} where {S, N<:GriddedMultiRegionFieldTuple}
 
 # Utils
-Base.size(f::GriddedMultiRegionField) = size(getregion(f.grid, 1))
+Base.size(f::GriddedMultiRegionField) = size(getregion(f, 1))
 
 @inline isregional(f::GriddedMultiRegionField) = true
 @inline devices(f::GriddedMultiRegionField) = devices(f.grid)

--- a/src/MultiRegion/unified_implicit_free_surface_solver.jl
+++ b/src/MultiRegion/unified_implicit_free_surface_solver.jl
@@ -66,6 +66,8 @@ build_implicit_step_solver(::Val{:PreconditionedConjugateGradient}, grid::MultiR
     throw(ArgumentError("Cannot use PCG solver with Multi-region grids!! Select :Default or :HeptadiagonalIterativeSolver as solver_method"))
 build_implicit_step_solver(::Val{:Default}, grid::ConformalCubedSphereGrid, settings, gravitational_acceleration) =
     PCGImplicitFreeSurfaceSolver(grid, settings, gravitational_acceleration)
+build_implicit_step_solver(::Val{:PreconditionedConjugateGradient}, grid::ConformalCubedSphereGrid, settings, gravitational_acceleration) =
+    PCGImplicitFreeSurfaceSolver(grid, settings, gravitational_acceleration)
 build_implicit_step_solver(::Val{:HeptadiagonalIterativeSolver}, grid::ConformalCubedSphereGrid, settings, gravitational_acceleration) =
     throw(ArgumentError("Cannot use Matrix solvers with ConformalCubedSphereGrid!! Select :Default or :PreconditionedConjugateGradient as solver_method"))
 

--- a/src/Solvers/preconditioned_conjugate_gradient_solver.jl
+++ b/src/Solvers/preconditioned_conjugate_gradient_solver.jl
@@ -195,6 +195,10 @@ function iterate!(x, solver, b, args...)
 
     @apply_regionally perform_iteration!(q, p, ρ, z, solver, args...)
 
+    auxiliary_actions!(solver.linear_operation!, q, p, args...)
+
+    @apply_regionally solver.linear_operation!(q, p, args...)
+
     α = ρ / dot(p, q)
 
     @debug "PreconditionedConjugateGradientSolver $(solver.iteration), |q|: $(norm(q))"
@@ -207,6 +211,8 @@ function iterate!(x, solver, b, args...)
 
     return nothing
 end
+
+auxiliary_actions!(args...) = nothing
 
 """ first iteration of the PCG """
 function initialize_solution!(q, x, b, solver, args...)

--- a/test/test_multi_region_cubed_sphere.jl
+++ b/test/test_multi_region_cubed_sphere.jl
@@ -3,7 +3,6 @@ include("data_dependencies.jl")
 
 using Oceananigans.Grids: φnode, λnode, halo_size
 using Oceananigans.Utils: Iterate, getregion
-using Oceananigans.Fields: replace_horizontal_vector_halos!
 using Oceananigans.MultiRegion: number_of_regions, fill_halo_regions!
 
 function get_range_of_indices(operation, index, Nx, Ny)


### PR DESCRIPTION
This PR extracts the major source code modifications from PR #3306, especially the elimination of replace_horizontal_vector_halos!, refinement of existing methods and addition of new ones to take the cubed sphere grid into consideration, and the improved vorticity computation function. A new test will be implemented to verify that the norm of the prognostic variables of the Rossby-Haurwitz wave remains almost constant as it propagates over the cubed sphere.