### PR TITLE
Generalize Checkpointer for Distributed architectures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.95.3"
+version = "0.95.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -21,6 +21,8 @@ tuple_string(tup::Tuple{}) = ""
 ##### set!
 #####
 
+set!(obj, ::Nothing) = nothing
+
 function set!(Φ::NamedTuple; kwargs...)
     for (fldname, value) in kwargs
         ϕ = getproperty(Φ, fldname)

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -1,6 +1,8 @@
 using Glob
 
 using Oceananigans
+using Oceananigans.Architectures: architecture
+using Oceananigans.DistributedComputations: Distributed
 using Oceananigans: fields, prognostic_fields
 using Oceananigans.Fields: offset_data
 using Oceananigans.TimeSteppers: RungeKutta3TimeStepper, QuasiAdamsBashforth2TimeStepper
@@ -81,6 +83,13 @@ function Checkpointer(model; schedule,
                       verbose = false,
                       cleanup = false,
                       properties = default_checkpointed_properties(model))
+
+    arch = architecture(model)
+
+    if arch isa Distributed
+        rank = arch.local_rank
+        prefix *= "_rank$rank"
+    end
 
     # Certain properties are required for `set!` to pickup from a checkpoint.
     required_properties = [:grid, :particles, :clock]

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -102,6 +102,9 @@ end
 """ Return the full prefix (the `superprefix`) associated with `checkpointer`. """
 checkpoint_superprefix(prefix) = prefix * "_iteration"
 
+# This is the default name used in the simulation.output_writers ordered dict.
+defaultname(::Checkpointer, nelems) = :checkpointer
+
 """
     checkpoint_path(iteration::Int, c::Checkpointer)
 
@@ -110,13 +113,10 @@ Return the path to the `c`heckpointer file associated with model `iteration`.
 checkpoint_path(iteration::Int, c::Checkpointer) =
     joinpath(c.dir, string(checkpoint_superprefix(c.prefix), iteration, ".jld2"))
 
-# This is the default name used in the simulation.output_writers ordered dict.
-defaultname(::Checkpointer, nelems) = :checkpointer
-
 """ Returns `filepath`. Shortcut for `run!(simulation, pickup=filepath)`. """
-checkpoint_path(filepath::AbstractString, output_writers) = filepath
+checkpoint_path(filepath::String, output_writers) = filepath
 
-function checkpoint_path(pickup, output_writers)
+function checkpoint_path(pickup::Bool, output_writers)
     checkpointers = filter(writer -> writer isa Checkpointer, collect(values(output_writers)))
     length(checkpointers) == 0 && error("No checkpointers found: cannot pickup simulation!")
     length(checkpointers) > 1 && error("Multiple checkpointers found: not sure which one to pickup simulation from!")

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -17,6 +17,20 @@ mutable struct Checkpointer{T, P} <: AbstractOutputWriter
     cleanup :: Bool
 end
 
+function default_checkpointed_properties(model)
+    properties = [:grid, :particles, :clock]
+    if has_ab2_timestepper(model)
+        push!(properties, :timestepper)
+    end
+    return properties
+end
+
+has_ab2_timestepper(model) = try
+    model.timestepper isa QuasiAdamsBashforth2TimeStepper
+catch
+    false
+end
+
 """
     Checkpointer(model;
                  schedule,
@@ -25,8 +39,7 @@ end
                  overwrite_existing = false,
                  verbose = false,
                  cleanup = false,
-                 properties = [:grid, :clock, :coriolis,
-                               :buoyancy, :closure, :timestepper, :particles])
+                 properties = default_checkpointed_properties(model))
 
 Construct a `Checkpointer` that checkpoints the model to a JLD2 file on `schedule.`
 The `model.clock.iteration` is included in the filename to distinguish between multiple checkpoint files.
@@ -58,8 +71,8 @@ Keyword arguments
              Default: `false`.
 
 - `properties`: List of model properties to checkpoint. This list _must_ contain
