### PR TITLE
Fill halo regions when lagrangian averaging Smagorinsky coefficient

### DIFF
--- a/src/TurbulenceClosures/turbulence_closure_implementations/Smagorinskys/dynamic_coefficient.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/Smagorinskys/dynamic_coefficient.jl
@@ -1,5 +1,6 @@
 using Oceananigans.Architectures: architecture
 using Oceananigans.Fields: interpolate
+using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Statistics
 
 struct DynamicCoefficient{A, FT, S}
@@ -301,6 +302,8 @@ function compute_coefficient_fields!(diffusivity_fields, closure::LagrangianAver
             parent(𝒥ᴸᴹ) .= max(mean(𝒥ᴸᴹ), 𝒥ᴸᴹ_min)
             parent(𝒥ᴹᴹ) .= mean(𝒥ᴹᴹ)
         else
+            fill_halo_regions!(𝒥ᴹᴹ⁻)
+            fill_halo_regions!(𝒥ᴸᴹ⁻)
             launch!(arch, grid, :xyz,
                     _lagrangian_average_LM_MM!, 𝒥ᴸᴹ, 𝒥ᴹᴹ, 𝒥ᴸᴹ⁻, 𝒥ᴹᴹ⁻, 𝒥ᴸᴹ_min, Σ, Σ̄, grid, Δt, u, v, w)
 


### PR DESCRIPTION
At the moment halo regions aren't being filled, so periodicity isn't being properly taken into account when calculating the lagrangian averaging. This PR fixes that.

@glwagner  can you double check that I included it in the right place?