### PR TITLE
Fix formatting and adds back interior velocity in tilted bottom boundary layer example

### DIFF
--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -106,7 +106,7 @@ B∞_field = BackgroundField(constant_stratification, parameters=(; ĝ, N² = N
 # This shows that to impose a no-flux boundary condition on the total buoyancy field ``B``, we must apply a boundary condition to the perturbation buoyancy ``b``,
 # ```math
 # ∂_z b = - N^{2} \cos{\theta}.
-#```
+# ```
 
 ∂z_b_bottom = - N² * cosd(θ)
 negative_background_diffusive_flux = GradientBoundaryCondition(∂z_b_bottom)

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -137,8 +137,7 @@ v_bcs = FieldBoundaryConditions(bottom = drag_bc_v)
 #
 # Let us also create `BackgroundField` for the along-slope interior velocity:
 
-@inline constant_velocity(x, z, t, p) = p.V∞
-V∞_field = BackgroundField(constant_velocity, parameters=(; V∞))
+V∞_field = BackgroundField(ConstantField(V∞))
 
 # ## Create the `NonhydrostaticModel`
 #

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -137,7 +137,7 @@ v_bcs = FieldBoundaryConditions(bottom = drag_bc_v)
 #
 # Let us also create `BackgroundField` for the along-slope interior velocity:
 
-V∞_field = BackgroundField(ConstantField(V∞))
+V∞_field = BackgroundField(V∞)
 
 # ## Create the `NonhydrostaticModel`
 #

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -112,7 +112,7 @@ B∞_field = BackgroundField(constant_stratification, parameters=(; ĝ, N² = N
 negative_background_diffusive_flux = GradientBoundaryCondition(∂z_b_bottom)
 b_bcs = FieldBoundaryConditions(bottom = negative_background_diffusive_flux)
 
-# ## Bottom drag and along-slope interior velicity
+# ## Bottom drag and along-slope interior velocity
 #
 # We impose bottom drag that follows Monin--Obukhov theory:
 


### PR DESCRIPTION
The formatting was off in this example:

![image](https://github.com/user-attachments/assets/8b490933-60b3-4d4e-9f8f-b7f0c64ca604)
