### PR TITLE
Add helper function for building `buoyancy` `KernelFunctionOperation`

### DIFF
--- a/src/BuoyancyModels/buoyancy_field.jl
+++ b/src/BuoyancyModels/buoyancy_field.jl
@@ -6,10 +6,15 @@ buoyancy(::BuoyancyTracer, grid, tracers) = tracers.b
 
 # TODO: move to Models
 buoyancy(model) = buoyancy(model.buoyancy, model.grid, model.tracers)
-buoyancy(b, grid, tracers) = KernelFunctionOperation{Center, Center, Center}(buoyancy_perturbationᶜᶜᶜ, grid, b.model, tracers)
+buoyancy(buoyancy::Buoyancy, grid, tracers) = buoyancy(buoyancy.model, grid, tracers)
+
+buoyancy(bm::AbstractBuoyancyModel, grid, tracers) =
+    KernelFunctionOperation{Center, Center, Center}(buoyancy_perturbationᶜᶜᶜ, grid, bm, tracers)
+
 BuoyancyField(model) = Field(buoyancy(model))
 
-buoyancy_frequency(b::Buoyancy, grid, tracers) = KernelFunctionOperation{Center, Center, Face}(∂z_b, grid, b.model, tracers)
-buoyancy_frequency(b, grid, tracers)           = KernelFunctionOperation{Center, Center, Face}(∂z_b, grid, b, tracers)
 buoyancy_frequency(model) = buoyancy_frequency(model.buoyancy, model.grid, model.tracers)
+buoyancy_frequency(b::Buoyancy, grid, tracers) = buoyancy_frequency(b.model, grid, tracers)
+buoyancy_frequency(bm::AbstractBuoyancyModel, grid, tracers) =
+    KernelFunctionOperation{Center, Center, Face}(∂z_b, grid, bm, tracers)
 


### PR DESCRIPTION
There is still a problem with the API, because we have a `Buoyancy` type, but then also a `buoyancy` constructor which returns a `KernelFunctionOperation`.

I think we should change `Buoyancy` to something else and reserve the colloquial "buoyancy" for the field. This still leaves an issue with the model property `model.buoyancy` but I feel that is a more minor issue. (We could also change the model property to something like `buoyancy_formulation` to distinguish between the concept of the "model" or "formulation" that is used to compute buoyancy, and the "buoyancy field" `b`, but I don't want to go so far yet.)