### PR TITLE
Create a narrower definition for initialization

### DIFF
--- a/ext/OceananigansReactantExt/Models.jl
+++ b/ext/OceananigansReactantExt/Models.jl
@@ -1,9 +1,31 @@
 module Models
 
-import Oceananigans.Models: initialization_update_state!
+import Oceananigans.Models: setup_update_state!, inititalize!
+import Oceananigans.Models.HydrostaticFreeSurfaceModels: set_barotropic_velocities!
 
+using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces:
+    compute_barotropic_velocities!
+
+using ..Grids: ReactantGrid
 using ..TimeSteppers: ReactantModel
 
-initialization_update_state!(::ReactantModel; kw...) = nothing
+setup_update_state!(::ReactantModel) = nothing
+set_barotropic_velocities!(fs, ::ReactantGrid, velocities) = nothing
+
+const ReactantHydrostaticFreeSurfaceModel = HydrostaticFreeSurfaceModel{<:Any, <:Any, <:ReactantState}
+
+function initialize!(model::ReactantHydrostaticFreeSurfaceModel)
+
+    if model.free_surface isa SplitExplicitFreeSurface
+        U = model.free_surface.barotropic_velocities.U
+        V = model.free_surface.barotropic_velocities.V
+        η = model.free_surface.η
+        u, v, w = model.velocities
+        compute_barotropic_velocities!(U, V, grid, u, v, η)
+    end
+
+    return nothing
+end
+
 
 end # module

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/SplitExplicitFreeSurfaces.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/SplitExplicitFreeSurfaces.jl
@@ -37,7 +37,7 @@ import Oceananigans.Models.HydrostaticFreeSurfaceModels: initialize_free_surface
 include("split_explicit_timesteppers.jl")
 include("split_explicit_free_surface.jl")
 include("distributed_split_explicit_free_surface.jl")
-include("initialize_split_explicit_substepping.jl")
+# include("initialize_split_explicit_substepping.jl")
 include("compute_slow_tendencies.jl")
 include("step_split_explicit_free_surface.jl")
 include("barotropic_split_explicit_corrector.jl")

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/SplitExplicitFreeSurfaces.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/SplitExplicitFreeSurfaces.jl
@@ -5,17 +5,20 @@ export FixedSubstepNumber, FixedTimeStepSize
 
 using Oceananigans
 using Oceananigans.Architectures
-using Oceananigans.Architectures: convert_to_device
 using Oceananigans.Fields
 using Oceananigans.Utils
 using Oceananigans.Grids
 using Oceananigans.Operators
 using Oceananigans.BoundaryConditions
 using Oceananigans.ImmersedBoundaries
+
+using Oceananigans.Architectures: convert_to_device
 using Oceananigans.Grids: AbstractGrid, topology
 using Oceananigans.ImmersedBoundaries: linear_index_to_tuple, mask_immersed_field!
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: AbstractFreeSurface,
                                                         free_surface_displacement_field
+
+using Oceananigans.TimeSteppers: QuasiAdmasBashforth2TimeStepper, SplitRungeKutta3TimeStepper
 
 using Adapt
 using Base

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/barotropic_split_explicit_corrector.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/barotropic_split_explicit_corrector.jl
@@ -1,10 +1,10 @@
 # Kernels to compute the vertical integral of the velocities
-@kernel function _compute_barotropic_mode!(U̅, V̅, grid, ::Nothing, u, v, η)
+@kernel function _compute_barotropic_velocities!(U̅, V̅, grid, ::Nothing, u, v, η)
     i, j  = @index(Global, NTuple)
     integrate_barotropic_mode!(U̅, V̅, i, j, grid, u, v, η)
 end
 
-@kernel function _compute_barotropic_mode!(U̅, V̅, grid, active_cells_map, u, v, η)
+@kernel function _compute_barotropic_velocities!(U̅, V̅, grid, active_cells_map, u, v, η)
     idx = @index(Global, Linear)
     i, j = linear_index_to_tuple(idx, active_cells_map)
     integrate_barotropic_mode!(U̅, V̅, i, j, grid, u, v, η)
@@ -37,11 +37,11 @@ end
 end
 
 # Note: this function is also used during initialization
-function compute_barotropic_mode!(U̅, V̅, grid, u, v, η)
+function compute_barotropic_velocities!(U̅, V̅, grid, u, v, η)
     active_columns = get_active_column_map(grid) # may be nothing
 
     launch!(architecture(grid), grid, :xy,
-            _compute_barotropic_mode!,
+            _compute_barotropic_velocities!,
             U̅, V̅, grid, active_columns, u, v, η; active_cells_map=active_columns)
 
     return nothing
