### PR TITLE
Rename output writers to `JLD2Writer` and `NetCDFWriter`

### DIFF
--- a/docs/src/model_setup/lagrangian_particles.md
+++ b/docs/src/model_setup/lagrangian_particles.md
@@ -120,7 +120,7 @@ model = NonhydrostaticModel(; grid, particles=lagrangian_particles)
 ```
 
 ```@example particles
-JLD2OutputWriter(model, (; particles=model.particles), filename="particles", schedule=TimeInterval(15))
+JLD2Writer(model, (; particles=model.particles), filename="particles", schedule=TimeInterval(15))
 ```
 
 When writing to NetCDF you should write particles to a separate file as the NetCDF dimensions differ for

--- a/docs/src/model_setup/output_writers.md
+++ b/docs/src/model_setup/output_writers.md
@@ -4,17 +4,17 @@
 `Oceananigans` provides three ways to write output:
 
 1. [`NetCDFOutputWriter`](@ref) for output of arrays and scalars that uses [NCDatasets.jl](https://github.com/Alexander-Barth/NCDatasets.jl)
-2. [`JLD2OutputWriter`](@ref) for arbitrary julia data structures that uses [JLD2.jl](https://github.com/JuliaIO/JLD2.jl)
+2. [`JLD2Writer`](@ref) for arbitrary julia data structures that uses [JLD2.jl](https://github.com/JuliaIO/JLD2.jl)
 3. [`Checkpointer`](@ref) that automatically saves as much model data as possible, using [JLD2.jl](https://github.com/JuliaIO/JLD2.jl)
 
 The `Checkpointer` is discussed in detail on a separate [section](@ref checkpointing) of the documentation.
 
 ## Basic usage
 
-[`NetCDFOutputWriter`](@ref) and [`JLD2OutputWriter`](@ref) require four inputs:
+[`NetCDFOutputWriter`](@ref) and [`JLD2Writer`](@ref) require four inputs:
 
 1. The `model` from which output data is sourced (required to initialize the `OutputWriter`).
-2. A key-value pairing of output "names" and "output" objects. `JLD2OutputWriter` accepts `NamedTuple`s and `Dict`s;
+2. A key-value pairing of output "names" and "output" objects. `JLD2Writer` accepts `NamedTuple`s and `Dict`s;
    `NetCDFOutputWriter` accepts `Dict`s with string-valued keys. Output objects are either `AbstractField`s or
    functions that return data when called via `func(model)`.
 3. A `schedule` on which output is written. `TimeInterval`, `IterationInterval`, `WallTimeInterval` schedule
@@ -34,7 +34,7 @@ Other important keyword arguments are
 Once an `OutputWriter` is created, it can be used to write output by adding it the
 ordered dictionary `simulation.output_writers`. prior to calling `run!(simulation)`.
 
-More specific detail about the `NetCDFOutputWriter` and `JLD2OutputWriter` is given below.
+More specific detail about the `NetCDFOutputWriter` and `JLD2Writer` is given below.
 
 !!! tip "Time step alignment and output writing"
     Oceananigans simulations will shorten the time step as needed to align model output with each
@@ -153,7 +153,7 @@ JLD2 is a fast HDF5 compatible file format written in pure Julia.
 JLD2 files can be opened in Julia with the [JLD2.jl](https://github.com/JuliaIO/JLD2.jl) package
 and in Python with the [h5py](https://www.h5py.org/) package.
 
-The `JLD2OutputWriter` receives either a `Dict`ionary or `NamedTuple` containing
+The `JLD2Writer` receives either a `Dict`ionary or `NamedTuple` containing
 `name, output` pairs. The `name` can be a symbol or string. The `output` must either be
 an `AbstractField` or a function called with `func(model)` that returns arbitrary output.
 Whenever output needs to be written, the functions will be called and the output
@@ -180,27 +180,27 @@ end
 c_avg = Field(Average(model.tracers.c, dims=(1, 2)))
 
 # Note that model.velocities is NamedTuple
-simulation.output_writers[:velocities] = JLD2OutputWriter(model, model.velocities,
-                                                          filename = "some_more_data.jld2",
-                                                          schedule = TimeInterval(20minute),
-                                                          init = init_save_some_metadata!)
+simulation.output_writers[:velocities] = JLD2Writer(model, model.velocities,
+                                                    filename = "some_more_data.jld2",
+                                                    schedule = TimeInterval(20minute),
+                                                    init = init_save_some_metadata!)
 ```
 
 and a time- and horizontal-average of tracer `c` every 20 minutes of simulation time
 to a file called `some_more_averaged_data.jld2`
 
 ```@example jld2_output_writer
-simulation.output_writers[:avg_c] = JLD2OutputWriter(model, (; c=c_avg),
+simulation.output_writers[:avg_c] = JLD2Writer(model, (; c=c_avg),
                                                      filename = "some_more_averaged_data.jld2",
                                                      schedule = AveragedTimeInterval(20minute, window=5minute))
 ```
 
-See [`JLD2OutputWriter`](@ref) for more information.
+See [`JLD2Writer`](@ref) for more information.
 
 ## Time-averaged output
 
 Time-averaged output is specified by setting the `schedule` keyword argument for either `NetCDFOutputWriter` or
-`JLD2OutputWriter` to [`AveragedTimeInterval`](@ref).
+`JLD2Writer` to [`AveragedTimeInterval`](@ref).
 
 With `AveragedTimeInterval`, the time-average of ``a`` is taken as a left Riemann sum corresponding to
 
