### PR TITLE
Implement `time_step!(sim::Simulation, Δt)`

### DIFF
--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -117,6 +117,13 @@ end
 
 const ModelCallsite = Union{TendencyCallsite, UpdateStateCallsite}
 
+""" Step `sim`ulation forward by Δt. """
+function time_step!(sim::Simulation, Δt)
+    sim.Δt = Δt
+    sim.align_time_step = false # ensure time step
+    return time_step!(sim)
+end
+
 """ Step `sim`ulation forward by one time step. """
 function time_step!(sim::Simulation)
 

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -120,7 +120,7 @@ const ModelCallsite = Union{TendencyCallsite, UpdateStateCallsite}
 """ Step `sim`ulation forward by Δt. """
 function time_step!(sim::Simulation, Δt)
     sim.Δt = Δt
-    sim.align_time_step = false # ensure time step
+    sim.align_time_step = false # ensure Δt
     return time_step!(sim)
 end
 

--- a/test/test_simulations.jl
+++ b/test/test_simulations.jl
@@ -189,6 +189,15 @@ function run_basic_simulation_tests(arch)
     @test iteration(simulation) == 4
     @test simulation.Δt == 1
 
+    simulation.stop_time = 5
+    simulation.Δt = 2
+    simulation.align_time_step = true
+    time_step!(simulation, 1)
+    @test !(simulation.align_time_step)
+    @test time(simulation) == 3.2
+    @test iteration(simulation) == 5
+    @test simulation.Δt == 1
+
     return nothing
 end
 


### PR DESCRIPTION
This is needed to implement @simone-silvestri's suggested interface for coupling. Leverages the new ability to ensure a constant time-step by setting `sim.align_time_step = false`.