### PR TITLE
Remove global `allowscalar` from testing suite attempt 2

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,8 +16,6 @@ end
 ##### Run tests!
 #####
 
-CUDA.allowscalar() do
-
 @testset "Oceananigans" begin
 
     if test_file != :none
@@ -230,5 +228,3 @@ CUDA.allowscalar() do
         include("test_convergence.jl")
     end
 end
-
-end #CUDA.allowscalar()


### PR DESCRIPTION
Because it does not allow us to catch problems where kernels erroneously run on the CPU (for example #4036), see:
 >             > and none of the tests of Oceananigans caught this?
>
> OK, none of Oceananigans tests caught this because they are all run within a `CUDA.allowscalar()`!
>
> https://github.com/CliMA/Oceananigans.jl/blob/e02564df8ab90fb8f994fddf465b10d123fdfc3a/test/runtests.jl#L19
>
> We should remove this `CUDA.allowscalar() do ... all-the-tests ... end`
>
> cc @glwagner

_Originally posted by @navidcy in https://github.com/CliMA/ClimaOcean.jl/issues/318#issuecomment-2585887372_
            
Probably will require a bit of fiddling to add `allowscalar` granularly in tests

closes #3039