### PR TITLE
(0.91.12) Fix non-optimal CATKE parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.91.11"
+version = "0.91.12"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_equation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_equation.jl
@@ -5,13 +5,13 @@ Parameters for the evolution of oceanic turbulent kinetic energy at the O(1 m) s
 isotropic turbulence and diapycnal mixing.
 """
 Base.@kwdef struct CATKEEquation{FT}
-    CʰⁱD  :: FT = 0.357 # Dissipation length scale shear coefficient for high Ri
-    CˡᵒD  :: FT = 0.926 # Dissipation length scale shear coefficient for low Ri
-    CᵘⁿD  :: FT = 1.437 # Dissipation length scale shear coefficient for high Ri
-    CᶜD   :: FT = 2.556 # Dissipation length scale convecting layer coefficient
+    CʰⁱD  :: FT = 0.579 # Dissipation length scale shear coefficient for high Ri
+    CˡᵒD  :: FT = 1.604 # Dissipation length scale shear coefficient for low Ri
+    CᵘⁿD  :: FT = 0.923 # Dissipation length scale shear coefficient for high Ri
+    CᶜD   :: FT = 3.254 # Dissipation length scale convecting layer coefficient
     CᵉD   :: FT = 0.0   # Dissipation length scale penetration layer coefficient
-    Cᵂu★  :: FT = 0.405 # Surface shear-driven TKE flux coefficient
-    CᵂwΔ  :: FT = 0.873 # Surface convective TKE flux coefficient
+    Cᵂu★  :: FT = 3.179 # Surface shear-driven TKE flux coefficient
+    CᵂwΔ  :: FT = 0.383 # Surface convective TKE flux coefficient
     Cᵂϵ   :: FT = 1.0   # Dissipative near-bottom TKE flux coefficient
 end
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_mixing_length.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_mixing_length.jl
@@ -16,7 +16,7 @@ Base.@kwdef struct CATKEMixingLength{FT}
     Cˢ   :: FT = 1.131  # Surface distance coefficient for shear length scale
     Cᵇ   :: FT = Inf    # Bottom distance coefficient for shear length scale
     Cˢᵖ  :: FT = 0.505  # Sheared convective plume coefficient
-    CRiᵟ :: FT = 0.102  # Stability function width 
+    CRiᵟ :: FT = 1.02   # Stability function width 
     CRi⁰ :: FT = 0.254  # Stability function lower Ri
     Cʰⁱu :: FT = 0.242  # Shear mixing length coefficient for momentum at high Ri
     Cˡᵒu :: FT = 0.361  # Shear mixing length coefficient for momentum at low Ri


### PR DESCRIPTION
This PR fixes the values for CATKE parameters:
- the "stability function Ri width" parameter
- all of the `CATKEEquation` parameters

It seems the job of copying these from the optimal set found by [Wagner et al 2024](https://glwagner.github.io/assets/pdf/CATKE.pdf#page=4.67)  was not finished.