### PR TITLE
Add ConformalMapping Type to OrthogonalSphericalShellGrid for Specialized Dispatch

### DIFF
--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -9,7 +9,7 @@ export AbstractCurvilinearGrid, AbstractHorizontallyCurvilinearGrid
 export XFlatGrid, YFlatGrid, ZFlatGrid
 export XRegularRG, YRegularRG, ZRegularRG, XYRegularRG, XYZRegularRG
 export LatitudeLongitudeGrid, XRegularLLG, YRegularLLG, ZRegularLLG
-export OrthogonalSphericalShellGrid, ConformalCubedSphereGrid, ZRegOrthogonalSphericalShellGrid
+export ConformalMapping, OrthogonalSphericalShellGrid, ConformalCubedSphereGrid, ZRegOrthogonalSphericalShellGrid
 export conformal_cubed_sphere_panel
 export node, nodes
 export ξnode, ηnode, rnode

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -9,7 +9,7 @@ export AbstractCurvilinearGrid, AbstractHorizontallyCurvilinearGrid
 export XFlatGrid, YFlatGrid, ZFlatGrid
 export XRegularRG, YRegularRG, ZRegularRG, XYRegularRG, XYZRegularRG
 export LatitudeLongitudeGrid, XRegularLLG, YRegularLLG, ZRegularLLG
-export ConformalMapping, OrthogonalSphericalShellGrid, ConformalCubedSphereGrid, ZRegOrthogonalSphericalShellGrid
+export OrthogonalSphericalShellGrid, ConformalCubedSphereGrid, ZRegOrthogonalSphericalShellGrid
 export conformal_cubed_sphere_panel
 export node, nodes
 export ξnode, ηnode, rnode

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -76,6 +76,7 @@ end
 const OSSG = OrthogonalSphericalShellGrid
 const ZRegOSSG = OrthogonalSphericalShellGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Number}
 const ZRegOrthogonalSphericalShellGrid = ZRegOSSG
+const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:ConformalCubedSphereMapping}
 
 # convenience constructor for OSSG without any conformal_mapping properties
 OrthogonalSphericalShellGrid(architecture, Nx, Ny, Nz, Hx, Hy, Hz, Lz,

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -9,6 +9,12 @@ using Adapt: adapt_structure
 using Oceananigans
 using Oceananigans.Grids: prettysummary, coordinate_summary, BoundedTopology, length
 
+struct ConformalMapping{FT, Rotation}
+    ξ :: Tuple{FT, FT}
+    η :: Tuple{FT, FT}
+    rotation :: Rotation
+end
+
 struct OrthogonalSphericalShellGrid{FT, TX, TY, TZ, A, R, FR, C, Arch} <: AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Arch}
     architecture :: Arch
     Nx :: Int
@@ -603,7 +609,7 @@ function conformal_cubed_sphere_panel(architecture::AbstractArchitecture = CPU()
                      Δzᵃᵃᶜ, Δzᵃᵃᶠ,
                      Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ)
 
