### PR TITLE
Add option to turn off time-step alignment

### DIFF
--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -90,6 +90,8 @@ more than one checkpointer.
 """
 function run!(sim; pickup=false)
 
+    start_run = time_ns()
+
     if we_want_to_pickup(pickup)
         set!(sim, pickup)
     end
@@ -106,6 +108,10 @@ function run!(sim; pickup=false)
         finalize!(callback, sim)
     end
 
+    # Increment the wall clock
+    end_run = time_ns()
+    sim.run_wall_time += 1e-9 * (end_run - start_run)
+
     return nothing
 end
 
@@ -114,42 +120,30 @@ const ModelCallsite = Union{TendencyCallsite, UpdateStateCallsite}
 """ Step `sim`ulation forward by one time step. """
 function time_step!(sim::Simulation)
 
-    start_time_step = time_ns()
-    model_callbacks = Tuple(cb for cb in values(sim.callbacks) if cb.callsite isa ModelCallsite)
-
-    if sim.align_time_step
-        Δt = aligned_time_step(sim, sim.Δt)
+    Δt = if sim.align_time_step
+        aligned_time_step(sim, sim.Δt)
+    else
+        sim.Δt
     end
 
-    if !(sim.initialized) # execute initialization step
+    initial_time_step = !(sim.initialized)
+    if initial_time_step # execute initialization step
         initialize!(sim)
         initialize!(sim.model)
+    end
 
-        if sim.running # check that initialization didn't stop time-stepping
-            if sim.verbose 
-                @info "Executing initial time step..."
-                start_time = time_ns()
-            end
+    if initial_time_step && sim.verbose 
+        @info "Executing initial time step..."
+        start_time = time_ns()
+    end
 
-            # Take first time-step
-            time_step!(sim.model, Δt, callbacks=model_callbacks)
-
-            if sim.verbose
-                elapsed_initial_step_time = prettytime(1e-9 * (time_ns() - start_time))
-                @info "    ... initial time step complete ($elapsed_initial_step_time)."
-            end
-        else
-            @warn "Simulation stopped during initialization."
-        end
-
-    else # business as usual...
-        if Δt < sim.minimum_relative_step * sim.Δt
-            next_time = sim.model.clock.time + Δt
-            @warn "Resetting clock to $next_time and skipping time step of size Δt = $Δt"
-            sim.model.clock.time = next_time
-        else
-            time_step!(sim.model, Δt, callbacks=model_callbacks)
-        end
+    if Δt < sim.minimum_relative_step * sim.Δt
+        next_time = sim.model.clock.time + Δt
+        @warn "Resetting clock to $next_time and skipping time step of size Δt = $Δt"
+        sim.model.clock.time = next_time
+    else
+        model_callbacks = Tuple(cb for cb in values(sim.callbacks) if cb.callsite isa ModelCallsite)
+        time_step!(sim.model, Δt, callbacks=model_callbacks)
     end
 
     # Callbacks and callback-like things
@@ -166,10 +160,10 @@ function time_step!(sim::Simulation)
         writer.schedule(sim.model) && write_output!(writer, sim.model) 
     end
 
-    end_time_step = time_ns()
-
-    # Increment the wall clock
-    sim.run_wall_time += 1e-9 * (end_time_step - start_time_step)
+    if initial_time_step && sim.verbose
+        elapsed_initial_step_time = prettytime(1e-9 * (time_ns() - start_time))
+        @info "    ... initial time step complete ($elapsed_initial_step_time)."
+    end
 
     return nothing
 end

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -116,7 +116,10 @@ function time_step!(sim::Simulation)
 
     start_time_step = time_ns()
     model_callbacks = Tuple(cb for cb in values(sim.callbacks) if cb.callsite isa ModelCallsite)
-    Δt = aligned_time_step(sim, sim.Δt)
+
+    if sim.align_time_step
+        Δt = aligned_time_step(sim, sim.Δt)
+    end
 
     if !(sim.initialized) # execute initialization step
         initialize!(sim)

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -18,6 +18,7 @@ mutable struct Simulation{ML, DT, ST, DI, OW, CB}
     output_writers :: OW
     callbacks :: CB
     run_wall_time :: Float64
+    align_time_step :: Bool
     running :: Bool
     initialized :: Bool
     verbose :: Bool
@@ -55,6 +56,7 @@ function Simulation(model; Δt,
                     stop_iteration = Inf,
                     stop_time = Inf,
                     wall_time_limit = Inf,
+                    align_time_step = true,
                     minimum_relative_step = 0)
 
    if verbose && stop_iteration == Inf && stop_time == Inf && wall_time_limit == Inf
@@ -92,6 +94,7 @@ function Simulation(model; Δt,
                      output_writers,
                      callbacks,
                      0.0,
+                     align_time_step,
                      false,
                      false,
                      verbose,

--- a/test/dependencies_for_runtests.jl
+++ b/test/dependencies_for_runtests.jl
@@ -5,7 +5,6 @@ using Random
 using Statistics
 using LinearAlgebra
 using Logging
-using Enzyme
 using SparseArrays
 using JLD2
 using FFTW

--- a/test/test_enzyme.jl
+++ b/test/test_enzyme.jl
@@ -1,5 +1,7 @@
 include("dependencies_for_runtests.jl")
 
+using Enzyme
+
 # Required presently
 Enzyme.API.looseTypeAnalysis!(true)
 Enzyme.API.maxtypeoffset!(2032)


### PR DESCRIPTION
This PR adds the option to "disable" time-step alignment for simulations. This is useful when creating coupled models with nested simulations. In the scenario of nested simulation, we would like the "main" simulation to manage their child simulations. For this, it's useful to ensure that the child simulations do not align their time-steps.

This PR also simplifies `time_step!` and changes its behavior somewhat. After this PR, calling `time_step!(sim)` will always take a time-step; also, only `run!` will be responsible for "stopping" a simulation.

Note that previously, `time_step!(sim)` would _not_ take a time-step if for some reason `sim.running == false` --- but only for the very first time-step. Even if `sim.running == false`, a simulation with `sim.initialized == true` would take a time-step. I think this behvior is a over-complicated and unnecessary. 