### PR TITLE
Update unified memory array

### DIFF
--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -94,7 +94,9 @@ cpu_architecture(::GPU) = CPU()
 
 unified_array(::CPU, a) = a
 unified_array(::GPU, a) = a
-unified_array(::GPU, a::AbstractArray) = cu(a; unified = true)
+
+# cu alters the type of `a`, so we convert it back to the correct type
+unified_array(::GPU, a::AbstractArray) = map(eltype(a), cu(a; unified = true))
 
 ## GPU to GPU copy of contiguous data
 @inline function device_copy_to!(dst::CuArray, src::CuArray; async::Bool = false) 

--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -94,16 +94,7 @@ cpu_architecture(::GPU) = CPU()
 
 unified_array(::CPU, a) = a
 unified_array(::GPU, a) = a
-
-function unified_array(::GPU, arr::AbstractArray) 
-    buf = Mem.alloc(Mem.Unified, sizeof(arr))
-    vec = unsafe_wrap(CuArray{eltype(arr),length(size(arr))}, convert(CuPtr{eltype(arr)}, buf), size(arr))
-    finalizer(vec) do _
-        Mem.free(buf)
-    end
-    copyto!(vec, arr)
-    return vec
-end
+unified_array(::GPU, a::AbstractArray) = cu(a; unified = true)
 
 ## GPU to GPU copy of contiguous data
 @inline function device_copy_to!(dst::CuArray, src::CuArray; async::Bool = false) 


### PR DESCRIPTION
updates the creation of a unified memory array following the (new?) CUDA.jl syntax

closes #3664 