### PR TITLE
Fix CFL calculation on flat grids

### DIFF
--- a/src/Advection/cell_advection_timescale.jl
+++ b/src/Advection/cell_advection_timescale.jl
@@ -16,12 +16,19 @@ function cell_advection_timescale(grid, velocities)
     return minimum(τ)
 end
 
-@inline function cell_advection_timescaleᶜᶜᶜ(i, j, k, grid, u, v, w)
+@inline _inverse_timescale(i, j, k, Δ, U, topo) = @inbounds abs(U[i, j, k]) / Δ
+@inline _inverse_timescale(i, j, k, Δ, U, topo::Flat) = 0
+
+@inline function cell_advection_timescaleᶜᶜᶜ(i, j, k, grid::AbstractGrid{FT, TX, TY, TZ}, u, v, w) where {FT, TX, TY, TZ}
     Δx = Δxᶠᶜᶜ(i, j, k, grid)
     Δy = Δyᶜᶠᶜ(i, j, k, grid)
     Δz = Δzᶜᶜᶠ(i, j, k, grid)
 
-    inverse_timescale = @inbounds abs(u[i, j, k]) / Δx + abs(v[i, j, k]) / Δy + abs(w[i, j, k]) / Δz
+    inverse_timescale_x = _inverse_timescale(i, j, k, Δx, u, TX())
+    inverse_timescale_y = _inverse_timescale(i, j, k, Δy, v, TY())
+    inverse_timescale_z = _inverse_timescale(i, j, k, Δz, w, TZ())
+    
+    inverse_timescale = inverse_timescale_x + inverse_timescale_y + inverse_timescale_z
      
     return 1 / inverse_timescale
 end

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -139,6 +139,20 @@ function advective_timescale_cfl_on_lat_lon_grid(arch, FT)
     return cfl(model) ≈ CFL_by_hand
 end
 
+function advective_timescale_cfl_on_flat_2d_grid(arch, FT)
+    Δx = 0.5
+    topo = (Periodic, Flat, Bounded)
+    grid = RectilinearGrid(arch, FT, topology=topo, size=(3, 3), x=(0, 3Δx), z=(0, 3Δx))
+
+    model = NonhydrostaticModel(; grid)
+    set!(model, v=1)
+
+    Δt = FT(1.7)
+    cfl = CFL(FT(Δt), Oceananigans.Advection.cell_advection_timescale)
+
+    return cfl(model) == 0
+end
+
 get_iteration(model) = model.clock.iteration
 get_time(model) = model.clock.time
 
@@ -177,6 +191,7 @@ end
                 @test advective_timescale_cfl_on_regular_grid(arch, FT)
                 @test advective_timescale_cfl_on_stretched_grid(arch, FT)
                 @test advective_timescale_cfl_on_lat_lon_grid(arch, FT)
+                @test advective_timescale_cfl_on_flat_2d_grid(arch, FT)
             end
         end
     end


### PR DESCRIPTION
This PR just implements the proposed solution in issue #3679 so that the CFL calculation is correct on flat grids. I also added a test that fails without the fix, and passes with the fix.

Resolves #3679