### PR TITLE
Creation of `FieldTimeSeries` from `BinaryOperation` of other FTS + some FTS bug fixes

### DIFF
--- a/src/AbstractOperations/at.jl
+++ b/src/AbstractOperations/at.jl
@@ -90,6 +90,9 @@ _compute_index_intersection(to_idx::Colon, from_idx::Colon, args...) = Colon()
 # Because `from_idx` imposes no restrictions, we just return `to_idx`.
 _compute_index_intersection(to_idx::UnitRange, from_idx::Colon, args...) = to_idx
 
+# for flattened fields
+_compute_index_intersection(::Type{Nothing}, ::Type{Nothing}, args...) = Colon()
+
 # This time we account for the possible range-reducing effect of interpolation on `from_idx`.
 function _compute_index_intersection(to_idx::Colon, from_idx::UnitRange, to_loc, from_loc)
     shifted_idx = restrict_index_for_interpolation(from_idx, from_loc, to_loc)
@@ -127,3 +130,4 @@ restrict_index_for_interpolation(from_idx, ::Type{Face},   ::Type{Face})   = Uni
 restrict_index_for_interpolation(from_idx, ::Type{Center}, ::Type{Center}) = UnitRange(first(from_idx),   last(from_idx))
 restrict_index_for_interpolation(from_idx, ::Type{Face},   ::Type{Center}) = UnitRange(first(from_idx),   last(from_idx)-1)
 restrict_index_for_interpolation(from_idx, ::Type{Center}, ::Type{Face})   = UnitRange(first(from_idx)+1, last(from_idx))
+restrict_index_for_interpolation(from_idx, ::Type{Nothing}, ::Type{Nothing}) = UnitRange(first(from_idx),   last(from_idx))

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -103,6 +103,10 @@ const YZFTS = FlavorOfFTS{Nothing, <:Any, <:Any, <:Any, <:Any}
 @propagate_inbounds getindex(f::XZFTS, i::Int, k::Int, n::Int) = getindex(f.data, i, 1, k, memory_index(f, n))
 @propagate_inbounds getindex(f::YZFTS, j::Int, k::Int, n::Int) = getindex(f.data, 1, j, k, memory_index(f, n))
 
+@propagate_inbounds getindex(f::XYFTS, i::Int, j::Int, n::Time) = getindex(f, i, j, 1, n)
+@propagate_inbounds getindex(f::XZFTS, i::Int, k::Int, n::Time) = getindex(f, i, 1, k, n)
+@propagate_inbounds getindex(f::YZFTS, j::Int, k::Int, n::Time) = getindex(f, 1, j, k, n)
+
 #####
 ##### Time interpolation / extrapolation
 ##### Local getindex with integers `(i, j, k)` and `n :: Time`


### PR DESCRIPTION
This PR primarily adds a method to `FieldTimeSeries` to build them from operations on other FTS similar to what can be done with `Field`. For example:

```julia
u10 = FieldTimeSeries("atmosphere.jld2", "u10")
Q   = FieldTimeSeries(- ρₐ / ρₒ * cᴰ * u10 * abs(u10))
```

This does work in a different way to e.g. `Field(- ρₐ / ρₒ * cᴰ * u10 * abs(u10))` where `u10` is instead a field, because FTS don't have `operand` properties so instead we're filling the data of the FTS when it is made (which is obviously *very* memory inefficient for big FTS).

I have also added some methods for `getindex` on FTS with a flat dimension and `Time` indexing as they don't exist like they do for 4D FTS, and some methods for `@at` to work on flattened fields. 
