### PR TITLE
Allow divergent Lagrangian-mean velocity by subtracting Stokes drift before pressure correction

### DIFF
--- a/src/Models/NonhydrostaticModels/pressure_correction.jl
+++ b/src/Models/NonhydrostaticModels/pressure_correction.jl
@@ -1,5 +1,40 @@
 import Oceananigans.TimeSteppers: calculate_pressure_correction!, pressure_correct_velocities!
 
+const c = Center()
+const f = Face()
+
+using Oceananigans.Grids: node
+using Oceananigans.StokesDrifts: StokesDrift, parameters_tuple
+
+function modulate_by_stokes_drift!(model, sgn, t=time(model))
+    stokes_drift = model.stokes_drift
+    if stokes_drift isa StokesDrift
+        grid = model.grid
+        arch = architecture(grid)
+        u, v, w = model.velocities
+        launch!(arch, grid, :xyz, _modulate_by_stokes_drift, u, v, w, sgn, grid, t, stokes_drift)
+    end
+    return nothing
+end
+
+@kernel function _modulate_by_stokes_drift(u, v, w, sgn, grid, time, sd)
+    i, j, k = @index(Global, NTuple)
+
+    pt = parameters_tuple(sd)
+    Xu = node(i, j, k, grid, f, c, c)
+    Xv = node(i, j, k, grid, c, f, c)
+    Xw = node(i, j, k, grid, c, c, f)
+
+    @inbounds begin
+        u[i, j, k] = u[i, j, k] + sgn * sd.uˢ(Xu..., time, pt...)
+        v[i, j, k] = v[i, j, k] + sgn * sd.vˢ(Xv..., time, pt...)
+        w[i, j, k] = w[i, j, k] + sgn * sd.wˢ(Xw..., time, pt...)
+    end
+end
+
+subtract_stokes_drift!(model, t=time(model)) = modulate_by_stokes_drift!(model, -1, t)
+add_stokes_drift!(model, t=time(model)) = modulate_by_stokes_drift!(model, +1, t)
+
 """
     calculate_pressure_correction!(model::NonhydrostaticModel, Δt)
 
@@ -7,14 +42,15 @@ Calculate the (nonhydrostatic) pressure correction associated `tendencies`, `vel
 """
 function calculate_pressure_correction!(model::NonhydrostaticModel, Δt)
 
+    subtract_stokes_drift!(model)
+
     # Mask immersed velocities
     foreach(mask_immersed_field!, model.velocities)
-
     fill_halo_regions!(model.velocities, model.clock, fields(model))
-
     solve_for_pressure!(model.pressures.pNHS, model.pressure_solver, Δt, model.velocities)
-
     fill_halo_regions!(model.pressures.pNHS)
+
+    add_stokes_drift!(model, time(model) + Δt)
 
     return nothing
 end


### PR DESCRIPTION
This experimental PR tweaks the pressure correction algorithm so that Lagrangian-mean velocities can be divergent. This might be convenient in practice, since otherwise users are tasked with correctly extracting the solenoidal part of the Stokes drift (eg Vanneste and Young 2022).

The simple change to the algorithm is basically to omit the dt_uS term on the RHS, and instead add the uS contribution manually. The pressure correction is performed on uE. For this to work users have to provide uS rather than dt_uS.

We could merge this, but if we do I want to change the user interface a bit. Basically I think users should either provide dt_uS or uS but not both. That allows the user to select the "mode" (divergnece-free uL, or divergence-free uE).

The new algorithm is illustrated by the following script which disproves a claim in McIntyre (1981) about the ultimate fate of oceanic momentum beneath forced surface waves (McIntyre claimed that the momentum propagates away in shallow water waves, but when the ocean is deep compared to the scale of the packet, the momentum actually stays put at the forcing site).

https://github.com/user-attachments/assets/32e4feb1-0fbc-44d9-8188-8cfeb090b78c

