### PR TITLE
Some corrections in the timestepper constructors

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -6,7 +6,7 @@ export CenterField, XFaceField, YFaceField, ZFaceField
 export BackgroundField
 export interior, data, xnode, ynode, znode
 export set!, compute!, @compute, regrid!
-export VelocityFields, TracerFields, TendencyFields, tracernames
+export VelocityFields, TracerFields, tracernames
 export interpolate
 
 using Oceananigans.Architectures

--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -191,7 +191,7 @@ Return a `NamedTuple` with tracer fields specified by `tracer_names` initialized
 `CenterField`s on `grid`. Fields may be passed via optional
 keyword arguments `kwargs` for each field.
 
-This function is used by `OutputWriters.Checkpointer` and `TendencyFields`.
+This function is used by `OutputWriters.Checkpointer`
 ```
 """
 TracerFields(tracer_names, grid; kwargs...) =
@@ -202,30 +202,6 @@ TracerFields(::Union{Tuple{}, Nothing}, grid, bcs) = NamedTuple()
 
 "Shortcut constructor for empty tracer fields."
 TracerFields(::NamedTuple{(), Tuple{}}, grid, bcs) = NamedTuple()
-
-"""
-    TendencyFields(grid, tracer_names;
-                   u = XFaceField(grid),
-                   v = YFaceField(grid),
-                   w = ZFaceField(grid),
-                   kwargs...)
-
-Return a `NamedTuple` with tendencies for all solution fields (velocity fields and
-tracer fields), initialized on `grid`. Optional `kwargs`
-can be specified to assign data arrays to each tendency field.
-"""
-function TendencyFields(grid, tracer_names;
-                        u = XFaceField(grid),
-                        v = YFaceField(grid),
-                        w = ZFaceField(grid),
-                        kwargs...)
-
-    velocities = (u=u, v=v, w=w)
-
-    tracers = TracerFields(tracer_names, grid; kwargs...)
-
-    return merge(velocities, tracers)
-end
 
 #####
 ##### Helper functions for NonhydrostaticModel constructor

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_field_tuples.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_field_tuples.jl
@@ -2,21 +2,21 @@ using Oceananigans.Grids: Center, Face
 using Oceananigans.Fields: XFaceField, YFaceField, ZFaceField, TracerFields
 using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, SplitRungeKutta3TimeStepper
 
-function HydrostaticFreeSurfaceVelocityFields(::Nothing, grid, clock, bcs=NamedTuple())
+function hydrostatic_velocity_fields(::Nothing, grid, clock, bcs=NamedTuple())
     u = XFaceField(grid, boundary_conditions=bcs.u)
     v = YFaceField(grid, boundary_conditions=bcs.v)
     w = ZFaceField(grid)
     return (u=u, v=v, w=w)
 end
 
-function HydrostaticFreeSurfaceTendencyFields(velocities, free_surface, grid, tracer_names)
+function hydrostatic_tendency_fields(velocities, free_surface, grid, tracer_names)
     u = XFaceField(grid)
     v = YFaceField(grid)
     tracers = TracerFields(tracer_names, grid)
     return merge((u=u, v=v), tracers)
 end
 
-function HydrostaticFreeSurfaceTendencyFields(velocities, free_surface::ExplicitFreeSurface, grid, tracer_names)
+function hydrostatic_tendency_fields(velocities, free_surface::ExplicitFreeSurface, grid, tracer_names)
     u = XFaceField(grid)
     v = YFaceField(grid)
     η = free_surface_displacement_field(velocities, free_surface, grid)
@@ -24,7 +24,7 @@ function HydrostaticFreeSurfaceTendencyFields(velocities, free_surface::Explicit
     return merge((u=u, v=v, η=η), tracers)
 end
 
-function HydrostaticFreeSurfaceTendencyFields(velocities, free_surface::SplitExplicitFreeSurface, grid, tracer_names)
+function hydrostatic_tendency_fields(velocities, free_surface::SplitExplicitFreeSurface, grid, tracer_names)
     u = XFaceField(grid)
     v = YFaceField(grid)
     U = deepcopy(free_surface.barotropic_velocities.U)
@@ -33,10 +33,10 @@ function HydrostaticFreeSurfaceTendencyFields(velocities, free_surface::SplitExp
     return merge((u=u, v=v, U=U, V=V), tracers)
 end
 
-PreviousHydrostaticTendencyFields(::Val{:QuasiAdamsBashforth2}, args...) = HydrostaticFreeSurfaceTendencyFields(args...)
-PreviousHydrostaticTendencyFields(::Val{:SplitRungeKutta3}, args...) = nothing
+previous_hydrostatic_tendency_fields(::Val{:QuasiAdamsBashforth2}, args...) = hydrostatic_tendency_fields(args...)
+previous_hydrostatic_tendency_fields(::Val{:SplitRungeKutta3}, args...) = nothing
 
-function PreviousHydrostaticTendencyFields(::Val{:SplitRungeKutta3}, velocities, free_surface::SplitExplicitFreeSurface, args...)
+function previous_hydrostatic_tendency_fields(::Val{:SplitRungeKutta3}, velocities, free_surface::SplitExplicitFreeSurface, args...)
     U = deepcopy(free_surface.barotropic_velocities.U)
     V = deepcopy(free_surface.barotropic_velocities.V)
     return (; U=U, V=V)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -194,11 +194,14 @@ function HydrostaticFreeSurfaceModel(; grid,
     implicit_solver   = implicit_diffusion_solver(time_discretization(closure), grid)
     prognostic_fields = hydrostatic_prognostic_fields(velocities, free_surface, tracers)
 
-    timestepper = TimeStepper(timestepper, grid, tracernames(tracers);
+    # QuasiAdamsBashforth2 requires χ as a third positional argument, while SplitRungeKutta3 requires
+    # the prognostic_fields as a third positional argument.
+    timestepper_arg = timestepper == :QuasiAdamsBashforth2 ? 0.1 : prognostic_fields
+
+    timestepper = TimeStepper(timestepper, grid, tracernames(tracers), timestepper_arg;
                               implicit_solver = implicit_solver,
                               Gⁿ = hydrostatic_tendency_fields(velocities, free_surface, grid, tracernames(tracers)),
-                              G⁻ = previous_hydrostatic_tendency_fields(Val(timestepper), velocities, free_surface, grid, tracernames(tracers)),
-                              prognostic_fields)
+                              G⁻ = previous_hydrostatic_tendency_fields(Val(timestepper), velocities, free_surface, grid, tracernames(tracers)))
 
     # Regularize forcing for model tracer and velocity fields.
     model_fields = merge(prognostic_fields, auxiliary_fields)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -179,7 +179,7 @@ function HydrostaticFreeSurfaceModel(; grid,
     closure = validate_closure(closure)
 
     # Either check grid-correctness, or construct tuples of fields
-    velocities         = HydrostaticFreeSurfaceVelocityFields(velocities, grid, clock, boundary_conditions)
+    velocities         = hydrostatic_velocity_fields(velocities, grid, clock, boundary_conditions)
     tracers            = TracerFields(tracers, grid, boundary_conditions)
     pressure           = PressureField(grid)
     diffusivity_fields = DiffusivityFields(diffusivity_fields, grid, tracernames(tracers), boundary_conditions, closure)
@@ -196,9 +196,9 @@ function HydrostaticFreeSurfaceModel(; grid,
 
     timestepper = TimeStepper(timestepper, grid, tracernames(tracers);
                               implicit_solver = implicit_solver,
-                              Gⁿ = HydrostaticFreeSurfaceTendencyFields(velocities, free_surface, grid, tracernames(tracers)),
-                              G⁻ = PreviousHydrostaticTendencyFields(Val(timestepper), velocities, free_surface, grid, tracernames(tracers)),
-                              Ψ⁻ = deepcopy(prognostic_fields))
+                              Gⁿ = hydrostatic_tendency_fields(velocities, free_surface, grid, tracernames(tracers)),
+                              G⁻ = previous_hydrostatic_tendency_fields(Val(timestepper), velocities, free_surface, grid, tracernames(tracers)),
+                              prognostic_fields)
 
     # Regularize forcing for model tracer and velocity fields.
     model_fields = merge(prognostic_fields, auxiliary_fields)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -194,11 +194,7 @@ function HydrostaticFreeSurfaceModel(; grid,
     implicit_solver   = implicit_diffusion_solver(time_discretization(closure), grid)
     prognostic_fields = hydrostatic_prognostic_fields(velocities, free_surface, tracers)
 
-    # QuasiAdamsBashforth2 requires χ as a third positional argument, while SplitRungeKutta3 requires
-    # the prognostic_fields as a third positional argument.
-    timestepper_arg = timestepper == :QuasiAdamsBashforth2 ? 0.1 : prognostic_fields
-
-    timestepper = TimeStepper(timestepper, grid, tracernames(tracers), timestepper_arg;
+    timestepper = TimeStepper(timestepper, grid, prognostic_fields;
                               implicit_solver = implicit_solver,
                               Gⁿ = hydrostatic_tendency_fields(velocities, free_surface, grid, tracernames(tracers)),
                               G⁻ = previous_hydrostatic_tendency_fields(Val(timestepper), velocities, free_surface, grid, tracernames(tracers)))

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -73,11 +73,8 @@ function hydrostatic_velocity_fields(velocities::PrescribedVelocityFields, grid,
 end
 
 hydrostatic_tendency_fields(::PrescribedVelocityFields, free_surface, grid, tracer_names) = 
-    TracerFields(tracer_names, grid)
+    merge((u=nothing, v=nothing), TracerFields(tracer_names, grid))
 
-hydrostatic_tendency_fields(::PrescribedVelocityFields, ::ExplicitFreeSurface, grid, tracer_names) = 
-    TracerFields(tracer_names, grid)
-    
 @inline fill_halo_regions!(::PrescribedVelocityFields, args...) = nothing
 @inline fill_halo_regions!(::FunctionField, args...) = nothing
 

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -72,17 +72,12 @@ function hydrostatic_velocity_fields(velocities::PrescribedVelocityFields, grid,
     return PrescribedVelocityFields(u, v, w, parameters)
 end
 
-function hydrostatic_tendency_fields(::PrescribedVelocityFields, free_surface, grid, tracer_names)
-    tracer_tendencies = TracerFields(tracer_names, grid)
-    momentum_tendencies = (u = nothing, v = nothing)
-    return merge(momentum_tendencies, tracer_tendencies)
-end
+hydrostatic_tendency_fields(::PrescribedVelocityFields, free_surface, grid, tracer_names) = 
+    TracerFields(tracer_names, grid)
 
-function hydrostatic_tendency_fields(::PrescribedVelocityFields, ::ExplicitFreeSurface, grid, tracer_names)
-    tracers = TracerFields(tracer_names, grid)
-    return merge((u = nothing, v = nothing, η = nothing), tracers)
-end
-
+hydrostatic_tendency_fields(::PrescribedVelocityFields, ::ExplicitFreeSurface, grid, tracer_names) = 
+    TracerFields(tracer_names, grid)
+    
 @inline fill_halo_regions!(::PrescribedVelocityFields, args...) = nothing
 @inline fill_halo_regions!(::FunctionField, args...) = nothing
 

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -56,7 +56,7 @@ end
 wrap_prescribed_field(X, Y, Z, f::Function, grid; kwargs...) = FunctionField{X, Y, Z}(f, grid; kwargs...)
 wrap_prescribed_field(X, Y, Z, f, grid; kwargs...) = field((X, Y, Z), f, grid)
 
-function HydrostaticFreeSurfaceVelocityFields(velocities::PrescribedVelocityFields, grid, clock, bcs)
+function hydrostatic_velocity_fields(velocities::PrescribedVelocityFields, grid, clock, bcs)
 
     parameters = velocities.parameters
     u = wrap_prescribed_field(Face, Center, Center, velocities.u, grid; clock, parameters)
@@ -72,13 +72,13 @@ function HydrostaticFreeSurfaceVelocityFields(velocities::PrescribedVelocityFiel
     return PrescribedVelocityFields(u, v, w, parameters)
 end
 
-function HydrostaticFreeSurfaceTendencyFields(::PrescribedVelocityFields, free_surface, grid, tracer_names)
+function hydrostatic_tendency_fields(::PrescribedVelocityFields, free_surface, grid, tracer_names)
     tracer_tendencies = TracerFields(tracer_names, grid)
     momentum_tendencies = (u = nothing, v = nothing)
     return merge(momentum_tendencies, tracer_tendencies)
 end
 
-function HydrostaticFreeSurfaceTendencyFields(::PrescribedVelocityFields, ::ExplicitFreeSurface, grid, tracer_names)
+function hydrostatic_tendency_fields(::PrescribedVelocityFields, ::ExplicitFreeSurface, grid, tracer_names)
     tracers = TracerFields(tracer_names, grid)
     return merge((u = nothing, v = nothing, η = nothing), tracers)
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
@@ -33,7 +33,7 @@ materialize_free_surface(free_surface::ExplicitFreeSurface{Nothing}, ::Prescribe
 materialize_free_surface(free_surface::ImplicitFreeSurface{Nothing}, ::PrescribedVelocityFields, ::SingleColumnGrid) = nothing
 materialize_free_surface(free_surface::SplitExplicitFreeSurface,     ::PrescribedVelocityFields, ::SingleColumnGrid) = nothing
 
-function HydrostaticFreeSurfaceVelocityFields(::Nothing, grid::SingleColumnGrid, clock, bcs=NamedTuple())
+function hydrostatic_velocity_fields(::Nothing, grid::SingleColumnGrid, clock, bcs=NamedTuple())
     u = XFaceField(grid, boundary_conditions=bcs.u)
     v = YFaceField(grid, boundary_conditions=bcs.v)
     w = ZeroField()

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -218,13 +218,15 @@ function NonhydrostaticModel(; grid,
 
     # Materialize background fields
     background_fields = BackgroundFields(background_fields, tracernames(tracers), grid, clock)
+    model_fields = merge(velocities, tracers, auxiliary_fields)
+    prognostic_fields = merge(velocities, tracers)
+
 
     # Instantiate timestepper if not already instantiated
     implicit_solver = implicit_diffusion_solver(time_discretization(closure), grid)
-    timestepper = TimeStepper(timestepper, grid, tracernames(tracers), implicit_solver=implicit_solver)
+    timestepper = TimeStepper(timestepper, grid, prognostic_fields; implicit_solver=implicit_solver)
 
     # Regularize forcing for model tracer and velocity fields.
-    model_fields = merge(velocities, tracers, auxiliary_fields)
     forcing = model_forcing(model_fields; forcing...)
 
     model = NonhydrostaticModel(arch, grid, clock, advection, buoyancy, coriolis, stokes_drift,

--- a/src/Models/ShallowWaterModels/shallow_water_model.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_model.jl
@@ -19,7 +19,7 @@ import Oceananigans.Models: default_nan_checker, timestepper
 
 const RectilinearGrids = Union{RectilinearGrid, ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:RectilinearGrid}}
 
-function ShallowWaterTendencyFields(grid, tracer_names, prognostic_names)
+function shallow_water_tendency_fields(grid, tracer_names, prognostic_names)
     u =  XFaceField(grid)
     v =  YFaceField(grid)
     h = CenterField(grid)
@@ -181,8 +181,8 @@ function ShallowWaterModel(;
 
     # Instantiate timestepper if not already instantiated
     timestepper = TimeStepper(timestepper, grid, tracernames(tracers);
-                              Gⁿ = ShallowWaterTendencyFields(grid, tracernames(tracers), prognostic_field_names),
-                              G⁻ = ShallowWaterTendencyFields(grid, tracernames(tracers), prognostic_field_names))
+                              Gⁿ = shallow_water_tendency_fields(grid, tracernames(tracers), prognostic_field_names),
+                              G⁻ = shallow_water_tendency_fields(grid, tracernames(tracers), prognostic_field_names))
 
     # Regularize forcing and closure for model tracer and velocity fields.
     model_fields = merge(solution, tracers)

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -11,7 +11,6 @@ using CUDA
 using KernelAbstractions
 using Oceananigans: AbstractModel, prognostic_fields
 using Oceananigans.Architectures: device
-using Oceananigans.Fields: TendencyFields
 using Oceananigans.Utils: work_layout
 
 """

--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -11,8 +11,8 @@ end
 """
     QuasiAdamsBashforth2TimeStepper(grid, prognostic_fields, χ = 0.1;
                                     implicit_solver = nothing,
-                                    Gⁿ = deepcopy(prognostic_fields),
-                                    G⁻ = deepcopy(prognostic_fields))
+                                    Gⁿ = map(similar, prognostic_fields),
+                                    G⁻ = map(similar, prognostic_fields))
 
 Return a 2nd-order quasi Adams-Bashforth (AB2) time stepper (`QuasiAdamsBashforth2TimeStepper`)
 on `grid`, with `tracers`, and AB2 parameter `χ`. The tendency fields `Gⁿ` and `G⁻`, usually equal to 
@@ -38,8 +38,8 @@ timestep (`G⁻`).
 """
 function QuasiAdamsBashforth2TimeStepper(grid, prognostic_fields, χ = 0.1;
                                          implicit_solver::IT = nothing,
-                                         Gⁿ = deepcopy(prognostic_fields),
-                                         G⁻ = deepcopy(prognostic_fields)) where IT
+                                         Gⁿ = map(similar, prognostic_fields),
+                                         G⁻ = map(similar, prognostic_fields)) where IT
 
     FT = eltype(grid)
     GT = typeof(Gⁿ)

--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -9,15 +9,14 @@ mutable struct QuasiAdamsBashforth2TimeStepper{FT, GT, IT} <: AbstractTimeSteppe
 end
 
 """
-    QuasiAdamsBashforth2TimeStepper(grid, tracers,
-                                    χ = 0.1;
+    QuasiAdamsBashforth2TimeStepper(grid, prognostic_fields, χ = 0.1;
                                     implicit_solver = nothing,
-                                    Gⁿ = TendencyFields(grid, tracers),
-                                    G⁻ = TendencyFields(grid, tracers))
+                                    Gⁿ = deepcopy(prognostic_fields),
+                                    G⁻ = deepcopy(prognostic_fields))
 
 Return a 2nd-order quasi Adams-Bashforth (AB2) time stepper (`QuasiAdamsBashforth2TimeStepper`)
-on `grid`, with `tracers`, and AB2 parameter `χ`. The tendency fields `Gⁿ` and `G⁻` can be
-specified via  optional `kwargs`.
+on `grid`, with `tracers`, and AB2 parameter `χ`. The tendency fields `Gⁿ` and `G⁻`, usually equal to 
+the prognostic_fields passed as positional argument, can be specified via  optional `kwargs`.
 
 The 2nd-order quasi Adams-Bashforth timestepper steps forward the state `Uⁿ` by `Δt` via
 
@@ -37,10 +36,10 @@ timestep (`G⁻`).
     Uⁿ⁺¹ = Uⁿ + Δt * Gⁿ
     ```
 """
-function QuasiAdamsBashforth2TimeStepper(grid, tracers, χ = 0.1;
+function QuasiAdamsBashforth2TimeStepper(grid, prognostic_fields, χ = 0.1;
                                          implicit_solver::IT = nothing,
-                                         Gⁿ = TendencyFields(grid, tracers),
-                                         G⁻ = TendencyFields(grid, tracers)) where IT
+                                         Gⁿ = deepcopy(prognostic_fields),
+                                         G⁻ = deepcopy(prognostic_fields)) where IT
 
     FT = eltype(grid)
     GT = typeof(Gⁿ)

--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -37,12 +37,10 @@ timestep (`G⁻`).
     Uⁿ⁺¹ = Uⁿ + Δt * Gⁿ
     ```
 """
