### PR TITLE
Update examples to use new fluxes notation

### DIFF
--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -90,18 +90,18 @@ uˢ(z) = Uˢ * exp(z / vertical_scale)
 #
 # At the surface ``z = 0``, Wagner et al. (2021) impose
 
-Qᵘ = -3.72e-5 # m² s⁻², surface kinematic momentum flux
+τx = -3.72e-5 # m² s⁻², surface kinematic momentum flux
 
-u_boundary_conditions = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
+u_boundary_conditions = FieldBoundaryConditions(top = FluxBoundaryCondition(τx))
 
 # Wagner et al. (2021) impose a linear buoyancy gradient `N²` at the bottom
 # along with a weak, destabilizing flux of buoyancy at the surface to faciliate
 # spin-up from rest.
 
-Qᵇ = 2.307e-8 # m² s⁻³, surface buoyancy flux
+Jᵇ = 2.307e-8 # m² s⁻³, surface buoyancy flux
 N² = 1.936e-5 # s⁻², initial and bottom buoyancy gradient
 
-b_boundary_conditions = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ),
+b_boundary_conditions = FieldBoundaryConditions(top = FluxBoundaryCondition(Jᵇ),
                                                 bottom = GradientBoundaryCondition(N²))
 
 # !!! info "The flux convention in Oceananigans"
@@ -153,7 +153,7 @@ bᵢ(x, y, z) = stratification(z) + 1e-1 * Ξ(z) * N² * model.grid.Lz
 # This initial condition is consistent with a wavy, quiescent ocean suddenly impacted
 # by winds. To this quiescent state we add noise scaled by the friction velocity to ``u`` and ``w``.
 
-u★ = sqrt(abs(Qᵘ))
+u★ = sqrt(abs(τx))
 uᵢ(x, y, z) = u★ * 1e-1 * Ξ(z)
 wᵢ(x, y, z) = u★ * 1e-1 * Ξ(z)
 

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -84,18 +84,18 @@ buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(thermal_expa
 # We calculate the surface temperature flux associated with surface cooling of
 # 200 W m⁻², reference density `ρₒ`, and heat capacity `cᴾ`,
 
-Qʰ = 200.0  # W m⁻², surface _heat_ flux
+Q = 200.0  # W m⁻², surface _heat_ flux
 ρₒ = 1026.0 # kg m⁻³, average density at the surface of the world ocean
 cᴾ = 3991.0 # J K⁻¹ kg⁻¹, typical heat capacity for seawater
 
-Qᵀ = Qʰ / (ρₒ * cᴾ) # K m s⁻¹, surface _temperature_ flux
+Jᵀ = Q / (ρₒ * cᴾ) # K m s⁻¹, surface _temperature_ flux
 
 # Finally, we impose a temperature gradient `dTdz` both initially and at the
 # bottom of the domain, culminating in the boundary conditions on temperature,
 
 dTdz = 0.01 # K m⁻¹
 
-T_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵀ),
+T_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Jᵀ),
                                 bottom = GradientBoundaryCondition(dTdz))
 
 # Note that a positive temperature flux at the surface of the ocean
@@ -111,26 +111,26 @@ u₁₀ = 10    # m s⁻¹, average wind velocity 10 meters above the ocean
 cᴰ = 2.5e-3 # dimensionless drag coefficient
 ρₐ = 1.225  # kg m⁻³, average density of air at sea-level
 
-Qᵘ = - ρₐ / ρₒ * cᴰ * u₁₀ * abs(u₁₀) # m² s⁻²
+τx = - ρₐ / ρₒ * cᴰ * u₁₀ * abs(u₁₀) # m² s⁻²
 
 # The boundary conditions on `u` are thus
 
-u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
+u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(τx))
 
 # For salinity, `S`, we impose an evaporative flux of the form
 
-@inline Qˢ(x, y, t, S, evaporation_rate) = - evaporation_rate * S # [salinity unit] m s⁻¹
+@inline Jˢ(x, y, t, S, evaporation_rate) = - evaporation_rate * S # [salinity unit] m s⁻¹
 nothing #hide
 
 # where `S` is salinity. We use an evporation rate of 1 millimeter per hour,
 
 evaporation_rate = 1e-3 / hour # m s⁻¹
 
