### PR TITLE
Nullify preferred axis for field arg

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.4"
 manifest_format = "2.0"
-project_hash = "fc80901e62b273c6815173b7a2bdcfd9bb441d24"
+project_hash = "9815a4091be3641fb9635ba2f3346c2241d20bcf"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]

--- a/Project.toml
+++ b/Project.toml
@@ -36,10 +36,11 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 [weakdeps]
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [extensions]
 OceananigansEnzymeExt = "Enzyme"
-OceananigansMakieExt = "MakieCore"
+OceananigansMakieExt = ["MakieCore", "Makie"]
 
 [compat]
 Adapt = "3, 4"
@@ -59,8 +60,9 @@ JLD2 = "0.4"
 KernelAbstractions = "0.9.21"
 LinearAlgebra = "1.9"
 Logging = "1.9"
-MakieCore = "0.7, 0.8"
 MPI = "0.16, 0.17, 0.18, 0.19, 0.20"
+MakieCore = "0.7, 0.8"
+Makie = "0.21"
 NCDatasets = "0.12.10, 0.13.1, 0.14"
 OffsetArrays = "1.4"
 OrderedCollections = "1.1"

--- a/ext/OceananigansMakieExt.jl
+++ b/ext/OceananigansMakieExt.jl
@@ -8,6 +8,10 @@ using MakieCore: AbstractPlot
 import MakieCore: convert_arguments, _create_plot
 import Makie: args_preferred_axis
 
+# Extending args_preferred_axis here ensures that Field
+# do not overstate a preference for being plotted in a 3D LScene.
+# Because often we are trying to plot 1D and 2D Field, even though
+# (perhaps incorrectly) all Field are AbstractArray{3}.
 args_preferred_axis(::Field) = nothing
 
 function drop_singleton_indices(N)

--- a/ext/OceananigansMakieExt.jl
+++ b/ext/OceananigansMakieExt.jl
@@ -6,6 +6,9 @@ using Oceananigans.ImmersedBoundaries: mask_immersed_field!
 
 using MakieCore: AbstractPlot
 import MakieCore: convert_arguments, _create_plot
+import Makie: args_preferred_axis
+
+args_preferred_axis(::Field) = nothing
 
 function drop_singleton_indices(N)
     if N == 1


### PR DESCRIPTION
This PR ensures that `Field` do not associated with a "preferred axis" (which will always be `LScene` because they are `AbstractArray{3}`). As a result the axis is determined later, hopefully by the converted form of the args.

Closes #3727, where `lines` was being plotted in an `LScene` if you included both field nodes and a field.