```julia
using Oceananigans
using GLMakie

ϵ = 0.1
λ = 60 # meters
g = 9.81

const k = 2π / λ

c = sqrt(g / k)
const δ = 500
const cᵍ = c / 2
const Uˢ = ϵ^2 * c

@inline A(ξ) = exp(- ξ^2 / 2δ^2)
@inline A′(ξ) = - ξ / δ^2 * A(ξ)
@inline A′′(ξ) = (ξ^2 / δ^2 - 1) * A(ξ) / δ^2

# Write the Stokes drift as
#
# uˢ(x, z, t) = A(x - cᵍ * t) * ûˢ(z)
#
# which describes a wave packet propogating with speed cᵍ. This implies

@inline    ûˢ(z)       = Uˢ * exp(2k * z)
@inline    uˢ(x, z, t) =         A(x - cᵍ * t) * ûˢ(z)
@inline ∂z_uˢ(x, z, t) =   2k *  A(x - cᵍ * t) * ûˢ(z)
@inline ∂t_uˢ(x, z, t) = - cᵍ * A′(x - cᵍ * t) * ûˢ(z)

# Note that if uˢ represents the solenoidal component of the Stokes drift,
# then
#
# ```math
# ∂z_wˢ = - ∂x_uˢ = - A′ * ûˢ .
# ```
#
# Thus, after integrating from bottom up to ``z`` and assuming that ``w`` at
# the bottom vanishes, we find that
#
# ```math
# wˢ = - A′ / 2k * ûˢ
# ```
#
# and

@inline ∂x_wˢ(x, z, t) = -  1 / 2k * A′′(x - cᵍ * t) * ûˢ(z)
@inline ∂t_wˢ(x, z, t) = + cᵍ / 2k * A′′(x - cᵍ * t) * ûˢ(z)
@inline    wˢ(x, z, t) = -  1 / 2k *  A′(x - cᵍ * t)  * ûˢ(z)

stokes_drift = StokesDrift(; uˢ, wˢ, ∂z_uˢ, ∂x_wˢ)
coriolis = FPlane(f=0.1)

grid = RectilinearGrid(size = (512, 1024),
                       x = (-2kilometers, 7kilometers),
                       z = (-4096, 0),
                       topology = (Periodic, Flat, Bounded))

#model = NonhydrostaticModel(; grid, stokes_drift, coriolis, tracers=:b, buoyancy=BuoyancyTracer())
model = NonhydrostaticModel(; grid, stokes_drift, tracers=:b) #, coriolis, buoyancy=BuoyancyTracer())

# Set Lagrangian-mean flow equal to uˢ,
uᵢ(x, z) = uˢ(x, z, 0)

# And put in a stable stratification,
N² = 0
bᵢ(x, z) = N² * z
set!(model, u=uᵢ, b=bᵢ)

Δx = minimum_xspacing(grid)
Δt = 0.2 * Δx / cᵍ
simulation = Simulation(model; Δt, stop_iteration = 1800)

progress(sim) = @info string("Iter: ", iteration(sim), ", time: ", prettytime(sim))
simulation.callbacks[:progress] = Callback(progress, IterationInterval(10))

filename = "surface_wave_induced_flow.jld2"
outputs = model.velocities
simulation.output_writers[:jld2] = JLD2OutputWriter(model, outputs; filename,
                                                    schedule = IterationInterval(10),
                                                    overwrite_existing = true)

run!(simulation)

ut = FieldTimeSeries(filename, "u")
wt = FieldTimeSeries(filename, "w")

times = ut.times
Nt = length(times)

fig = Figure(size=(800, 800))
axU = Axis(fig[1, 1], xlabel="x (m)", ylabel="U = H⁻¹ ∫ u dz (m s⁻¹)")
axu = Axis(fig[2, 1], xlabel="x (m)", ylabel="z (m)")
axw = Axis(fig[3, 1], xlabel="x (m)", ylabel="z (m)")

slider = Slider(fig[4, 1], range=1:Nt, startvalue=1)
n = slider.value

rowsize!(fig.layout, 1, Relative(0.2))

u = XFaceField(grid)
U = Field(Average(u, dims=3))

Un = @lift begin
    parent(u) .= parent(ut[$n])
    compute!(U)
    U
end

un = @lift interior(ut[$n], :, 1, :)
wn = @lift interior(wt[$n], :, 1, :)

xu, yu, zu = nodes(ut)
xw, yw, zw = nodes(wt)

lines!(axU, xu, U)
heatmap!(axu, xu, zu, un, colormap=:balance, colorrange=(-5e-6, 5e-6))
heatmap!(axw, xw, zw, wn, colormap=:balance, colorrange=(-5e-6, 5e-6))

display(fig)

record(fig, "surface_wave_induced_flow.mp4", 1:Nt, framerate=12) do nn
    n[] = nn
end
```
