### PR TITLE
Go back to support `BoundaryCondition(Classification, args...)`

### DIFF
--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -56,6 +56,9 @@ function BoundaryCondition(classification::AbstractBoundaryConditionClassificati
     return BoundaryCondition(classification, condition)
 end
 
+# Convenience constructor
+BoundaryCondition(Classification::DataType, args...; kwargs...) = BoundaryCondition(Classification(), args...; kwargs...)
+
 # Adapt boundary condition struct to be GPU friendly and passable to GPU kernels.
 Adapt.adapt_structure(to, b::BoundaryCondition) =
     BoundaryCondition(Adapt.adapt(to, b.classification), Adapt.adapt(to, b.condition))


### PR DESCRIPTION
It looks like this constructor was indeed removed by mistake in #3482.
This is a change that breaks several other codes / packages. I reintroduce it here.

On the other hand, if we want to keep it out of the codebase, I will switch this PR to a version bump. 
I vote for reintroducing this convenience constructor.