### PR TITLE
Remove redundant advection aliases

### DIFF
--- a/benchmark/benchmark_advection_schemes.jl
+++ b/benchmark/benchmark_advection_schemes.jl
@@ -44,7 +44,7 @@ if GPU in Architectures
 end
 
 for Arch in Architectures
-    suite_arch = speedups_suite(suite[@tagged Arch], base_case=(Arch, CenteredSecondOrder))
+    suite_arch = speedups_suite(suite[@tagged Arch], base_case=(Arch, Centered))
     df_arch = speedups_dataframe(suite_arch, slowdown=true)
     sort!(df_arch, :Schemes, by=string)
     benchmarks_pretty_table(df_arch, title="Advection schemes relative performance ($Arch)")

--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -17,9 +17,7 @@ export
     advective_tracer_flux_z,
 
     AdvectionScheme,
-    Centered, CenteredSecondOrder, CenteredFourthOrder,
-    UpwindBiased, UpwindBiasedFirstOrder, UpwindBiasedThirdOrder, UpwindBiasedFifthOrder,
-    WENO, WENOThirdOrder, WENOFifthOrder,
+    Centered, UpwindBiased, WENO, 
     VectorInvariant, WENOVectorInvariant,
     FluxFormAdvection,
     EnergyConserving,

--- a/src/Advection/centered_reconstruction.jl
+++ b/src/Advection/centered_reconstruction.jl
@@ -85,9 +85,6 @@ on_architecture(to, scheme::Centered{N, FT}) where {N, FT} =
 # Useful aliases
 Centered(grid, FT::DataType=Float64; kwargs...) = Centered(FT; grid, kwargs...)
 
-CenteredSecondOrder(grid=nothing, FT::DataType=Float64) = Centered(grid, FT; order=2)
-CenteredFourthOrder(grid=nothing, FT::DataType=Float64) = Centered(grid, FT; order=4)
-
 const ACAS = AbstractCenteredAdvectionScheme
 
 # left and right biased for Centered reconstruction are just symmetric!

--- a/src/Advection/positivity_preserving_tracer_advection_operators.jl
+++ b/src/Advection/positivity_preserving_tracer_advection_operators.jl
@@ -4,7 +4,7 @@ const ω̂₁ = 5/18
 const ω̂ₙ = 5/18  
 const ε₂ = 1e-20
 
-# Here in the future we can easily add UpwindBiasedFifthOrder 
+# Here in the future we can easily add UpwindBiased
 const BoundPreservingScheme = PositiveWENO
 
 # Is this immersed-boundary safe without having to extend it in ImmersedBoundaries.jl? I think so... (velocity on immmersed boundaries is masked to 0)

--- a/src/Advection/upwind_biased_reconstruction.jl
+++ b/src/Advection/upwind_biased_reconstruction.jl
@@ -3,9 +3,9 @@
 #####
 
 """
-    struct UpwindBiasedFifthOrder <: AbstractUpwindBiasedAdvectionScheme{3}
+    struct UpwindBiased <: AbstractUpwindBiasedAdvectionScheme{3}
 
-Upwind-biased fifth-order advection scheme.
+Upwind-biased reconstruction scheme.
 """
 struct UpwindBiased{N, FT, XT, YT, ZT, CA, SI} <: AbstractUpwindBiasedAdvectionScheme{N, FT} 
     "Coefficient for Upwind reconstruction on stretched ``x``-faces" 

--- a/src/Advection/upwind_biased_reconstruction.jl
+++ b/src/Advection/upwind_biased_reconstruction.jl
@@ -95,10 +95,6 @@ on_architecture(to, scheme::UpwindBiased{N, FT}) where {N, FT} =
 # Useful aliases
 UpwindBiased(grid, FT::DataType=Float64; kwargs...) = UpwindBiased(FT; grid, kwargs...)
 
-UpwindBiasedFirstOrder(grid=nothing, FT::DataType=Float64) = UpwindBiased(grid, FT; order = 1)
-UpwindBiasedThirdOrder(grid=nothing, FT::DataType=Float64) = UpwindBiased(grid, FT; order = 3)
-UpwindBiasedFifthOrder(grid=nothing, FT::DataType=Float64) = UpwindBiased(grid, FT; order = 5)
-
 const AUAS = AbstractUpwindBiasedAdvectionScheme
 
 # symmetric interpolation for UpwindBiased and WENO

