### PR TITLE
Fix `ConjugateGradientPoissonSolver` construction with default pre-conditioner

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -6,16 +6,16 @@ module Oceananigans
 
 export
     # Architectures
-    CPU, GPU, 
+    CPU, GPU,
 
     # Logging
     OceananigansLogger,
 
     # Grids
     Center, Face,
-    Periodic, Bounded, Flat, 
+    Periodic, Bounded, Flat,
     FullyConnected, LeftConnected, RightConnected,
-    RectilinearGrid, 
+    RectilinearGrid,
     LatitudeLongitudeGrid,
     OrthogonalSphericalShellGrid,
     xnodes, ynodes, znodes, nodes,
@@ -30,8 +30,8 @@ export
     Distributed, Partition,
 
     # Advection schemes
-    Centered, CenteredSecondOrder, CenteredFourthOrder, 
-    UpwindBiased, UpwindBiasedFirstOrder, UpwindBiasedThirdOrder, UpwindBiasedFifthOrder, 
+    Centered, CenteredSecondOrder, CenteredFourthOrder,
+    UpwindBiased, UpwindBiasedFirstOrder, UpwindBiasedThirdOrder, UpwindBiasedFifthOrder,
     WENO, WENOThirdOrder, WENOFifthOrder,
     VectorInvariant, WENOVectorInvariant, EnergyConserving, EnstrophyConserving,
     TracerAdvection,
@@ -88,7 +88,7 @@ export
 
     # Hydrostatic free surface model stuff
     VectorInvariant, ExplicitFreeSurface, ImplicitFreeSurface, SplitExplicitFreeSurface,
-    HydrostaticSphericalCoriolis, 
+    HydrostaticSphericalCoriolis,
     PrescribedVelocityFields,
 
     # Time stepping
@@ -123,7 +123,7 @@ export
 
     # Units
     Time
-    
+
 using Printf
 using Logging
 using Statistics
@@ -144,7 +144,7 @@ import Base:
     iterate, similar, show,
     getindex, lastindex, setindex!,
     push!
-    
+
 #####
 ##### Abstract types
 #####
@@ -207,6 +207,7 @@ include("Fields/Fields.jl")
 include("AbstractOperations/AbstractOperations.jl")
 include("TimeSteppers/TimeSteppers.jl")
 include("Advection/Advection.jl")
+include("ImmersedBoundaries/ImmersedBoundaries.jl")
 include("Solvers/Solvers.jl")
 include("OutputReaders/OutputReaders.jl")
 include("DistributedComputations/DistributedComputations.jl")
@@ -224,7 +225,7 @@ include("Forcings/Forcings.jl")
 include("Biogeochemistry.jl")
 
 # TODO: move above
-include("ImmersedBoundaries/ImmersedBoundaries.jl")
+# include("ImmersedBoundaries/ImmersedBoundaries.jl")
 include("Models/Models.jl")
 
 # Output and Physics, time-stepping, and models

--- a/src/Solvers/conjugate_gradient_poisson_solver.jl
+++ b/src/Solvers/conjugate_gradient_poisson_solver.jl
@@ -1,5 +1,7 @@
-using Oceananigans.Operators: divᶜᶜᶜ, ∇²ᶜᶜᶜ 
+using Oceananigans.Operators: divᶜᶜᶜ, ∇²ᶜᶜᶜ
 using Statistics: mean
+
+using Oceananigans.ImmersedBoundaries
 
 using KernelAbstractions: @kernel, @index
 
@@ -66,7 +68,7 @@ function ConjugateGradientPoissonSolver(grid;
                                                         preconditioner,
                                                         template_field = rhs,
                                                         kw...)
-        
+
     return ConjugateGradientPoissonSolver(grid, rhs, conjugate_gradient_solver)
 end
 
@@ -160,7 +162,7 @@ end
 @inline Ac(i, j, k, grid) = - Ax⁻(i, j, k, grid) - Ax⁺(i, j, k, grid) -
                               Ay⁻(i, j, k, grid) - Ay⁺(i, j, k, grid) -
                               Az⁻(i, j, k, grid) - Az⁺(i, j, k, grid)
-                              
+
 @inline heuristic_residual(i, j, k, grid, r) =
     @inbounds 1 / Ac(i, j, k, grid) * (r[i, j, k] - 2 * Ax⁻(i, j, k, grid) / (Ac(i, j, k, grid) + Ac(i-1, j, k, grid)) * r[i-1, j, k] -
                                                     2 * Ax⁺(i, j, k, grid) / (Ac(i, j, k, grid) + Ac(i+1, j, k, grid)) * r[i+1, j, k] -
@@ -174,4 +176,3 @@ end
     active = !inactive_cell(i, j, k, grid)
     @inbounds p[i, j, k] = heuristic_residual(i, j, k, grid, r) * active
 end
-

--- a/test/test_preconditioned_conjugate_gradient_solver.jl
+++ b/test/test_preconditioned_conjugate_gradient_solver.jl
@@ -1,6 +1,6 @@
 include("dependencies_for_runtests.jl")
 
-using Oceananigans.Solvers: solve!
+using Oceananigans.Solvers: solve!, ConjugateGradientPoissonSolver
 using Statistics
 
 function identity_operator!(b, x)
@@ -61,11 +61,17 @@ function run_poisson_equation_test(grid)
     return nothing
 end
 
+function construct_conjugate_gradient_poisson_solver_with_default_preconditioner(grid)
+    solver = ConjugateGradientPoissonSolver(grid)
+    return true
+end
+
 @testset "ConjugateGradientSolver" begin
     for arch in archs
         @info "Testing ConjugateGradientSolver [$(typeof(arch))]..."
         grid = RectilinearGrid(arch, size=(4, 8, 4), extent=(1, 3, 1))
         run_identity_operator_test(grid)
         run_poisson_equation_test(grid)
+        construct_conjugate_gradient_poisson_solver_with_default_preconditioner(grid)
     end
 end


### PR DESCRIPTION
I added a test that fails due to #3829. I should also test the non-FFT case and test that the proper pre-conditioner was initialized. So the test could be better but it does fail as it should.

What we need is a `using Oceananigans.ImmersedBoundaries` but the solvers module is defined well before the immersed boundaries module.

So for a solver to depend on the immersed boundaries module, and really just the `ImmersedBoundaryGrid` type then the immersed boundaries module needs to be included first.

Based on these comments maybe it's desirable to change the order of inclusion? But maybe it'll take some work. So otherwise we probably need to define another abstract type in `src/Oceananigans.jl` but this solution isn't ideal.

https://github.com/CliMA/Oceananigans.jl/blob/13bf409616af8c155b72d8869b7b8f97ae0e844b/src/Oceananigans.jl#L214-L228

Resolves #3829