### PR TITLE
Missing a method for `cpu_interpolating_time_indices`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.95.25"
+version = "0.95.26"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.95.24"
+version = "0.95.25"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -220,8 +220,8 @@ include("ImmersedBoundaries/ImmersedBoundaries.jl")
 include("TimeSteppers/TimeSteppers.jl")
 include("Advection/Advection.jl")
 include("Solvers/Solvers.jl")
-include("OutputReaders/OutputReaders.jl")
 include("DistributedComputations/DistributedComputations.jl")
+include("OutputReaders/OutputReaders.jl")
 include("OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl")
 
 # TODO: move here

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -228,6 +228,10 @@ include("OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl")
 #include("MultiRegion/MultiRegion.jl")
 
 # Physics, time-stepping, and models
+# TODO: move here
+# include("Advection/Advection.jl")
+# include("TimeSteppers/TimeSteppers.jl")
+# include("Solvers/Solvers.jl")
 include("Coriolis/Coriolis.jl")
 include("BuoyancyFormulations/BuoyancyFormulations.jl")
 include("StokesDrifts.jl")

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -1,7 +1,7 @@
 using Oceananigans.Grids: _node
 using Oceananigans.Fields: interpolator, _interpolate, FractionalIndices, flatten_node
 using Oceananigans.Architectures: architecture
-using Oceananigans.DistributedComputations: child_architecture
+using Oceananigans.DistributedComputations: child_architecture, Distributed
 
 import Oceananigans.Fields: interpolate
 

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -1,6 +1,7 @@
 using Oceananigans.Grids: _node
 using Oceananigans.Fields: interpolator, _interpolate, FractionalIndices, flatten_node
 using Oceananigans.Architectures: architecture
+using Oceananigans.DistributedComputations: child_architecture
 
 import Oceananigans.Fields: interpolate
 

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -293,13 +293,15 @@ end
 # for ranges. if `times` is a vector that resides on the GPU, it has to be moved to the CPU for safe indexing.
 # TODO: Copying the whole array is a bit unclean, maybe find a way that avoids the penalty of allocating and copying memory.
 # This would require refactoring `FieldTimeSeries` to include a cpu-allocated times array
-cpu_interpolating_time_indices(::CPU, times, time_indexing, t, arch) = TimeInterpolator(time_indexing, times, t)
+cpu_interpolating_time_indices(::CPU, times, time_indexing, t) = TimeInterpolator(time_indexing, times, t)
 cpu_interpolating_time_indices(::CPU, times::AbstractVector, time_indexing, t) = TimeInterpolator(time_indexing, times, t)
 
 function cpu_interpolating_time_indices(::GPU, times::AbstractVector, time_indexing, t)
     cpu_times = on_architecture(CPU(), times)
     return TimeInterpolator(time_indexing, cpu_times, t)
 end
+
+cpu_interpolating_time_indices(arch::Distributed, args...) = cpu_interpolating_time_indices(child_architecture(arch), args...)
 
 # Fallbacks that do nothing
 update_field_time_series!(fts, time::Time) = nothing


### PR DESCRIPTION
required for distributed simulations with ECCO restoring in `ClimaOcean`