### PR TITLE
Remove `GKSwstype: "100"` from buildkite environment variables

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,6 @@ env:
   JULIA_MINOR_VERSION: "1.10"
   SVERDRUP_HOME: "/data5/glwagner"
   TARTARUS_HOME: "/storage5/buildkite-agent"
-  GKSwstype: "100" # See: https://github.com/jheinen/GR.jl/issues/278
   JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
 
 steps:


### PR DESCRIPTION
I think this was needed when we used Plots for docs, and is no longer needed for CairoMakie.