--- a/src/Advection/vector_invariant_upwinding.jl
+++ b/src/Advection/vector_invariant_upwinding.jl
@@ -27,7 +27,7 @@ end
 @inline extract_centered_scheme(scheme::AUAS) = scheme.advecting_velocity_scheme
 
 """
-    OnlySelfUpwinding(; cross_scheme = CenteredSecondOrder(),
+    OnlySelfUpwinding(; cross_scheme = Centered(),
                         δU_stencil   = FunctionStencil(divergence_smoothness),
                         δV_stencil   = FunctionStencil(divergence_smoothness),
                         δu²_stencil  = FunctionStencil(u_smoothness),
@@ -43,7 +43,7 @@ Keyword arguments
 =================  
 
 - `cross_scheme`: Advection scheme used for cross-reconstructed terms (tangential velocities) 
-                  in the kinetic energy gradient and the divergence flux. Defaults to `CenteredSecondOrder()`.
+                  in the kinetic energy gradient and the divergence flux. Defaults to `Centered()`.
 - `δU_stencil`: Stencil used for smoothness indicators of `δx_U` in case of a `WENO` upwind reconstruction. 
                 Defaults to `FunctionStencil(divergence_smoothness)`
 - `δV_stencil`: Same as `δU_stencil` but for the smoothness of `δy_V`
@@ -52,7 +52,7 @@ Keyword arguments
 - `δv²_stencil`: Same as `δu²_stencil` but for the smoothness of `δy_v²`
                  Defaults to `FunctionStencil(v_smoothness)`
 """
