### PR TITLE
Add support for loading data generated prior to 0.95.0 with FieldTimeSeries

### DIFF
--- a/src/OutputReaders/set_field_time_series.jl
+++ b/src/OutputReaders/set_field_time_series.jl
@@ -36,6 +36,7 @@ function set!(fts::InMemoryFTS, path::String=fts.path, name::String=fts.name)
 
         # Note: use the CPU for this step
         field_n = Field(location(fts), path, name, file_iter,
+                        grid = on_architecture(CPU(), fts.grid),    
                         architecture = cpu_architecture(arch),
                         indices = fts.indices,
                         boundary_conditions = fts.boundary_conditions)


### PR DESCRIPTION
The issue is that the grid cannot be reconstructed. So we add some limited support for doing that.