-function QuasiAdamsBashforth2TimeStepper(grid, tracers,
-                                         χ = 0.1;
+function QuasiAdamsBashforth2TimeStepper(grid, tracers, χ = 0.1;
                                          implicit_solver::IT = nothing,
                                          Gⁿ = TendencyFields(grid, tracers),
-                                         G⁻ = TendencyFields(grid, tracers),
-                                         kw...) where IT
+                                         G⁻ = TendencyFields(grid, tracers)) where IT
 
     FT = eltype(grid)
     GT = typeof(Gⁿ)

--- a/src/TimeSteppers/runge_kutta_3.jl
+++ b/src/TimeSteppers/runge_kutta_3.jl
@@ -19,13 +19,13 @@ struct RungeKutta3TimeStepper{FT, TG, TI} <: AbstractTimeStepper
 end
 
 """
-    RungeKutta3TimeStepper(grid, tracers;
+    RungeKutta3TimeStepper(grid, prognostic_fields;
                            implicit_solver = nothing,
-                           Gⁿ = TendencyFields(grid, tracers),
-                           G⁻ = TendencyFields(grid, tracers))
+                           Gⁿ = deepcopy(prognostic_fields),
+                           G⁻ = deepcopy(prognostic_fields))
 
 Return a 3rd-order Runge0Kutta timestepper (`RungeKutta3TimeStepper`) on `grid` and with `tracers`.
-The tendency fields `Gⁿ` and `G⁻` can be specified via  optional `kwargs`.
+The tendency fields `Gⁿ` and `G⁻`, typically equal to the prognositc_fields can be modified via an optional `kwargs`.
 
 The scheme described by [LeMoin1991](@citet). In a nutshel, the 3rd-order
 Runge Kutta timestepper steps forward the state `Uⁿ` by `Δt` via 3 substeps. A pressure correction
@@ -45,10 +45,10 @@ and constants ``γ¹ = 8/15``, ``γ² = 5/12``, ``γ³ = 3/4``,
 The state at the first substep is taken to be the one that corresponds to the ``n``-th timestep,
 `U¹ = Uⁿ`, and the state after the third substep is then the state at the `Uⁿ⁺¹ = U⁴`.
 """
