### PR TITLE
Add non-trivial default boundary conditions for `FieldTimeSeries`

### DIFF
--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -24,7 +24,7 @@ using Oceananigans.Units: Time
 using Oceananigans.Utils: launch!
 
 import Oceananigans.Architectures: architecture, on_architecture
-import Oceananigans.BoundaryConditions: fill_halo_regions!, BoundaryCondition, getbc
+import Oceananigans.BoundaryConditions: fill_halo_regions!, BoundaryCondition, getbc, FieldBoundaryConditions
 import Oceananigans.Fields: Field, set!, interior, indices, interpolate!
 
 #####

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -373,7 +373,7 @@ function FieldTimeSeries(loc, grid, times=();
                          path = nothing,
                          name = nothing,
                          time_indexing = Clamp(),
-                         boundary_conditions = nothing,
+                         boundary_conditions = FieldBoundaryConditions(grid, loc),
                          reader_kw = NamedTuple())
 
     LX, LY, LZ = loc

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -1,4 +1,4 @@
-kinclude("dependencies_for_runtests.jl")
+include("dependencies_for_runtests.jl")
 
 using Oceananigans.Utils: Time
 using Oceananigans.Fields: indices, interpolate!

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -1,4 +1,4 @@
-include("dependencies_for_runtests.jl")
+kinclude("dependencies_for_runtests.jl")
 
 using Oceananigans.Utils: Time
 using Oceananigans.Fields: indices, interpolate!
@@ -140,8 +140,11 @@ end
                 @test v3[2] isa Field
             end
 
-            # Tests that we can interpolate
+            # Tests construction + that we can interpolate
             u3i = FieldTimeSeries{Face, Center, Center}(u3.grid, u3.times)
+            @test !isnothing(u3i.boundary_conditions)
+            @test u3i.boundary_conditions isa FieldBoundaryConditions
+            
             interpolate!(u3i, u3)
             @test all(interior(u3i) .≈ interior(u3))
 


### PR DESCRIPTION
These were not add originally because they were not needed, but may be needed now @simone-silvestri 