### PR TITLE
Move distributed macros to Oceananigans

### DIFF
--- a/src/DistributedComputations/DistributedComputations.jl
+++ b/src/DistributedComputations/DistributedComputations.jl
@@ -4,8 +4,10 @@ export
     Distributed, Partition, Equal, Fractional, 
     child_architecture, reconstruct_global_grid, partition,
     inject_halo_communication_boundary_conditions,
-    DistributedFFTBasedPoissonSolver
-
+    DistributedFFTBasedPoissonSolver, mpi_initialized, mpi_rank, 
+    mpi_size, global_barrier, global_communicator,
+    @root, @onrank, @distribute, @handshake
+    
 using MPI
 
 using Oceananigans
@@ -14,6 +16,7 @@ using Oceananigans.Grids
 using OffsetArrays
 using CUDA: CuArray
 
+include("distributed_macros.jl")
 include("distributed_architectures.jl")
 include("partition_assemble.jl")
 include("distributed_grids.jl")

--- a/src/DistributedComputations/distributed_macros.jl
+++ b/src/DistributedComputations/distributed_macros.jl
@@ -1,0 +1,156 @@
+using MPI
+
+#####
+##### Handle commands, typically downloading files
+##### which should be executed by only one rank or distributed among ranks
+#####
+
+# Utilities to make the macro work importing only Oceananigans.DistributedComputations and not MPI
+mpi_initialized()     = MPI.Initialized()
+mpi_rank(comm)        = MPI.Comm_rank(comm)
+mpi_size(comm)        = MPI.Comm_size(comm)
+global_barrier(comm)  = MPI.Barrier(comm) 
+global_communicator() = MPI.COMM_WORLD
+
+"""
+    @root communicator exs...
+
+Perform `exs` only on rank 0 in communicator, otherwise known as the "root" rank.
+Other ranks will wait for the root rank to finish before continuing.
+If `communicator` is not provided, `MPI.COMM_WORLD` is used.
+"""
+macro root(communicator, exp)
+    command = quote
+        if Oceananigans.DistributedComputations.mpi_initialized()
+            rank = Oceananigans.DistributedComputations.mpi_rank($communicator)
+            if rank == 0
+                $exp
+            end
+            Oceananigans.DistributedComputations.global_barrier($communicator)
+        else
+            $exp
+        end
+    end
+    return esc(command)
+end
+
+macro root(exp)
+    command = quote
+        @root Oceananigans.DistributedComputations.global_communicator() $exp
+    end
+    return esc(command)
+end
+
+"""
+    @onrank communicator rank exs...
+
+Perform `exp` only on rank `rank` (0-based index) in `communicator`.
+Other ranks will wait for rank `rank` to finish before continuing.
+The expression is run anyways if MPI in not initialized.
+If `communicator` is not provided, `MPI.COMM_WORLD` is used.
+"""
+macro onrank(communicator, on_rank, exp)
+    command = quote
+        mpi_initialized = Oceananigans.DistributedComputations.mpi_initialized()
+        if !mpi_initialized
+            $exp
+        else
+            rank = Oceananigans.DistributedComputations.mpi_rank($communicator)
+            if rank == $on_rank
+                $exp
+            end
+            Oceananigans.DistributedComputations.global_barrier($communicator)
+        end
+    end
+
+    return esc(command)
+end
+
+macro onrank(rank, exp)
+    command = quote
+        @onrank Oceananigans.DistributedComputations.global_communicator() $rank $exp
+    end
+    return esc(command)
+end
+
+""" 
+    @distribute communicator for i in iterable
+        ...
+    end
+
+Distribute a `for` loop among different ranks in `communicator`.
+If `communicator` is not provided, `MPI.COMM_WORLD` is used.
+"""
+macro distribute(communicator, exp)
+    if exp.head != :for
+        error("The `@distribute` macro expects a `for` loop")
+    end
+
+    iterable = exp.args[1].args[2]
+    variable = exp.args[1].args[1]
+    forbody  = exp.args[2]
+
+    # Safety net if the iterable variable has the same name as the 
+    # reserved variable names (nprocs, counter, rank)
+    nprocs  = ifelse(variable == :nprocs,  :othernprocs,  :nprocs)
+    counter = ifelse(variable == :counter, :othercounter, :counter)
+    rank    = ifelse(variable == :rank,    :otherrank,    :rank)
+
+    new_loop = quote
+        mpi_initialized = Oceananigans.DistributedComputations.mpi_initialized()
+        if !mpi_initialized
+            $exp
+        else
+            $rank   = Oceananigans.DistributedComputations.mpi_rank($communicator)
+            $nprocs = Oceananigans.DistributedComputations.mpi_size($communicator)
+            for ($counter, $variable) in enumerate($iterable)
+                if ($counter - 1) % $nprocs == $rank
+                    $forbody
+                end
+            end
+            Oceananigans.DistributedComputations.global_barrier($communicator)
+        end
+    end
+
+    return esc(new_loop)
+end
+
+macro distribute(exp)
+    command = quote
+        @distribute Oceananigans.DistributedComputations.global_communicator() $exp
+    end
+    return esc(command)
+end
+
+"""
+    @handshake communicator exs...
+
+perform `exs` on all ranks in `communicator`, but only one rank at a time, where
+ranks `r2 > r1` wait for rank `r1` to finish before executing `exs`.
+If `communicator` is not provided, `MPI.COMM_WORLD` is used.
+"""
+macro handshake(communicator, exp)
+    command = quote
+        mpi_initialized = Oceananigans.DistributedComputations.mpi_initialized()
+        if !mpi_initialized
+            $exp
+        else
+            rank   = Oceananigans.DistributedComputations.mpi_rank($communicator)
+            nprocs = Oceananigans.DistributedComputations.mpi_size($communicator)
+            for r in 0 : nprocs -1
+                if rank == r
+                    $exp
+                end
+                Oceananigans.DistributedComputations.global_barrier($communicator)
+            end
+        end
+    end
+    return esc(command)
+end
+
+macro handshake(exp)
+    command = quote
+        @handshake Oceananigans.DistributedComputations.global_communicator() $exp
+    end
+    return esc(command)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,6 +182,7 @@ CUDA.allowscalar() do
         reset_cuda_if_necessary()
         include("test_distributed_transpose.jl")
         include("test_distributed_poisson_solvers.jl")
