### PR TITLE
Add `child_architecture` methods for `Fields` and `FieldTimeSeries`

### DIFF
--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -257,8 +257,8 @@ true
 To use more than one CPU, we use the `Distributed` architecture,
 
 ```jldoctest grids
-child_architecture = CPU()
-architecture = Distributed(child_architecture)
+device_architecture = CPU()
+architecture = Distributed(device_architecture)
 
 # output
 [ Info: MPI has not been initialized, so we are calling MPI.Init().

--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -54,12 +54,12 @@ architecture(a::SubArray) = architecture(parent(a))
 architecture(a::OffsetArray) = architecture(parent(a))
 
 """
-    child_architecture(arch)
+    device_architecture(arch)
 
 Return `arch`itecture of child processes.
 On single-process, non-distributed systems, return `arch`.
 """
-child_architecture(arch) = arch
+device_architecture(arch) = arch
 
 array_type(::CPU) = Array
 array_type(::GPU) = CuArray

--- a/src/DistributedComputations/DistributedComputations.jl
+++ b/src/DistributedComputations/DistributedComputations.jl
@@ -2,7 +2,7 @@ module DistributedComputations
 
 export
     Distributed, Partition, Equal, Fractional, 
-    child_architecture, reconstruct_global_grid, 
+    device_architecture, reconstruct_global_grid, 
     inject_halo_communication_boundary_conditions,
     DistributedFFTBasedPoissonSolver
 

--- a/src/DistributedComputations/distributed_fft_based_poisson_solver.jl
+++ b/src/DistributedComputations/distributed_fft_based_poisson_solver.jl
@@ -99,7 +99,7 @@ function DistributedFFTBasedPoissonSolver(global_grid, local_grid, planner_flag=
     storage = TransposableField(CenterField(local_grid), FT)
 
     arch = architecture(storage.xfield.grid)
-    child_arch = child_architecture(arch)
+    child_arch = device_architecture(arch)
 
     # Build _global_ eigenvalues
     topo = (TX, TY, TZ) = topology(global_grid)

--- a/src/DistributedComputations/distributed_fft_tridiagonal_solver.jl
+++ b/src/DistributedComputations/distributed_fft_tridiagonal_solver.jl
@@ -163,7 +163,7 @@ function DistributedFourierTridiagonalPoissonSolver(global_grid, local_grid, pla
         error("`DistributedFourierTridiagonalPoissonSolver` requires that the stretched direction (dimension $tridiagonal_dim) is `Bounded`.")
 
     FT         = Complex{eltype(local_grid)}
-    child_arch = child_architecture(local_grid)
+    child_arch = device_architecture(local_grid)
     storage    = TransposableField(CenterField(local_grid), FT)
 
     topo = (TX, TY, TZ) = topology(global_grid)

--- a/src/DistributedComputations/distributed_fields.jl
+++ b/src/DistributedComputations/distributed_fields.jl
@@ -28,19 +28,19 @@ const DistributedField      = Field{<:Any, <:Any, <:Any, <:Any, <:DistributedGri
 const DistributedFieldTuple = NamedTuple{S, <:NTuple{N, DistributedField}} where {S, N}
 const DistributedFTS        = FieldTimeSeries{LX, LY, LZ, TI, K, I, D, <:DistributedGrid} where {LX, LY, LZ, TI, K, I, D}
 
-child_architecture(field::AbstractField)    = architecture(field)
-child_architecture(field::DistributedField) = child_architecture(architecture(field))
-child_architecture(field::DistributedFTS)   = child_architecture(architecture(field))
+device_architecture(field::AbstractField)    = architecture(field)
+device_architecture(field::DistributedField) = device_architecture(architecture(field))
+device_architecture(field::DistributedFTS)   = device_architecture(architecture(field))
 
 function set!(u::DistributedField, f::Function)
     arch = architecture(u)
-    if child_architecture(arch) isa GPU
+    if device_architecture(arch) isa GPU
         cpu_grid = on_architecture(cpu_architecture(arch), u.grid)
         u_cpu = Field(location(u), cpu_grid, eltype(u); indices = indices(u))
         f_field = field(location(u), f, cpu_grid)
         set!(u_cpu, f_field)
         set!(u, u_cpu)
-    elseif child_architecture(arch) isa CPU
+    elseif device_architecture(arch) isa CPU
         f_field = field(location(u), f, u.grid)
         set!(u, f_field)
     end

--- a/src/DistributedComputations/distributed_fields.jl
+++ b/src/DistributedComputations/distributed_fields.jl
@@ -3,7 +3,15 @@ import Oceananigans.BoundaryConditions: fill_halo_regions!
 
 using CUDA: CuArray
 using Oceananigans.Grids: topology
-using Oceananigans.Fields: validate_field_data, indices, validate_boundary_conditions, validate_indices, recv_from_buffers!
+
+using Oceananigans.Fields: validate_boundary_conditions, 
+                           validate_field_data, 
+                           validate_indices,
+                           AbstractField,  
+                           indices, 
+                           recv_from_buffers!   
+
+using Oceananigans.OutputReaders: FieldTimeSeries
 
 function Field((LX, LY, LZ)::Tuple, grid::DistributedGrid, data, old_bcs, indices::Tuple, op, status)
     arch = architecture(grid)
@@ -18,6 +26,11 @@ end
 
 const DistributedField      = Field{<:Any, <:Any, <:Any, <:Any, <:DistributedGrid}
 const DistributedFieldTuple = NamedTuple{S, <:NTuple{N, DistributedField}} where {S, N}
+const DistributedFTS        = FieldTimeSeries{LX, LY, LZ, TI, K, I, D, <:DistributedGrid} where {LX, LY, LZ, TI, K, I, D}
+
+child_architecture(field::AbstractField)    = architecture(field)
+child_architecture(field::DistributedField) = child_architecture(architecture(field))
+child_architecture(field::DistributedFTS)   = child_architecture(architecture(field))
 
 function set!(u::DistributedField, f::Function)
     arch = architecture(u)

--- a/src/DistributedComputations/distributed_kernel_launching.jl
+++ b/src/DistributedComputations/distributed_kernel_launching.jl
@@ -1,7 +1,7 @@
 import Oceananigans.Utils: launch!
 
 function launch!(arch::Distributed, args...; kwargs...)
-    child_arch = child_architecture(arch)
+    child_arch = device_architecture(arch)
     return launch!(child_arch, args...; kwargs...)
 end
 

--- a/src/DistributedComputations/distributed_on_architecture.jl
+++ b/src/DistributedComputations/distributed_on_architecture.jl
@@ -17,10 +17,10 @@ DisambiguationTypes = Union{Array,
                             Tuple,
                             NamedTuple}
 
-on_architecture(arch::Distributed, a::DisambiguationTypes) = on_architecture(child_architecture(arch), a)
+on_architecture(arch::Distributed, a::DisambiguationTypes) = on_architecture(device_architecture(arch), a)
 
 function on_architecture(new_arch::Distributed, old_grid::LatitudeLongitudeGrid) 
-    child_arch = child_architecture(new_arch)
+    child_arch = device_architecture(new_arch)
     old_properties = (old_grid.Δλᶠᵃᵃ, old_grid.Δλᶜᵃᵃ, old_grid.λᶠᵃᵃ,  old_grid.λᶜᵃᵃ,
                       old_grid.Δφᵃᶠᵃ, old_grid.Δφᵃᶜᵃ, old_grid.φᵃᶠᵃ,  old_grid.φᵃᶜᵃ,
                       old_grid.Δzᵃᵃᶠ, old_grid.Δzᵃᵃᶜ, old_grid.zᵃᵃᶠ,  old_grid.zᵃᵃᶜ,
@@ -41,7 +41,7 @@ function on_architecture(new_arch::Distributed, old_grid::LatitudeLongitudeGrid)
 end
 
 function on_architecture(new_arch::Distributed, old_grid::RectilinearGrid)
-    child_arch = child_architecture(new_arch)
+    child_arch = device_architecture(new_arch)
     old_properties = (old_grid.Δxᶠᵃᵃ, old_grid.Δxᶜᵃᵃ, old_grid.xᶠᵃᵃ, old_grid.xᶜᵃᵃ,
                       old_grid.Δyᵃᶠᵃ, old_grid.Δyᵃᶜᵃ, old_grid.yᵃᶠᵃ, old_grid.yᵃᶜᵃ,
                       old_grid.Δzᵃᵃᶠ, old_grid.Δzᵃᵃᶜ, old_grid.zᵃᵃᶠ, old_grid.zᵃᵃᶜ)

--- a/src/DistributedComputations/halo_communication.jl
+++ b/src/DistributedComputations/halo_communication.jl
@@ -221,7 +221,7 @@ for side in [:southwest, :southeast, :northwest, :northeast]
         $fill_corner_halo!(c, corner, indices, loc, arch, grid, buffers, ::Nothing, args...; kwargs...) = nothing
 
         function $fill_corner_halo!(c, corner, indices, loc, arch, grid, buffers, sd, args...; kwargs...) 
-            child_arch = child_architecture(arch)
+            child_arch = device_architecture(arch)
             local_rank = arch.local_rank
 
             recv_req = $recv_and_fill_side_halo!(c, grid, arch, loc, local_rank, corner, buffers)
@@ -282,7 +282,7 @@ for side in [:west, :east, :south, :north]
 
             sync_device!(arch)
 
-            child_arch = child_architecture(arch)
+            child_arch = device_architecture(arch)
             local_rank = bc_side.condition.from
 
             recv_req = $recv_and_fill_side_halo!(c, grid, arch, loc, local_rank, bc_side.condition.to, buffers)

--- a/src/DistributedComputations/partition_assemble.jl
+++ b/src/DistributedComputations/partition_assemble.jl
@@ -148,7 +148,7 @@ function partition_global_array(arch::Distributed, c_global::AbstractArray, n)
                             1 + sum(ny[1:rj-1]) : sum(ny[1:rj]), 
                             1:nz]
     end
-    return on_architecture(child_architecture(arch), c_local)
+    return on_architecture(device_architecture(arch), c_local)
 end
 
 """
@@ -191,5 +191,5 @@ function construct_global_array(arch::Distributed, c_local::AbstractArray, n)
         MPI.Allreduce!(c_global, +, arch.communicator)
     end
 
-    return on_architecture(child_architecture(arch), c_global)
+    return on_architecture(device_architecture(arch), c_global)
 end

--- a/src/DistributedComputations/transposable_field.jl
+++ b/src/DistributedComputations/transposable_field.jl
@@ -142,7 +142,7 @@ function twin_grid(grid::DistributedGrid; local_direction = :y)
     yG = R[2] == 1 ? y : assemble_coordinate(y, ny, arch, 2)
     zG = R[3] == 1 ? z : assemble_coordinate(z, nz, arch, 3)
 
-    child_arch = child_architecture(arch)
+    child_arch = device_architecture(arch)
 
     FT = eltype(grid)
 

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -7,7 +7,7 @@ using Oceananigans.Grids: topology, node, _node,
                           ZRegOrthogonalSphericalShellGrid,
                           RectilinearGrid, LatitudeLongitudeGrid
 
-using Oceananigans.Architectures: child_architecture
+using Oceananigans.Architectures: device_architecture
 
 # GPU-compatile middle point calculation
 @inline middle_point(l, h) = Base.unsafe_trunc(Int, (l + h) / 2)
@@ -350,8 +350,8 @@ function interpolate!(to_field::Field, from_field::AbstractField)
 
     # In case architectures are `Distributed` we
     # verify that the fields are on the same child architecture
-    to_arch   = child_architecture(to_arch)
-    from_arch = child_architecture(from_arch)
+    to_arch   = device_architecture(to_arch)
+    from_arch = device_architecture(from_arch)
 
     if !isnothing(from_arch) && to_arch != from_arch
         msg = "Cannot interpolate! because from_field is on $from_arch while to_field is on $to_arch."

--- a/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/split_explicit_free_surface_kernels.jl
@@ -8,7 +8,7 @@ using Oceananigans.ImmersedBoundaries: peripheral_node, immersed_inactive_node, 
 using Oceananigans.ImmersedBoundaries: inactive_node, IBG, c, f, ZColumnMap
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!, active_surface_map, active_interior_map
 using Oceananigans.ImmersedBoundaries: active_linear_index_to_tuple, ActiveCellsIBG, ActiveZColumnsIBG
-using Oceananigans.DistributedComputations: child_architecture
+using Oceananigans.DistributedComputations: device_architecture
 using Oceananigans.DistributedComputations: Distributed
 
 using Printf

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -249,7 +249,7 @@ update_field_time_series!(fts, n::Int) = nothing
 # Linear extrapolation, simple version
 function update_field_time_series!(fts::PartlyInMemoryFTS, time_index::Time)
     t = time_index.time
-    ñ, n₁, n₂ = cpu_interpolating_time_indices(child_architecture(fts), fts.times, fts.time_indexing, t)
+    ñ, n₁, n₂ = cpu_interpolating_time_indices(device_architecture(fts), fts.times, fts.time_indexing, t)
     return update_field_time_series!(fts, n₁, n₂)
 end
 

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -249,7 +249,7 @@ update_field_time_series!(fts, n::Int) = nothing
 # Linear extrapolation, simple version
 function update_field_time_series!(fts::PartlyInMemoryFTS, time_index::Time)
     t = time_index.time
-    ñ, n₁, n₂ = cpu_interpolating_time_indices(architecture(fts), fts.times, fts.time_indexing, t)
+    ñ, n₁, n₂ = cpu_interpolating_time_indices(child_architecture(fts), fts.times, fts.time_indexing, t)
     return update_field_time_series!(fts, n₁, n₂)
 end
 

--- a/src/Solvers/discrete_transforms.jl
+++ b/src/Solvers/discrete_transforms.jl
@@ -1,4 +1,4 @@
-import Oceananigans.Architectures: architecture, child_architecture
+import Oceananigans.Architectures: architecture, device_architecture
 
 abstract type AbstractTransformDirection end
 
@@ -17,7 +17,7 @@ struct DiscreteTransform{P, D, G, Δ, Ω, N, T, Σ}
 end
 
 # Includes support for distributed architectures
-architecture(transform::DiscreteTransform) = child_architecture(architecture(transform.grid))
+architecture(transform::DiscreteTransform) = device_architecture(architecture(transform.grid))
 
 #####
 ##### Normalization factors
@@ -81,7 +81,7 @@ end
 NoTransform() = DiscreteTransform([nothing for _ in fieldnames(DiscreteTransform)]...)
 
 function DiscreteTransform(plan, direction, grid, dims)
-    arch = child_architecture(grid) # In case we are doing it on a DistributedGrid
+    arch = device_architecture(grid) # In case we are doing it on a DistributedGrid
 
     isnothing(plan) && return NoTransform()
 

--- a/test/utils_for_runtests.jl
+++ b/test/utils_for_runtests.jl
@@ -7,7 +7,7 @@ using KernelAbstractions: @kernel, @index
 
 using Oceananigans
 using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, RungeKutta3TimeStepper, update_state!
-using Oceananigans.DistributedComputations: Distributed, Partition, child_architecture, Fractional, Equal
+using Oceananigans.DistributedComputations: Distributed, Partition, device_architecture, Fractional, Equal
 
 import Oceananigans.Fields: interior
 


### PR DESCRIPTION
In addition, this PR changes the input to `cpu_interpolating_time_indices` from `architecture(fts)` to `child_architecture(fts)` to make sure that the function works also for a distributed `FieldTimeSeries`