### PR TITLE
Disambiguate tracer fluxes on an immersed boundary

### DIFF
--- a/src/ImmersedBoundaries/conditional_fluxes.jl
+++ b/src/ImmersedBoundaries/conditional_fluxes.jl
@@ -81,6 +81,48 @@ end
 @inline _advective_tracer_flux_y(i, j, k, ibg::IBG, args...) = conditional_flux_cfc(i, j, k, ibg, zero(ibg), advective_tracer_flux_y(i, j, k, ibg, args...))
 @inline _advective_tracer_flux_z(i, j, k, ibg::IBG, args...) = conditional_flux_ccf(i, j, k, ibg, zero(ibg), advective_tracer_flux_z(i, j, k, ibg, args...))
 
+# Disambiguation for tracer fluxes....
+@inline _advective_tracer_flux_x(i, j, k, ibg::IBG, advection::TracerAdvection, args...) =
+        _advective_tracer_flux_x(i, j, k, ibg, advection.x, args...)
+
+@inline _advective_tracer_flux_y(i, j, k, ibg::IBG, advection::TracerAdvection, args...) =
+        _advective_tracer_flux_y(i, j, k, ibg, advection.y, args...)
+
+@inline _advective_tracer_flux_z(i, j, k, ibg::IBG, advection::TracerAdvection, args...) =
+        _advective_tracer_flux_z(i, j, k, ibg, advection.z, args...)
+
+# Fallback for `nothing` advection
+@inline _advective_tracer_flux_x(i, j, k, ibg::IBG, ::Nothing, args...) = zero(ibg)
+@inline _advective_tracer_flux_y(i, j, k, ibg::IBG, ::Nothing, args...) = zero(ibg)
+@inline _advective_tracer_flux_z(i, j, k, ibg::IBG, ::Nothing, args...) = zero(ibg)
+
+# Fallback for `nothing` advection and `ZeroField` tracers and velocities
+@inline _advective_tracer_flux_x(i, j, k, ibg::IBG, ::Nothing, ::ZeroField, ::ZeroField) = zero(ibg)
+@inline _advective_tracer_flux_y(i, j, k, ibg::IBG, ::Nothing, ::ZeroField, ::ZeroField) = zero(ibg)
+@inline _advective_tracer_flux_z(i, j, k, ibg::IBG, ::Nothing, ::ZeroField, ::ZeroField) = zero(ibg)
+
+@inline _advective_tracer_flux_x(i, j, k, ibg::IBG, ::Nothing, U, ::ZeroField) = zero(ibg)
+@inline _advective_tracer_flux_y(i, j, k, ibg::IBG, ::Nothing, V, ::ZeroField) = zero(ibg)
+@inline _advective_tracer_flux_z(i, j, k, ibg::IBG, ::Nothing, W, ::ZeroField) = zero(ibg)
+@inline _advective_tracer_flux_x(i, j, k, ibg::IBG, ::Nothing, ::ZeroField, c) = zero(ibg)
+@inline _advective_tracer_flux_y(i, j, k, ibg::IBG, ::Nothing, ::ZeroField, c) = zero(ibg)
+@inline _advective_tracer_flux_z(i, j, k, ibg::IBG, ::Nothing, ::ZeroField, c) = zero(ibg)
+
+# Fallback for `ZeroField` tracers and velocities
+@inline _advective_tracer_flux_x(i, j, k, ibg::IBG, scheme, ::ZeroField, ::ZeroField) = zero(ibg)
+@inline _advective_tracer_flux_y(i, j, k, ibg::IBG, scheme, ::ZeroField, ::ZeroField) = zero(ibg)
+@inline _advective_tracer_flux_z(i, j, k, ibg::IBG, scheme, ::ZeroField, ::ZeroField) = zero(ibg)
+
+# Fallback for `ZeroField` tracers
+@inline _advective_tracer_flux_x(i, j, k, ibg::IBG, scheme, U, ::ZeroField) = zero(ibg)
+@inline _advective_tracer_flux_y(i, j, k, ibg::IBG, scheme, V, ::ZeroField) = zero(ibg)
+@inline _advective_tracer_flux_z(i, j, k, ibg::IBG, scheme, W, ::ZeroField) = zero(ibg)
+
+# Fallback for `ZeroField` velocities
+@inline _advective_tracer_flux_x(i, j, k, ibg::IBG, scheme, ::ZeroField, c) = zero(ibg)
+@inline _advective_tracer_flux_y(i, j, k, ibg::IBG, scheme, ::ZeroField, c) = zero(ibg)
+@inline _advective_tracer_flux_z(i, j, k, ibg::IBG, scheme, ::ZeroField, c) = zero(ibg)
+
 #####
 ##### "Boundary-aware" reconstruct
 #####

