### PR TITLE
Fixes `getbc` for `FieldTimeSeries`

### DIFF
--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -602,13 +602,6 @@ function interior(fts::FieldTimeSeries)
     return view(parent(fts), i_view..., :)
 end
 
-# FieldTimeSeries boundary conditions
-const CPUFTSBC = BoundaryCondition{<:Any, <:FieldTimeSeries}
-const GPUFTSBC = BoundaryCondition{<:Any, <:GPUAdaptedFieldTimeSeries}
-const FTSBC = Union{CPUFTSBC, GPUFTSBC}
-
-@inline getbc(bc::FTSBC, i::Int, j::Int, grid::AbstractGrid, clock, args...) = bc.condition[i, j, Time(clock.time)]
-
 #####
 ##### Fill halo regions
 #####


### PR DESCRIPTION
I might be missing something but I don't think the current `getbc` for `FieldTimeSeries` boundary conditions works:
https://github.com/CliMA/Oceananigans.jl/blob/abb66e32d333562dd9aaeb7dd2ed8fac5e781368/src/OutputReaders/field_time_series.jl#L610
so this PR fixes it so now you can do e.g.
```julia
using Oceananigans
grid = RectilinearGrid(size=(16, 16, 16), x=(0, 2π), y=(0, 1), z=(0, 1), topology=(Periodic, Bounded, Bounded))
boundary_fts = FieldTimeSeries((Center, Nothing, Center), grid, [0:0.1:2;], time_indexing=Oceananigans.OutputReaders.Cyclical())
bcs = (; a = FieldBoundaryConditions(south = ValueBoundaryCondition(boundary_fts)))
[set!(boundary_fts[n], t) for (n, t) in enumerate(boundary_fts.times)]
model = NonhydrostaticModel(; grid, boundary_conditions=bcs, tracers=:a)
time_step!(model, 1.5)
model.tracers.a[1, :, 1]
22-element OffsetArray(::Vector{Float64}, -2:19) with eltype Float64 with indices -2:19:
 0.0
 0.0
 3.0200000000000005
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
 ⋮
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
```
