### PR TITLE
For output readers, make `reader_kw` default to an empty `NamedTuple`

### DIFF
--- a/src/OutputReaders/field_dataset.jl
+++ b/src/OutputReaders/field_dataset.jl
@@ -24,15 +24,15 @@ linearly.
 
 - `grid`: May be specified to override the grid used in the JLD2 file.
 
-- `reader_kw`: A dictionary of keyword arguments to pass to the reader (currently only JLD2)
-               to be used when opening files.
+- `reader_kw`: A named tuple or dictionary of keyword arguments to pass to the reader
+               (currently only JLD2) to be used when opening files.
 """
 function FieldDataset(filepath;
                       architecture = CPU(),
                       grid = nothing,
                       backend = InMemory(),
                       metadata_paths = ["metadata"],
-                      reader_kw = Dict{Symbol, Any}())
+                      reader_kw = NamedTuple())
 
   file = jldopen(filepath; reader_kw...)
 

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -370,7 +370,7 @@ function FieldTimeSeries(loc, grid, times=();
                          name = nothing,
                          time_indexing = Linear(),
                          boundary_conditions = nothing,
-                         reader_kw = Dict{Symbol, Any}())
+                         reader_kw = NamedTuple())
 
     LX, LY, LZ = loc
 
@@ -439,8 +439,8 @@ Keyword arguments
            comparison to recorded save times. Defaults to times associated with `iterations`.
            Takes precedence over `iterations` if `times` is specified.
 
-- `reader_kw`: A dictionary of keyword arguments to pass to the reader (currently only JLD2)
-               to be used when opening files.
+- `reader_kw`: A named tuple or dictionary of keyword arguments to pass to the reader
+               (currently only JLD2) to be used when opening files.
 """
 function FieldTimeSeries(path::String, name::String;
                          backend = InMemory(),
@@ -451,7 +451,7 @@ function FieldTimeSeries(path::String, name::String;
                          time_indexing = Linear(),
                          iterations = nothing,
                          times = nothing,
-                         reader_kw = Dict{Symbol, Any}())
+                         reader_kw = NamedTuple())
 
     file = jldopen(path; reader_kw...)
 
@@ -549,7 +549,7 @@ end
           architecture = nothing,
           indices = (:, :, :),
           boundary_conditions = nothing,
-          reader_kw = Dict{Symbol, Any}())
+          reader_kw = NamedTuple())
 
 Load a field called `name` saved in a JLD2 file at `path` at `iter`ation.
 Unless specified, the `grid` is loaded from `path`.
@@ -559,7 +559,7 @@ function Field(location, path::String, name::String, iter;
                architecture = nothing,
                indices = (:, :, :),
                boundary_conditions = nothing,
-               reader_kw = Dict{Symbol, Any}())
+               reader_kw = NamedTuple())
 
     # Default to CPU if neither architecture nor grid is specified
     if isnothing(architecture)

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -390,7 +390,7 @@ end
         @testset "FieldDataset{$Backend} parallel reading" begin
             @info "  Testing FieldDataset{$Backend} parallel reading..."
 
-            reader_kw = Dict(:parallel_read => true)
+            reader_kw = (parallel_read = true,)
             ds = FieldDataset(filepath3d; backend=Backend(), reader_kw)
 
             @test ds isa FieldDataset

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -390,7 +390,7 @@ end
         @testset "FieldDataset{$Backend} parallel reading" begin
             @info "  Testing FieldDataset{$Backend} parallel reading..."
 
-            reader_kw = (parallel_read = true,)
+            reader_kw = (; parallel_read = true)
             ds = FieldDataset(filepath3d; backend=Backend(), reader_kw)
 
             @test ds isa FieldDataset


### PR DESCRIPTION
Resolves #3898