### PR TITLE
Support for different file formats & creation of files in runtime

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -103,6 +103,7 @@ export
     StateChecker, CFL, AdvectiveCFL, DiffusiveCFL,
 
     # Output writers
+    output!,
     NetCDFOutputWriter, JLD2OutputWriter, Checkpointer,
     TimeInterval, IterationInterval, AveragedTimeInterval, SpecifiedTimes,
     FileSizeLimit, AndSchedule, OrSchedule, written_names,

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -188,8 +188,6 @@ function JLD2OutputWriter(model, outputs; filename, schedule,
     # Convert each output to WindowedTimeAverage if schedule::AveragedTimeWindow is specified
     schedule, outputs = time_average_outputs(schedule, outputs, model)
 
-    initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, model)
-
     return JLD2OutputWriter(filepath, outputs, schedule, array_type, init,
                             including, part, file_splitting, overwrite_existing, verbose, jld2_kw)
 end
@@ -254,6 +252,10 @@ function write_output!(writer::JLD2OutputWriter, model)
 
     verbose = writer.verbose
     current_iteration = model.clock.iteration
+
+    if !isfile(writer.filepath)
+        initialize_jld2_file!(writer, model)
+    end
 
     # Some logic to handle writing to existing files
     if iteration_exists(writer.filepath, current_iteration)

--- a/src/Simulations/Simulations.jl
+++ b/src/Simulations/Simulations.jl
@@ -6,7 +6,7 @@ export run!
 export Callback, add_callback!
 export iteration
 export stopwatch
-export JLD2_output!
+export output!
 
 using Oceananigans.Models
 using Oceananigans.Diagnostics

--- a/src/Simulations/callback.jl
+++ b/src/Simulations/callback.jl
@@ -75,12 +75,12 @@ struct GenericCallbackName end
 unique_name(::GenericCallbackName, existing) = unique_name(:callback, existing)
 
 """
-    add_callback!(simulation, callback::Callback; name = GenericName(), callback_kw...)
+    add_callback!(simulation, callback::Callback; name = GenericCallbackName(), callback_kw...)
 
-    add_callback!(simulation, func, schedule=IterationInterval(1); name = GenericName(), callback_kw...)
+    add_callback!(simulation, func, schedule=IterationInterval(1); name = GenericCallbackName(), callback_kw...)
 
 Add `Callback(func, schedule)` to `simulation.callbacks` under `name`. The default
-`GenericName()` generates a name of the form `:callbackN`, where `N`
+`GenericCallbackName()` generates a name of the form `:callbackN`, where `N`
 is big enough for the name to be unique.
 
 If `name::Symbol` is supplied, it may be modified if `simulation.callbacks[name]`
@@ -97,7 +97,7 @@ function add_callback!(simulation, callback::Callback; name = GenericCallbackNam
 end
 
 function add_callback!(simulation, func, schedule = IterationInterval(1);
-                       name = GenericName(), callback_kw...)
+                       name = GenericCallbackName(), callback_kw...)
 
     callback = Callback(func, schedule; callback_kw...)
     return add_callback!(simulation, callback; name)

--- a/src/Simulations/output_helpers.jl
+++ b/src/Simulations/output_helpers.jl
@@ -5,7 +5,15 @@
 struct GenericJLD2Name end
 unique_name(::GenericJLD2Name, existing) = unique_name(:jld2, existing)
 
+struct GenericNetCDFName end
+unique_name(::GenericNetCDFName, existing) = unique_name(:nc, existing)
+
+struct GenericPickUpName end
+unique_name(::GenericPickUpName, existing) = unique_name(:pickup, existing)
+
 struct JLD2Format end
+struct NetCDFFormat end
+struct Checkpoint end
 
 """
     output!(simulation, outputs [, format=JLD2Format()]; kw...)
@@ -14,8 +22,8 @@ struct JLD2Format end
 output!(simulation, outputs; kw...) = output!(simulation, outputs, JLD2Format(); kw...)
 
 function output!(simulation, outputs, ::JLD2Format; kw...)
-    if !(name ∈ keys(kw))
-        name = GenericJLD2Name()        
+    if !("name" ∈ keys(kw))
+        name = GenericJLD2Name()
     end
     name = unique_name(name, keys(simulation.output_writers))
     ow = JLD2OutputWriter(simulation.model, outputs; kw...)
@@ -23,3 +31,22 @@ function output!(simulation, outputs, ::JLD2Format; kw...)
     return nothing
 end
 
+function output!(simulation, outputs, ::NetCDFFormat; kw...)
+    if !("name" ∈ keys(kw))
+        name = GenericNetCDFName()        
+    end
+    name = unique_name(name, keys(simulation.output_writers))
+    ow = NetCDFOutputWriter(simulation.model, outputs; kw...)
+    simulation.output_writers[name] = ow
+    return nothing
+end
+
+function output!(simulation, outputs, ::Checkpoint; kw...)
+    if !(name ∈ keys(kw))
+        name = GenericPickUpName()        
+    end
+    name = unique_name(name, keys(simulation.output_writers))
+    ow = Checkpointer(simulation.model, kw...)
+    simulation.output_writers[name] = ow
+    return nothing
+end


### PR DESCRIPTION
This PR completes the output_helpers.jl to support different output_writers: 
- NetCDFOutputWriter
- Checkpointer

Additionally, it ensures that the output of `NetCDFOutputWriter` and `JLD2OutputWriter` are created during the simulation `run!` instead of when the writer is instantiated. 

I don't particularly like the fact that the `NetCDFOutputWriter` struct requires to parametric value for the dataset, which requires to open a dataset to instantiate it. I solved this by opening a temporal netCDF the first time it's called ("a hack"), i.e. `Dataset(Base.Filesystem.tempname(),"c")`.