@@ -237,7 +237,7 @@ model = NonhydrostaticModel(grid=RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1
 
 simulation = Simulation(model, Δt=10minutes, stop_time=30days)
 
-simulation.output_writers[:velocities] = JLD2OutputWriter(model, model.velocities,
-                                                          filename = "even_more_averaged_velocity_data.jld2",
-                                                          schedule = AveragedTimeInterval(4days, window=1day, stride=2))
+simulation.output_writers[:velocities] = JLD2Writer(model, model.velocities,
+                                                    filename = "even_more_averaged_velocity_data.jld2",
+                                                    schedule = AveragedTimeInterval(4days, window=1day, stride=2))
 ```

--- a/examples/baroclinic_adjustment.jl
+++ b/examples/baroclinic_adjustment.jl
@@ -146,17 +146,17 @@ slicers = (east = (grid.Nx, :, :),
 for side in keys(slicers)
     indices = slicers[side]
 
-    simulation.output_writers[side] = JLD2OutputWriter(model, (; b, ζ);
-                                                       filename = filename * "_$(side)_slice",
-                                                       schedule = TimeInterval(save_fields_interval),
-                                                       overwrite_existing = true,
-                                                       indices)
+    simulation.output_writers[side] = JLD2Writer(model, (; b, ζ);
+                                                 filename = filename * "_$(side)_slice",
+                                                 schedule = TimeInterval(save_fields_interval),
+                                                 overwrite_existing = true,
+                                                 indices)
 end
 
-simulation.output_writers[:zonal] = JLD2OutputWriter(model, (; b=B, u=U, v=V);
-                                                     filename = filename * "_zonal_average",
-                                                     schedule = TimeInterval(save_fields_interval),
-                                                     overwrite_existing = true)
+simulation.output_writers[:zonal] = JLD2Writer(model, (; b=B, u=U, v=V);
+                                               filename = filename * "_zonal_average",
+                                               schedule = TimeInterval(save_fields_interval),
+                                               overwrite_existing = true)
 
 # Now we're ready to _run_.
 

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -171,7 +171,7 @@ progress(sim) = @printf("Iteration: %d, time: %s, Δt: %s\n",
 
 add_callback!(simulation, progress, IterationInterval(100))
 
-# and a basic `JLD2OutputWriter` that writes velocities and both
+# and a basic `JLD2Writer` that writes velocities and both
 # the two-dimensional and horizontally-averaged plankton concentration,
 
 outputs = (w = model.velocities.w,
@@ -179,10 +179,10 @@ outputs = (w = model.velocities.w,
            avg_P = Average(model.tracers.P, dims=(1, 2)))
 
 simulation.output_writers[:simple_output] =
-    JLD2OutputWriter(model, outputs,
-                     schedule = TimeInterval(20minutes),
-                     filename = "convecting_plankton.jld2",
-                     overwrite_existing = true)
+    JLD2Writer(model, outputs,
+               schedule = TimeInterval(20minutes),
+               filename = "convecting_plankton.jld2",
+               overwrite_existing = true)
 
 # !!! info "Using multiple output writers"
 #     Because each output writer is associated with a single output `schedule`,

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -98,7 +98,7 @@ model = NonhydrostaticModel(; grid,
 
 # ## Simulation set-up
 #
-# We set up a simulation that runs up to ``t = 40`` with a `JLD2OutputWriter` that saves the flow
+# We set up a simulation that runs up to ``t = 40`` with a `JLD2Writer` that saves the flow
 # speed, ``\sqrt{u^2 + w^2}``, the buoyancy, ``b``, and the vorticity, ``\partial_z u - \partial_x w``.
 
 simulation = Simulation(model, Δt=1e-2, stop_time=40.0)
@@ -136,20 +136,20 @@ s = @at (Center, Center, Center) sqrt(u^2 + w^2)
 ζ = ∂z(u) - ∂x(w)
 nothing #hide
 
-# We create a `JLD2OutputWriter` that saves the speed, and the vorticity. Because we want
+# We create a `JLD2Writer` that saves the speed, and the vorticity. Because we want
 # to post-process buoyancy and compute the buoyancy variance dissipation (which is proportional
 # to ``|\boldsymbol{\nabla} b|^2``) we use the `with_halos = true`. This way, the halos for
 # the fields are saved and thus when we load them as fields they will come with the proper
 # boundary conditions.
 #
-# We then add the `JLD2OutputWriter` to the `simulation`.
+# We then add the `JLD2Writer` to the `simulation`.
 
 saved_output_filename = "horizontal_convection.jld2"
 
-simulation.output_writers[:fields] = JLD2OutputWriter(model, (; s, b, ζ),
-                                                      schedule = TimeInterval(0.5),
-                                                      filename = saved_output_filename,
-                                                      with_halos = true,
+simulation.output_writers[:fields] = JLD2Writer(model, (; s, b, ζ),
+                                                schedule = TimeInterval(0.5),
+                                                filename = saved_output_filename,
+                                                with_halos = true,
                                                       overwrite_existing = true)
 nothing #hide
 

--- a/examples/internal_tide.jl
+++ b/examples/internal_tide.jl
@@ -180,10 +180,10 @@ N² = ∂z(b)
 filename = "internal_tide"
 save_fields_interval = 30minutes
 
-simulation.output_writers[:fields] = JLD2OutputWriter(model, (; u, u′, w, b, N²);
-                                                      filename,
-                                                      schedule = TimeInterval(save_fields_interval),
-                                                      overwrite_existing = true)
+simulation.output_writers[:fields] = JLD2Writer(model, (; u, u′, w, b, N²);
+                                                filename,
+                                                schedule = TimeInterval(save_fields_interval),
+                                                overwrite_existing = true)
 
 # We are ready -- let's run!
 

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -121,9 +121,9 @@ simulation = Simulation(model, Δt = 0.1 * 2π/ω, stop_iteration = 20)
 # and add an output writer that saves the vertical velocity field every two iterations:
 
 filename = "internal_wave.jld2"
-simulation.output_writers[:velocities] = JLD2OutputWriter(model, model.velocities; filename,
-                                                          schedule = IterationInterval(1),
-                                                          overwrite_existing = true)
+simulation.output_writers[:velocities] = JLD2Writer(model, model.velocities; filename,
+                                                    schedule = IterationInterval(1),
+                                                    overwrite_existing = true)
 
 # With initial conditions set and an output writer at the ready, we run the simulation
 

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -379,10 +379,10 @@ total_vorticity = Field(∂z(u) + ∂z(model.background_fields.velocities.u) - �
 total_b = Field(b + model.background_fields.tracers.b)
 
 simulation.output_writers[:vorticity] =
-    JLD2OutputWriter(model, (ω=perturbation_vorticity, Ω=total_vorticity, b=b, B=total_b, KE=mean_perturbation_kinetic_energy),
-                     schedule = TimeInterval(0.10 / estimated_growth_rate),
-                     filename = "kelvin_helmholtz_instability.jld2",
-                     overwrite_existing = true)
+    JLD2Writer(model, (ω=perturbation_vorticity, Ω=total_vorticity, b=b, B=total_b, KE=mean_perturbation_kinetic_energy),
+               schedule = TimeInterval(0.10 / estimated_growth_rate),
+               filename = "kelvin_helmholtz_instability.jld2",
+               overwrite_existing = true)
 
 # And now we...
 

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -205,10 +205,10 @@ output_interval = 5minutes
 fields_to_output = merge(model.velocities, model.tracers, (; νₑ=model.diffusivity_fields.νₑ))
 
 simulation.output_writers[:fields] =
-    JLD2OutputWriter(model, fields_to_output,
-                     schedule = TimeInterval(output_interval),
-                     filename = "langmuir_turbulence_fields.jld2",
-                     overwrite_existing = true)
+    JLD2Writer(model, fields_to_output,
+               schedule = TimeInterval(output_interval),
+               filename = "langmuir_turbulence_fields.jld2",
+               overwrite_existing = true)
 
 # ### An "averages" writer
 #
@@ -225,10 +225,10 @@ wu = Average(w * u, dims=(1, 2))
 wv = Average(w * v, dims=(1, 2))
 
 simulation.output_writers[:averages] =
-    JLD2OutputWriter(model, (; U, V, B, wu, wv),
-                     schedule = AveragedTimeInterval(output_interval, window=2minutes),
-                     filename = "langmuir_turbulence_averages.jld2",
-                     overwrite_existing = true)
+    JLD2Writer(model, (; U, V, B, wu, wv),
+               schedule = AveragedTimeInterval(output_interval, window=2minutes),
+               filename = "langmuir_turbulence_averages.jld2",
+               overwrite_existing = true)
 
 # ## Running the simulation
 #

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -203,9 +203,9 @@ add_callback!(simulation, progress_message, IterationInterval(20))
 
 # ## Output
 #
-# We use the `JLD2OutputWriter` to save ``x, z`` slices of the velocity fields,
+# We use the `JLD2Writer` to save ``x, z`` slices of the velocity fields,
 # tracer fields, and eddy diffusivities. The `prefix` keyword argument
-# to `JLD2OutputWriter` indicates that output will be saved in
+# to `JLD2Writer` indicates that output will be saved in
 # `ocean_wind_mixing_and_convection.jld2`.
 
 ## Create a NamedTuple with eddy viscosity
@@ -214,11 +214,11 @@ eddy_viscosity = (; νₑ = model.diffusivity_fields.νₑ)
 filename = "ocean_wind_mixing_and_convection"
 
 simulation.output_writers[:slices] =
-    JLD2OutputWriter(model, merge(model.velocities, model.tracers, eddy_viscosity),
-                     filename = filename * ".jld2",
-                     indices = (:, grid.Ny/2, :),
-                     schedule = TimeInterval(1minute),
-                     overwrite_existing = true)
+    JLD2Writer(model, merge(model.velocities, model.tracers, eddy_viscosity),
+               filename = filename * ".jld2",
+               indices = (:, grid.Ny/2, :),
+               schedule = TimeInterval(1minute),
+               overwrite_existing = true)
 
 # We're ready:
 

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -106,13 +106,13 @@ axislegend()
 current_figure() #hide
 
 # Very interesting! Next, we run the simulation a bit longer and make an animation.
-# For this, we use the `JLD2OutputWriter` to write data to disk as the simulation progresses.
+# For this, we use the `JLD2Writer` to write data to disk as the simulation progresses.
 
 simulation.output_writers[:temperature] =
-    JLD2OutputWriter(model, model.tracers,
-                     filename = "one_dimensional_diffusion.jld2",
-                     schedule=IterationInterval(100),
-                     overwrite_existing = true)
+    JLD2Writer(model, model.tracers,
+               filename = "one_dimensional_diffusion.jld2",
+               schedule=IterationInterval(100),
+               overwrite_existing = true)
 
 # We run the simulation for 10,000 more iterations,
 

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -106,10 +106,10 @@ s = sqrt(u^2 + v^2)
 # We pass these operations to an output writer below to calculate and output them during the simulation.
 filename = "two_dimensional_turbulence"
 
-simulation.output_writers[:fields] = JLD2OutputWriter(model, (; ω, s),
-                                                      schedule = TimeInterval(0.6),
-                                                      filename = filename * ".jld2",
-                                                      overwrite_existing = true)
+simulation.output_writers[:fields] = JLD2Writer(model, (; ω, s),
+                                                schedule = TimeInterval(0.6),
+                                                filename = filename * ".jld2",
+                                                overwrite_existing = true)
 
 # ## Running the simulation
 #

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -96,7 +96,7 @@ export
     CFL, AdvectiveCFL, DiffusiveCFL,
 
     # Output writers
-    NetCDFOutputWriter, JLD2OutputWriter, Checkpointer,
+    NetCDFOutputWriter, JLD2Writer, Checkpointer,
     TimeInterval, IterationInterval, WallTimeInterval, AveragedTimeInterval,
     SpecifiedTimes, FileSizeLimit, AndSchedule, OrSchedule, written_names,
 

--- a/src/OutputWriters/OutputWriters.jl
+++ b/src/OutputWriters/OutputWriters.jl
@@ -1,7 +1,7 @@
 module OutputWriters
 
 export
-    JLD2OutputWriter, NetCDFOutputWriter, written_names,
+    JLD2Writer, NetCDFOutputWriter, written_names,
     Checkpointer, WindowedTimeAverage, FileSizeLimit,
     TimeInterval, IterationInterval, WallTimeInterval, AveragedTimeInterval
 

--- a/src/OutputWriters/jld2_output_writer.jl
+++ b/src/OutputWriters/jld2_output_writer.jl
@@ -9,7 +9,7 @@ default_included_properties(::NonhydrostaticModel) = [:grid, :coriolis, :buoyanc
 default_included_properties(::ShallowWaterModel) = [:grid, :coriolis, :closure]
 default_included_properties(::HydrostaticFreeSurfaceModel) = [:grid, :coriolis, :buoyancy, :closure]
 
-mutable struct JLD2OutputWriter{O, T, D, IF, IN, FS, KW} <: AbstractOutputWriter
+mutable struct JLD2Writer{O, T, D, IF, IN, FS, KW} <: AbstractOutputWriter
     filepath :: String
     outputs :: O
     schedule :: T
@@ -24,23 +24,23 @@ mutable struct JLD2OutputWriter{O, T, D, IF, IN, FS, KW} <: AbstractOutputWriter
 end
 
 noinit(args...) = nothing
-ext(::Type{JLD2OutputWriter}) = ".jld2"
+ext(::Type{JLD2Writer}) = ".jld2"
 
 """
-    JLD2OutputWriter(model, outputs; filename, schedule,
-                     dir = ".",
-                     indices = (:, :, :),
-                     with_halos = true,
-                     array_type = Array{Float32},
-                     file_splitting = NoFileSplitting(),
-                     overwrite_existing = false,
-                     init = noinit,
-                     including = [:grid, :coriolis, :buoyancy, :closure],
-                     verbose = false,
-                     part = 1,
-                     jld2_kw = Dict{Symbol, Any}())
+    JLD2Writer(model, outputs; filename, schedule,
+               dir = ".",
+               indices = (:, :, :),
+               with_halos = true,
+               array_type = Array{Float32},
+               file_splitting = NoFileSplitting(),
+               overwrite_existing = false,
+               init = noinit,
+               including = [:grid, :coriolis, :buoyancy, :closure],
+               verbose = false,
+               part = 1,
+               jld2_kw = Dict{Symbol, Any}())
 
-Construct a `JLD2OutputWriter` for an Oceananigans `model` that writes `label, output` pairs
+Construct a `JLD2Writer` for an Oceananigans `model` that writes `label, output` pairs
 in `outputs` to a JLD2 file.
 
 The argument `outputs` may be a `Dict` or `NamedTuple`. The keys of `outputs` are symbols or
@@ -127,33 +127,33 @@ end
 c_avg =  Field(Average(model.tracers.c, dims=(1, 2)))
 
 # Note that model.velocities is NamedTuple
-simulation.output_writers[:velocities] = JLD2OutputWriter(model, model.velocities,
-                                                          filename = "some_data.jld2",
-                                                          schedule = TimeInterval(20minute),
-                                                          init = init_save_some_metadata!)
+simulation.output_writers[:velocities] = JLD2Writer(model, model.velocities,
+                                                    filename = "some_data.jld2",
+                                                    schedule = TimeInterval(20minute),
+                                                    init = init_save_some_metadata!)
 ```
 
 and a time- and horizontal-average of tracer ``c`` every 20 minutes of simulation time
 to a file called `some_averaged_data.jld2`
 
 ```@example
-simulation.output_writers[:avg_c] = JLD2OutputWriter(model, (; c=c_avg),
-                                                     filename = "some_averaged_data.jld2",
-                                                     schedule = AveragedTimeInterval(20minute, window=5minute))
+simulation.output_writers[:avg_c] = JLD2Writer(model, (; c=c_avg),
+                                               filename = "some_averaged_data.jld2",
+                                               schedule = AveragedTimeInterval(20minute, window=5minute))
 ```
 """
-function JLD2OutputWriter(model, outputs; filename, schedule,
-                          dir = ".",
-                          indices = (:, :, :),
-                          with_halos = true,
-                          array_type = Array{Float32},
-                          file_splitting = NoFileSplitting(),
-                          overwrite_existing = false,
-                          init = noinit,
-                          including = default_included_properties(model),
-                          verbose = false,
-                          part = 1,
-                          jld2_kw = Dict{Symbol, Any}())
+function JLD2Writer(model, outputs; filename, schedule,
+                    dir = ".",
+                    indices = (:, :, :),
+                    with_halos = true,
+                    array_type = Array{Float32},
+                    file_splitting = NoFileSplitting(),
+                    overwrite_existing = false,
+                    init = noinit,
+                    including = default_included_properties(model),
+                    verbose = false,
+                    part = 1,
+                    jld2_kw = Dict{Symbol, Any}())
 
     mkpath(dir)
     filename = auto_extension(filename, ".jld2")
@@ -172,8 +172,8 @@ function JLD2OutputWriter(model, outputs; filename, schedule,
 
     initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, model)
 
-    return JLD2OutputWriter(filepath, outputs, schedule, array_type, init,
-                            including, part, file_splitting, overwrite_existing, verbose, jld2_kw)
+    return JLD2Writer(filepath, outputs, schedule, array_type, init,
+                      including, part, file_splitting, overwrite_existing, verbose, jld2_kw)
 end
 
 function initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, model)
@@ -213,7 +213,7 @@ function initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, mode
     return nothing
 end
 
-initialize_jld2_file!(writer::JLD2OutputWriter, model) =
+initialize_jld2_file!(writer::JLD2Writer, model) =
     initialize_jld2_file!(writer.filepath, writer.init, writer.jld2_kw, writer.including, writer.outputs, model)
 
 function iteration_exists(filepath, iter=0)
@@ -232,7 +232,7 @@ function iteration_exists(filepath, iter=0)
     return zero_exists
 end
 
-function write_output!(writer::JLD2OutputWriter, model)
+function write_output!(writer::JLD2Writer, model)
 
     verbose = writer.verbose
     current_iteration = model.clock.iteration
@@ -295,7 +295,7 @@ function jld2output!(path, iter, time, data, kwargs)
     return nothing
 end
 
-function start_next_file(model, writer::JLD2OutputWriter)
+function start_next_file(model, writer::JLD2Writer)
     verbose = writer.verbose
 
     verbose && @info begin
@@ -320,15 +320,15 @@ function start_next_file(model, writer::JLD2OutputWriter)
     return nothing
 end
 
-Base.summary(ow::JLD2OutputWriter) =
-    string("JLD2OutputWriter writing ", prettykeys(ow.outputs), " to ", ow.filepath, " on ", summary(ow.schedule))
+Base.summary(ow::JLD2Writer) =
+    string("JLD2Writer writing ", prettykeys(ow.outputs), " to ", ow.filepath, " on ", summary(ow.schedule))
 
-function Base.show(io::IO, ow::JLD2OutputWriter)
+function Base.show(io::IO, ow::JLD2Writer)
 
     averaging_schedule = output_averaging_schedule(ow)
     Noutputs = length(ow.outputs)
 
-    print(io, "JLD2OutputWriter scheduled on $(summary(ow.schedule)):", "\n",
+    print(io, "JLD2Writer scheduled on $(summary(ow.schedule)):", "\n",
               "├── filepath: ", relpath(ow.filepath), "\n",
               "├── $Noutputs outputs: ", prettykeys(ow.outputs), show_averaging_schedule(averaging_schedule), "\n",
               "├── array type: ", show_array_type(ow.array_type), "\n",

--- a/src/OutputWriters/windowed_time_average.jl
+++ b/src/OutputWriters/windowed_time_average.jl
@@ -68,9 +68,9 @@ model = NonhydrostaticModel(grid=RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1
 
 simulation = Simulation(model, Δt=10minutes, stop_time=30days)
 
-simulation.output_writers[:velocities] = JLD2OutputWriter(model, model.velocities,
-                                                          filename= "averaged_velocity_data.jld2",
-                                                          schedule = AveragedTimeInterval(4days, window=2days, stride=2))
+simulation.output_writers[:velocities] = JLD2Writer(model, model.velocities,
+                                                    filename= "averaged_velocity_data.jld2",
+                                                    schedule = AveragedTimeInterval(4days, window=2days, stride=2))
 ```
 """
 function AveragedTimeInterval(interval; window=interval, stride=1)

--- a/test/regression_tests/hydrostatic_free_turbulence_regression_test.jl
+++ b/test/regression_tests/hydrostatic_free_turbulence_regression_test.jl
@@ -94,12 +94,12 @@ function run_hydrostatic_free_turbulence_regression_test(grid, free_surface; reg
         
         directory =  joinpath(dirname(@__FILE__), "data")
         outputs   = (; u, v, w, η)
-        simulation.output_writers[:fields] = JLD2OutputWriter(model, outputs,
-                                                              dir = directory,
-                                                              schedule = IterationInterval(stop_iteration),
-                                                              filename = output_filename,
-                                                              with_halos = true,
-                                                              overwrite_existing = true)
+        simulation.output_writers[:fields] = JLD2Writer(model, outputs,
+                                                        dir = directory,
+                                                        schedule = IterationInterval(stop_iteration),
+                                                        filename = output_filename,
+                                                        with_halos = true,
+                                                        overwrite_existing = true)
     end
    
     # Let's gooooooo!

--- a/test/test_jld2_output_writer.jl
+++ b/test/test_jld2_output_writer.jl
@@ -3,7 +3,7 @@ include("dependencies_for_runtests.jl")
 using Oceananigans.Fields: FunctionField
 
 #####
-##### JLD2OutputWriter tests
+##### JLD2Writer tests
 #####
 
 function jld2_sliced_field_output(model, outputs=model.velocities)
@@ -17,13 +17,13 @@ function jld2_sliced_field_output(model, outputs=model.velocities)
 
     simulation = Simulation(model, Δt=1.0, stop_iteration=1)
 
-    simulation.output_writers[:velocities] = JLD2OutputWriter(model, outputs,
-                                                              schedule = TimeInterval(1),
-                                                              indices = (1:2, 1:4, :),
-                                                              with_halos = false,
-                                                              dir = ".",
-                                                              filename = "test.jld2",
-                                                              overwrite_existing = true)
+    simulation.output_writers[:velocities] = JLD2Writer(model, outputs,
+                                                        schedule = TimeInterval(1),
+                                                        indices = (1:2, 1:4, :),
+                                                        with_halos = false,
+                                                        dir = ".",
+                                                        filename = "test.jld2",
+                                                        overwrite_existing = true)
 
     run!(simulation)
 
@@ -49,16 +49,16 @@ function test_jld2_size_file_splitting(arch)
         file["boundary_conditions/fake"] = π
     end
 
-    ow = JLD2OutputWriter(model, (; u=model.velocities.u);
-                          dir = ".",
-                          filename = "test.jld2",
-                          schedule = IterationInterval(1),
-                          init = fake_bc_init,
-                          including = [:grid],
-                          array_type = Array{Float64},
-                          with_halos = true,
-                          file_splitting = FileSizeLimit(200KiB),
-                          overwrite_existing = true)
+    ow = JLD2Writer(model, (; u=model.velocities.u);
+                    dir = ".",
+                    filename = "test.jld2",
+                    schedule = IterationInterval(1),
+                    init = fake_bc_init,
+                    including = [:grid],
+                    array_type = Array{Float64},
+                    with_halos = true,
+                    file_splitting = FileSizeLimit(200KiB),
+                    overwrite_existing = true)
 
     push!(simulation.output_writers, ow)
 
@@ -97,16 +97,16 @@ function test_jld2_time_file_splitting(arch)
         file["boundary_conditions/fake"] = π
     end
 
-    ow = JLD2OutputWriter(model, (; u=model.velocities.u);
-                          dir = ".",
-                          filename = "test",
-                          schedule = IterationInterval(1),
-                          init = fake_bc_init,
-                          including = [:grid],
-                          array_type = Array{Float64},
-                          with_halos = true,
-                          file_splitting = TimeInterval(3seconds),
-                          overwrite_existing = true)
+    ow = JLD2Writer(model, (; u=model.velocities.u);
+                    dir = ".",
+                    filename = "test",
+                    schedule = IterationInterval(1),
+                    init = fake_bc_init,
+                    including = [:grid],
+                    array_type = Array{Float64},
+                    with_halos = true,
+                    file_splitting = TimeInterval(3seconds),
+                    overwrite_existing = true)
 
     push!(simulation.output_writers, ow)
 
@@ -154,12 +154,12 @@ function test_jld2_time_averaging_of_horizontal_averages(model)
                       uv = Field(Average(u * v, dims=(1, 2))),
                       wT = Field(Average(w * T, dims=(1, 2))))
 
-    simulation.output_writers[:fluxes] = JLD2OutputWriter(model, average_fluxes,
-                                                          schedule = AveragedTimeInterval(4Δt, window=2Δt),
-                                                          dir = ".",
-                                                          with_halos = false,
-                                                          filename = "jld2_time_averaging_test.jld2",
-                                                          overwrite_existing = true)
+    simulation.output_writers[:fluxes] = JLD2Writer(model, average_fluxes,
+                                                    schedule = AveragedTimeInterval(4Δt, window=2Δt),
+                                                    dir = ".",
+                                                    with_halos = false,
+                                                    filename = "jld2_time_averaging_test.jld2",
+                                                    overwrite_existing = true)
 
     run!(simulation)
 
@@ -226,13 +226,13 @@ function test_jld2_time_averaging(arch)
             jld2_outputs = Dict("c1" => ∫c1_dxdy, "c2" => ∫c2_dxdy)
             horizontal_average_jld2_filepath = "decay_averaged_field_test.jld2"
 
-            simulation.output_writers[:horizontal_average] = JLD2OutputWriter(model,
-                                                                              jld2_outputs,
-                                                                              schedule = TimeInterval(10Δt),
-                                                                              dir = ".",
-                                                                              with_halos = false,
-                                                                              filename = horizontal_average_jld2_filepath,
-                                                                              overwrite_existing = true)
+            simulation.output_writers[:horizontal_average] = JLD2Writer(model,
+                                                                        jld2_outputs,
+                                                                        schedule = TimeInterval(10Δt),
+                                                                        dir = ".",
+                                                                        with_halos = false,
+                                                                        filename = horizontal_average_jld2_filepath,
+                                                                        overwrite_existing = true)
 
             multiple_time_average_jld2_filepath = "decay_windowed_time_average_test.jld2"
             single_time_average_jld2_filepath = "single_decay_windowed_time_average_test.jld2"
@@ -240,21 +240,21 @@ function test_jld2_time_averaging(arch)
 
             single_jld2_output = Dict("c1" => ∫c1_dxdy)
 
-            simulation.output_writers[:single_output_time_average] = JLD2OutputWriter(model,
-                                                                                      single_jld2_output,
-                                                                                      schedule = AveragedTimeInterval(10Δt, window = window, stride = stride),
-                                                                                      dir = ".",
-                                                                                      with_halos = false,
-                                                                                      filename = single_time_average_jld2_filepath,
-                                                                                      overwrite_existing = true)
+            simulation.output_writers[:single_output_time_average] = JLD2Writer(model,
+                                                                                single_jld2_output,
+                                                                                schedule = AveragedTimeInterval(10Δt, window = window, stride = stride),
+                                                                                dir = ".",
+                                                                                with_halos = false,
+                                                                                filename = single_time_average_jld2_filepath,
+                                                                                overwrite_existing = true)
 
-            simulation.output_writers[:multiple_output_time_average] = JLD2OutputWriter(model,
-                                                                                        jld2_outputs,
-                                                                                        schedule = AveragedTimeInterval(10Δt, window = window, stride = stride),
-                                                                                        dir = ".",
-                                                                                        with_halos = false,
-                                                                                        filename = multiple_time_average_jld2_filepath,
-                                                                                        overwrite_existing = true)
+            simulation.output_writers[:multiple_output_time_average] = JLD2Writer(model,
+                                                                                  jld2_outputs,
+                                                                                  schedule = AveragedTimeInterval(10Δt, window = window, stride = stride),
+                                                                                  dir = ".",
+                                                                                  with_halos = false,
+                                                                                  filename = multiple_time_average_jld2_filepath,
+                                                                                  overwrite_existing = true)
 
             run!(simulation)
 
@@ -347,40 +347,40 @@ for arch in archs
 
         vanilla_outputs = merge(model.velocities, function_and_background_fields, operation_outputs)
 
-        simulation.output_writers[:velocities] = JLD2OutputWriter(model, vanilla_outputs,
-                                                                  schedule = IterationInterval(1),
-                                                                  dir = ".",
-                                                                  filename = "vanilla_jld2_test",
-                                                                  indices = (:, :, :),
-                                                                  with_halos = false,
-                                                                  overwrite_existing = true)
+        simulation.output_writers[:velocities] = JLD2Writer(model, vanilla_outputs,
+                                                            schedule = IterationInterval(1),
+                                                            dir = ".",
+                                                            filename = "vanilla_jld2_test",
+                                                            indices = (:, :, :),
+                                                            with_halos = false,
+                                                            overwrite_existing = true)
 
-        simulation.output_writers[:sliced] = JLD2OutputWriter(model, model.velocities,
+        simulation.output_writers[:sliced] = JLD2Writer(model, model.velocities,
+                                                        schedule = TimeInterval(1),
+                                                        indices = (1:2, 1:4, :),
+                                                        with_halos = false,
+                                                        dir = ".",
+                                                        filename = "sliced_jld2_test",
+                                                        overwrite_existing = true)
+
+        func_outputs = (u = model -> u, v = model -> v, w = model -> w)
+        
+        simulation.output_writers[:sliced_funcs] = JLD2Writer(model, func_outputs,
                                                               schedule = TimeInterval(1),
                                                               indices = (1:2, 1:4, :),
                                                               with_halos = false,
                                                               dir = ".",
-                                                              filename = "sliced_jld2_test",
+                                                              filename = "sliced_funcs_jld2_test",
                                                               overwrite_existing = true)
 
-        func_outputs = (u = model -> u, v = model -> v, w = model -> w)
-        
-        simulation.output_writers[:sliced_funcs] = JLD2OutputWriter(model, func_outputs,
+
+        simulation.output_writers[:sliced_func_fields] = JLD2Writer(model, function_and_background_fields,
                                                                     schedule = TimeInterval(1),
                                                                     indices = (1:2, 1:4, :),
                                                                     with_halos = false,
                                                                     dir = ".",
-                                                                    filename = "sliced_funcs_jld2_test",
+                                                                    filename = "sliced_func_fields_jld2_test",
                                                                     overwrite_existing = true)
-
-
-        simulation.output_writers[:sliced_func_fields] = JLD2OutputWriter(model, function_and_background_fields,
-                                                                          schedule = TimeInterval(1),
-                                                                          indices = (1:2, 1:4, :),
-                                                                          with_halos = false,
-                                                                          dir = ".",
-                                                                          filename = "sliced_func_fields_jld2_test",
-                                                                          overwrite_existing = true)
 
 
 

--- a/test/test_lagrangian_particle_tracking.jl
+++ b/test/test_lagrangian_particle_tracking.jl
@@ -26,9 +26,8 @@ function particle_tracking_simulation(; grid, particles, timestepper=:RungeKutta
     sim = Simulation(model, Δt=1e-2, stop_iteration=1)
 
     jld2_filepath = "test_particles.jld2"
-    sim.output_writers[:particles_jld2] =
-        JLD2OutputWriter(model, (; particles=model.particles),
-            filename="test_particles", schedule=IterationInterval(1))
+    sim.output_writers[:particles_jld2] = JLD2Writer(model, (; particles=model.particles),
+                                                     filename="test_particles", schedule=IterationInterval(1))
 
     nc_filepath = "test_particles.nc"
     sim.output_writers[:particles_nc] =
@@ -133,9 +132,8 @@ function run_simple_particle_tracking_tests(grid, timestepper=:QuasiAdamsBashfor
         sim = Simulation(model, Δt=1e-2, stop_iteration=1)
 
         jld2_filepath = "test_particles.jld2"
-        sim.output_writers[:particles_jld2] =
-            JLD2OutputWriter(model, (; particles=model.particles),
-                             filename=jld2_filepath, schedule=IterationInterval(1))
+        sim.output_writers[:particles_jld2] = JLD2Writer(model, (; particles=model.particles),
+                                                         filename=jld2_filepath, schedule=IterationInterval(1))
 
         nc_filepath = "test_particles.nc"
         sim.output_writers[:particles_nc] =

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -42,44 +42,39 @@ function generate_some_interesting_simulation_data(Nx, Ny, Nz; architecture=CPU(
     split_filepath = "test_split_output.jld2"
     unsplit_filepath = "test_unsplit_output.jld2"
 
-    simulation.output_writers[:jld2_3d_with_halos] =
-        JLD2OutputWriter(model, fields_to_output,
-                         filename = filepath3d,
-                         with_halos = true,
-                         schedule = TimeInterval(30seconds),
-                         overwrite_existing = true)
+    simulation.output_writers[:jld2_3d_with_halos] = JLD2Writer(model, fields_to_output,
+                                                                filename = filepath3d,
+                                                                with_halos = true,
+                                                                schedule = TimeInterval(30seconds),
+                                                                overwrite_existing = true)
 
-    simulation.output_writers[:jld2_2d_with_halos] =
-        JLD2OutputWriter(model, fields_to_output,
-                         filename = filepath2d,
-                         indices = (:, :, grid.Nz),
-                         with_halos = true,
-                         schedule = TimeInterval(30seconds),
-                         overwrite_existing = true)
+    simulation.output_writers[:jld2_2d_with_halos] = JLD2Writer(model, fields_to_output,
+                                                                filename = filepath2d,
+                                                                indices = (:, :, grid.Nz),
+                                                                with_halos = true,
+                                                                schedule = TimeInterval(30seconds),
+                                                                overwrite_existing = true)
 
     profiles = NamedTuple{keys(fields_to_output)}(Field(Average(f, dims=(1, 2))) for f in fields_to_output)
 
-    simulation.output_writers[:jld2_1d_with_halos] =
-        JLD2OutputWriter(model, profiles,
-                         filename = filepath1d,
-                         with_halos = true,
-                         schedule = TimeInterval(30seconds),
-                         overwrite_existing = true)
+    simulation.output_writers[:jld2_1d_with_halos] = JLD2Writer(model, profiles,
+                                                                filename = filepath1d,
+                                                                with_halos = true,
+                                                                schedule = TimeInterval(30seconds),
+                                                                overwrite_existing = true)
 
-    simulation.output_writers[:unsplit_jld2] =
-        JLD2OutputWriter(model, profiles,
-                         filename = unsplit_filepath,
-                         with_halos = true,
-                         schedule = TimeInterval(10seconds),
-                         overwrite_existing = true)
+    simulation.output_writers[:unsplit_jld2] = JLD2Writer(model, profiles,
+                                                          filename = unsplit_filepath,
+                                                          with_halos = true,
+                                                          schedule = TimeInterval(10seconds),
+                                                          overwrite_existing = true)
 
-    simulation.output_writers[:split_jld2] =
-        JLD2OutputWriter(model, profiles,
-                         filename = split_filepath,
-                         with_halos = true,
-                         schedule = TimeInterval(10seconds),
-                         file_splitting = TimeInterval(30seconds),
-                         overwrite_existing = true)
+    simulation.output_writers[:split_jld2] = JLD2Writer(model, profiles,
+                                                        filename = split_filepath,
+                                                        with_halos = true,
+                                                        schedule = TimeInterval(10seconds),
+                                                        file_splitting = TimeInterval(30seconds),
+                                                        overwrite_existing = true)
 
     run!(simulation)
 
@@ -278,10 +273,10 @@ end
                 model = NonhydrostaticModel(; grid, boundary_conditions = (; u=u_bcs, v=v_bcs))
                 simulation = Simulation(model; Δt=1, stop_iteration=1)
                 
-                simulation.output_writers[:jld2] = JLD2OutputWriter(model, model.velocities,
-                                                                    filename = "test_cuarray_bc.jld2",
-                                                                    schedule=IterationInterval(1),
-                                                                    overwrite_existing = true)
+                simulation.output_writers[:jld2] = JLD2Writer(model, model.velocities,
+                                                              filename = "test_cuarray_bc.jld2",
+                                                              schedule=IterationInterval(1),
+                                                              overwrite_existing = true)
                 
                 run!(simulation)
                 

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -68,11 +68,11 @@ function test_dependency_adding(model)
     dimensions = Dict("time_average" => ("xF", "yC", "zC"))
 
     # JLD2 dependencies test
-    jld2_output_writer = JLD2OutputWriter(model, output,
-                                          schedule = TimeInterval(4),
-                                          dir = ".",
-                                          filename = "test.jld2",
-                                          overwrite_existing = true)
+    jld2_output_writer = JLD2Writer(model, output,
+                                    schedule = TimeInterval(4),
+                                    dir = ".",
+                                    filename = "test.jld2",
+                                    overwrite_existing = true)
 
     windowed_time_average = jld2_output_writer.outputs.time_average
     @test dependencies_added_correctly!(model, windowed_time_average, jld2_output_writer)
@@ -120,7 +120,7 @@ function test_creating_and_appending(model, output_writer)
     if output_writer === NetCDFOutputWriter
         ds = NCDataset(filepath)
         time_length = length(ds["time"])
-    elseif output_writer === JLD2OutputWriter
+    elseif output_writer === JLD2Writer
         ds = jldopen(filepath)
         time_length = length(keys(ds["timeseries/t"]))
     end
@@ -144,10 +144,10 @@ function test_windowed_time_averaging_simulation(model)
     model.clock.iteration = model.clock.time = 0
     simulation = Simulation(model, Δt=1.0, stop_iteration=0)
 
-    jld2_output_writer = JLD2OutputWriter(model, model.velocities,
-                                          schedule = AveragedTimeInterval(π, window=1),
-                                          filename = jld_filename1,
-                                          overwrite_existing = true)
+    jld2_output_writer = JLD2Writer(model, model.velocities,
+                                    schedule = AveragedTimeInterval(π, window=1),
+                                    filename = jld_filename1,
+                                    overwrite_existing = true)
 
     # https://github.com/Alexander-Barth/NCDatasets.jl/issues/105
     nc_filepath1 = "windowed_time_average_test1.nc"
@@ -194,10 +194,10 @@ function test_windowed_time_averaging_simulation(model)
     # time_interval == time_averaging_window
     model.clock.iteration = model.clock.time = 0
 
-    simulation.output_writers[:jld2] = JLD2OutputWriter(model, model.velocities,
-                                                        schedule = AveragedTimeInterval(π, window=π),
-                                                        filename = jld_filename2,
-                                                        overwrite_existing = true)
+    simulation.output_writers[:jld2] = JLD2Writer(model, model.velocities,
+                                                  schedule = AveragedTimeInterval(π, window=π),
+                                                  filename = jld_filename2,
+                                                  overwrite_existing = true)
 
     nc_filepath2 = "windowed_time_average_test2.nc"
     nc_outputs = Dict(string(name) => field for (name, field) in pairs(model.velocities))
@@ -229,7 +229,7 @@ end
     for arch in archs
 
         @info "Testing that writers create file and append to it properly"
-        for output_writer in (NetCDFOutputWriter, JLD2OutputWriter)
+        for output_writer in (NetCDFOutputWriter, JLD2Writer)
             grid = RectilinearGrid(arch, topology=topo, size=(1, 1, 1), extent=(1, 1, 1))
             model = NonhydrostaticModel(; grid)
             test_creating_and_appending(model, output_writer)

--- a/validation/isotropic_mixing_closures/compare_closures.jl
+++ b/validation/isotropic_mixing_closures/compare_closures.jl
@@ -61,7 +61,7 @@ advection = WENO(order=9)
 closure = nothing
 simulation = wind_driven_turbulence_simulation(grid, advection, closure)
 outputs = merge(simulation.model.velocities, simulation.model.tracers)
-output_writer = JLD2OutputWriter(simulation.model, outputs; filename, schedule, overwrite_existing=true)
+output_writer = JLD2Writer(simulation.model, outputs; filename, schedule, overwrite_existing=true)
 simulation.output_writers[:jld2] = output_writer
 run!(simulation)
 
@@ -71,7 +71,7 @@ advection = WENO(order=5)
 closure = nothing
 simulation = wind_driven_turbulence_simulation(grid, advection, closure)
 outputs = merge(simulation.model.velocities, simulation.model.tracers)
-output_writer = JLD2OutputWriter(simulation.model, outputs; filename, schedule, overwrite_existing=true)
+output_writer = JLD2Writer(simulation.model, outputs; filename, schedule, overwrite_existing=true)
 simulation.output_writers[:jld2] = output_writer
 run!(simulation)
 
@@ -84,7 +84,7 @@ outputs = merge(simulation.model.velocities, simulation.model.tracers)
 νₑ = simulation.model.diffusivity_fields.νₑ
 κₑ = simulation.model.diffusivity_fields.κₑ.b
 outputs = merge(outputs, (; νₑ, κₑ))
-output_writer = JLD2OutputWriter(simulation.model, outputs; filename, schedule, overwrite_existing=true)
+output_writer = JLD2Writer(simulation.model, outputs; filename, schedule, overwrite_existing=true)
 simulation.output_writers[:jld2] = output_writer
 run!(simulation)
 
@@ -96,7 +96,7 @@ simulation = wind_driven_turbulence_simulation(grid, advection, closure)
 outputs = merge(simulation.model.velocities, simulation.model.tracers)
 νₑ = simulation.model.diffusivity_fields.νₑ
 outputs = merge(outputs, (; νₑ))
-output_writer = JLD2OutputWriter(simulation.model, outputs; filename, schedule, overwrite_existing=true)
+output_writer = JLD2Writer(simulation.model, outputs; filename, schedule, overwrite_existing=true)
 simulation.output_writers[:jld2] = output_writer
 run!(simulation)
 
@@ -108,7 +108,7 @@ simulation = wind_driven_turbulence_simulation(grid, advection, closure)
 outputs = merge(simulation.model.velocities, simulation.model.tracers)
 νₑ = simulation.model.diffusivity_fields.νₑ
 outputs = merge(outputs, (; νₑ))
-output_writer = JLD2OutputWriter(simulation.model, outputs; filename, schedule, overwrite_existing=true)
+output_writer = JLD2Writer(simulation.model, outputs; filename, schedule, overwrite_existing=true)
 simulation.output_writers[:jld2] = output_writer
 run!(simulation)
 
@@ -122,7 +122,7 @@ outputs = merge(simulation.model.velocities, simulation.model.tracers)
 𝒥ᴹᴹ = simulation.model.diffusivity_fields.𝒥ᴹᴹ
 νₑ = simulation.model.diffusivity_fields.νₑ
 outputs = merge(outputs, (; 𝒥ᴸᴹ, 𝒥ᴹᴹ, νₑ))
-output_writer = JLD2OutputWriter(simulation.model, outputs; filename, schedule, overwrite_existing=true)
+output_writer = JLD2Writer(simulation.model, outputs; filename, schedule, overwrite_existing=true)
 simulation.output_writers[:jld2] = output_writer
 run!(simulation)
 
@@ -138,6 +138,6 @@ outputs = merge(simulation.model.velocities, simulation.model.tracers)
 𝒥ᴹᴹ⁻ = simulation.model.diffusivity_fields.𝒥ᴹᴹ⁻
 νₑ = simulation.model.diffusivity_fields.νₑ
 outputs = merge(outputs, (; 𝒥ᴸᴹ, 𝒥ᴹᴹ, 𝒥ᴸᴹ⁻, 𝒥ᴹᴹ⁻, νₑ))
-output_writer = JLD2OutputWriter(simulation.model, outputs; filename, schedule, overwrite_existing=true)
+output_writer = JLD2Writer(simulation.model, outputs; filename, schedule, overwrite_existing=true)
 simulation.output_writers[:jld2] = output_writer
 run!(simulation)


### PR DESCRIPTION
Let's make these names less verbose. I'm starting with the `JLD2Writer` first and will work on the `NetCDFWriter` after 
https://github.com/CliMA/Oceananigans.jl/pull/4046 is merged.