### PR TITLE
Introduces `SumOfFields`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.91.4"
+version = "0.91.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -54,5 +54,6 @@ end
 end
 
 include("set!.jl")
+include("sum_of_fields.jl")
 
 end # module

--- a/src/Fields/sum_of_fields.jl
+++ b/src/Fields/sum_of_fields.jl
@@ -1,0 +1,79 @@
+using Base: @propagate_inbounds
+using Oceananigans.Fields: AbstractField, location
+
+import Adapt: adapt_structure
+import Base: getindex, show, summary
+import Oceananigans.BoundaryConditions: fill_halo_regions!
+import Oceananigans.ImmersedBoundaries: mask_immersed_field!, mask_immersed_field_xy!
+
+"""
+    SumOfFields{N, F}
+
+`SumOfFields` objects hold `N` field/fields and return their sum when indexed.
+"""
+struct SumOfFields{N, LX, LY, LZ, G, T, F} <: AbstractField{LX, LY, LZ, G, T, 3}
+    fields :: F
+      grid :: G
+    
+    function SumOfFields{N}(fields...) where N
+        grid = first(fields).grid
+        loc = location(first(fields))
+
+        all(f.grid == grid for f in fields) || 
+            throw(ArgumentError("All `fields` must be on the same grid"))
+
+        all(location(f) == loc for f in fields) || 
+            throw(ArgumentError("All `fields` must be on the same location"))
+
+        T = eltype(first(fields).data)
+        F = typeof(fields)
+        G = typeof(grid)
+
+        return new{N, loc..., G, T, F}(fields, grid)
+    end
+end
+
+adapt_structure(to, sum::SumOfFields{N}) where N = SumOfFields{N}((adapt_structure(to, field) for field in sum.fields)...)
+
+summary(::SumOfFields{N, LX, LY, LZ}) where {N, LX, LY, LZ}  = "Sum of $N fields at ($LX, $LY, $LZ)"
+
+show(io::IO, sof::SumOfFields{N, LX, LY, LZ}) where {N, LX, LY, LZ} = print(io, summary(sof))
+
+@propagate_inbounds function getindex(s::SumOfFields{N, LX, LY, LZ, G, T, F}, i...) where {N, LX, LY, LZ, G, T, F}
+    first = getindex(SumOfFields{3, F, LX, LY, LZ, G, T}((s.fields[1], s.fields[2], s.fields[3]), s.grid), i...)
+    last = getindex(SumOfFields{N - 3, F, LX, LY, LZ, G, T}(s.fields[4:N], s.grid), i...)
+    return first + last
+end
+
+@propagate_inbounds getindex(s::SumOfFields{1}, i...) = getindex(s.fields[1], i...)
+@propagate_inbounds getindex(s::SumOfFields{2}, i...) = getindex(s.fields[1], i...) + getindex(s.fields[2], i...)
+
+@propagate_inbounds getindex(s::SumOfFields{3}, i...) = 
+    getindex(s.fields[1], i...) + getindex(s.fields[2], i...) + getindex(s.fields[3], i...)
+    
+@propagate_inbounds getindex(s::SumOfFields{4}, i...) = 
+    getindex(s.fields[1], i...) + getindex(s.fields[2], i...) + getindex(s.fields[3], i...) + getindex(s.fields[4], i...)
+
+function mask_immersed_field!(sof::SumOfFields, value=zero(eltype(sof.grid)))
+    for field in sof.fields
+        mask_immersed_field!(field, value)
+    end
+    
+    return nothing
+end
+
+function mask_immersed_field_xy!(sof::SumOfFields, value=zero(eltype(sof.grid)))
+    for field in sof.fields
+        mask_immersed_field_xy!(field, value)
+    end
+    
+    return nothing
+end
+
+function fill_halo_regions!(sof::SumOfFields)
+    for f in sof.fields
+        fill_halo_regions!(f)
+    end
+    
+    return nothing
+end

--- a/src/Fields/sum_of_fields.jl
+++ b/src/Fields/sum_of_fields.jl
@@ -20,10 +20,10 @@ struct SumOfFields{N, LX, LY, LZ, G, T, F} <: AbstractField{LX, LY, LZ, G, T, 3}
         loc = location(first(fields))
 
         all(f.grid == grid for f in fields) || 
-            throw(ArgumentError("All `fields` must be on the same grid"))
+            throw(ArgumentError("All `fields` in `SumOfFields` must be on the same grid"))
 
         all(location(f) == loc for f in fields) || 
-            throw(ArgumentError("All `fields` must be on the same location"))
+            throw(ArgumentError("All `fields` in `SumOfFields` must be on the same location"))
 
         T = eltype(first(fields).data)
         F = typeof(fields)

