### PR TITLE
Fix horizontally `Flat` WENO advection

### DIFF
--- a/src/Advection/flat_advective_fluxes.jl
+++ b/src/Advection/flat_advective_fluxes.jl
@@ -23,16 +23,22 @@ end
 
 Grids = [:XFlatGrid, :YFlatGrid, :ZFlatGrid, :XFlatGrid, :YFlatGrid, :ZFlatGrid]
 
-for side in (:left_biased, :right_biased, :symmetric)
-    for (dir, Grid) in zip([:xᶠᵃᵃ, :yᵃᶠᵃ, :zᵃᵃᶠ, :xᶜᵃᵃ, :yᵃᶜᵃ, :zᵃᵃᶜ], Grids)
-        interp_function = Symbol(side, :_interpolate_, dir)
-        @eval begin
-            @inline $interp_function(i, j, k, grid::$Grid, scheme, ψ, args...)           = @inbounds ψ[i, j, k]
-            @inline $interp_function(i, j, k, grid::$Grid, scheme, ψ::Function, args...) = @inbounds ψ(i, j, k, grid, args...)
+for (dir, Grid) in zip([:xᶠᵃᵃ, :yᵃᶠᵃ, :zᵃᵃᶠ, :xᶜᵃᵃ, :yᵃᶜᵃ, :zᵃᵃᶜ], Grids)
+    bias_interp = Symbol(:biased_interpolate_, dir)
+    symm_interp = Symbol(:symmetric_interpolate_, dir)
+    @eval begin
+        @inline $symm_interp(i, j, k, grid::$Grid, scheme, ψ, args...)           = @inbounds ψ[i, j, k]
+        @inline $symm_interp(i, j, k, grid::$Grid, scheme, ψ::Function, args...) = @inbounds ψ(i, j, k, grid, args...)
 
-            @inline $interp_function(i, j, k, grid::$Grid, scheme::AbstractUpwindBiasedAdvectionScheme, ψ, args...)           = @inbounds ψ[i, j, k]
-            @inline $interp_function(i, j, k, grid::$Grid, scheme::AbstractUpwindBiasedAdvectionScheme, ψ::Function, args...) = @inbounds ψ(i, j, k, grid, args...)
-            @inline $interp_function(i, j, k, grid::$Grid, scheme::AbstractUpwindBiasedAdvectionScheme, ψ::Function, S::AbstractSmoothnessStencil, args...) = @inbounds ψ(i, j, k, grid, args...)
-        end
+        @inline $symm_interp(i, j, k, grid::$Grid, scheme::AbstractUpwindBiasedAdvectionScheme, ψ, args...)           = @inbounds ψ[i, j, k]
+        @inline $symm_interp(i, j, k, grid::$Grid, scheme::AbstractUpwindBiasedAdvectionScheme, ψ::Function, args...) = @inbounds ψ(i, j, k, grid, args...)
+        @inline $symm_interp(i, j, k, grid::$Grid, scheme::AbstractUpwindBiasedAdvectionScheme, ψ::Function, S::AbstractSmoothnessStencil, args...) = @inbounds ψ(i, j, k, grid, args...)
+    
+        @inline $bias_interp(i, j, k, grid::$Grid, scheme, bias, ψ, args...)           = @inbounds ψ[i, j, k]
+        @inline $bias_interp(i, j, k, grid::$Grid, scheme, bias, ψ::Function, args...) = @inbounds ψ(i, j, k, grid, args...)
+
+        @inline $bias_interp(i, j, k, grid::$Grid, scheme::AbstractUpwindBiasedAdvectionScheme, bias, ψ, args...)           = @inbounds ψ[i, j, k]
+        @inline $bias_interp(i, j, k, grid::$Grid, scheme::AbstractUpwindBiasedAdvectionScheme, bias, ψ::Function, args...) = @inbounds ψ(i, j, k, grid, args...)
+        @inline $bias_interp(i, j, k, grid::$Grid, scheme::AbstractUpwindBiasedAdvectionScheme, bias, ψ::Function, S::AbstractSmoothnessStencil, args...) = @inbounds ψ(i, j, k, grid, args...)
     end
 end

