### PR TITLE
Precision error when converting to 0 - 360

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.95.10"
+version = "0.95.11"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -88,6 +88,9 @@ end
     return ifelse(- 100sqrt(eps(x)) ≤ x < 0, 360 + x, x₀)
 end
 
+# No need to check precision for integers
+@inline convert_to_0_360(x::Integer) = ((x % 360) + 360) % 360
+
 # Find n for which 360 * n ≤ λ ≤ 360 * (n + 1)
 @inline find_λ_range(λ) = ifelse((λ < 0) & (mod(λ, 360) != 0), λ ÷ 360 - 1, λ ÷ 360)
 

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -82,7 +82,7 @@ end
 end
 
 # Because of precision problems with numbers close to 0, 
-# we need to make sure we are in the correct range.
+# we need to make sure we approach the correct limit from the right.
 @inline function convert_to_0_360(x) 
     x₀ = ((x % 360) + 360) % 360
     return ifelse(- 100sqrt(eps(x)) ≤ x < 0, 360 + x, x₀)

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -83,9 +83,10 @@ end
 
 # Because of precision errors with numbers close to 0, 
 # we need to make sure we approach the correct limit also from the left.
-@inline function convert_to_0_360(x) 
+@inline function convert_to_0_360(x::FT) where FT 
     x₀ = ((x % 360) + 360) % 360
-    return ifelse(- 100sqrt(eps(x)) ≤ x < 0, 360 + x, x₀)
+    x⁻ = - eps(convert(FT, 360))
+    return ifelse(x⁻ ≤ x < 0, 360 + x, x₀)
 end
 
 # No need to check precision for integers

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -82,7 +82,7 @@ end
 end
 
 # Because of precision errors with numbers close to 0, 
-# we need to make sure we approach the correct limit from the right.
+# we need to make sure we approach the correct limit also from the left.
 @inline function convert_to_0_360(x) 
     x₀ = ((x % 360) + 360) % 360
     return ifelse(- 100sqrt(eps(x)) ≤ x < 0, 360 + x, x₀)

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -81,7 +81,12 @@ end
     return fractional_index(x, xn, Nx) 
 end
 
-@inline convert_to_0_360(x) = ((x % 360) + 360) % 360
+# Because of precision problems with numbers close to 0, 
+# we need to make sure we are in the correct range.
+@inline function convert_to_0_360(x) 
+    x₀ = ((x % 360) + 360) % 360
+    return ifelse(- 100sqrt(eps(x)) ≤ x ≤ 0, 360 + x, x₀)
+end
 
 # Find n for which 360 * n ≤ λ ≤ 360 * (n + 1)
 @inline find_λ_range(λ) = ifelse((λ < 0) & (mod(λ, 360) != 0), λ ÷ 360 - 1, λ ÷ 360)
@@ -105,6 +110,7 @@ end
     Δλ = λ₁ - λ₀
     λc = convert_to_λ₀_λ₀_plus360(λ, λ₀ - Δλ/2) # Making sure we have the right range
     FT = eltype(grid)
+    @show λ, λc, λ₀, λ₁, Δλ
     return convert(FT, (λc - λ₀) / (λ₁ - λ₀)) + 1 # 1 - based indexing 
 end
 

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -85,7 +85,7 @@ end
 # we need to make sure we are in the correct range.
 @inline function convert_to_0_360(x) 
     x₀ = ((x % 360) + 360) % 360
-    return ifelse(- 100sqrt(eps(x)) ≤ x ≤ 0, 360 + x, x₀)
+    return ifelse(- 100sqrt(eps(x)) ≤ x < 0, 360 + x, x₀)
 end
 
 # Find n for which 360 * n ≤ λ ≤ 360 * (n + 1)

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -113,7 +113,6 @@ end
     Δλ = λ₁ - λ₀
     λc = convert_to_λ₀_λ₀_plus360(λ, λ₀ - Δλ/2) # Making sure we have the right range
     FT = eltype(grid)
-    @show λ, λc, λ₀, λ₁, Δλ
     return convert(FT, (λc - λ₀) / (λ₁ - λ₀)) + 1 # 1 - based indexing 
 end
 

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -81,7 +81,7 @@ end
     return fractional_index(x, xn, Nx) 
 end
 