--- a/src/ImmersedBoundaries/conditional_fluxes.jl
+++ b/src/ImmersedBoundaries/conditional_fluxes.jl
@@ -2,6 +2,7 @@ using Oceananigans.Advection: AbstractAdvectionScheme, advection_buffers
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑxᶜᵃᵃ, ℑyᵃᶠᵃ, ℑyᵃᶜᵃ, ℑzᵃᵃᶠ, ℑzᵃᵃᶜ 
 using Oceananigans.TurbulenceClosures: AbstractTurbulenceClosure, AbstractTimeDiscretization
 using Oceananigans.Advection: LOADV, HOADV, WENO, TracerAdvection
+using Oceananigans.Fields: ZeroField
 
 const ATC = AbstractTurbulenceClosure
 const ATD = AbstractTimeDiscretization

--- a/src/ImmersedBoundaries/conditional_fluxes.jl
+++ b/src/ImmersedBoundaries/conditional_fluxes.jl
@@ -1,7 +1,7 @@
 using Oceananigans.Advection: AbstractAdvectionScheme, advection_buffers
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑxᶜᵃᵃ, ℑyᵃᶠᵃ, ℑyᵃᶜᵃ, ℑzᵃᵃᶠ, ℑzᵃᵃᶜ 
 using Oceananigans.TurbulenceClosures: AbstractTurbulenceClosure, AbstractTimeDiscretization
-using Oceananigans.Advection: LOADV, HOADV, WENO
+using Oceananigans.Advection: LOADV, HOADV, WENO, TracerAdvection
 
 const ATC = AbstractTurbulenceClosure
 const ATD = AbstractTimeDiscretization

--- a/test/test_immersed_advection.jl
+++ b/test/test_immersed_advection.jl
@@ -124,6 +124,15 @@ for arch in archs
                 run_tracer_conservation_test(g, scheme)
             end
         end
+
+        for adv in advection_schemes, buffer in [1, 2, 3, 4, 5]
+            directional_scheme = adv(order = advective_order(buffer, adv))
+            scheme = TracerAdvection(directional_scheme, directional_scheme, directional_scheme)
+            for g in [grid, ibg]
+                @info "  Testing immersed tracer conservation [$(typeof(arch)), $(summary(scheme)), $(typeof(g).name.wrapper)]"
+                run_tracer_conservation_test(g, scheme)
+            end
+        end
     end
 
     @testset "Immersed momentum reconstruction" begin

--- a/test/test_immersed_advection.jl
+++ b/test/test_immersed_advection.jl
@@ -9,7 +9,8 @@ using Oceananigans.Advection:
         _biased_interpolate_xᶜᵃᵃ, 
         _biased_interpolate_xᶠᵃᵃ, 
         _biased_interpolate_yᵃᶜᵃ, 
-        _biased_interpolate_yᵃᶠᵃ
+        _biased_interpolate_yᵃᶠᵃ,
+        TracerAdvection
 
 advection_schemes = [Centered, UpwindBiased, WENO]
 


### PR DESCRIPTION
PR #3668 Introduced ambiguity for `TracerAdvection` on `ImmersedBoundaryGrid`s
This PR removes the ambiguity and adds a test to make sure this method is tested