### PR TITLE
Change default `hydrostatic_pressure_anomaly` to `CenterField(grid)` in `NonhydrostaticModel`

### DIFF
--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -71,7 +71,7 @@ end
     biogeochemistry::AbstractBGCOrNothing = nothing,
                                velocities = nothing,
                   nonhydrostatic_pressure = CenterField(grid),
-             hydrostatic_pressure_anomaly = nothing,
+             hydrostatic_pressure_anomaly = CenterField(grid),
                        diffusivity_fields = nothing,
                           pressure_solver = nothing,
                         immersed_boundary = nothing,
@@ -104,10 +104,10 @@ Keyword arguments
   - `velocities`: The model velocities. Default: `nothing`.
   - `nonhydrostatic_pressure`: The nonhydrostatic pressure field. Default: `CenterField(grid)`.
   - `hydrostatic_pressure_anomaly`: An optional field that stores the part of the nonhydrostatic pressure
-                                    in hydrostatic balance with the buoyancy field. If `nothing` (default), the anomaly
-                                    is not computed. If `CenterField(grid)`, the anomaly is precomputed by
+                                    in hydrostatic balance with the buoyancy field. If `CenterField(grid)` (default), the anomaly is precomputed by
                                     vertically integrating the buoyancy field. In this case, the `nonhydrostatic_pressure` represents
-                                    only the part of pressure that deviates from the hydrostatic anomaly.
+                                    only the part of pressure that deviates from the hydrostatic anomaly. If `nothing`, the anomaly
+                                    is not computed. 
   - `diffusivity_fields`: Diffusivity fields. Default: `nothing`.
   - `pressure_solver`: Pressure solver to be used in the model. If `nothing` (default), the model constructor
     chooses the default based on the `grid` provide.
