### PR TITLE
`Adapt`ing all fields of the `OrthogonalSphericalShellGrid`

### DIFF
--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -969,8 +969,8 @@ function Adapt.adapt_structure(to, grid::OrthogonalSphericalShellGrid)
                                                     adapt(to, grid.Azᶠᶜᵃ),
                                                     adapt(to, grid.Azᶜᶠᵃ),
                                                     adapt(to, grid.Azᶠᶠᵃ),
-                                                    grid.radius,
-                                                    grid.conformal_mapping)
+                                                    adapt(to, grid.radius),
+                                                    adapt(to, grid.conformal_mapping))
 end
 
 function Base.summary(grid::OrthogonalSphericalShellGrid)

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -969,7 +969,7 @@ function Adapt.adapt_structure(to, grid::OrthogonalSphericalShellGrid)
                                                     adapt(to, grid.Azᶠᶜᵃ),
                                                     adapt(to, grid.Azᶜᶠᵃ),
                                                     adapt(to, grid.Azᶠᶠᵃ),
-                                                    adapt(to, grid.radius),
+                                                    grid.radius,
                                                     adapt(to, grid.conformal_mapping))
 end
 


### PR DESCRIPTION
This PR improves the `adapt_structure` method of the `OrthogonalSphericalShellGrid` to allow a more complicated `conformal_mapping` to be transferred to the GPU