### PR TITLE
(0.91.13) Use SeawaterPolynomials 0.3.5

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -721,9 +721,9 @@ uuid = "6c6a2e73-6563-6170-7368-637461726353"
 version = "1.2.1"
 
 [[deps.SeawaterPolynomials]]
-git-tree-sha1 = "6d85acd6de472f8e6da81c61c7c5b6280a55e0bc"
+git-tree-sha1 = "78f965a2f0cd5250a20c9aba9979346dd2b35734"
 uuid = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
-version = "0.3.4"
+version = "0.3.5"
 
 [[deps.SentinelArrays]]
 deps = ["Dates", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.91.12"
+version = "0.91.13"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -70,7 +70,7 @@ Pkg = "1.9"
 Printf = "1.9"
 Random = "1.9"
 Rotations = "1.0"
-SeawaterPolynomials = "0.3.4"
+SeawaterPolynomials = "0.3.5"
 SparseArrays = "1.9"
 Statistics = "1.9"
 StructArrays = "0.4, 0.5, 0.6"
@@ -84,12 +84,12 @@ DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+OrthogonalSphericalShellGrids = "c2be9673-fb75-4747-82dc-aa2bb9f4aed0"
 OpenMPI_jll = "fe0851c0-eecd-5654-98d4-656369965a5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
-OrthogonalSphericalShellGrids = "c2be9673-fb75-4747-82dc-aa2bb9f4aed0"
 
 [targets]
-test = ["BenchmarkTools", "Coverage", "CUDA_Runtime_jll", "DataDeps", "Enzyme", "InteractiveUtils", "MPIPreferences", "OpenMPI_jll", "Test", "TimerOutputs", "TimesDates", "SafeTestsets", "OrthogonalSphericalShellGrids"]
+test = ["BenchmarkTools", "Coverage", "CUDA_Runtime_jll", "DataDeps", "Enzyme", "InteractiveUtils", "MPIPreferences", "OrthogonalSphericalShellGrids", "OpenMPI_jll", "SafeTestsets", "Test", "TimerOutputs", "TimesDates"]

--- a/src/Models/seawater_density.jl
+++ b/src/Models/seawater_density.jl
@@ -93,7 +93,7 @@ julia> set!(model, S = 34.7, T = 0.5)
 julia> density_operation = seawater_density(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: ρ (generic function with 2 methods)
+├── kernel_function: ρ (generic function with 3 methods)
 └── arguments: ("BoussinesqEquationOfState{Float64}", "1×1×100 Field{Center, Center, Center} on RectilinearGrid on CPU", "1×1×100 Field{Center, Center, Center} on RectilinearGrid on CPU", "KernelFunctionOperation at (Center, Center, Center)")
 
 julia> density_field = Field(density_operation)
@@ -114,7 +114,7 @@ julia> compute!(density_field)
 ├── operand: KernelFunctionOperation at (Center, Center, Center)
 ├── status: time=0.0
 └── data: 1×1×106 OffsetArray(::Array{Float64, 3}, 1:1, 1:1, -2:103) with eltype Float64 with indices 1:1×1:1×-2:103
-    └── max=1027.81, min=1027.71, mean=1027.76
+    └── max=1032.38, min=1027.73, mean=1030.06
 ```
 
 Values for `temperature`, `salinity` and `geopotential_height` can be passed to


### PR DESCRIPTION
This PR bumps SeawaterPolynomials 0.3.5 and fixes a doctest. The changes in this PR would remedy the docs built failing in #3766.