### PR TITLE
Optimizes fill_halo_regions_open.jl

### DIFF
--- a/src/BoundaryConditions/fill_halo_regions_open.jl
+++ b/src/BoundaryConditions/fill_halo_regions_open.jl
@@ -61,13 +61,13 @@ end
 # no open fills
 @inline get_open_halo_filling(args...) = nothing, nothing
 
-@inline get_open_halo_filling(field, indices, boundary_conditions, ::Tuple{Face, Center, Center}, grid) = 
+@inline get_open_halo_filling(field, indices, boundary_conditions, loc::Tuple{Face, Center, Center}, grid) = 
     _fill_west_and_east_open_halo!, fill_halo_size(field, fill_west_and_east_halo!, indices, boundary_conditions, loc, grid)
 
-@inline get_open_halo_filling(field, indices, boundary_conditions, ::Tuple{Center, Face, Center}, loc) = 
+@inline get_open_halo_filling(field, indices, boundary_conditions, loc::Tuple{Center, Face, Center}, grid) = 
     _fill_south_and_north_open_halo!, fill_halo_size(field, fill_south_and_north_halo!, indices, boundary_conditions, loc, grid)
 
-@inline get_open_halo_filling(field, indices, boundary_conditions, ::Tuple{Center, Center, Face}, loc) = 
+@inline get_open_halo_filling(field, indices, boundary_conditions, loc::Tuple{Center, Center, Face}, grid) = 
     _fill_bottom_and_top_open_halo!, fill_halo_size(field, fill_bottom_and_top_halo!, indices, boundary_conditions, loc, grid)
 
 @kernel function _fill_west_and_east_open_halo!(c, west_bc, east_bc, loc, grid, args) 

--- a/src/BoundaryConditions/fill_halo_regions_open.jl
+++ b/src/BoundaryConditions/fill_halo_regions_open.jl
@@ -22,8 +22,9 @@ function fill_open_boundary_regions!(field, boundary_conditions, indices, loc, g
     return nothing
 end
 
-fill_open_boundary_regions!(fields::NTuple, boundary_conditions, indices, loc, grid, args...; kwargs...) =
-    [fill_open_boundary_regions!(field, boundary_conditions[n], indices, loc[n], grid, args...; kwargs...) for (n, field) in enumerate(fields)]
+
+fill_open_boundary_regions!(fields::NTuple, boundary_conditions, indices, loc, grid, args...; kwargs...) = 
+    ntuple(n->fill_open_boundary_regions!(fields[n], boundary_conditions[n], indices, loc[n], grid, args...; kwargs...), Val(length(fields)))
 
 # for regular halo fills
 @inline left_velocity_open_boundary_condition(boundary_condition, loc) = nothing

--- a/src/BoundaryConditions/fill_halo_regions_open.jl
+++ b/src/BoundaryConditions/fill_halo_regions_open.jl
@@ -13,7 +13,7 @@ function fill_open_boundary_regions!(field, boundary_conditions, indices, loc, g
     right_bc = right_velocity_open_boundary_condition(boundary_conditions, loc)
 
     # gets `fill_function`, the function which fills open boundaries at `loc` and informs `fill_size` 
-    fill_function, fill_size = get_open_halo_filling(field, regular_fill_function, indices, boundary_conditions, loc, grid)
+    fill_function, fill_size = get_open_halo_filling(field, indices, boundary_conditions, loc, grid)
 
     fill_open_halo_event!(fill_function, field, left_bc, right_bc, fill_size, loc, arch, grid, args) 
 
@@ -61,13 +61,13 @@ end
 # no open fills
 @inline get_open_halo_filling(args...) = nothing, nothing
 
-@inline get_open_halo_filling(field, regular_fill_function, indices, boundary_conditions, ::Tuple{Face, Center, Center}, grid) = 
+@inline get_open_halo_filling(field, indices, boundary_conditions, ::Tuple{Face, Center, Center}, grid) = 
     _fill_west_and_east_open_halo!, fill_halo_size(field, fill_west_and_east_halo!, indices, boundary_conditions, loc, grid)
 
-@inline get_open_halo_filling(field, regular_fill_function, indices, boundary_conditions, ::Tuple{Center, Face, Center}, loc) = 
+@inline get_open_halo_filling(field, indices, boundary_conditions, ::Tuple{Center, Face, Center}, loc) = 
     _fill_south_and_north_open_halo!, fill_halo_size(field, fill_south_and_north_halo!, indices, boundary_conditions, loc, grid)
 
-@inline get_open_halo_filling(field, regular_fill_function, indices, boundary_conditions, ::Tuple{Center, Center, Face}, loc) = 
+@inline get_open_halo_filling(field, indices, boundary_conditions, ::Tuple{Center, Center, Face}, loc) = 
     _fill_bottom_and_top_open_halo!, fill_halo_size(field, fill_bottom_and_top_halo!, indices, boundary_conditions, loc, grid)
 
 @kernel function _fill_west_and_east_open_halo!(c, west_bc, east_bc, loc, grid, args) 


### PR DESCRIPTION
I was doing some profiling on a model with no open boundaries and discovered that this function was causing a big slow down. I guess this is because the compiler isn't managing to work out its just a load of nothing operations but this change appears to make it completely go away.

