### PR TITLE
Remove grid requirements from a `Model` in a `Simulation`

### DIFF
--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -23,6 +23,8 @@ import Oceananigans.Architectures: architecture
 import Oceananigans.TimeSteppers: reset!
 import Oceananigans.Solvers: iteration
 
+import Base
+
 # A prototype interface for AbstractModel.
 #
 # TODO: decide if we like this.
@@ -34,6 +36,7 @@ import Oceananigans.Solvers: iteration
 
 iteration(model::AbstractModel) = model.clock.iteration
 Base.time(model::AbstractModel) = model.clock.time
+Base.eltype(model::AbstractModel) = eltype(model.grid)
 architecture(model::AbstractModel) = model.grid.architecture
 initialize!(model::AbstractModel) = nothing
 total_velocities(model::AbstractModel) = nothing

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -23,8 +23,6 @@ import Oceananigans.Architectures: architecture
 import Oceananigans.TimeSteppers: reset!
 import Oceananigans.Solvers: iteration
 
-import Base
-
 # A prototype interface for AbstractModel.
 #
 # TODO: decide if we like this.

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -73,7 +73,7 @@ function Simulation(model; Δt,
 
    # Convert numbers to floating point; otherwise preserve type (eg for DateTime types)
    #    TODO: implement TT = timetype(model) and FT = eltype(model)
-   TT = eltype(model.grid)
+   TT = eltype(model)
    Δt = Δt isa Number ? TT(Δt) : Δt
    stop_time = stop_time isa Number ? TT(stop_time) : stop_time
 

--- a/src/Simulations/time_step_wizard.jl
+++ b/src/Simulations/time_step_wizard.jl
@@ -108,7 +108,7 @@ function new_time_step(old_Δt, wizard, model)
     new_Δt = min(wizard.max_change * old_Δt, new_Δt)
     new_Δt = max(wizard.min_change * old_Δt, new_Δt)
     new_Δt = clamp(new_Δt, wizard.min_Δt, wizard.max_Δt)
-    new_Δt = all_reduce(min, new_Δt, architecture(model.grid))
+    new_Δt = all_reduce(min, new_Δt, architecture(model))
 
     return new_Δt
 end


### PR DESCRIPTION
This PR allows us to remove the grid from the `OceanSeaIceModel` type defined in ClimaOcean.jl
(see https://github.com/CliMA/ClimaOcean.jl/blob/a193aee12de264600dda9ca196acdb52ee3a726d/src/OceanSeaIceModels/ocean_sea_ice_model.jl#L20)