### PR TITLE
Generalize `DiscreteBoundaryFunction` to functions of any arguments

### DIFF
--- a/src/BoundaryConditions/discrete_boundary_function.jl
+++ b/src/BoundaryConditions/discrete_boundary_function.jl
@@ -35,18 +35,19 @@ const UnparameterizedDBF = DiscreteBoundaryFunction{<:Nothing}
 const UnparameterizedDBFBC = BoundaryCondition{<:Any, <:UnparameterizedDBF}
 const DBFBC = BoundaryCondition{<:Any, <:DiscreteBoundaryFunction}
 
-@inline getbc(bc::UnparameterizedDBFBC, i::Integer, j::Integer, grid::AbstractGrid, clock, model_fields, args...) =
-    bc.condition.func(i, j, grid, clock, model_fields)
+# In the functions below, we often have args = (clock, model_fields)
+@inline getbc(bc::UnparameterizedDBFBC, i::Integer, j::Integer, grid::AbstractGrid, args...) =
+    bc.condition.func(i, j, grid, args...)
 
-@inline getbc(bc::DBFBC, i::Integer, j::Integer, grid::AbstractGrid, clock, model_fields, args...) =
-    bc.condition.func(i, j, grid, clock, model_fields, bc.condition.parameters)
+@inline getbc(bc::DBFBC, i::Integer, j::Integer, grid::AbstractGrid, args...) =
+    bc.condition.func(i, j, grid, args..., bc.condition.parameters)
 
 # 3D function for immersed boundary conditions
-@inline getbc(bc::UnparameterizedDBFBC, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, model_fields, args...) =
-    bc.condition.func(i, j, k, grid, clock, model_fields)
+@inline getbc(bc::UnparameterizedDBFBC, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, args...) =
+    bc.condition.func(i, j, k, grid, args...)
 
-@inline getbc(bc::DBFBC, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, model_fields, args...) =
-    bc.condition.func(i, j, k, grid, clock, model_fields, bc.condition.parameters)
+@inline getbc(bc::DBFBC, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, args...) =
+    bc.condition.func(i, j, k, grid, args..., bc.condition.parameters)
 
 # Don't re-convert DiscreteBoundaryFunctions passed to BoundaryCondition constructor
 BoundaryCondition(Classification::DataType, condition::DiscreteBoundaryFunction) = BoundaryCondition(Classification(), condition)


### PR DESCRIPTION
This makes it so that discrete-form function boundary conditions

```
bc(i, j, grid, a, b, c, d)
```

will work provided that `fill_halo_regions!` is called with

```julia
fill_halo_regions!(field, a, b, c, d)
```

The trade-off here is between code clarity and generality. I added a comment to make it clear that at least for Oceananigans models, we use `clock, model_fields`.

@simone-silvestri wants to advertise Oceananigans as more generally applicable to any model using a finite volume grid, so this will help achieve that goal...