@@ -146,18 +146,7 @@ function NonhydrostaticModel(; grid,
 
     if hydrostatic_pressure_anomaly isa DefaultHydrostaticPressureAnomaly
         # Manage treatment of the hydrostatic pressure anomaly:
-        
-        if grid isa ImmersedBoundaryGrid
-            # Separate the hydrostatic pressure anomaly
-            # from the nonhydrostatic pressure contribution.
-            # See https://github.com/CliMA/Oceananigans.jl/issues/3677.
-            
-            hydrostatic_pressure_anomaly = CenterField(grid)
-        else
-            # Use a single combined pressure, saving memory and computation.
-            
-            hydrostatic_pressure_anomaly = nothing
-        end
+        hydrostatic_pressure_anomaly = CenterField(grid)
     end
 
     # Check validity of hydrostatic_pressure_anomaly.

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -146,7 +146,18 @@ function NonhydrostaticModel(; grid,
 
     if hydrostatic_pressure_anomaly isa DefaultHydrostaticPressureAnomaly
         # Manage treatment of the hydrostatic pressure anomaly:
-        hydrostatic_pressure_anomaly = CenterField(grid)
+
+        if !isnothing(buoyancy)
+            # Separate the hydrostatic pressure anomaly
+            # from the nonhydrostatic pressure contribution.
+            # See https://github.com/CliMA/Oceananigans.jl/issues/3677.
+
+            hydrostatic_pressure_anomaly = CenterField(grid)
+        else
+            # Use a single combined pressure, saving memory and computation.
+
+            hydrostatic_pressure_anomaly = nothing
+        end
     end
 
     # Check validity of hydrostatic_pressure_anomaly.

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -150,7 +150,8 @@ function NonhydrostaticModel(; grid,
         if !isnothing(buoyancy)
             # Separate the hydrostatic pressure anomaly
             # from the nonhydrostatic pressure contribution.
-            # See https://github.com/CliMA/Oceananigans.jl/issues/3677.
+            # See https://github.com/CliMA/Oceananigans.jl/issues/3677
+            # and https://github.com/CliMA/Oceananigans.jl/issues/3795.
 
             hydrostatic_pressure_anomaly = CenterField(grid)
         else

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -71,7 +71,7 @@ end
     biogeochemistry::AbstractBGCOrNothing = nothing,
                                velocities = nothing,
                   nonhydrostatic_pressure = CenterField(grid),
-             hydrostatic_pressure_anomaly = CenterField(grid),
+             hydrostatic_pressure_anomaly = DefaultHydrostaticPressureAnomaly(),
                        diffusivity_fields = nothing,
                           pressure_solver = nothing,
                         immersed_boundary = nothing,


### PR DESCRIPTION
Closes https://github.com/CliMA/Oceananigans.jl/issues/3795 by changing the default configuration of  `NonhydrostaticModel` to `hydrostatic_pressure_anomaly = CenterField(grid)`. The spurious large-scale flow is developed due to numerical noise in the buoyancy field when the hydrostatic pressure anomaly is treated explicitly. When hydrostatic pressure anomaly is computed using the implicit integral of the buoyancy field, no spurious kinetic energy is introduced.
Here's the MWE as in https://github.com/CliMA/Oceananigans.jl/issues/3795:
```julia
using Oceananigans
using Oceananigans.Units
using SeawaterPolynomials
using SeawaterPolynomials.TEOS10
using Printf

eos = TEOS10.TEOS10EquationOfState()

arch = CPU()
grid = RectilinearGrid(CPU(), Float64,
                       topology = (Bounded, Flat, Bounded),
                       size = (100, 100),
                       halo = (4, 4),
                          x = (0, 100),
                          z = (-100, 0))

model = NonhydrostaticModel(; grid = grid,
                          buoyancy = SeawaterBuoyancy(),
                          advection = UpwindBiased(order=1),
                          timestepper = :RungeKutta3,
                          tracers = (:T, :S))

@inline T_initial(x, z) = 20
@inline S_initial(x, z) = 35
@inline w_initial(x, z) = rand() * 1e-6

set!(model, T=T_initial, S=S_initial, w=w_initial)

u, v, w = model.velocities
T, S = model.tracers.T, model.tracers.S

KE = @at (Center, Center, Center) 0.5 * (u^2 + v^2 + w^2)
KE_total = Field(Integral(KE))

simulation = Simulation(model, Δt=1e-3, stop_time=40days)
wizard = TimeStepWizard(max_change=1.05, max_Δt=10minutes, cfl=0.6)
simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(10))

wall_clock = [time_ns()]

function print_progress(sim)
  compute!(KE_total)
    @printf("[%05.2f%%] i: %d, t: %s, wall time: %s, max(u): (%6.3e, %6.3e, %6.3e) m/s, max(T) %6.3e, max(S) %6.3e, Total KE %6.3e, next Δt: %s\n",
            100 * (sim.model.clock.time / sim.stop_time),
            sim.model.clock.iteration,
            prettytime(sim.model.clock.time),
            prettytime(1e-9 * (time_ns() - wall_clock[1])),
            maximum(abs, sim.model.velocities.u),
            maximum(abs, sim.model.velocities.v),
            maximum(abs, sim.model.velocities.w),
            maximum(abs, sim.model.tracers.T),
            maximum(abs, sim.model.tracers.S),
            maximum(KE_total),
            prettytime(sim.Δt))

    wall_clock[1] = time_ns()

    return nothing
end

simulation.callbacks[:print_progress] = Callback(print_progress, IterationInterval(1000))

run!(simulation)
```

Here's the output now that hydrostatic pressure integral is treated implicitly:
```julia
[ Info: Initializing simulation...
[00.00%] i: 0, t: 0 seconds, wall time: 5.459 seconds, max(u): (4.452e-07, 0.000e+00, 5.593e-07) m/s, max(T) 2.000e+01, max(S) 3.500e+01, Total KE 2.025e-10, next Δt: 1.050 ms
[ Info:     ... simulation initialization complete (5.237 seconds)
[ Info: Executing initial time step...
[ Info:     ... initial time step complete (3.569 seconds).
[00.00%] i: 1000, t: 27.405 seconds, wall time: 7.989 seconds, max(u): (4.452e-07, 0.000e+00, 5.593e-07) m/s, max(T) 2.000e+01, max(S) 3.500e+01, Total KE 2.025e-10, next Δt: 138.076 ms
[00.11%] i: 2000, t: 1.009 hours, wall time: 4.283 seconds, max(u): (4.449e-07, 0.000e+00, 5.591e-07) m/s, max(T) 2.000e+01, max(S) 3.500e+01, Total KE 2.023e-10, next Δt: 18.157 seconds
[08.39%] i: 3000, t: 3.354 days, wall time: 4.340 seconds, max(u): (4.195e-07, 0.000e+00, 5.393e-07) m/s, max(T) 2.000e+01, max(S) 3.500e+01, Total KE 1.879e-10, next Δt: 10 minutes
[25.75%] i: 4000, t: 10.299 days, wall time: 4.455 seconds, max(u): (3.739e-07, 0.000e+00, 4.983e-07) m/s, max(T) 2.000e+01, max(S) 3.500e+01, Total KE 1.632e-10, next Δt: 10 minutes
[43.11%] i: 5000, t: 17.243 days, wall time: 4.470 seconds, max(u): (3.365e-07, 0.000e+00, 4.596e-07) m/s, max(T) 2.000e+01, max(S) 3.500e+01, Total KE 1.440e-10, next Δt: 10 minutes
[60.47%] i: 6000, t: 24.188 days, wall time: 4.402 seconds, max(u): (3.049e-07, 0.000e+00, 4.242e-07) m/s, max(T) 2.000e+01, max(S) 3.500e+01, Total KE 1.286e-10, next Δt: 10 minutes
[77.83%] i: 7000, t: 31.132 days, wall time: 4.416 seconds, max(u): (2.779e-07, 0.000e+00, 3.925e-07) m/s, max(T) 2.000e+01, max(S) 3.500e+01, Total KE 1.160e-10, next Δt: 10 minutes
[95.19%] i: 8000, t: 38.077 days, wall time: 4.495 seconds, max(u): (2.545e-07, 0.000e+00, 3.739e-07) m/s, max(T) 2.000e+01, max(S) 3.500e+01, Total KE 1.055e-10, next Δt: 10 minutes
[ Info: Simulation is stopping after running for 45.330 seconds.
[ Info: Simulation time 40 days equals or exceeds stop time 40 days.
```
This is the expected behavior as no spurious kinetic energy is introduced.

@glwagner @simone-silvestri @sandreza 