### PR TITLE
Add `finalize!` for callbacks

### DIFF
--- a/src/Simulations/callback.jl
+++ b/src/Simulations/callback.jl
@@ -21,6 +21,7 @@ Initialize `callback`. By default, this does nothing, but
 can be optionally specialized on the type parameters of `Callback`.
 """
 initialize!(callback::Callback, sim) = nothing
+finalize!(callback::Callback, sim) = nothing
 
 """
     Callback(func, schedule=IterationInterval(1);

--- a/src/Simulations/callback.jl
+++ b/src/Simulations/callback.jl
@@ -7,8 +7,8 @@ import Oceananigans: initialize!
 struct Callback{P, F, S, CS}
     func :: F
     schedule :: S
-    parameters :: P
     callsite :: CS
+    parameters :: P
 end
 
 @inline (callback::Callback)(sim) = callback.func(sim, callback.parameters)
@@ -17,11 +17,31 @@ end
 """
     initialize!(callback::Callback, sim)
 
-Initialize `callback`. By default, this does nothing, but
-can be optionally specialized on the type parameters of `Callback`.
+Initialize `callback` at the beginning of `run!(sim)`.
+By default, this calls `initialize!` on `callback.func`,
+which in turn does nothing by default.
+
+`initialize!` can be specialized on `callback.parameters`,
+or specialized for `callback.func`.
+`
 """
-initialize!(callback::Callback, sim) = nothing
-finalize!(callback::Callback, sim) = nothing
+initialize!(callback::Callback, sim) = initialize!(callback.func, sim)
+
+"""
+    finalize!(callback::Callback, sim)
+
+Finalize `callback` at the end of `run!(sim)`.
+By default, this calls `finalize!` on `callback.func`,
+which in turn does nothing by default.
+
+`finalize!` can be specialized on `callback.parameters`,
+or specialized for `callback.func`.
+`
+"""
+finalize!(callback::Callback, sim) = finalize!(callback.func, sim)
+
+initialize!(func, sim) = nothing
+finalize!(func, sim) = nothing
 
 """
     Callback(func, schedule=IterationInterval(1);
@@ -50,7 +70,7 @@ function Callback(func, schedule=IterationInterval(1);
                   parameters = nothing,
                   callsite = TimeStepCallsite())
 
-    return Callback(func, schedule, parameters, callsite)
+    return Callback(func, schedule, callsite, parameters)
 end
 
 Base.summary(cb::Callback{Nothing}) = string("Callback of ", prettysummary(cb.func, false), " on ", summary(cb.schedule))

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -102,6 +102,10 @@ function run!(sim; pickup=false)
         time_step!(sim)
     end
 
+    for callback in values(sim.callbacks) 
+        finalize!(callback, sim)
+    end
+
     return nothing
 end
 
@@ -151,6 +155,7 @@ function time_step!(sim::Simulation)
     end
 
     for callback in values(sim.callbacks)
+        initialize!(callback, sim)
         callback.callsite isa TimeStepCallsite && callback.schedule(sim.model) && callback(sim)
     end
 


### PR DESCRIPTION
Adds `finalize!(callback, sim)`. By default, it does nothing. This gets called after the time-stepping loop is done. It only gets called if using `run!`.

Also actually calls `initialize!` for callbacks which previously was not called.