-    conformal_mapping = (; ξ, η, rotation)
+    conformal_mapping = ConformalMapping(ξ, η, rotation)
 
     grid = OrthogonalSphericalShellGrid{TX, TY, TZ}(CPU(), Nξ, Nη, Nz, Hx, Hy, Hz, Lz,
                                                     coordinate_arrays...,
@@ -876,7 +882,7 @@ function conformal_cubed_sphere_panel(filepath::AbstractString, architecture = C
     φᶠᶜᵃ = offset_data(zeros(FT, architecture, Txᶠᶜ, Tyᶠᶜ), loc_fc, topology[1:2], N[1:2], H[1:2])
     φᶜᶠᵃ = offset_data(zeros(FT, architecture, Txᶜᶠ, Tyᶜᶠ), loc_cf, topology[1:2], N[1:2], H[1:2])
 
-    conformal_mapping = (ξ = (-1, 1), η = (-1, 1))
+    conformal_mapping = ConformalMapping(ξ, η, rotation)
 
     return OrthogonalSphericalShellGrid{TX, TY, TZ}(architecture, Nξ, Nη, Nz, Hx, Hy, Hz, Lz,
                                                      λᶜᶜᵃ,  λᶠᶜᵃ,  λᶜᶠᵃ,  λᶠᶠᵃ,

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -883,6 +883,7 @@ function conformal_cubed_sphere_panel(filepath::AbstractString, architecture = C
     φᶠᶜᵃ = offset_data(zeros(FT, architecture, Txᶠᶜ, Tyᶠᶜ), loc_fc, topology[1:2], N[1:2], H[1:2])
     φᶜᶠᵃ = offset_data(zeros(FT, architecture, Txᶜᶠ, Tyᶜᶠ), loc_cf, topology[1:2], N[1:2], H[1:2])
 
+    ξ, η = (-1, 1), (-1, 1)
     conformal_mapping = ConformalCubedSphereMapping(ξ, η, rotation)
 
     return OrthogonalSphericalShellGrid{TX, TY, TZ}(architecture, Nξ, Nη, Nz, Hx, Hy, Hz, Lz,

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -9,7 +9,7 @@ using Adapt: adapt_structure
 using Oceananigans
 using Oceananigans.Grids: prettysummary, coordinate_summary, BoundedTopology, length
 
-struct ConformalCubedSphereMapping{FT, Rotation}
+struct CubedSphereConformalMapping{FT, Rotation}
     ξ :: Tuple{FT, FT}
     η :: Tuple{FT, FT}
     rotation :: Rotation
@@ -76,7 +76,7 @@ end
 const OSSG = OrthogonalSphericalShellGrid
 const ZRegOSSG = OrthogonalSphericalShellGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Number}
 const ZRegOrthogonalSphericalShellGrid = ZRegOSSG
-const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:ConformalCubedSphereMapping}
+const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:CubedSphereConformalMapping}
 
 # convenience constructor for OSSG without any conformal_mapping properties
 OrthogonalSphericalShellGrid(architecture, Nx, Ny, Nz, Hx, Hy, Hz, Lz,
@@ -610,7 +610,7 @@ function conformal_cubed_sphere_panel(architecture::AbstractArchitecture = CPU()
                      Δzᵃᵃᶜ, Δzᵃᵃᶠ,
                      Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ)
 
-    conformal_mapping = ConformalCubedSphereMapping(ξ, η, rotation)
+    conformal_mapping = CubedSphereConformalMapping(ξ, η, rotation)
 
     grid = OrthogonalSphericalShellGrid{TX, TY, TZ}(CPU(), Nξ, Nη, Nz, Hx, Hy, Hz, Lz,
                                                     coordinate_arrays...,
@@ -884,7 +884,7 @@ function conformal_cubed_sphere_panel(filepath::AbstractString, architecture = C
     φᶜᶠᵃ = offset_data(zeros(FT, architecture, Txᶜᶠ, Tyᶜᶠ), loc_cf, topology[1:2], N[1:2], H[1:2])
 
     ξ, η = (-1, 1), (-1, 1)
-    conformal_mapping = ConformalCubedSphereMapping(ξ, η, rotation)
+    conformal_mapping = CubedSphereConformalMapping(ξ, η, rotation)
 
     return OrthogonalSphericalShellGrid{TX, TY, TZ}(architecture, Nξ, Nη, Nz, Hx, Hy, Hz, Lz,
                                                      λᶜᶜᵃ,  λᶠᶜᵃ,  λᶜᶠᵃ,  λᶠᶠᵃ,

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -9,7 +9,7 @@ using Adapt: adapt_structure
 using Oceananigans
 using Oceananigans.Grids: prettysummary, coordinate_summary, BoundedTopology, length
 
-struct ConformalMapping{FT, Rotation}
+struct ConformalCubedSphereMapping{FT, Rotation}
     ξ :: Tuple{FT, FT}
     η :: Tuple{FT, FT}
     rotation :: Rotation
@@ -609,7 +609,7 @@ function conformal_cubed_sphere_panel(architecture::AbstractArchitecture = CPU()
                      Δzᵃᵃᶜ, Δzᵃᵃᶠ,
                      Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ)
 
-    conformal_mapping = ConformalMapping(ξ, η, rotation)
+    conformal_mapping = ConformalCubedSphereMapping(ξ, η, rotation)
 
     grid = OrthogonalSphericalShellGrid{TX, TY, TZ}(CPU(), Nξ, Nη, Nz, Hx, Hy, Hz, Lz,
                                                     coordinate_arrays...,
@@ -882,7 +882,7 @@ function conformal_cubed_sphere_panel(filepath::AbstractString, architecture = C
     φᶠᶜᵃ = offset_data(zeros(FT, architecture, Txᶠᶜ, Tyᶠᶜ), loc_fc, topology[1:2], N[1:2], H[1:2])
     φᶜᶠᵃ = offset_data(zeros(FT, architecture, Txᶜᶠ, Tyᶜᶠ), loc_cf, topology[1:2], N[1:2], H[1:2])
 
-    conformal_mapping = ConformalMapping(ξ, η, rotation)
+    conformal_mapping = ConformalCubedSphereMapping(ξ, η, rotation)
 
     return OrthogonalSphericalShellGrid{TX, TY, TZ}(architecture, Nξ, Nη, Nz, Hx, Hy, Hz, Lz,
                                                      λᶜᶜᵃ,  λᶠᶜᵃ,  λᶜᶠᵃ,  λᶠᶠᵃ,

--- a/src/Operators/vorticity_operators.jl
+++ b/src/Operators/vorticity_operators.jl
@@ -1,11 +1,13 @@
+using Oceananigans.Grids: ConformalCubedSpherePanel
+
 """ Vertical circulation associated with horizontal velocities u, v. """
 @inline Γᶠᶠᶜ(i, j, k, grid, u, v) = δxᶠᶠᶜ(i, j, k, grid, Δy_qᶜᶠᶜ, v) - δyᶠᶠᶜ(i, j, k, grid, Δx_qᶠᶜᶜ, u)
 
 """
-     ζ₃ᶠᶠᶜ(i, j, k, grid, u, v)
+    ζ₃ᶠᶠᶜ(i, j, k, grid, u, v)
 
- The vertical vorticity associated with horizontal velocities ``u`` and ``v``.
- """
+The vertical vorticity associated with horizontal velocities ``u`` and ``v``.
+"""
 @inline ζ₃ᶠᶠᶜ(i, j, k, grid, u, v) = Γᶠᶠᶜ(i, j, k, grid, u, v) / Azᶠᶠᶜ(i, j, k, grid)
 
 #####
@@ -14,12 +16,10 @@
 #####
 
 """
-     Γᶠᶠᶜ(i, j, k, grid, u, v)
+    Γᶠᶠᶜ(i, j, k, grid, u, v)
 
- The vertical circulation associated with horizontal velocities ``u`` and ``v``.
- """
-const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:ConformalCubedSphereMapping}
-
+The vertical circulation associated with horizontal velocities ``u`` and ``v``.
+"""
 @inline function Γᶠᶠᶜ(i, j, k, grid::ConformalCubedSpherePanel, u, v)
     # South-west corner
     if i == 1 && j == 1

--- a/src/Operators/vorticity_operators.jl
+++ b/src/Operators/vorticity_operators.jl
@@ -18,7 +18,9 @@
 
  The vertical circulation associated with horizontal velocities ``u`` and ``v``.
  """
-@inline function Γᶠᶠᶜ(i, j, k, grid::OrthogonalSphericalShellGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:ConformalMapping, <:Any}, u, v)
+const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:ConformalCubedSphereMapping}
+
+@inline function Γᶠᶠᶜ(i, j, k, grid::ConformalCubedSpherePanel, u, v)
     # South-west corner
     if i == 1 && j == 1
         return Δy_qᶜᶠᶜ(i, j, k, grid, v) - Δx_qᶠᶜᶜ(i, j, k, grid, u) + Δx_qᶠᶜᶜ(i, j-1, k, grid, u)

--- a/src/Operators/vorticity_operators.jl
+++ b/src/Operators/vorticity_operators.jl
@@ -18,7 +18,7 @@
 
  The vertical circulation associated with horizontal velocities ``u`` and ``v``.
  """
-@inline function Γᶠᶠᶜ(i, j, k, grid::OrthogonalSphericalShellGrid, u, v)
+@inline function Γᶠᶠᶜ(i, j, k, grid::OrthogonalSphericalShellGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:ConformalMapping, <:Any}, u, v)
     # South-west corner
     if i == 1 && j == 1
         return Δy_qᶜᶠᶜ(i, j, k, grid, v) - Δx_qᶠᶜᶜ(i, j, k, grid, u) + Δx_qᶠᶜᶜ(i, j-1, k, grid, u)


### PR DESCRIPTION
This PR introduces a new `ConformalMapping` type for the `OrthogonalSphericalShellGrid` and updates the grid construction to incorporate this type as a parameter. The goal is to enable dispatch over various conformal mapping types (e.g., cubed sphere and tripolar) and embed these mappings directly within the `OrthogonalSphericalShellGrid` structure.