--- a/src/Operators/interpolation_operators.jl
+++ b/src/Operators/interpolation_operators.jl
@@ -1,19 +1,6 @@
 using Oceananigans.Grids: Flat
 
 #####
-##### Base interpolation operators without grid
-#####
-
-@inline ℑxᶜᵃᵃ(i, j, k, u) = @inbounds (u[i,   j, k] + u[i+1, j, k]) / 2
-@inline ℑxᶠᵃᵃ(i, j, k, c) = @inbounds (c[i-1, j, k] + c[i,   j, k]) / 2
-
-@inline ℑyᵃᶜᵃ(i, j, k, v) = @inbounds (v[i, j,   k] + v[i,  j+1, k]) / 2
-@inline ℑyᵃᶠᵃ(i, j, k, c) = @inbounds (c[i, j-1, k] + c[i,  j,   k]) / 2
-
-@inline ℑzᵃᵃᶜ(i, j, k, w) = @inbounds (w[i, j,   k] + w[i, j, k+1]) / 2
-@inline ℑzᵃᵃᶠ(i, j, k, c) = @inbounds (c[i, j, k-1] + c[i, j,   k]) / 2
-
-#####
 ##### Base interpolation operators
 #####
 

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -229,6 +229,22 @@ topos_3d = ((Periodic, Periodic, Bounded),
             end
         end
 
+        for topo in [topos_3d..., topos_2d...]
+            size = Flat in topo ? (10, 10, 10) : (10, 10)
+            halo = Flat in topo ? (7, 7, 7)  : (7, 7)
+            x    = topo[1] == Flat ? nothing : (0, 1)
+            y    = topo[2] == Flat ? nothing : (0, 1)
+
+            grid = RectilinearGrid(arch; size, halo, x, y, z=(-1, 0), topology=topo)
+
+            for advection in [WENOVectorInvariant(), VectorInvariant(), WENO()]
+                @testset "Time-stepping HydrostaticFreeSurfaceModels with $advection [$arch, $topo]" begin
+                    @info "  Testing time-stepping HydrostaticFreeSurfaceModels with $advection [$arch, $topo]..."
+                    @test time_step_hydrostatic_model_works(grid; momentum_advection=advection)
+                end
+            end
+        end
+
         for coriolis in (nothing, FPlane(f=1), BetaPlane(f₀=1, β=0.1))
             @testset "Time-stepping HydrostaticFreeSurfaceModels [$arch, $(typeof(coriolis))]" begin
                 @info "  Testing time-stepping HydrostaticFreeSurfaceModels [$arch, $(typeof(coriolis))]..."

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -230,8 +230,8 @@ topos_3d = ((Periodic, Periodic, Bounded),
         end
 
         for topo in [topos_3d..., topos_2d...]
-            size = Flat in topo ? (10, 10, 10) : (10, 10)
-            halo = Flat in topo ? (7, 7, 7)  : (7, 7)
+            size = Flat in topo ? (10, 10) : (10, 10, 10)
+            halo = Flat in topo ? (7,  7)  : (7, 7, 7)
             x    = topo[1] == Flat ? nothing : (0, 1)
             y    = topo[2] == Flat ? nothing : (0, 1)
 


### PR DESCRIPTION
I recently encountered a bounds error when trying `WENOVectorInvariant` on a horizontally flat grid. 

The problem was two-fold
- the `Flat` interpolators were not updated to the new syntax
- we were using a wrong signature for interpolations in the WENO stencil that does not account for the grid topology
- (bonus!) there are no tests for `WENOVectorInvariant`

This PR should resolve these issues

edit, I will also remove the "no-grid" interpolation operators to not allow something like this.