@@ -58,7 +58,7 @@ function barotropic_split_explicit_corrector!(u, v, free_surface, grid)
     # NOTE: the filtered `U̅` and `V̅` have been copied in the instantaneous `U` and `V`,
     # so we use the filtered velocities as "work arrays" to store the vertical integrals
     # of the instantaneous velocities `u` and `v`.
-    compute_barotropic_mode!(U̅, V̅, grid, u, v, η)
+    compute_barotropic_velocities!(U̅, V̅, grid, u, v, η)
     
     # add in "good" barotropic mode
     launch!(arch, grid, :xyz, _barotropic_split_explicit_corrector!,

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/compute_slow_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/compute_slow_tendencies.jl
@@ -41,7 +41,7 @@ end
     return ifelse(immersed, zero(grid), Gⁿ⁺¹)
 end
 
-@inline function compute_split_explicit_forcing!(GUⁿ, GVⁿ, grid, Guⁿ, Gvⁿ, 
+@inline function compute_split_explicit_slow_tendency!(GUⁿ, GVⁿ, grid, Guⁿ, Gvⁿ, 
                                                  timestepper::QuasiAdamsBashforth2TimeStepper, stage)
     active_cells_map = get_active_column_map(grid)
 
@@ -108,7 +108,7 @@ end
     @inbounds GVⁿ[i, j, 1] = 2 * GVi / 3 + GV⁻[i, j, 1]
 end
 
-@inline function compute_split_explicit_forcing!(GUⁿ, GVⁿ, grid, Guⁿ, Gvⁿ, 
+@inline function compute_split_explicit_slow_tendency!(GUⁿ, GVⁿ, grid, Guⁿ, Gvⁿ, 
                                                  timestepper::SplitRungeKutta3TimeStepper, stage)
 
     GU⁻ = timestepper.G⁻.U
@@ -141,7 +141,7 @@ function compute_free_surface_tendency!(grid, model, free_surface::SplitExplicit
     stage = model.clock.stage
 
     @apply_regionally begin
-        compute_split_explicit_forcing!(GUⁿ, GVⁿ, grid, Guⁿ, Gvⁿ, baroclinic_timestepper, Val(stage))
+        compute_split_explicit_slow_tendency!(GUⁿ, GVⁿ, grid, Guⁿ, Gvⁿ, baroclinic_timestepper, Val(stage))
         initialize_free_surface_state!(free_surface, baroclinic_timestepper, barotropic_timestepper, Val(stage))
     end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/compute_slow_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/compute_slow_tendencies.jl
@@ -142,7 +142,6 @@ function compute_free_surface_tendency!(grid, model, free_surface::SplitExplicit
 
     @apply_regionally begin
         compute_split_explicit_slow_tendency!(GUⁿ, GVⁿ, grid, Guⁿ, Gvⁿ, baroclinic_timestepper, Val(stage))
-        initialize_free_surface_state!(free_surface, baroclinic_timestepper, barotropic_timestepper, Val(stage))
     end
 
     fields_to_fill = (GUⁿ, GVⁿ)

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/compute_slow_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/compute_slow_tendencies.jl
@@ -42,7 +42,7 @@ end
 end
 
 @inline function compute_split_explicit_slow_tendency!(GUⁿ, GVⁿ, grid, Guⁿ, Gvⁿ, 
-                                                 timestepper::QuasiAdamsBashforth2TimeStepper, stage)
+                                                       timestepper::QuasiAdamsBashforth2TimeStepper, stage)
     active_cells_map = get_active_column_map(grid)
 
     Gu⁻ = timestepper.G⁻.u
@@ -109,7 +109,7 @@ end
 end
 
 @inline function compute_split_explicit_slow_tendency!(GUⁿ, GVⁿ, grid, Guⁿ, Gvⁿ, 
-                                                 timestepper::SplitRungeKutta3TimeStepper, stage)
+                                                       timestepper::SplitRungeKutta3TimeStepper, stage)
 
     GU⁻ = timestepper.G⁻.U
     GV⁻ = timestepper.G⁻.V
@@ -146,7 +146,7 @@ function compute_free_surface_tendency!(grid, model, free_surface::SplitExplicit
     end
 
     fields_to_fill = (GUⁿ, GVⁿ)
-    fill_halo_regions!(fields_to_fill; async = true)
+    fill_halo_regions!(fields_to_fill; async=true)
 
     return nothing
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/initialize_split_explicit_substepping.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/initialize_split_explicit_substepping.jl
@@ -15,7 +15,7 @@ using Oceananigans.Operators: Δz
 function initialize_free_surface!(sefs::SplitExplicitFreeSurface, grid, velocities)
     barotropic_velocities = sefs.barotropic_velocities
     u, v, w = velocities
-    @apply_regionally compute_barotropic_mode!(barotropic_velocities.U,
+    @apply_regionally compute_barotropic_velocities!(barotropic_velocities.U,
                                                barotropic_velocities.V,
                                                grid, u, v, sefs.η)
 
@@ -31,7 +31,7 @@ function initialize_free_surface_state!(free_surface, baroclinic_timestepper, ti
     η = free_surface.η
     U, V = free_surface.barotropic_velocities
 
-    initialize_free_surface_timestepper!(timestepper, η, U, V)
+    setup_free_surface_timestepper!(timestepper, η, U, V)
 
     fill!(free_surface.filtered_state.η, 0)
     fill!(free_surface.filtered_state.U, 0)
@@ -55,7 +55,7 @@ function initialize_free_surface_state!(free_surface, baroclinic_ts::SplitRungeK
     parent(V) .= parent(Vⁿ⁻¹)
     parent(η) .= parent(ηⁿ⁻¹)
 
-    initialize_free_surface_timestepper!(barotropic_ts, η, U, V)
+    setup_free_surface_timestepper!(barotropic_ts, η, U, V)
 
     fill!(free_surface.filtered_state.η, 0)
     fill!(free_surface.filtered_state.U, 0)

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/initialize_split_explicit_substepping.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/initialize_split_explicit_substepping.jl
@@ -1,6 +1,4 @@
 using Oceananigans.ImmersedBoundaries: get_active_column_map, peripheral_node
-using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, SplitRungeKutta3TimeStepper
-using Oceananigans.Operators: Δz
 
 # This file contains two different initializations methods performed at different stages of the simulation.
 #

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_timesteppers.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_timesteppers.jl
@@ -118,9 +118,9 @@ function materialize_timestepper(name::Symbol, args...)
     return materialize_timestepper(TS, args...)
 end
 
-initialize_free_surface_timestepper!(::ForwardBackwardScheme, args...) = nothing
+setup_free_surface_timestepper!(::ForwardBackwardScheme, args...) = nothing
 
-function initialize_free_surface_timestepper!(timestepper::AdamsBashforth3Scheme, η, U, V)
+function setup_free_surface_timestepper!(timestepper::AdamsBashforth3Scheme, η, U, V)
     parent(timestepper.Uᵐ⁻¹) .= parent(U)
     parent(timestepper.Vᵐ⁻¹) .= parent(V)
 

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -11,7 +11,7 @@ using Oceananigans.Fields: Field, CenterField, tracernames, VelocityFields, Trac
 using Oceananigans.Forcings: model_forcing
 using Oceananigans.Grids: AbstractCurvilinearGrid, AbstractHorizontallyCurvilinearGrid, architecture, halo_size
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
-using Oceananigans.Models: AbstractModel, validate_model_halo, NaNChecker, validate_tracer_advection, extract_boundary_conditions, initialization_update_state!
+using Oceananigans.Models: AbstractModel, validate_model_halo, NaNChecker, validate_tracer_advection, extract_boundary_conditions, setup_update_state!
 using Oceananigans.TimeSteppers: Clock, TimeStepper, update_state!, AbstractLagrangianParticles, SplitRungeKutta3TimeStepper
 using Oceananigans.TurbulenceClosures: validate_closure, with_tracers, build_diffusivity_fields, add_closure_specific_boundary_conditions
 using Oceananigans.TurbulenceClosures: time_discretization, implicit_diffusion_solver
@@ -218,7 +218,7 @@ function HydrostaticFreeSurfaceModel(; grid,
                                         free_surface, forcing, closure, particles, biogeochemistry, velocities, tracers,
                                         pressure, diffusivity_fields, timestepper, auxiliary_fields, vertical_coordinate)
 
-    initialization_update_state!(model; compute_tendencies=false)
+    setup_update_state!(model; compute_tendencies=false)
 
     return model
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/set_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/set_hydrostatic_free_surface_model.jl
@@ -60,9 +60,21 @@ model.velocities.u
         @apply_regionally set!(ϕ, value)
     end
 
-    # initialize!(model)
-    initialization_update_state!(model; compute_tendencies=false)
+    # TODO: allow barotropic velocities to be set independently
+    set_barotropic_velocities!(model.free_surface, model.grid, model.velocities) 
+    setup_update_state!(model; compute_tendencies=false)
 
     return nothing
+end
+
+# Utility for calling compute_barotropic_velocities
+set_barotropic_velocities!(free_surface, grid, velocities) = nothing
+
+function set_barotropic_velocities!(sefs::SplitExplicitFreeSurface, grid, velocities)
+    U = sefs.barotropic_velocities.U
+    V = sefs.barotropic_velocities.V
+    η = sefs.η
+    u, v, w = velocities
+    return compute_barotropic_velocities!(U, V, grid, u, v, η)
 end
 

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -39,7 +39,7 @@ architecture(model::AbstractModel) = model.grid.architecture
 initialize!(model::AbstractModel) = nothing
 total_velocities(model::AbstractModel) = nothing
 timestepper(model::AbstractModel) = model.timestepper
-initialization_update_state!(model::AbstractModel; kw...) = update_state!(model; kw...) # fallback
+setup_update_state!(model::AbstractModel; kw...) = update_state!(model; kw...) # fallback
 
 # Fallback for any abstract model that does not contain `FieldTimeSeries`es
 update_model_field_time_series!(model::AbstractModel, clock::Clock) = nothing

--- a/test/test_split_explicit_vertical_integrals.jl
+++ b/test/test_split_explicit_vertical_integrals.jl
@@ -4,7 +4,7 @@ using Oceananigans.Fields: VelocityFields
 using Oceananigans.Models.HydrostaticFreeSurfaceModels
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: materialize_free_surface
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: SplitExplicitFreeSurface
-using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces: compute_barotropic_mode!,
+using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces: compute_barotropic_velocities!,
                                                                                   barotropic_split_explicit_corrector!,
                                                                                   initialize_free_surface_state!
 
@@ -63,7 +63,7 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces
             set!(u, set_u_check)
             exact_U = similar(U)
             set!(exact_U, set_U_check)
-            compute_barotropic_mode!(U, V, grid, u, v, η̅)
+            compute_barotropic_velocities!(U, V, grid, u, v, η̅)
             tolerance = 1e-3
             @test all((Array(interior(U) .- interior(exact_U))) .< tolerance)
 
@@ -72,7 +72,7 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces
             set!(v, set_v_check)
             exact_V = similar(V)
             set!(exact_V, set_V_check)
-            compute_barotropic_mode!(U, V, grid, u, v, η̅)
+            compute_barotropic_velocities!(U, V, grid, u, v, η̅)
             @test all((Array(interior(V) .- interior(exact_V))) .< tolerance)
         end
 
@@ -82,12 +82,12 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces
 
             set!(u, 0)
             set!(U, 1)
-            compute_barotropic_mode!(U, V, grid, u, v, η̅)
+            compute_barotropic_velocities!(U, V, grid, u, v, η̅)
             @test all(Array(interior(U)) .== 0.0)
 
             set!(u, 1)
             set!(U, 1)
-            compute_barotropic_mode!(U, V, grid, u, v, η̅)
+            compute_barotropic_velocities!(U, V, grid, u, v, η̅)
             @test all(Array(interior(U)) .≈ Lz)
 
             set_u_check(x, y, z) = sin(x)
@@ -95,7 +95,7 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces
             set!(u, set_u_check)
             exact_U = similar(U)
             set!(exact_U, set_U_check)
-            compute_barotropic_mode!(U, V, grid, u, v, η̅)
+            compute_barotropic_velocities!(U, V, grid, u, v, η̅)
             @test all(Array(interior(U)) .≈ Array(interior(exact_U)))
 
             set_v_check(x, y, z) = sin(x) * z * cos(y)
@@ -103,7 +103,7 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces
             set!(v, set_v_check)
             exact_V = similar(V)
             set!(exact_V, set_V_check)
-            compute_barotropic_mode!(U, V, grid, u, v, η̅)
+            compute_barotropic_velocities!(U, V, grid, u, v, η̅)
             @test all(Array(interior(V)) .≈ Array(interior(exact_V)))
         end
 


### PR DESCRIPTION
This PR changes the names of functions and moves a few things around so that:

1) "setup" is defined as the activities that occur prior to running a Simulation / doing a time-stepping loop
2) "initialization" is defined as the action one takes _just prior_ to running a simulation, after setup

Initialization is combined with the concept of the "first time step". Note, this is compiled by Reactant.

This organization will help us avoid launching kernels when we are not able to; eg when we are using Reactant, while still ensuring that a simulation is correct.

Note there is a TODO to allow users to set the barotropic velocity directly for the split explicit free surface stepper. The split explicit barotropic velocity is, strictly speaking, and independent prognostic variable.