### PR TITLE
Don't return special length for PartlyInMemory time series

### DIFF
--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -587,8 +587,6 @@ Base.length(fts::FlavorOfFTS)     = length(fts.times)
 Base.lastindex(fts::FlavorOfFTS)  = length(fts.times)
 Base.firstindex(fts::FlavorOfFTS) = 1
 
-Base.length(fts::PartlyInMemoryFTS) = length(fts.backend)
-
 function interior(fts::FieldTimeSeries)
     loc = map(instantiate, location(fts))
     topo = map(instantiate, topology(fts.grid))


### PR DESCRIPTION
I'm not sure why this was added, so we will see if something breaks. But through usage I've realized that its inconvenient (and unexpected) that the length of `FieldTimeSeries` depends on the backend. My intuition is that the length stays the same regardless of _where_ the data is (in memory, or on disk, or a combination of the two). It's also helpful that behavior is the same between backends, which makes switching backends for performance reasons painless.