### PR TITLE
Make vertical line plots in y and z

### DIFF
--- a/ext/OceananigansMakieExt.jl
+++ b/ext/OceananigansMakieExt.jl
@@ -77,10 +77,10 @@ function convert_field_argument(f::Field)
         ξ1_cpu = on_architecture(CPU(), ξ1)
 
         # Shenanigans
-        if d1 === 3 # vertical plot...
-            return fi_cpu, ξ1_cpu
-        else
+        if d1 === 1 # horizontal plot, in x
             return ξ1_cpu, fi_cpu
+        else # vertical plot instead
+            return fi_cpu, ξ1_cpu
         end
 
     elseif D == 2


### PR DESCRIPTION
This PR changes how the Makie extension works so that `lines` will make a vertical plot for 1D input in y OR z. Previously it only made a vertical plot for z. Typically though, it's only the first dimension "x" that we want to be horizontal (there are exceptions, but this just changes default behavior and can be overrridden).