### PR TITLE
Bugfix in distributed fill halos

### DIFF
--- a/src/DistributedComputations/distributed_fields.jl
+++ b/src/DistributedComputations/distributed_fields.jl
@@ -68,7 +68,7 @@ function synchronize_communication!(field)
         cooperative_waitall!(arch.mpi_requests)
 
         # Reset MPI tag
-        arch.mpi_tag[] -= arch.mpi_tag[]
+        arch.mpi_tag[] = 0
 
         # Reset MPI requests
         empty!(arch.mpi_requests)

--- a/src/DistributedComputations/halo_communication.jl
+++ b/src/DistributedComputations/halo_communication.jl
@@ -104,7 +104,7 @@ function fill_halo_regions!(c::OffsetArray, bcs, indices, loc, grid::Distributed
     end
     
     arch = architecture(grid)
-    
+
     fill_halos!, bcs = permute_boundary_conditions(bcs) 
     number_of_tasks  = length(fill_halos!)
 
@@ -118,6 +118,7 @@ function fill_halo_regions!(c::OffsetArray, bcs, indices, loc, grid::Distributed
     # This is the case only if any of the boundary conditions is a distributed communication 
     # boundary condition (DCBCT) _and_ the `only_local_halos` keyword argument is false.
     increment_tag = any(isa.(bcs, DCBCT)) && !only_local_halos
+    
     if increment_tag 
         arch.mpi_tag[] += 1
     end


### PR DESCRIPTION
The code now uses an incremental tag counter to track how many mpi requests are live. 
This tag is reset when communication is synchronized.

As it is defined right now, the tag is always incremented at the end of a `fill_halo_regions!` on a distributed grid, irrespective of what happened in the `fill_halo_regions!`, with the assumption that all cores participate in the `fill_halo_regions!` so the tags are correctly synchronized. 
https://github.com/CliMA/Oceananigans.jl/blob/315e66bb330b44acc2a0daf74ae357ee66e801d1/src/DistributedComputations/halo_communication.jl#L117-L121

Unfortunately, I experienced a situation where this was not the case. 
In this case, I wanted to do different things on different cores, which is allowed when using the `only_local_halos = true` keyword argument (a very rare occurrence, but a possibility nonetheless).

For example, if we execute this code on the main branch
```julia
arch = Distributed(CPU())
grid = RectilinearGrid(size = (2, 2, 1), extent = (1, 1, 1))
c = Field(grid)

if rank == 0
    fill_halo_regions!(c; only_local_halos = true)
end
```
The mpi_tag will be `1` on rank 0 and `0` on other ranks. This means that in subsequent halo passes, MPI will stall because it cannot match the tag cores communicating with rank 0.

This PR fixes this issue by incrementing the tag _only_ if we have actually launched a mpi send or receive operation, that happens when at least one of the `bcs` is a distributed boundary condition _and_ `only_local_halos == false`