-# Because of precision problems with numbers close to 0, 
+# Because of precision errors with numbers close to 0, 
 # we need to make sure we approach the correct limit from the right.
 @inline function convert_to_0_360(x) 
     x₀ = ((x % 360) + 360) % 360

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -187,10 +187,11 @@ function run_field_interpolation_tests(grid)
     end
 
     @info "Testing the convert function"
-    @test convert_to_0_360(0.0)   == 0
     for n in 1:30
         @test convert_to_0_360(- 10.e0^(-n)) > 359
         @test convert_to_0_360(- 10.f0^(-n)) > 359
+        @test convert_to_0_360(10.e0^(-n))   < 1
+        @test convert_to_0_360(10.f0^(-n))   < 1
     end
 
     # Check interpolation on Windowed fields

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -6,7 +6,7 @@ using Oceananigans.Fields: ReducedField, has_velocities
 using Oceananigans.Fields: VelocityFields, TracerFields, interpolate, interpolate!
 using Oceananigans.Fields: reduced_location
 using Oceananigans.Fields: fractional_indices, interpolator
-using Oceananigans.Fields: convert_to_0_360
+using Oceananigans.Fields: convert_to_0_360, convert_to_λ₀_λ₀_plus360
 using Oceananigans.Grids: ξnode, ηnode, rnode
 using Oceananigans.Grids: total_length
 using Oceananigans.Grids: λnode
@@ -186,12 +186,22 @@ function run_field_interpolation_tests(grid)
         end
     end
 
-    @info "Testing the convert function"
+    @info "Testing the convert functions"
     for n in 1:30
         @test convert_to_0_360(- 10.e0^(-n)) > 359
         @test convert_to_0_360(- 10.f0^(-n)) > 359
         @test convert_to_0_360(10.e0^(-n))   < 1
         @test convert_to_0_360(10.f0^(-n))   < 1
+    end
+
+    # Generating a random longitude left bound between -1000 and 1000
+    λs₀ = rand(1000) .* 2000 .- 1000
+
+    # Generating a random interpolation longitude
+    λsᵢ = rand(1000) .* 2000 .- 1000
+
+    for λ₀ in λs₀, λᵢ in λsᵢ
+        @test λ₀ ≤ convert_to_λ₀_λ₀_plus360(λᵢ, λ₀) ≤ λ₀ + 360
     end
 
     # Check interpolation on Windowed fields

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -186,6 +186,13 @@ function run_field_interpolation_tests(grid)
         end
     end
 
+    @info "Testing the convert function"
+    @test convert_to_0_360(0.0)   == 0
+    for n in 1:30
+        @test convert_to_0_360(- 10.e0^(-n)) > 359
+        @test convert_to_0_360(- 10.f0^(-n)) > 359
+    end
+
     # Check interpolation on Windowed fields
     wf = ZFaceField(grid; indices=(:, :, grid.Nz+1))
     If = Field{Center, Center, Nothing}(grid)


### PR DESCRIPTION
With the recent change in interpolation in #4074, we are hitting an error in ClimaOcean.jl (see https://github.com/CliMA/ClimaOcean.jl/actions/runs/13301013435/job/37142339229).

This is because the convert function
https://github.com/CliMA/Oceananigans.jl/blob/399695072641a53cfa02f8d9bc34c5f2ad54dffa/src/Fields/interpolate.jl#L84 is susceptible to precision errors when the input is small enough:
```julia
julia> convert_to_0_360(-1e-12)
359.999999999999

julia> convert_to_0_360(-1e-13)
359.9999999999999

julia> convert_to_0_360(-1e-14)
0.0
```
This is not acceptable because a negative number should always be on the "left" side of the zero corresponding to values between 359 and 360, i.e. moving to zero from the left side should result in 360 not 0.
In ClimaOcean we were hitting this error because the bathymetry we interpolate from starts at `-1.4e-14` instead of 0, exposing this issue. 
This PR fixes this problem by making sure we are on the correct side of the zero when converting to the 0 - 360 range