--- a/src/ImmersedBoundaries/mask_immersed_field.jl
+++ b/src/ImmersedBoundaries/mask_immersed_field.jl
@@ -10,6 +10,13 @@ mask_immersed_field!(field, grid, loc, value) = nothing
 mask_immersed_field!(field::Field, value=zero(eltype(field.grid))) =
     mask_immersed_field!(field, field.grid, location(field), value)
 
+function mask_immersed_field!(sumofarrays::SumOfArrays, value=zero(eltype(sumofarrays.arrays[1])))
+    loc = @inbounds location(sumofarrays.arrays[1])
+    grid = @inbounds sumofarrays.arrays[1].grid
+
+   return mask_immersed_field!(sumofarrays, grid, loc, value)
+end
+
 """
     mask_immersed_field!(field::Field, grid::ImmersedBoundaryGrid, loc, value)
 
@@ -23,7 +30,7 @@ function mask_immersed_field!(field::Field, grid::ImmersedBoundaryGrid, loc, val
 end
 
 function mask_immersed_field!(sumofarrays::SumOfArrays, grid::ImmersedBoundaryGrid, loc, value; k, mask)
-    arch = architecture(sumofarrays.arrays[1])
+    arch = @inbounds architecture(sumofarrays.arrays[1])
     loc = instantiate.(loc)
 
     for field in sumofarrays.arrays
@@ -62,7 +69,7 @@ end
 end
 
 function mask_immersed_field_xy!(sumofarrays::SumOfArrays, grid::ImmersedBoundaryGrid, loc, value; k, mask)
-    arch = architecture(sumofarrays.arrays[1])
+    arch = @inbounds architecture(sumofarrays.arrays[1])
     loc = instantiate.(loc)
 
     for field in sumofarrays.arrays

--- a/src/ImmersedBoundaries/mask_immersed_field.jl
+++ b/src/ImmersedBoundaries/mask_immersed_field.jl
@@ -22,6 +22,17 @@ function mask_immersed_field!(field::Field, grid::ImmersedBoundaryGrid, loc, val
     return nothing
 end
 
+function mask_immersed_field!(sumofarrays::SumOfArrays, grid::ImmersedBoundaryGrid, loc, value; k, mask)
+    arch = architecture(sumofarrays.arrays[1])
+    loc = instantiate.(loc)
+
+    for field in sumofarrays.arrays
+        launch!(arch, grid, :xyz,
+                _mask_immersed_field!, field, loc, grid, value, k, mask)
+    end
+
+    return nothing
+end
 
 @kernel function _mask_immersed_field!(field, loc, grid, value)
     i, j, k = @index(Global, NTuple)

--- a/src/ImmersedBoundaries/mask_immersed_field.jl
+++ b/src/ImmersedBoundaries/mask_immersed_field.jl
@@ -10,14 +10,6 @@ mask_immersed_field!(field, grid, loc, value) = nothing
 mask_immersed_field!(field::Field, value=zero(eltype(field.grid))) =
     mask_immersed_field!(field, field.grid, location(field), value)
 
-function mask_immersed_field!(sumofarrays::SumOfArrays, value=zero(eltype(sumofarrays.arrays[1])))
-    for field in sumofarrays.arrays
-        mask_immersed_field!(field, value)
-    end
-    
-    return nothing
-end
-
 """
     mask_immersed_field!(field::Field, grid::ImmersedBoundaryGrid, loc, value)
 
@@ -39,14 +31,6 @@ mask_immersed_field_xy!(field,     args...; kw...) = nothing
 mask_immersed_field_xy!(::Nothing, args...; kw...) = nothing
 mask_immersed_field_xy!(field, value=zero(eltype(field.grid)); k, mask = peripheral_node) =
     mask_immersed_field_xy!(field, field.grid, location(field), value; k, mask)
-
-function mask_immersed_field_xy!(sumofarrays::SumOfArrays, value=zero(eltype(sumofarrays.arrays[1])))
-    for field in sumofarrays.arrays
-        mask_immersed_field_xy!(field, value)
-    end
-
-    return nothing
-end
 
 """
     mask_immersed_field_xy!(field::Field, grid::ImmersedBoundaryGrid, loc, value; k, mask=peripheral_node)


### PR DESCRIPTION
This PR adds a method to `mask_immersed_field!` for `SumOfArrays`. I was trying to make a model which has an auxiliary field which is a `SumOfArrays` but ran into the error that all of the prognostic and auxiliary fields in the `HydrostaticFreeSurfaceModel` get masked during the `update_state!` step.

(Ran into the issue here: https://github.com/OceanBioME/OceanBioME.jl/pull/195)