-# We build the `Flux` evaporation `BoundaryCondition` with the function `Qˢ`,
-# indicating that `Qˢ` depends on salinity `S` and passing
+# We build the `Flux` evaporation `BoundaryCondition` with the function `Jˢ`,
+# indicating that `Jˢ` depends on salinity `S` and passing
 # the parameter `evaporation_rate`,
 
-evaporation_bc = FluxBoundaryCondition(Qˢ, field_dependencies=:S, parameters=evaporation_rate)
+evaporation_bc = FluxBoundaryCondition(Jˢ, field_dependencies=:S, parameters=evaporation_rate)
 
 # The full salinity boundary conditions are
 
@@ -173,7 +173,7 @@ model = NonhydrostaticModel(; grid, buoyancy,
 Tᵢ(x, y, z) = 20 + dTdz * z + dTdz * model.grid.Lz * 1e-6 * Ξ(z)
 
 ## Velocity initial condition: random noise scaled by the friction velocity.
-uᵢ(x, y, z) = sqrt(abs(Qᵘ)) * 1e-3 * Ξ(z)
+uᵢ(x, y, z) = sqrt(abs(τx)) * 1e-3 * Ξ(z)
 
 ## `set!` the `model` fields using functions or constants:
 set!(model, u=uᵢ, w=uᵢ, T=Tᵢ, S=35)

--- a/validation/vertical_mixing_closures/gpu_tkevd_ensemble.jl
+++ b/validation/vertical_mixing_closures/gpu_tkevd_ensemble.jl
@@ -17,13 +17,13 @@ grid = RectilinearGrid(size=sz, halo=halo, z=(-128, 0), topology=(Flat, Flat, Bo
 
 closure = CuArray([CATKEVerticalDiffusivity() for i=1:Ex, j=1:Ey])
                                       
-Qᵇ = CuArray([+1e-8 for i=1:Ex, j=1:Ey])
-Qᵘ = CuArray([-1e-4 for i=1:Ex, j=1:Ey])
-Qᵛ = CuArray([0.0   for i=1:Ex, j=1:Ey])
+Jᵇ = CuArray([+1e-8 for i=1:Ex, j=1:Ey])
+τx = CuArray([-1e-4 for i=1:Ex, j=1:Ey])
+τy = CuArray([0.0   for i=1:Ex, j=1:Ey])
 
-u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
-v_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵛ))
-b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ))
+u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(τx))
+v_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(τy))
+b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Jᵇ))
 
 # Half rotating, half not
 f_ij(i, j) = j < Ey/2 ? 1e-4 : 0.0

--- a/validation/vertical_mixing_closures/heterogeneous_windy_convection.jl
+++ b/validation/vertical_mixing_closures/heterogeneous_windy_convection.jl
@@ -38,11 +38,11 @@ z_bottom(x, y) = - Lz * (1 - (2y / Ly)^2)
 grid = ImmersedBoundaryGrid(grid, PartialCellBottom(z_bottom, minimum_fractional_cell_height=0.1))
 
 @show grid
-@inline Qᵇ(x, y, t) = 1e-7
-@inline Qᵘ(x, y, t) = -1e-3 * cos(π * y / Ly)
+@inline Jᵇ(x, y, t) = 1e-7
+@inline τx(x, y, t) = -1e-3 * cos(π * y / Ly)
 
-b_top_bc = FluxBoundaryCondition(Qᵇ)
-u_top_bc = FluxBoundaryCondition(Qᵘ)
+b_top_bc = FluxBoundaryCondition(Jᵇ)
+u_top_bc = FluxBoundaryCondition(τx)
 
 b_bcs = FieldBoundaryConditions(top=b_top_bc)
 u_bcs = FieldBoundaryConditions(top=u_top_bc)


### PR DESCRIPTION
This PR updates the examples to use the notation for fluxes which is used by [Wagner et al 2024](https://glwagner.github.io/assets/pdf/CATKE.pdf) and which we are planning to use for subsequent work as well. In short this is:

* $Q$ for heat flux
* $\tau_x$ and $\tau_y$ for the zonal and meridional _kinematic_ momentum flux. The momentum flux is therefore $\rho_o \tau_x$, where $\rho_o$ is the ocean surface density. This is also consistent with the notation used for Clima's atmosphere model
* $J^c$ for the flux of a tracer $c$.