+        include("test_distributed_macros.jl")
     end
 
     if group == :distributed_hydrostatic_model || group == :all

--- a/test/test_distributed_macros.jl
+++ b/test/test_distributed_macros.jl
@@ -1,0 +1,59 @@
+using MPI
+using Oceananigans.DistributedComputations
+
+@testset begin
+    rank = MPI.Comm_rank(MPI.COMM_WORLD)
+
+    @onrank 0 begin
+        @test rank == 0
+    end
+
+    @root begin
+        @test rank == 0
+    end
+
+    @onrank 1 begin
+        @test rank == 1
+    end
+
+    @onrank 2 begin
+        @test rank == 2
+    end
+
+    @onrank 3 begin
+        @test rank == 3
+    end
+
+    a = Int[]
+    
+    @distribute for i in 1:10
+        push!(a, i)
+    end
+
+    @root begin
+        @test a == [1, 5, 9]
+    end
+
+    @onrank 1 begin
+        @test a == [2, 6, 10]
+    end
+
+    @onrank 2 begin
+        @test a == [3, 7]
+    end
+
+    @onrank 3 begin
+        @test a == [4, 8]
+    end
+
+    split_comm = MPI.Comm_split(MPI.COMM_WORLD, rank % 2, rank)
+
+    a = Int[]
+    
+    @distribute split_comm for i in 1:10
+        push!(a, i)
+    end
+
+    @onrank split_comm 0 @test a == [1, 3, 5, 7, 9]
+    @onrank split_comm 1 @test a == [2, 4, 6, 8, 10]
+end


### PR DESCRIPTION
We have distributed macros in ClimaOcean.jl, but they are not ClimaOcean-specific, so they should live in Oceananigans.