### PR TITLE
Adds `viscosity(model)` method and similarly for `diffusivity`

### DIFF
--- a/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
@@ -65,6 +65,9 @@ const c = Center()
 viscosity(closure::Tuple, K) = Tuple(viscosity(closure[n], K[n]) for n = 1:length(closure))
 diffusivity(closure::Tuple, K, id) = Tuple(diffusivity(closure[n], K[n], id) for n = 1:length(closure))
 
+viscosity(model) = viscosity(model.closure, model.diffusivity_fields)
+diffusivity(model, id) = diffusivity(model.closure, model.diffusivity_fields, id)
+
 @inline formulation(::AbstractScalarDiffusivity{TD, F}) where {TD, F} = F()
 
 Base.summary(::VerticalFormulation) = "VerticalFormulation"

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -312,9 +312,13 @@ end
                     model = NonhydrostaticModel(; grid, closure, tracers=:c)
                     c = model.tracers.c
                     u = model.velocities.u
+
                     κ = diffusivity(model.closure, model.diffusivity_fields, Val(:c))
+                    @test diffusivity(model, Val(:c)) == diffusivity(model.closure, model.diffusivity_fields, Val(:c))
                     κ_dx_c = κ * ∂x(c)
+
                     ν = viscosity(model.closure, model.diffusivity_fields)
+                    @test viscosity(model) == viscosity(model.closure, model.diffusivity_fields)
                     ν_dx_u = ν * ∂x(u)
                     @test ν_dx_u[1, 1, 1] == 0
                     @test κ_dx_c[1, 1, 1] == 0


### PR DESCRIPTION
Quality of life improvement. Now users can get viscosity and diffusivity of a model simply as

```julia
ν = viscosity(model)
κ = diffusivity(model, Val(:b))
```
instead of having to pass `model.diffusivity_fields` and `model.closure` as separate arguments.