-                `:grid`, `:timestepper`, and `:particles`.
-                Default: `[:grid, :timestepper, :particles, :clock, :coriolis, :buoyancy, :closure]`
+                `:grid`, `:particles` and :clock`, and if using AB2 timestepping then also
+                `:timestepper`. Default: default_checkpointed_properties(model)
 """
 function Checkpointer(model; schedule,
                       dir = ".",
@@ -67,11 +80,14 @@ function Checkpointer(model; schedule,
                       overwrite_existing = false,
                       verbose = false,
                       cleanup = false,
-                      properties = [:grid, :timestepper, :particles, :clock,
-                                    :coriolis, :buoyancy, :closure])
+                      properties = default_checkpointed_properties(model))
 
     # Certain properties are required for `set!` to pickup from a checkpoint.
-    required_properties = (:grid, :timestepper, :particles)
+    required_properties = [:grid, :particles, :clock]
+
+    if has_ab2_timestepper(model)
+        push!(required_properties, :timestepper)
+    end
 
     for rp in required_properties
         if rp ∉ properties
@@ -98,6 +114,9 @@ end
 #####
 ##### Checkpointer utils
 #####
+
+checkpointer_address(::NonhydrostaticModel) = "NonhydrostaticModel"
+checkpointer_address(::HydrostaticFreeSurfaceModel) = "HydrostaticFreeSurfaceModel"
 
 """ Return the full prefix (the `superprefix`) associated with `checkpointer`. """
 checkpoint_superprefix(prefix) = prefix * "_iteration"
@@ -158,21 +177,24 @@ end
 function write_output!(c::Checkpointer, model)
     filepath = checkpoint_path(model.clock.iteration, c)
     c.verbose && @info "Checkpointing to file $filepath..."
+    addr = checkpointer_address(model)
 
     t1 = time_ns()
-    jldopen(filepath, "w") do file
-        file["checkpointed_properties"] = c.properties
-        serializeproperties!(file, model, c.properties)
 
-        model_fields = fields(model)
+    jldopen(filepath, "w") do file
+        file["$addr/checkpointed_properties"] = c.properties
+        serializeproperties!(file, model, c.properties, addr)
+
+        model_fields = prognostic_fields(model)
         field_names = keys(model_fields)
         for name in field_names
-            serializeproperty!(file, string(name), model_fields[name])
+            full_address = "$addr/$name"
+            serializeproperty!(file, full_address, model_fields[name])
         end
     end
 
     t2, sz = time_ns(), filesize(filepath)
-    c.verbose && @info "Checkpointing done: time=$(prettytime((t2-t1)/1e9)), size=$(pretty_filesize(sz))"
+    c.verbose && @info "Checkpointing done: time=$(prettytime((t2 - t1) * 1e-9)), size=$(pretty_filesize(sz))"
 
     c.cleanup && cleanup_checkpoints(c)
 
@@ -190,7 +212,7 @@ end
 ##### set! for checkpointer filepaths
 #####
 
-set!(model, ::Nothing) = nothing
+set!(model::AbstractModel, ::Nothing) = nothing
 
 """
     set!(model, filepath::AbstractString)
@@ -198,34 +220,37 @@ set!(model, ::Nothing) = nothing
 Set data in `model.velocities`, `model.tracers`, `model.timestepper.Gⁿ`, and
 `model.timestepper.G⁻` to checkpointed data stored at `filepath`.
 """
-function set!(model, filepath::AbstractString)
+function set!(model::AbstractModel, filepath::AbstractString)
+
+    addr = checkpointer_address(model)
 
     jldopen(filepath, "r") do file
 
         # Validate the grid
-        checkpointed_grid = file["grid"]
+        checkpointed_grid = file["$addr/grid"]
+
         model.grid == checkpointed_grid ||
-             @warn "The grid associated with $filepath and model.grid are not the same!"
+            @warn "The grid associated with $filepath and model.grid are not the same!"
 
         model_fields = prognostic_fields(model)
 
-        for name in propertynames(model_fields)
-            if string(name) ∈ keys(file) # Test if variable exist in checkpoint.
+        for name in keys(model_fields)
+            if string(name) ∈ keys(file) # Test if variable exists in checkpoint.
                 model_field = model_fields[name]
-                parent_data = file["$name/data"] #  Allow different halo size by loading only the interior
-                copyto!(model_field.data.parent, parent_data)
+                parent_data = file["$addr/$name/data"]
+                copyto!(parent(model_field), parent_data)
             else
                 @warn "Field $name does not exist in checkpoint and could not be restored."
             end
         end
 
-        set_time_stepper!(model.timestepper, file, model_fields)
+        set_time_stepper!(model.timestepper, file, model_fields, addr)
 
         if !isnothing(model.particles)
-            copyto!(model.particles.properties, file["particles"])
+            copyto!(model.particles.properties, file["$addr/particles"])
         end
 
-        checkpointed_clock = file["clock"]
+        checkpointed_clock = file["$addr/clock"]
 
         # Update model clock
         model.clock.iteration = checkpointed_clock.iteration
@@ -236,17 +261,17 @@ function set!(model, filepath::AbstractString)
     return nothing
 end
 
-function set_time_stepper_tendencies!(timestepper, file, model_fields)
+function set_time_stepper_tendencies!(timestepper, file, model_fields, addr)
     for name in propertynames(model_fields)
-        if string(name) ∈ keys(file["timestepper/Gⁿ"]) # Test if variable tendencies exist in checkpoint
+        if string(name) ∈ keys(file["$addr/timestepper/Gⁿ"]) # Test if variable tendencies exist in checkpoint
             # Tendency "n"
-            parent_data = file["timestepper/Gⁿ/$name/data"]
+            parent_data = file["$addr/timestepper/Gⁿ/$name/data"]
 
             tendencyⁿ_field = timestepper.Gⁿ[name]
             copyto!(tendencyⁿ_field.data.parent, parent_data)
 
             # Tendency "n-1"
-            parent_data = file["timestepper/G⁻/$name/data"]
+            parent_data = file["$addr/timestepper/G⁻/$name/data"]
 
             tendency⁻_field = timestepper.G⁻[name]
             copyto!(tendency⁻_field.data.parent, parent_data)
@@ -258,9 +283,7 @@ function set_time_stepper_tendencies!(timestepper, file, model_fields)
     return nothing
 end
 
-set_time_stepper!(timestepper::RungeKutta3TimeStepper, file, model_fields) =
-    set_time_stepper_tendencies!(timestepper, file, model_fields)
-
-set_time_stepper!(timestepper::QuasiAdamsBashforth2TimeStepper, file, model_fields) =
-    set_time_stepper_tendencies!(timestepper, file, model_fields)
+set_time_stepper!(timestepper::RungeKutta3TimeStepper, args...) = nothing
+set_time_stepper!(timestepper::QuasiAdamsBashforth2TimeStepper, args...) =
+    set_time_stepper_tendencies!(timestepper, args...)
 

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -212,8 +212,6 @@ end
 ##### set! for checkpointer filepaths
 #####
 
-set!(model::AbstractModel, ::Nothing) = nothing
-
 """
     set!(model, filepath::AbstractString)
 

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -135,7 +135,7 @@ checkpoint_path(iteration::Int, c::Checkpointer) =
 """ Returns `filepath`. Shortcut for `run!(simulation, pickup=filepath)`. """
 checkpoint_path(filepath::String, output_writers) = filepath
 
-function checkpoint_path(pickup::Bool, output_writers)
+function checkpoint_path(pickup, output_writers)
     checkpointers = filter(writer -> writer isa Checkpointer, collect(values(output_writers)))
     length(checkpointers) == 0 && error("No checkpointers found: cannot pickup simulation!")
     length(checkpointers) > 1 && error("Multiple checkpointers found: not sure which one to pickup simulation from!")

--- a/src/OutputWriters/output_writer_utils.jl
+++ b/src/OutputWriters/output_writer_utils.jl
@@ -169,6 +169,7 @@ serializeproperty!(file, address, p::LagrangianParticles) = serializeproperty!(f
 
 saveproperties!(file, structure, ps) = [saveproperty!(file, "$p", getproperty(structure, p)) for p in ps]
 serializeproperties!(file, structure, ps) = [serializeproperty!(file, "$p", getproperty(structure, p)) for p in ps]
+serializeproperties!(file, structure, ps, addr) = [serializeproperty!(file, "$addr/$p", getproperty(structure, p)) for p in ps]
 
 # Don't check arrays because we don't need that noise.
 has_reference(T, ::AbstractArray{<:Number}) = false

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -1,11 +1,11 @@
-using Oceananigans.Fields: set!
 using Oceananigans.OutputWriters: WindowedTimeAverage, checkpoint_superprefix
 using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, RungeKutta3TimeStepper, update_state!, next_time, unit_time
 
 using Oceananigans: AbstractModel, run_diagnostic!, write_output!
 
 import Oceananigans: initialize!
-import Oceananigans.OutputWriters: checkpoint_path, set!
+import Oceananigans.Fields: set!
+import Oceananigans.OutputWriters: checkpoint_path
 import Oceananigans.TimeSteppers: time_step!
 import Oceananigans.Utils: schedule_aligned_time_step
 
@@ -55,6 +55,12 @@ function aligned_time_step(sim::Simulation, Δt)
     return aligned_Δt
 end
 
+function set!(sim::Simulation, pickup::Union{Bool, Integer, String})
+    checkpoint_file_path = checkpoint_path(pickup, sim.output_writers)
+    set!(sim.model, checkpoint_file_path)
+    return nothing
+end
+
 """
     run!(simulation; pickup=false)
 
@@ -85,8 +91,7 @@ more than one checkpointer.
 function run!(sim; pickup=false)
 
     if we_want_to_pickup(pickup)
-        checkpoint_file_path = checkpoint_path(pickup, sim.output_writers)
-        set!(sim.model, checkpoint_file_path)
+        set!(sim, pickup)
     end
 
     sim.initialized = false
@@ -102,24 +107,12 @@ end
 
 const ModelCallsite = Union{TendencyCallsite, UpdateStateCallsite}
 
-
-function time_step_or_skip!(sim)
-    model_callbacks = Tuple(cb for cb in values(sim.callbacks) if cb.callsite isa ModelCallsite)
-    Δt = aligned_time_step(sim, sim.Δt)
-    if Δt < sim.minimum_relative_step * sim.Δt
-        next_time = sim.model.clock.time + Δt
-        @warn "Resetting clock to $next_time and skipping time step of size Δt = $Δt"
-        sim.model.clock.time = next_time
-    else
-        time_step!(sim.model, Δt, callbacks=model_callbacks)
-    end
-end
-
-
 """ Step `sim`ulation forward by one time step. """
 function time_step!(sim::Simulation)
 
     start_time_step = time_ns()
+    model_callbacks = Tuple(cb for cb in values(sim.callbacks) if cb.callsite isa ModelCallsite)
+    Δt = aligned_time_step(sim, sim.Δt)
 
     if !(sim.initialized) # execute initialization step
         initialize!(sim)
@@ -131,7 +124,8 @@ function time_step!(sim::Simulation)
                 start_time = time_ns()
             end
 
-            time_step_or_skip!(sim)
+            # Take first time-step
+            time_step!(sim.model, Δt, callbacks=model_callbacks)
 
             if sim.verbose
                 elapsed_initial_step_time = prettytime(1e-9 * (time_ns() - start_time))
@@ -142,7 +136,13 @@ function time_step!(sim::Simulation)
         end
 
     else # business as usual...
-        time_step_or_skip!(sim)
+        if Δt < sim.minimum_relative_step * sim.Δt
+            next_time = sim.model.clock.time + Δt
+            @warn "Resetting clock to $next_time and skipping time step of size Δt = $Δt"
+            sim.model.clock.time = next_time
+        else
+            time_step!(sim.model, Δt, callbacks=model_callbacks)
+        end
     end
 
     # Callbacks and callback-like things


### PR DESCRIPTION
This PR generalized the Checkpointer for Distributed architectures by adding "_rank$rank" to the Checkpointer prefix. I believe this is the only change needed to support distributed checkpointing and pickup for simulations that use the same number of MPI ranks.

This PR depends on #4003. I added it because @simone-silvestri suggested "revamping" a PR for distributed Checkpointing. However, I think all that is really needed are these 5 lines so best to start simple.

TODO:
- [ ] test
