### PR TITLE
(0.95.5) Correctly account for field names in `ContinuousBoundaryFunctions`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.95.2"
+version = "0.95.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/BoundaryConditions/continuous_boundary_function.jl
+++ b/src/BoundaryConditions/continuous_boundary_function.jl
@@ -72,7 +72,7 @@ The regularization of `bc.condition::ContinuousBoundaryFunction` requries
    of the boundary.
 """
 function regularize_boundary_condition(bc::BoundaryCondition{C, <:ContinuousBoundaryFunction},
-                                       grid, loc, dim, Side, prognostic_field_names) where C
+                                       grid, loc, dim, Side, field_names) where C
 
     boundary_func = bc.condition
 
@@ -81,7 +81,7 @@ function regularize_boundary_condition(bc::BoundaryCondition{C, <:ContinuousBoun
 
     indices, interps = index_and_interp_dependencies(LX, LY, LZ,
                                                      boundary_func.field_dependencies,
-                                                     prognostic_field_names)
+                                                     field_names)
 
     regularized_boundary_func = ContinuousBoundaryFunction{LX, LY, LZ, Side}(boundary_func.func,
                                                                              boundary_func.parameters,

--- a/src/ImmersedBoundaries/mask_immersed_field.jl
+++ b/src/ImmersedBoundaries/mask_immersed_field.jl
@@ -12,6 +12,11 @@ mask_immersed_field!(::OneField, args...) = nothing
 mask_immersed_field!(::ZeroField, args...) = nothing
 mask_immersed_field!(::ConstantField, args...) = nothing
 
+# No masking for constant fields
+mask_immersed_field_xy!(::OneField, args...; kw...) = nothing
+mask_immersed_field_xy!(::ZeroField, args...; kw...) = nothing
+mask_immersed_field_xy!(::ConstantField, args...; kw...) = nothing
+
 mask_immersed_field!(field, grid, loc, value) = nothing
 mask_immersed_field!(field::Field, value=zero(eltype(field.grid))) =
     mask_immersed_field!(field, field.grid, location(field), value)

--- a/src/ImmersedBoundaries/mask_immersed_field.jl
+++ b/src/ImmersedBoundaries/mask_immersed_field.jl
@@ -2,9 +2,15 @@ using KernelAbstractions: @kernel, @index
 using Statistics
 using Oceananigans.AbstractOperations: BinaryOperation
 using Oceananigans.Fields: location, XReducedField, YReducedField, ZReducedField, Field, ReducedField
+using Oceananigans.Fields: ConstantField, OneField, ZeroField
 
 instantiate(T::Type) = T()
 instantiate(t) = t
+
+# No masking for constant fields
+mask_immersed_field!(::OneField, args...) = nothing
+mask_immersed_field!(::ZeroField, args...) = nothing
+mask_immersed_field!(::ConstantField, args...) = nothing
 
 mask_immersed_field!(field, grid, loc, value) = nothing
 mask_immersed_field!(field::Field, value=zero(eltype(field.grid))) =

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -158,14 +158,14 @@ function HydrostaticFreeSurfaceModel(; grid,
                                          extract_boundary_conditions(diffusivity_fields))
 
     # Next, we form a list of default boundary conditions:
-    prognostic_field_names = (:u, :v, :w, tracernames(tracers)..., :η, keys(auxiliary_fields)...)
-    default_boundary_conditions = NamedTuple{prognostic_field_names}(Tuple(FieldBoundaryConditions()
-                                                                           for name in prognostic_field_names))
+    hydrostatic_field_names = field_names(free_surface, tracernames(tracers), auxiliary_fields)
+    default_boundary_conditions = NamedTuple{hydrostatic_field_names}(Tuple(FieldBoundaryConditions()
+                                                                      for name in hydrostatic_field_names))
 
     # Then we merge specified, embedded, and default boundary conditions. Specified boundary conditions
     # have precedence, followed by embedded, followed by default.
     boundary_conditions = merge(default_boundary_conditions, embedded_boundary_conditions, boundary_conditions)
-    boundary_conditions = regularize_field_boundary_conditions(boundary_conditions, grid, prognostic_field_names)
+    boundary_conditions = regularize_field_boundary_conditions(boundary_conditions, grid, hydrostatic_field_names)
 
     # Finally, we ensure that closure-specific boundary conditions, such as
     # those required by CATKEVerticalDiffusivity, are enforced:

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -103,6 +103,7 @@ topos_3d = ((Periodic, Periodic, Bounded),
             @test grid isa SingleColumnGrid
             @test isnothing(model.free_surface)
             @test !(:η ∈ keys(fields(model))) # doesn't include free surface
+            @test field_names(model) == keys(fields(model))
         end
     end
 
@@ -114,6 +115,7 @@ topos_3d = ((Periodic, Periodic, Bounded),
                 model = HydrostaticFreeSurfaceModel(; grid)
                 @test model isa HydrostaticFreeSurfaceModel
                 @test :η ∈ keys(fields(model)) # contrary to the SingleColumnGrid case
+                @test field_names(model) == keys(fields(model))
             end
         end
     end
@@ -125,6 +127,18 @@ topos_3d = ((Periodic, Periodic, Bounded),
                 grid = RectilinearGrid(arch, FT, topology=topo, size=(1, 1, 1), extent=(1, 2, 3))
                 model = HydrostaticFreeSurfaceModel(; grid)
                 @test model isa HydrostaticFreeSurfaceModel
+            end
+        end
+    end
+
+    for FreeSurface in (ExplicitFreeSurface, ImplicitFreeSurface, SpliExplicitFreeSurface, Nothing)
+        @testset "$topo model construction" begin
+            @info "  Testing $free_surface model construction..."
+            for arch in archs, FT in float_types
+                grid = RectilinearGrid(arch, FT, topology=topo, size=(1, 1, 1), extent=(1, 2, 3))
+                model = HydrostaticFreeSurfaceModel(; grid, free_surface=FreeSurface())
+                @test model isa HydrostaticFreeSurfaceModel
+                @test field_names(model) == keys(fields(model))
             end
         end
     end


### PR DESCRIPTION
continuous boundary functions with field dependencies are broken at the moment because of the recent changes with split explicit that changed the order of the fields outputted by `fields(model)`.

This PR corrects this bug and introduces 
(1) some tests 
(2) a `field_names` function to be able to change the field names in a `HydrostaticFreeSurfaceModel` depending on different inputs