-function RungeKutta3TimeStepper(grid, tracers;
+function RungeKutta3TimeStepper(grid, prognostic_fields;
                                 implicit_solver::TI = nothing,
-                                Gⁿ::TG = TendencyFields(grid, tracers),
-                                G⁻ = TendencyFields(grid, tracers)) where {TI, TG}
+                                Gⁿ::TG = deepcopy(prognostic_fields),
+                                G⁻ = deepcopy(prognostic_fields)) where {TI, TG}
 
     !isnothing(implicit_solver) &&
         @warn("Implicit-explicit time-stepping with RungeKutta3TimeStepper is not tested. " * 

--- a/src/TimeSteppers/runge_kutta_3.jl
+++ b/src/TimeSteppers/runge_kutta_3.jl
@@ -21,11 +21,11 @@ end
 """
     RungeKutta3TimeStepper(grid, prognostic_fields;
                            implicit_solver = nothing,
-                           Gⁿ = deepcopy(prognostic_fields),
-                           G⁻ = deepcopy(prognostic_fields))
+                           Gⁿ = map(similar, prognostic_fields),
+                           G⁻ = map(similar, prognostic_fields))
 
 Return a 3rd-order Runge0Kutta timestepper (`RungeKutta3TimeStepper`) on `grid` and with `tracers`.
-The tendency fields `Gⁿ` and `G⁻`, typically equal to the prognositc_fields can be modified via an optional `kwargs`.
+The tendency fields `Gⁿ` and `G⁻`, typically equal to the prognostic_fields can be modified via an optional `kwargs`.
 
 The scheme described by [LeMoin1991](@citet). In a nutshel, the 3rd-order
 Runge Kutta timestepper steps forward the state `Uⁿ` by `Δt` via 3 substeps. A pressure correction
@@ -47,8 +47,8 @@ The state at the first substep is taken to be the one that corresponds to the ``
 """
 function RungeKutta3TimeStepper(grid, prognostic_fields;
                                 implicit_solver::TI = nothing,
-                                Gⁿ::TG = deepcopy(prognostic_fields),
-                                G⁻ = deepcopy(prognostic_fields)) where {TI, TG}
+                                Gⁿ::TG = map(similar, prognostic_fields),
+                                G⁻     = map(similar, prognostic_fields)) where {TI, TG}
 
     !isnothing(implicit_solver) &&
         @warn("Implicit-explicit time-stepping with RungeKutta3TimeStepper is not tested. " * 

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -19,14 +19,14 @@ struct SplitRungeKutta3TimeStepper{FT, TG, TE, PF, TI} <: AbstractTimeStepper
 end
 
 """
-    SplitRungeKutta3TimeStepper(grid, tracers, prognostic_fields;
-                                implicit_solver = nothing,
-                                Gⁿ = TendencyFields(grid, tracers),
-                                G⁻ = nothing)
+    SplitRungeKutta3TimeStepper(grid, prognostic_fields, args...;
+                                implicit_solver::TI = nothing,
+                                Gⁿ::TG = deepcopy(prognostic_fields),
+                                Ψ⁻::PF = deepcopy(prognostic_fields)
+                                G⁻::TE = nothing) where {TI, TG, PF, TE}
 
 Return a 3rd-order `SplitRungeKutta3TimeStepper` on `grid` and with `tracers`.
-The tendency fields `Gⁿ` and `G⁻`, can be specified via optional `kwargs`.
-The previous prognostic state Ψ⁻ is a deep copy of the `prognostic_fields` positional argument.
+The tendency fields `Gⁿ` and `G⁻`, and the previous state ` Ψ⁻` can be modified via optional `kwargs`.
 
 The scheme described by [Lan2022](@citet). In a nutshell, the 3rd-order Runge Kutta timestepper 
 steps forward the state `Uⁿ` by `Δt` via 3 substeps. A barotropic velocity correction step is applied 
@@ -45,10 +45,11 @@ at the ``m``-th substep, and constants ``γ¹ = 1`, ``γ² = 1/4``, ``γ³ = 1/3
 The state at the first substep is taken to be the one that corresponds to the ``n``-th timestep,
 `U¹ = Uⁿ`, and the state after the third substep is then the state at the `Uⁿ⁺¹ = U³`.
 """
-function SplitRungeKutta3TimeStepper(grid, tracers, prognostic_fields;
+function SplitRungeKutta3TimeStepper(grid, prognostic_fields, args...;
                                      implicit_solver::TI = nothing,
-                                     Gⁿ::TG = TendencyFields(grid, tracers),
-                                     G⁻::TE = nothing) where {TI, TG, TE}
+                                     Gⁿ::TG = deepcopy(prognostic_fields),
+                                     Ψ⁻::PF = deepcopy(prognostic_fields)
+                                     G⁻::TE = nothing) where {TI, TG, PF, TE}
 
 
     @warn("Split barotropic-baroclinic time stepping with SplitRungeKutta3TimeStepper is not tested and experimental.\n" *
@@ -64,7 +65,6 @@ function SplitRungeKutta3TimeStepper(grid, tracers, prognostic_fields;
     ζ² = 3 // 4
     ζ³ = 1 // 3
 
-    Ψ⁻ = deepcopy(prognostic_fields)
     PF = typeof(Ψ⁻)
     FT = eltype(grid)
 

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -13,13 +13,13 @@ struct SplitRungeKutta3TimeStepper{FT, TG, TE, PF, TI} <: AbstractTimeStepper
     ζ² :: FT
     ζ³ :: FT
     Gⁿ :: TG
-    G⁻ :: TE # only used as storage when needed 
+    G⁻ :: TE # only needed for barotropic velocities in the barotropic step
     Ψ⁻ :: PF # prognostic state at the previous timestep
     implicit_solver :: TI
 end
 
 """
-    SplitRungeKutta3TimeStepper(grid, tracers;
+    SplitRungeKutta3TimeStepper(grid, tracers, prognostic_fields;
                                 implicit_solver = nothing,
                                 Gⁿ = TendencyFields(grid, tracers),
                                 G⁻ = nothing,
@@ -27,7 +27,7 @@ end
 
 Return a 3rd-order `SplitRungeKutta3TimeStepper` on `grid` and with `tracers`.
 The tendency fields `Gⁿ` and `G⁻`, can be specified via optional `kwargs`.
-The previous prognostic state Ψ⁻ is a deep copy of the `prognostic_fields` keyword argument.
+The previous prognostic state Ψ⁻ is a deep copy of the `prognostic_fields` positional argument.
 
 The scheme described by [Lan2022](@citet). In a nutshel, the 3rd-order
 Runge Kutta timestepper steps forward the state `Uⁿ` by `Δt` via 3 substeps. A baroptropic velocity correction
@@ -46,11 +46,10 @@ at the ``m``-th substep, and constants ``γ¹ = 1`, ``γ² = 1/4``, ``γ³ = 1/3
 The state at the first substep is taken to be the one that corresponds to the ``n``-th timestep,
 `U¹ = Uⁿ`, and the state after the third substep is then the state at the `Uⁿ⁺¹ = U³`.
 """
-function SplitRungeKutta3TimeStepper(grid, tracers;
+function SplitRungeKutta3TimeStepper(grid, tracers, prognostic_fields;
                                      implicit_solver::TI = nothing,
                                      Gⁿ::TG = TendencyFields(grid, tracers),
-                                     G⁻::TE = nothing,
-                                     prognostic_fields = TendencyFields(grid, tracers)) where {TI, TG, TE}
+                                     G⁻::TE = nothing) where {TI, TG, TE}
 
 
     @warn("Split barotropic-baroclinic time stepping with SplitRungeKutta3TimeStepper is not tested and experimental.\n" *

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -22,8 +22,7 @@ end
     SplitRungeKutta3TimeStepper(grid, tracers, prognostic_fields;
                                 implicit_solver = nothing,
                                 Gⁿ = TendencyFields(grid, tracers),
-                                G⁻ = nothing,
-                                prognostic_fields = TendencyFields(grid, tracers))
+                                G⁻ = nothing)
 
 Return a 3rd-order `SplitRungeKutta3TimeStepper` on `grid` and with `tracers`.
 The tendency fields `Gⁿ` and `G⁻`, can be specified via optional `kwargs`.

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -13,7 +13,7 @@ struct SplitRungeKutta3TimeStepper{FT, TG, TE, PF, TI} <: AbstractTimeStepper
     ζ² :: FT
     ζ³ :: FT
     Gⁿ :: TG
-    G⁻ :: TE # only used as storage when needed
+    G⁻ :: TE # only used as storage when needed 
     Ψ⁻ :: PF # prognostic state at the previous timestep
     implicit_solver :: TI
 end
@@ -26,7 +26,8 @@ end
                                 prognostic_fields = TendencyFields(grid, tracers))
 
 Return a 3rd-order `SplitRungeKutta3TimeStepper` on `grid` and with `tracers`.
-The tendency fields `Gⁿ` and `G⁻`, as well as the previous prognostic state Ψ⁻ can be specified via optional `kwargs`.
+The tendency fields `Gⁿ` and `G⁻`, can be specified via optional `kwargs`.
+The previous prognostic state Ψ⁻ is a deep copy of the `prognostic_fields` keyword argument.
 
 The scheme described by [Lan2022](@citet). In a nutshel, the 3rd-order
 Runge Kutta timestepper steps forward the state `Uⁿ` by `Δt` via 3 substeps. A baroptropic velocity correction

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -21,8 +21,8 @@ end
 """
     SplitRungeKutta3TimeStepper(grid, prognostic_fields, args...;
                                 implicit_solver::TI = nothing,
-                                Gⁿ::TG = deepcopy(prognostic_fields),
-                                Ψ⁻::PF = deepcopy(prognostic_fields)
+                                Gⁿ::TG = map(similar, prognostic_fields),
+                                Ψ⁻::PF = map(similar, prognostic_fields)
                                 G⁻::TE = nothing) where {TI, TG, PF, TE}
 
 Return a 3rd-order `SplitRungeKutta3TimeStepper` on `grid` and with `tracers`.
@@ -47,8 +47,8 @@ The state at the first substep is taken to be the one that corresponds to the ``
 """
 function SplitRungeKutta3TimeStepper(grid, prognostic_fields, args...;
                                      implicit_solver::TI = nothing,
-                                     Gⁿ::TG = deepcopy(prognostic_fields),
-                                     Ψ⁻::PF = deepcopy(prognostic_fields),
+                                     Gⁿ::TG = map(similar, prognostic_fields),
+                                     Ψ⁻::PF = map(similar, prognostic_fields),
                                      G⁻::TE = nothing) where {TI, TG, PF, TE}
 
 

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -22,8 +22,8 @@ end
     SplitRungeKutta3TimeStepper(grid, tracers;
                                 implicit_solver = nothing,
                                 Gⁿ = TendencyFields(grid, tracers),
-                                G⁻ = TendencyFields(grid, tracers),
-                                Ψ⁻ = TendencyFields(grid, tracers))
+                                G⁻ = nothing,
+                                prognostic_fields = TendencyFields(grid, tracers))
 
 Return a 3rd-order `SplitRungeKutta3TimeStepper` on `grid` and with `tracers`.
 The tendency fields `Gⁿ` and `G⁻`, as well as the previous prognostic state Ψ⁻ can be specified via optional `kwargs`.
@@ -48,8 +48,8 @@ The state at the first substep is taken to be the one that corresponds to the ``
 function SplitRungeKutta3TimeStepper(grid, tracers;
                                      implicit_solver::TI = nothing,
                                      Gⁿ::TG = TendencyFields(grid, tracers),
-                                     G⁻::TE = TendencyFields(grid, tracers),
-                                     Ψ⁻::PF = TendencyFields(grid, tracers)) where {TI, TG, TE, PF}
+                                     G⁻::TE = nothing,
+                                     prognostic_fields = TendencyFields(grid, tracers)) where {TI, TG, TE}
 
 
     @warn("Split barotropic-baroclinic time stepping with SplitRungeKutta3TimeStepper is not tested and experimental.\n" *
@@ -65,6 +65,8 @@ function SplitRungeKutta3TimeStepper(grid, tracers;
     ζ² = 3 // 4
     ζ³ = 1 // 3
 
+    Ψ⁻ = deepcopy(prognostic_fields)
+    PF = typeof(Ψ⁻)
     FT = eltype(grid)
 
     return SplitRungeKutta3TimeStepper{FT, TG, TE, PF, TI}(γ², γ³, ζ², ζ³, Gⁿ, G⁻, Ψ⁻, implicit_solver)

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -29,9 +29,9 @@ Return a 3rd-order `SplitRungeKutta3TimeStepper` on `grid` and with `tracers`.
 The tendency fields `Gⁿ` and `G⁻`, can be specified via optional `kwargs`.
 The previous prognostic state Ψ⁻ is a deep copy of the `prognostic_fields` positional argument.
 
-The scheme described by [Lan2022](@citet). In a nutshel, the 3rd-order
-Runge Kutta timestepper steps forward the state `Uⁿ` by `Δt` via 3 substeps. A baroptropic velocity correction
-step is applied after at each substep.
+The scheme described by [Lan2022](@citet). In a nutshell, the 3rd-order Runge Kutta timestepper 
+steps forward the state `Uⁿ` by `Δt` via 3 substeps. A barotropic velocity correction step is applied 
+after at each substep.
 
 The state `U` after each substep `m` is
 

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -48,7 +48,7 @@ The state at the first substep is taken to be the one that corresponds to the ``
 function SplitRungeKutta3TimeStepper(grid, prognostic_fields, args...;
                                      implicit_solver::TI = nothing,
                                      Gⁿ::TG = deepcopy(prognostic_fields),
-                                     Ψ⁻::PF = deepcopy(prognostic_fields)
+                                     Ψ⁻::PF = deepcopy(prognostic_fields),
                                      G⁻::TE = nothing) where {TI, TG, PF, TE}
 
 

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -65,7 +65,6 @@ function SplitRungeKutta3TimeStepper(grid, prognostic_fields, args...;
     ζ² = 3 // 4
     ζ³ = 1 // 3
 
-    PF = typeof(Ψ⁻)
     FT = eltype(grid)
 
     return SplitRungeKutta3TimeStepper{FT, TG, TE, PF, TI}(γ², γ³, ζ², ζ³, Gⁿ, G⁻, Ψ⁻, implicit_solver)


### PR DESCRIPTION
closes #3967 

Also, the default tendencies in the timestepper constructor should be a copy of the prognostic fields because the very definition of a prognostic field is a field that is evolved in time (requiring a tendency). 
We have no more use for the `TendencyFields` function.