### PR TITLE
Export operators for surface / horizontally-reduced derivatives

### DIFF
--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -39,6 +39,8 @@ export δzᶠᶠᶠ, δzᶠᶠᶜ, δzᶠᶜᶠ, δzᶠᶜᶜ, δzᶜᶠᶠ, δz
 
 # Derivatives
 export ∂xᶜᵃᵃ, ∂xᶠᵃᵃ, ∂yᵃᶜᵃ, ∂yᵃᶠᵃ, ∂zᵃᵃᶜ, ∂zᵃᵃᶠ
+export ∂xᶜᶜᵃ, ∂xᶜᶠᵃ, ∂xᶠᶜᵃ, ∂xᶠᶠᵃ
+export ∂yᶜᶜᵃ, ∂yᶜᶠᵃ, ∂yᶠᶜᵃ, ∂yᶠᶠᵃ
 
 export ∂xᶠᶠᶠ, ∂xᶠᶠᶜ, ∂xᶠᶜᶠ, ∂xᶠᶜᶜ, ∂xᶜᶠᶠ, ∂xᶜᶠᶜ, ∂xᶜᶜᶠ, ∂xᶜᶜᶜ
 export ∂yᶠᶠᶠ, ∂yᶠᶠᶜ, ∂yᶠᶜᶠ, ∂yᶠᶜᶜ, ∂yᶜᶠᶠ, ∂yᶜᶠᶜ, ∂yᶜᶜᶠ, ∂yᶜᶜᶜ


### PR DESCRIPTION
I think the necessity of this PR possibly implies that we should combine / coalesce the `Operations` and `AbstractOperations` modules. Which by the way have pretty similar names if you didn't notice.