-OnlySelfUpwinding(; cross_scheme = CenteredSecondOrder(),
+OnlySelfUpwinding(; cross_scheme = Centered(),
                     δU_stencil   = FunctionStencil(divergence_smoothness),
                     δV_stencil   = FunctionStencil(divergence_smoothness),
                     δu²_stencil  = FunctionStencil(u_smoothness),
@@ -60,7 +60,7 @@ OnlySelfUpwinding(; cross_scheme = CenteredSecondOrder(),
                     ) = OnlySelfUpwinding(extract_centered_scheme(cross_scheme), δU_stencil, δV_stencil, δu²_stencil, δv²_stencil)
 
 """
-    CrossAndSelfUpwinding(; cross_scheme       = CenteredSecondOrder(),
+    CrossAndSelfUpwinding(; cross_scheme       = Centered(),
                             divergence_stencil = DefaultStencil(),
                             δu²_stencil        = FunctionStencil(u_smoothness),
                             δv²_stencil        = FunctionStencil(v_smoothness)) 
@@ -74,7 +74,7 @@ Keyword arguments
 =================  
 
 - `cross_scheme`: Advection scheme used for cross-reconstructed terms (tangential velocities) 
-                  in the kinetic energy gradient. Defaults to `CenteredSecondOrder()`.
+                  in the kinetic energy gradient. Defaults to `Centered()`.
 - `divergence_stencil`: Stencil used for smoothness indicators of `δx_U + δy_V` in case of a 
                         `WENO` upwind reconstruction. Defaults to `DefaultStencil()`.
 - `δu²_stencil`: Stencil used for smoothness indicators of `δx_u²` in case of a `WENO` upwind reconstruction. 
@@ -82,7 +82,7 @@ Keyword arguments
 - `δv²_stencil`: Same as `δu²_stencil` but for the smoothness of `δy_v²`
                  Defaults to `FunctionStencil(v_smoothness)`
 """
-CrossAndSelfUpwinding(; cross_scheme       = CenteredSecondOrder(),
+CrossAndSelfUpwinding(; cross_scheme       = Centered(),
                         divergence_stencil = DefaultStencil(),
                         δu²_stencil        = FunctionStencil(u_smoothness),
                         δv²_stencil        = FunctionStencil(v_smoothness),

--- a/src/Advection/weno_reconstruction.jl
+++ b/src/Advection/weno_reconstruction.jl
@@ -119,10 +119,6 @@ end
 
 WENO(grid, FT::DataType=Float64; kwargs...) = WENO(FT; grid, kwargs...)
 
-# Some usefull aliases
-WENOThirdOrder(grid=nothing, FT::DataType=Float64;  kwargs...) = WENO(grid, FT; order=3, kwargs...)
-WENOFifthOrder(grid=nothing, FT::DataType=Float64;  kwargs...) = WENO(grid, FT; order=5, kwargs...)
-
 # Flavours of WENO
 const PositiveWENO = WENO{<:Any, <:Any, <:Any, <:Any, <:Any, <:Tuple}
 

--- a/src/Biogeochemistry.jl
+++ b/src/Biogeochemistry.jl
@@ -1,7 +1,7 @@
 module Biogeochemistry
 
 using Oceananigans.Grids: Center, xnode, ynode, znode
-using Oceananigans.Advection: div_Uc, CenteredSecondOrder
+using Oceananigans.Advection: div_Uc, Centered
 using Oceananigans.Architectures: device, architecture
 using Oceananigans.Fields: ZeroField
 

--- a/src/Forcings/advective_forcing.jl
+++ b/src/Forcings/advective_forcing.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Advection: UpwindBiasedFifthOrder, div_Uc, div_𝐯u, div_𝐯v, div_𝐯w
+using Oceananigans.Advection: div_Uc, div_𝐯u, div_𝐯v, div_𝐯w
 using Oceananigans.Fields: ZeroField, ConstantField
 using Oceananigans.Utils: SumOfArrays
 using Adapt

--- a/src/Grids/automatic_halo_sizing.jl
+++ b/src/Grids/automatic_halo_sizing.jl
@@ -8,10 +8,10 @@ Example
 =======
 
 ```jldoctest
-using Oceananigans.Advection: CenteredFourthOrder
+using Oceananigans.Advection: Centered(order=4)
 using Oceananigans.Grids: required_halo_size_x
 
-required_halo_size_x(CenteredFourthOrder())
+required_halo_size_x(Centered(order=4))
 
 # output
 2
@@ -28,10 +28,10 @@ Example
 =======
 
 ```jldoctest
-using Oceananigans.Advection: CenteredFourthOrder
+using Oceananigans.Advection: Centered(order=4)
 using Oceananigans.Grids: required_halo_size_y
 
-required_halo_size_y(CenteredFourthOrder())
+required_halo_size_y(Centered(order=4))
 
 # output
 2
@@ -48,10 +48,10 @@ Example
 =======
 
 ```jldoctest
-using Oceananigans.Advection: CenteredFourthOrder
+using Oceananigans.Advection: Centered(order=4)
 using Oceananigans.Grids: required_halo_size_z
 
-required_halo_size_z(CenteredFourthOrder())
+required_halo_size_z(Centered(order=4))
 
 # output
 2

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -3,7 +3,7 @@ using OrderedCollections: OrderedDict
 
 using Oceananigans.DistributedComputations
 using Oceananigans.Architectures: AbstractArchitecture
-using Oceananigans.Advection: AbstractAdvectionScheme, CenteredSecondOrder, VectorInvariant, adapt_advection_order
+using Oceananigans.Advection: AbstractAdvectionScheme, Centered, VectorInvariant, adapt_advection_order
 using Oceananigans.BuoyancyModels: validate_buoyancy, regularize_buoyancy, SeawaterBuoyancy, g_Earth
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
 using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochemistry, biogeochemical_auxiliary_fields
@@ -57,7 +57,7 @@ default_free_surface(grid; gravitational_acceleration=g_Earth) =
     HydrostaticFreeSurfaceModel(; grid,
                                 clock = Clock{eltype(grid)}(time = 0),
                                 momentum_advection = VectorInvariant(),
-                                tracer_advection = CenteredSecondOrder(),
+                                tracer_advection = Centered(),
                                 buoyancy = SeawaterBuoyancy(eltype(grid)),
                                 coriolis = nothing,
                                 free_surface = default_free_surface(grid, gravitational_acceleration=g_Earth),
@@ -104,7 +104,7 @@ Keyword arguments
 function HydrostaticFreeSurfaceModel(; grid,
                                      clock = Clock{eltype(grid)}(time = 0),
                                      momentum_advection = VectorInvariant(),
-                                     tracer_advection = CenteredSecondOrder(),
+                                     tracer_advection = Centered(),
                                      buoyancy = nothing,
                                      coriolis = nothing,
                                      free_surface = default_free_surface(grid, gravitational_acceleration=g_Earth),

--- a/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
@@ -43,7 +43,7 @@ end
 validate_velocity_boundary_conditions(::SingleColumnGrid, velocities) = nothing
 validate_velocity_boundary_conditions(::SingleColumnGrid, ::PrescribedVelocityFields) = nothing
 validate_momentum_advection(momentum_advection, ::SingleColumnGrid) = nothing
-validate_tracer_advection(tracer_advection_tuple::NamedTuple, ::SingleColumnGrid) = CenteredSecondOrder(), tracer_advection_tuple
+validate_tracer_advection(tracer_advection_tuple::NamedTuple, ::SingleColumnGrid) = Centered(), tracer_advection_tuple
 validate_tracer_advection(tracer_advection::AbstractAdvectionScheme, ::SingleColumnGrid) = tracer_advection, NamedTuple()
 
 compute_w_from_continuity!(velocities, arch, ::SingleColumnGrid; kwargs...) = nothing

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -11,7 +11,7 @@ export
 
 using Oceananigans: AbstractModel, fields, prognostic_fields
 using Oceananigans.AbstractOperations: AbstractOperation
-using Oceananigans.Advection: AbstractAdvectionScheme, CenteredSecondOrder, VectorInvariant
+using Oceananigans.Advection: AbstractAdvectionScheme, Centered, VectorInvariant
 using Oceananigans.Fields: AbstractField, Field, flattened_unique_values, boundary_conditions
 using Oceananigans.Grids: AbstractGrid, halo_size, inflate_halo_size
 using Oceananigans.OutputReaders: update_field_time_series!, extract_field_time_series
@@ -80,7 +80,7 @@ extract_boundary_conditions(field::Field) = field.boundary_conditions
 
 """ Returns a default_tracer_advection, tracer_advection `tuple`. """
 validate_tracer_advection(invalid_tracer_advection, grid) = error("$invalid_tracer_advection is invalid tracer_advection!")
-validate_tracer_advection(tracer_advection_tuple::NamedTuple, grid) = CenteredSecondOrder(), tracer_advection_tuple
+validate_tracer_advection(tracer_advection_tuple::NamedTuple, grid) = Centered(), tracer_advection_tuple
 validate_tracer_advection(tracer_advection::AbstractAdvectionScheme, grid) = tracer_advection, NamedTuple()
 validate_tracer_advection(tracer_advection::Nothing, grid) = nothing, NamedTuple()
 

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -3,7 +3,7 @@ using OrderedCollections: OrderedDict
 
 using Oceananigans.Architectures: AbstractArchitecture
 using Oceananigans.DistributedComputations: Distributed
-using Oceananigans.Advection: CenteredSecondOrder, adapt_advection_order
+using Oceananigans.Advection: Centered, adapt_advection_order
 using Oceananigans.BuoyancyModels: validate_buoyancy, regularize_buoyancy, SeawaterBuoyancy
 using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochemistry, biogeochemical_auxiliary_fields
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
@@ -56,7 +56,7 @@ end
 """
     NonhydrostaticModel(;           grid,
                                     clock = Clock{eltype(grid)}(time = 0),
-                                advection = CenteredSecondOrder(),
+                                advection = Centered(),
                                  buoyancy = nothing,
                                  coriolis = nothing,
                              stokes_drift = nothing,
@@ -113,7 +113,7 @@ Keyword arguments
 """
 function NonhydrostaticModel(; grid,
                              clock = Clock{eltype(grid)}(time = 0),
-                             advection = CenteredSecondOrder(),
+                             advection = Centered(),
                              buoyancy = nothing,
                              coriolis = nothing,
                              stokes_drift = nothing,

--- a/src/Models/ShallowWaterModels/shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_model.jl
@@ -3,7 +3,7 @@ using Oceananigans: AbstractModel, AbstractOutputWriter, AbstractDiagnostic
 using Oceananigans.Architectures: AbstractArchitecture, CPU
 using Oceananigans.AbstractOperations: @at, KernelFunctionOperation
 using Oceananigans.DistributedComputations
-using Oceananigans.Advection: CenteredSecondOrder, VectorInvariant
+using Oceananigans.Advection: Centered, VectorInvariant
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
 using Oceananigans.Fields: Field, tracernames, TracerFields, XFaceField, YFaceField, CenterField, compute!
 using Oceananigans.Forcings: model_forcing
@@ -62,7 +62,7 @@ struct VectorInvariantFormulation end
     ShallowWaterModel(; grid,
                         gravitational_acceleration,
                               clock = Clock{eltype(grid)}(time = 0),
-                 momentum_advection = UpwindBiasedFifthOrder(),
+                 momentum_advection = UpwindBiased(order=5),
                    tracer_advection = WENO(),
                      mass_advection = WENO(),
                            coriolis = nothing,
@@ -86,7 +86,7 @@ Keyword arguments
   - `gravitational_acceleration`: (required) The gravitational acceleration constant.
   - `clock`: The `clock` for the model.
   - `momentum_advection`: The scheme that advects velocities. See `Oceananigans.Advection`.
-    Default: `UpwindBiasedFifthOrder()`.
+    Default: `UpwindBiased(order=5)`.
   - `tracer_advection`: The scheme that advects tracers. See `Oceananigans.Advection`. Default: `WENO()`.
   - `mass_advection`: The scheme that advects the mass equation. See `Oceananigans.Advection`. Default:
     `WENO()`.
@@ -113,7 +113,7 @@ function ShallowWaterModel(;
                            grid,
                            gravitational_acceleration,
                                clock = Clock{eltype(grid)}(time=0),
-                  momentum_advection = UpwindBiasedFifthOrder(),
+                  momentum_advection = UpwindBiased(order=5),
                     tracer_advection = WENO(),
                       mass_advection = WENO(),
                             coriolis = nothing,

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -134,10 +134,10 @@ topos_3d = ((Periodic, Periodic, Bounded),
             grid = RectilinearGrid(topology=topo, size=(1, 1, 1), extent=(1, 2, 3), halo=(1, 1, 1))
             hcabd_closure = ScalarBiharmonicDiffusivity()
 
-            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid=grid, tracer_advection=CenteredFourthOrder())
-            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid=grid, tracer_advection=UpwindBiasedThirdOrder())
-            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid=grid, tracer_advection=UpwindBiasedFifthOrder())
-            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid=grid, momentum_advection=UpwindBiasedFifthOrder())
+            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid=grid, tracer_advection=Centered(order=4))
+            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid=grid, tracer_advection=UpwindBiased(order=3))
+            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid=grid, tracer_advection=UpwindBiased(order=5))
+            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid=grid, momentum_advection=UpwindBiased(order=5))
             @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid=grid, closure=hcabd_closure)
 
             # Big enough
@@ -146,13 +146,13 @@ topos_3d = ((Periodic, Periodic, Bounded),
             model = HydrostaticFreeSurfaceModel(grid=bigger_grid, closure=hcabd_closure)
             @test model isa HydrostaticFreeSurfaceModel
 
-            model = HydrostaticFreeSurfaceModel(grid=bigger_grid, momentum_advection=UpwindBiasedFifthOrder())
+            model = HydrostaticFreeSurfaceModel(grid=bigger_grid, momentum_advection=UpwindBiased(order=5))
             @test model isa HydrostaticFreeSurfaceModel
 
             model = HydrostaticFreeSurfaceModel(grid=bigger_grid, closure=hcabd_closure)
             @test model isa HydrostaticFreeSurfaceModel
 
-            model = HydrostaticFreeSurfaceModel(grid=bigger_grid, tracer_advection=UpwindBiasedFifthOrder())
+            model = HydrostaticFreeSurfaceModel(grid=bigger_grid, tracer_advection=UpwindBiased(order=5))
             @test model isa HydrostaticFreeSurfaceModel
         end
     end
@@ -246,7 +246,7 @@ topos_3d = ((Periodic, Periodic, Bounded),
             end
         end
 
-        for momentum_advection in (VectorInvariant(), WENOVectorInvariant(), CenteredSecondOrder(), WENO())
+        for momentum_advection in (VectorInvariant(), WENOVectorInvariant(), Centered(), WENO())
             @testset "Time-stepping HydrostaticFreeSurfaceModels [$arch, $(typeof(momentum_advection))]" begin
                 @info "  Testing time-stepping HydrostaticFreeSurfaceModels [$arch, $(typeof(momentum_advection))]..."
                 @test time_step_hydrostatic_model_works(rectilinear_grid; momentum_advection)

--- a/test/test_nonhydrostatic_models.jl
+++ b/test/test_nonhydrostatic_models.jl
@@ -54,7 +54,7 @@ using Oceananigans.Grids: required_halo_size_x, required_halo_size_y, required_h
         end
 
         # Model ensures that halos are at least of size 3
-        for scheme in (WENO(), UpwindBiased())
+        for scheme in (WENO(), UpwindBiased(order=5))
             model = NonhydrostaticModel(advection=scheme, grid=minimal_grid)
             @test model.grid.Hx == 3 && model.grid.Hy == 3 && model.grid.Hz == 3
 

--- a/test/test_nonhydrostatic_models.jl
+++ b/test/test_nonhydrostatic_models.jl
@@ -45,7 +45,7 @@ using Oceananigans.Grids: required_halo_size_x, required_halo_size_y, required_h
         @test model.grid.Hx == 1 && model.grid.Hy == 3 && model.grid.Hz == 4
 
         # Model ensures that halos are at least of size 2
-        for scheme in (CenteredFourthOrder(), UpwindBiasedThirdOrder())
+        for scheme in (Centered(order=4), UpwindBiased(order=3))
             model = NonhydrostaticModel(advection=scheme, grid=minimal_grid)
             @test model.grid.Hx == 2 && model.grid.Hy == 2 && model.grid.Hz == 2
 
@@ -54,7 +54,7 @@ using Oceananigans.Grids: required_halo_size_x, required_halo_size_y, required_h
         end
 
         # Model ensures that halos are at least of size 3
-        for scheme in (WENO(), UpwindBiasedFifthOrder())
+        for scheme in (WENO(), UpwindBiased())
             model = NonhydrostaticModel(advection=scheme, grid=minimal_grid)
             @test model.grid.Hx == 3 && model.grid.Hy == 3 && model.grid.Hz == 3
 

--- a/test/test_shallow_water_models.jl
+++ b/test/test_shallow_water_models.jl
@@ -197,7 +197,7 @@ end
         end
 
         # Advection = nothing is broken as halo does not have a maximum
-        for advection in (nothing, CenteredSecondOrder(), WENO())
+        for advection in (nothing, Centered(), WENO())
             @testset "Time-stepping ShallowWaterModels [$arch, $(typeof(advection))]" begin
                 @info "  Testing time-stepping ShallowWaterModels [$arch, $(typeof(advection))]..."
                 @test time_stepping_shallow_water_model_works(arch, topos[1], nothing, advection)

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -250,11 +250,11 @@ Closures = (ScalarDiffusivity,
             CATKEVerticalDiffusivity)
 
 advection_schemes = (nothing,
-                     UpwindBiasedFirstOrder(),
-                     CenteredSecondOrder(),
-                     UpwindBiasedThirdOrder(),
-                     CenteredFourthOrder(),
-                     UpwindBiasedFifthOrder(),
+                     UpwindBiased(order=1),
+                     Centered(order=2),
+                     UpwindBiased(order=3),
+                     Centered(order=4),
+                     UpwindBiased(order=5),
                      WENO())
 
 @inline ∂t_uˢ_uniform(z, t, h) = exp(z / h) * cos(t)

--- a/validation/advection/plot_rates_convergence_advection.jl
+++ b/validation/advection/plot_rates_convergence_advection.jl
@@ -56,13 +56,13 @@ pnorm = 1
 uh(x, y, z) = U * h(x, y, z)
 
 schemes = (
-    CenteredFourthOrder(), 
-    UpwindBiasedFifthOrder(), 
-    WENO(order = 3),
-    WENO(order = 5),
-    WENO(order = 7),
-    WENO(order = 9),
-    WENO(order = 11)
+    Centered(order=4), 
+    UpwindBiased(order=5), 
+    WENO(order=3),
+    WENO(order=5),
+    WENO(order=7),
+    WENO(order=9),
+    WENO(order=11)
 )s
 
 error = Dict()

--- a/validation/biogeochemistry/simple_plankton_continuous_form_biogeochemistry.jl
+++ b/validation/biogeochemistry/simple_plankton_continuous_form_biogeochemistry.jl
@@ -5,7 +5,7 @@ using Oceananigans.Grids: znode
 using Oceananigans.Forcings: maybe_constant_field
 using Oceananigans.Architectures: device, architecture
 using Oceananigans.Utils: launch!
-using Oceananigans.Advection: CenteredSecondOrder
+using Oceananigans.Advection: Centered
 using Oceananigans.Fields: Field, TracerFields, CenterField
 
 import Oceananigans.Biogeochemistry:
@@ -43,7 +43,7 @@ function SimplePlanktonGrowthDeath(FT=Float64; grid,
                                    advection_scheme = nothing)
 
     if sinking_velocity != 0
-        advection_scheme = CenteredSecondOrder()
+        advection_scheme = Centered()
     end
 
     u, v, w = maybe_constant_field.((0, 0, - sinking_velocity))

--- a/validation/convergence_tests/src/OneDimensionalCosineAdvectionDiffusion.jl
+++ b/validation/convergence_tests/src/OneDimensionalCosineAdvectionDiffusion.jl
@@ -14,7 +14,7 @@ using ConvergenceTests: compute_error
 c(x, y, z, t, U, κ) = exp(-κ * t) * cos(x - U * t)
 
 function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4,
-                  architecture = CPU(), topo = (Periodic, Periodic, Periodic), advection = CenteredSecondOrder())
+                  architecture = CPU(), topo = (Periodic, Periodic, Periodic), advection = Centered())
 
     #####
     ##### Test advection-diffusion in the x-direction

--- a/validation/convergence_tests/src/OneDimensionalGaussianAdvectionDiffusion.jl
+++ b/validation/convergence_tests/src/OneDimensionalGaussianAdvectionDiffusion.jl
@@ -15,7 +15,7 @@ using ConvergenceTests: compute_error
 c(x, y, z, t, U, κ, t₀) = 1 / √(4π * κ * (t + t₀)) * exp(-(x - U * t)^2 / σ(t, κ, t₀))
 
 function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4, width = 0.05,
-                  architecture = CPU(), topo = (Periodic, Periodic, Periodic), advection = CenteredSecondOrder())
+                  architecture = CPU(), topo = (Periodic, Periodic, Periodic), advection = Centered())
 
     t₀ = width^2 / 4κ
 

--- a/validation/convergence_tests/src/TwoDimensionalGaussianAdvectionDiffusion.jl
+++ b/validation/convergence_tests/src/TwoDimensionalGaussianAdvectionDiffusion.jl
@@ -16,7 +16,7 @@ using ConvergenceTests: compute_error
 c(x, y, z, t, U, κ, t₀) = 1 / √(4π * κ * (t + t₀)) * exp(-((x - U * t)^2 + (y - U * t)^2) / σ(t, κ, t₀))
 
 function run_test(; Nx, Δt, stop_iteration, U = 1, κ = 1e-4, width = 0.05,
-                  architecture = CPU(), topo = (Periodic, Periodic, Periodic), advection = CenteredSecondOrder())
+                  architecture = CPU(), topo = (Periodic, Periodic, Periodic), advection = Centered())
 
     t₀ = width^2 / 4κ
 

--- a/validation/distributed_simulations/distributed_shallow_water_turbulence.jl
+++ b/validation/distributed_simulations/distributed_shallow_water_turbulence.jl
@@ -19,7 +19,7 @@ local_rank = MPI.Comm_rank(arch.communicator)
 
 model = ShallowWaterModel(grid = grid,
                           timestepper = :RungeKutta3,
-                          momentum_advection = UpwindBiasedFifthOrder(),
+                          momentum_advection = UpwindBiased(order=5),
                           gravitational_acceleration = 1)
 
 set!(model, h=1)

--- a/validation/immersed_boundaries/2D_rough_rayleighbenard.jl
+++ b/validation/immersed_boundaries/2D_rough_rayleighbenard.jl
@@ -77,7 +77,7 @@ function run_simulation(solver, preconditioner; Nr, Ra, Nz, Pr=1, IPS_reltol=1e-
     
     if solver == "FFT"
         model = NonhydrostaticModel(; grid,
-                                    # advection = CenteredSecondOrder(),
+                                    # advection = Centered(),
                                     advection = WENO(order=7),
                                     tracers = (:b),
                                     buoyancy = BuoyancyTracer(),
@@ -87,7 +87,7 @@ function run_simulation(solver, preconditioner; Nr, Ra, Nz, Pr=1, IPS_reltol=1e-
     else
         model = NonhydrostaticModel(; grid,
                                     pressure_solver = ImmersedPoissonSolver(grid, preconditioner=preconditioner, reltol=IPS_reltol),
-                                    # advection = CenteredSecondOrder(),
+                                    # advection = Centered(),
                                     advection = WENO(order=7),
                                     tracers = (:b),
                                     buoyancy = BuoyancyTracer(),

--- a/validation/immersed_boundaries/cylinder_flow_with_tracer.jl
+++ b/validation/immersed_boundaries/cylinder_flow_with_tracer.jl
@@ -27,14 +27,14 @@ const nu = 2*R/Re  # viscosity
 
 """
     run_cylinder_steadyflow(output_time_interval = 1, stop_time = 100, arch = CPU(), Nh = 250, ν = 1/20,
-                    momentum_advection = UpwindBiasedFifthOrder(), radius = R)
+                    momentum_advection = UpwindBiased(order=5), radius = R)
 
 Run the steady state cylinder validation experiment until `stop_time` using `momentum_advection`
 scheme or formulation, with horizontal resolution `Nh`, viscosity `ν`, and cylinder radius `R`, on `arch`itecture.
 """
 
 function run_cylinder_steadystate(; output_time_interval = 1, stop_time = 100, arch = CPU(), Nh = 250, ν = nu, 
-                                    advection = UpwindBiasedFifthOrder(), radius = R)
+                                    advection = UpwindBiased(order=5), radius = R)
 
 
     inside_cylinder(x, y, z) = (x^2 + y^2) <= radius # immersed solid
@@ -380,7 +380,7 @@ function analyze_cylinder_steadystate(experiment_name)
     Plots.savefig(analysisplot, "analysis_" * experiment_name * ".png")
 end
 
-advection = CenteredSecondOrder()
+advection = Centered()
 experiment_name = run_cylinder_steadystate(Nh = 350, advection = advection, radius = R, stop_time = 100, ν = nu)
 visualize_cylinder_steadystate(experiment_name)
 analyze_cylinder_steadystate(experiment_name)

--- a/validation/immersed_boundaries/internal_tide.jl
+++ b/validation/immersed_boundaries/internal_tide.jl
@@ -45,7 +45,7 @@ tidal_forcing(x, y, z, t) = 1e-4 * cos(t)
 for free_surface in (ExplicitFreeSurface, )
     
     model = HydrostaticFreeSurfaceModel(grid = grid_with_bump,
-                                        momentum_advection = CenteredSecondOrder(),
+                                        momentum_advection = Centered(),
                                         free_surface = free_surface(gravitational_acceleration=10),
                                         closure = ScalarDiffusivity(VerticallyImplicitTimeDiscretization(), ν=1e-2, κ=1e-2),
                                         tracers = :b,

--- a/validation/immersed_boundaries/nonlinear_topography.jl
+++ b/validation/immersed_boundaries/nonlinear_topography.jl
@@ -57,7 +57,7 @@ function run_simulation(solver, preconditioner)
     if solver == "FFT"
         model = NonhydrostaticModel(; grid,
                                     # advection = WENO(),
-                                    advection = CenteredSecondOrder(),
+                                    advection = Centered(),
                                     tracers = :b,
                                     buoyancy = BuoyancyTracer(),
                                     # timestepper = :RungeKutta3,
@@ -67,7 +67,7 @@ function run_simulation(solver, preconditioner)
         model = NonhydrostaticModel(; grid,
                                     pressure_solver = ImmersedPoissonSolver(grid, preconditioner=preconditioner, reltol=1e-8),
                                     # advection = WENO(),
-                                    advection = CenteredSecondOrder(),
+                                    advection = Centered(),
                                     tracers = :b,
                                     buoyancy = BuoyancyTracer(),
                                     # timestepper = :RungeKutta3,

--- a/validation/immersed_boundaries/resting_stratified_bumpy_ocean.jl
+++ b/validation/immersed_boundaries/resting_stratified_bumpy_ocean.jl
@@ -5,8 +5,8 @@ using Printf
 using GLMakie
 
 arch = CPU()
-tracer_advection = CenteredSecondOrder()
-momentum_advection = CenteredSecondOrder()
+tracer_advection = Centered()
+momentum_advection = Centered()
 
 underlying_grid = RectilinearGrid(arch,
                                   size=(128, 64), halo=(3, 3), 

--- a/validation/immersed_boundaries/tracer_advection_over_bump.jl
+++ b/validation/immersed_boundaries/tracer_advection_over_bump.jl
@@ -6,7 +6,7 @@ using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
 using Printf
 
 arch = CPU()
-tracer_advection = CenteredSecondOrder()
+tracer_advection = Centered()
 
 underlying_grid = RectilinearGrid(arch,
                                   size=(128, 64), halo=(3, 3), 

--- a/validation/lagrangian_particles/particles_in_convection.jl
+++ b/validation/lagrangian_particles/particles_in_convection.jl
@@ -41,7 +41,7 @@ particles = LagrangianParticles(x=x₀, y=y₀, z=z₀, restitution=0)
 b_bcs = FieldBoundaryConditions(top=FluxBoundaryCondition(1e-8))
 
 model = NonhydrostaticModel(; grid, particles,
-                            advection = UpwindBiasedFifthOrder(),
+                            advection = UpwindBiased(order=5),
                             timestepper = :RungeKutta3,
                             tracers = :b,
                             buoyancy = BuoyancyTracer(),

--- a/validation/mesoscale_turbulence/zonally_averaged_abernathey_channel.jl
+++ b/validation/mesoscale_turbulence/zonally_averaged_abernathey_channel.jl
@@ -142,7 +142,7 @@ closure = (horizontal_closure, vertical_closure)
                                        
 model = NonhydrostaticModel(architecture,
                             grid = grid,
-                            advection = UpwindBiasedFifthOrder(),
+                            advection = UpwindBiased(order=5),
                             buoyancy = BuoyancyTracer(),
                             coriolis = coriolis,
                             closure = closure,

--- a/validation/multi_region/multi_region_internal_tide.jl
+++ b/validation/multi_region/multi_region_internal_tide.jl
@@ -49,7 +49,7 @@ mrg_with_bump  = MultiRegionGrid(grid_with_bump, partition=XPartition(2), device
 tidal_forcing(x, y, z, t) = 1e-4 * cos(t)
 
 model = HydrostaticFreeSurfaceModel(grid = mrg_with_bump,
-                                    momentum_advection = CenteredSecondOrder(),
+                                    momentum_advection = Centered(),
                                     free_surface = ExplicitFreeSurface(gravitational_acceleration=10),
                                     closure = ScalarDiffusivity(VerticallyImplicitTimeDiscretization(), ν=1e-2, κ=1e-2),
                                     tracers = :b,
@@ -80,7 +80,7 @@ run!(simulation)
 """
 
 model_ref = HydrostaticFreeSurfaceModel(grid = grid_with_bump,
-                                        momentum_advection = CenteredSecondOrder(),
+                                        momentum_advection = Centered(),
                                         free_surface = ExplicitFreeSurface(gravitational_acceleration=10),
                                         closure = ScalarDiffusivity(VerticallyImplicitTimeDiscretization(), ν=1e-2, κ=1e-2),
                                         tracers = :b,

--- a/validation/open_boundaries/oscillating_flow.jl
+++ b/validation/open_boundaries/oscillating_flow.jl
@@ -48,7 +48,7 @@ function run_cylinder(grid, boundary_conditions; plot=true, stop_time = 50, simn
     cylinder_forcing = Relaxation(; rate = 1 / (2 * Δt), mask = cylinder)
 
     global model = NonhydrostaticModel(; grid,
-                                       advection = UpwindBiasedFifthOrder(),
+                                       advection = UpwindBiased(order=5),
                                        forcing = (u = cylinder_forcing, v = cylinder_forcing, w = cylinder_forcing),
                                        boundary_conditions)
 

--- a/validation/periodic_advection/periodic_advection.jl
+++ b/validation/periodic_advection/periodic_advection.jl
@@ -99,7 +99,7 @@ end
 L = 1
 ϕs = (ϕ_Gaussian, ϕ_Square)
 time_steppers = (:RungeKutta3,)
-advection_schemes = (CenteredSecondOrder(), CenteredFourthOrder(), UpwindBiasedThirdOrder(), UpwindBiasedFifthOrder(), WENO())
+advection_schemes = (Centered(order=2), Centered(order=4), UpwindBiased(order=3), UpwindBiased(order=5), WENO())
 Ns = [16, 64]
 CFLs = (0.5, 1.7)
 Us = [+1, -1]

--- a/validation/stommel_gyre/plot_stommel_gyre_advection.py
+++ b/validation/stommel_gyre/plot_stommel_gyre_advection.py
@@ -6,7 +6,7 @@ import cmocean
 import ffmpeg
 
 shapes = ("Gaussian", "Square")
-schemes = ("CenteredSecondOrder", "CenteredFourthOrder", "WENO")
+schemes = ("Centered", "CenteredFourthOrder", "WENO")
 Ns = (32, 256)
 CFLs = (0.05, 0.30)
 

--- a/validation/stommel_gyre/stommel_gyre_advection.jl
+++ b/validation/stommel_gyre/stommel_gyre_advection.jl
@@ -100,7 +100,7 @@ ic_name(::typeof(ϕ_λ_Gaussian)) = ic_name(ϕ_Gaussian)
 ic_name(::typeof(ϕ_λ_Square))   = ic_name(ϕ_Square)
 
 ϕ_λs = (ϕ_λ_Gaussian, ϕ_λ_Square)
-schemes = (CenteredSecondOrder(), CenteredFourthOrder(), WENO())
+schemes = (Centered(), CenteredFourthOrder(), WENO())
 Ns = (32, 256)
 CFLs = (0.05,)
 

--- a/validation/thermal_bubble/plot_thermal_bubble_advection.py
+++ b/validation/thermal_bubble/plot_thermal_bubble_advection.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import cmocean
 import ffmpeg
 
-# schemes = ("CenteredSecondOrder", "CenteredFourthOrder", "WENO")
+# schemes = ("Centered", "CenteredFourthOrder", "WENO")
 schemes = ("WENO",)
 Ns = (32, 128)
 

--- a/validation/thermal_bubble/thermal_bubble.jl
+++ b/validation/thermal_bubble/thermal_bubble.jl
@@ -69,7 +69,7 @@ function print_progress(simulation)
                    progress, i, t, u_max, w_max, T_min, T_max, CFL)
 end
 
-schemes = (WENO(), CenteredFourthOrder())
+schemes = (WENO(), Centered(order=4))
 Ns = (32, 128)
 
 for scheme in schemes, N in Ns


### PR DESCRIPTION
Since they have been removed from the exported methods, I think we do not have a need for them anymore.