### PR TITLE
Add inlines for general interpolation

### DIFF
--- a/src/Operators/interpolation_utils.jl
+++ b/src/Operators/interpolation_utils.jl
@@ -118,11 +118,11 @@ for LX in (:Center, :Face), LY in (:Center, :Face), LZ in (:Center, :Face)
         to   = (eval(IX), eval(IY), eval(IZ))
         interp_func = Symbol(interpolation_operator(from, to))
         @eval begin
-            ℑxyz(i, j, k, grid, from::F, to::T, c) where {F<:Tuple{<:$LX, <:$LY, <:$LZ}, T<:Tuple{<:$IX, <:$IY, <:$IZ}} = 
-                $interp_func(i, j, k, grid, c)
+            @inline ℑxyz(i, j, k, grid, from::F, to::T, c) where {F<:Tuple{<:$LX, <:$LY, <:$LZ}, T<:Tuple{<:$IX, <:$IY, <:$IZ}} = 
+                         $interp_func(i, j, k, grid, c)
          
-            ℑxyz(i, j, k, grid, from::F, to::T, f, args...) where {F<:Tuple{<:$LX, <:$LY, <:$LZ}, T<:Tuple{<:$IX, <:$IY, <:$IZ}} = 
-                $interp_func(i, j, k, grid, f, args...)
+            @inline ℑxyz(i, j, k, grid, from::F, to::T, f, args...) where {F<:Tuple{<:$LX, <:$LY, <:$LZ}, T<:Tuple{<:$IX, <:$IY, <:$IZ}} = 
+                         $interp_func(i, j, k, grid, f, args...)
         end
     end
 end

--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
@@ -101,7 +101,7 @@ ScalarDiffusivity{ExplicitTimeDiscretization}(ν=0.0, κ=Oceananigans.Turbulence
 
 ```jldoctest ScalarDiffusivity
 julia> @inline function another_κ(i, j, k, grid, clock, fields, p)
-           z = znode(i, j, k, grid)
+           z = znode(i, j, k, grid, Center(), Center(), Face())
            return 2000 * exp(z / p.depth_scale)
        end
 another_κ (generic function with 1 method)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
@@ -89,7 +89,7 @@ ScalarDiffusivity{ExplicitTimeDiscretization}(ν=ν (generic function with 1 met
 ```jldoctest ScalarDiffusivity
 julia> using Oceananigans.Grids: znode
 
-julia> @inline function κ(i, j, k, grid, ℓx, ℓy, ℓz)
+julia> @inline function κ(i, j, k, grid, ℓx, ℓy, ℓz, clock, fields)
            z = znode(i, j, k, grid, ℓx, ℓy, ℓz)
            return 2000 * exp(z / depth_scale)
        end
@@ -100,7 +100,7 @@ ScalarDiffusivity{ExplicitTimeDiscretization}(ν=0.0, κ=Oceananigans.Turbulence
 ```
 
 ```jldoctest ScalarDiffusivity
-julia> @inline function another_κ(i, j, k, grid, p)
+julia> @inline function another_κ(i, j, k, grid, clock, fields, p)
            z = znode(i, j, k, grid)
            return 2000 * exp(z / p.depth_scale)
        end

--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_diffusivity.jl
@@ -53,11 +53,15 @@ value of keyword argument `discrete_form`, the constructor expects:
   a `LatitudeLongitudeGrid`.
 
 * `discrete_form = true`:
-  - with `loc = (nothing, nothing, nothing)` (default):
-    functions of `(i, j, k, grid, ℓx, ℓy, ℓz)` with `ℓx`, `ℓy`,
+  - with `loc = (nothing, nothing, nothing)` and `parameters = nothing` (default):
+    functions of `(i, j, k, grid, ℓx, ℓy, ℓz, clock, fields)` with `ℓx`, `ℓy`,
     and `ℓz` either `Face()` or `Center()`.
   - with `loc = (ℓx, ℓy, ℓz)` with `ℓx`, `ℓy`, and `ℓz` either
-    `Face()` or `Center()`: functions of `(i, j, k, grid)`.
+    `Face()` or `Center()` and `parameters = nothing`: functions of `(i, j, k, grid, clock, fields)`.
+  - with `loc = (nothing, nothing, nothing)` and specified `parameters`:
+    functions of `(i, j, k, grid, ℓx, ℓy, ℓz, clock, fields, parameters)`.
+  - with `loc = (ℓx, ℓy, ℓz)` and specified `parameters`:
+    functions of `(i, j, k, grid, clock, fields, parameters)`.
 
 * `parameters`: `NamedTuple` with parameters used by the functions
   that compute viscosity and/or diffusivity; default: `nothing`.


### PR DESCRIPTION
some inline were missing for the general interpolation function. 
This PR fixes it

edit: also corrects a bug in the documentation