### PR TITLE
Solving Poisson equation for `p * dt` instead of `p`

### DIFF
--- a/src/Models/NonhydrostaticModels/pressure_correction.jl
+++ b/src/Models/NonhydrostaticModels/pressure_correction.jl
@@ -24,16 +24,21 @@ end
 #####
 
 """
-Update the predictor velocities u, v, and w with the non-hydrostatic pressure via
+Update the predictor velocities u, v, and w with the timestep-multiplied non-hydrostatic pressure via
 
-    `u^{n+1} = u^n - δₓp_{NH} / Δx * Δt`
+    `u^{n+1} = u^n - δₓp_{NH} / Δx`
+
+    Note that `p_{NH}` is the nonhydrostatic pressure muiltiplied by the timestep which enforces the incompressibility condition.
 """
 @kernel function _pressure_correct_velocities!(U, grid, Δt, pNHS)
     i, j, k = @index(Global, NTuple)
 
-    @inbounds U.u[i, j, k] -= ∂xᶠᶜᶜ(i, j, k, grid, pNHS) * Δt
-    @inbounds U.v[i, j, k] -= ∂yᶜᶠᶜ(i, j, k, grid, pNHS) * Δt
-    @inbounds U.w[i, j, k] -= ∂zᶜᶜᶠ(i, j, k, grid, pNHS) * Δt
+    # @inbounds U.u[i, j, k] -= ∂xᶠᶜᶜ(i, j, k, grid, pNHS) * Δt
+    # @inbounds U.v[i, j, k] -= ∂yᶜᶠᶜ(i, j, k, grid, pNHS) * Δt
+    # @inbounds U.w[i, j, k] -= ∂zᶜᶜᶠ(i, j, k, grid, pNHS) * Δt
+    @inbounds U.u[i, j, k] -= ∂xᶠᶜᶜ(i, j, k, grid, pNHS)
+    @inbounds U.v[i, j, k] -= ∂yᶜᶠᶜ(i, j, k, grid, pNHS)
+    @inbounds U.w[i, j, k] -= ∂zᶜᶜᶠ(i, j, k, grid, pNHS)
 end
 
 "Update the solution variables (velocities and tracers)."

--- a/src/Models/NonhydrostaticModels/solve_for_pressure.jl
+++ b/src/Models/NonhydrostaticModels/solve_for_pressure.jl
@@ -13,28 +13,32 @@ using Oceananigans.Solvers: solve!
     i, j, k = @index(Global, NTuple)
     active = !inactive_cell(i, j, k, grid)
     δ = divᶜᶜᶜ(i, j, k, grid, Ũ.u, Ũ.v, Ũ.w)
-    @inbounds rhs[i, j, k] = active * δ / Δt
+    # @inbounds rhs[i, j, k] = active * δ / Δt
+    @inbounds rhs[i, j, k] = active * δ
 end
 
 @kernel function _fourier_tridiagonal_source_term!(rhs, ::XDirection, grid, Δt, Ũ)
     i, j, k = @index(Global, NTuple)
     active = !inactive_cell(i, j, k, grid)
     δ = divᶜᶜᶜ(i, j, k, grid, Ũ.u, Ũ.v, Ũ.w)
-    @inbounds rhs[i, j, k] = active * Δxᶜᶜᶜ(i, j, k, grid) * δ / Δt
+    # @inbounds rhs[i, j, k] = active * Δxᶜᶜᶜ(i, j, k, grid) * δ / Δt
+    @inbounds rhs[i, j, k] = active * Δxᶜᶜᶜ(i, j, k, grid) * δ
 end
 
 @kernel function _fourier_tridiagonal_source_term!(rhs, ::YDirection, grid, Δt, Ũ)
     i, j, k = @index(Global, NTuple)
     active = !inactive_cell(i, j, k, grid)
     δ = divᶜᶜᶜ(i, j, k, grid, Ũ.u, Ũ.v, Ũ.w)
-    @inbounds rhs[i, j, k] = active * Δyᶜᶜᶜ(i, j, k, grid) * δ / Δt
+    # @inbounds rhs[i, j, k] = active * Δyᶜᶜᶜ(i, j, k, grid) * δ / Δt
+    @inbounds rhs[i, j, k] = active * Δyᶜᶜᶜ(i, j, k, grid) * δ
 end
 
 @kernel function _fourier_tridiagonal_source_term!(rhs, ::ZDirection, grid, Δt, Ũ)
     i, j, k = @index(Global, NTuple)
     active = !inactive_cell(i, j, k, grid)
     δ = divᶜᶜᶜ(i, j, k, grid, Ũ.u, Ũ.v, Ũ.w)
-    @inbounds rhs[i, j, k] = active * Δzᶜᶜᶜ(i, j, k, grid) * δ / Δt
+    # @inbounds rhs[i, j, k] = active * Δzᶜᶜᶜ(i, j, k, grid) * δ / Δt
+    @inbounds rhs[i, j, k] = active * Δzᶜᶜᶜ(i, j, k, grid) * δ
 end
 
 function compute_source_term!(pressure, solver::DistributedFFTBasedPoissonSolver, Δt, Ũ)


### PR DESCRIPTION
Closes #4067 

This change solves $p \text{d}t$ in the Poisson equation rather than $p$ as it is currently.
The advantage of this is that this avoids numerical instabilities that occur when we compute the RHS of 
```math
\nabla ^2 p = -\frac{\nabla \cdot \boldsymbol{u}_*}{\Delta t}
```

when $\Delta t$ is extremely small, which occurs when we take small timesteps, which are almost inevitable when using some sort of `TimeInterval`.
In this change, we solve for 
```math
\psi  \equiv \int_n^{n+1} p \text{d} t \approx p^{n+1} \Delta t
```
and update the pressure correction with
```math
\boldsymbol{u}_{n+1} = \boldsymbol{u}_* - \nabla \psi.
```
The full derivation can be found here https://github.com/CliMA/Oceananigans.jl/issues/4067#issuecomment-2619120179

This is a huge change as `model.pressures.pNHS` now gives $p \text{d}t$. However if we decide to go through with this change, we can discuss the detail of what to expose to the user/change some of the variable name notation to avoid confusion.
Currently this issue has a workaround using the `minimum_relative_step` flag in `Simulation`, however I think it could be useful to implement this PR as it is a fundamental fix.

Here I provide a staircase convection validation script to illustrate consistent behaviour before and after this PR fix:
```julia
using Oceananigans
using Printf
using Oceananigans.Solvers: ConjugateGradientPoissonSolver, FFTBasedPoissonSolver

#####
##### Model setup
#####
Nx = 64
Nz = 64

grid = RectilinearGrid(CPU(), Float64,
                       size = (Nx, Nz),
                       halo = (4, 4),
                       x = (0, 1),
                       z = (0, 1),
                       topology = (Bounded, Flat, Bounded))

slope(x) = (5 + tanh(40*(x - 1/6)) + tanh(40*(x - 2/6)) + tanh(40*(x - 3/6)) + tanh(40*(x - 4/6)) + tanh(40*(x - 5/6))) / 10

grid = ImmersedBoundaryGrid(grid, GridFittedBottom(slope))
                       
@info "Created $grid"
reltol = 1e-7
abstol = 1e-7
maxiter = 1000
# preconditioner = nothing
preconditioner = FFTBasedPoissonSolver(grid.underlying_grid)
pressure_solver = ConjugateGradientPoissonSolver(grid; maxiter, reltol, abstol, preconditioner)
model = NonhydrostaticModel(; grid,
                            pressure_solver,
                            advection = WENO(order=5),
                            coriolis = FPlane(f=0.1),
                            tracers = (:b, :c),
                            buoyancy = BuoyancyTracer())

@info "Created $model"
@info "with pressure solver $(model.pressure_solver)"

# Cold blob
h = 0.03
x₀ = 0.75
z₀ = 0.9
b_background(x, z) = z
b_blob(x, z) = -5 * exp(-((x - x₀)^2 + (z - z₀)^2) / 2h^2)
bᵢ(x, z) = b_background(x, z) + b_blob(x, z)
set!(model, b=bᵢ, c=1)

#####
##### Simulation
#####
Δt = 1e-2
simulation = Simulation(model, Δt=Δt, stop_time = 10)

# wizard = TimeStepWizard(max_change=1.05, max_Δt=1e-1, cfl=0.6)
# simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(1))

wall_time = Ref(time_ns())

b, c = model.tracers
u, v, w = model.velocities
B = Field(Integral(b))
C = Field(Integral(c))
compute!(B)
compute!(C)
B₀ = B[1, 1, 1]
C₀ = C[1, 1, 1]
δ = ∂x(u) + ∂y(v) + ∂z(w)

function progress(sim)
    elapsed = time_ns() - wall_time[]

    compute!(B)
    compute!(C)
    Bₙ = B[1, 1, 1]
    Cₙ = C[1, 1, 1]

    msg = @sprintf("Iter: %d, next Δt: %s, time: %s, wall time: %s, ΔB: %.3f %%, ΔC: %.3f %%, max|δ|: %.2e, residual extrema %s, pressure extrema %s",
                   iteration(sim), prettytime(sim.Δt), prettytime(sim), prettytime(1e-9 * elapsed),
                   100 * (Bₙ - B₀) / B₀,
                   100 * (Cₙ - C₀) / C₀,
                   maximum(abs, δ),
                   extrema(interior(model.pressure_solver.conjugate_gradient_solver.residual)), 
                   extrema(interior(model.pressures.pNHS)))

    pressure_solver = sim.model.pressure_solver
    if sim.model.pressure_solver isa ConjugateGradientPoissonSolver
        solver_iterations = pressure_solver.conjugate_gradient_solver.iteration 
        msg *= string(", solver iterations: ", solver_iterations)
    end

    @info msg

    wall_time[] = time_ns()

    return nothing
end
                   
simulation.callbacks[:p] = Callback(progress, IterationInterval(50))

prefix = "staircase_convection"

outputs = merge(model.velocities, model.tracers, (; p=model.pressures.pNHS, δ))

simulation.output_writers[:jld2] = JLD2Writer(model, outputs;
                                                    filename = prefix * "_fields",
                                                    # schedule = TimeInterval(0.1),
                                                    schedule = IterationInterval(10),
                                                    overwrite_existing = true)

simulation.output_writers[:timeseries] = JLD2Writer(model, (; B, C);
                                                          filename = prefix * "_time_series",
                                                        #   schedule = TimeInterval(0.1),
                                                          schedule = IterationInterval(10),
                                                          overwrite_existing = true)

run!(simulation)
```
which gives an output of

https://github.com/user-attachments/assets/b8a64348-3569-47f1-84d3-64bbc0f613eb

Here I made a video of the field anomalies before and after the fix:

https://github.com/user-attachments/assets/7046f4a5-0f25-4035-8eb5-b929ca324c2f

This shows that the behavior of the flow did not change after the fix. Not sure what is going on with pressure, perhaps I made a multiplicative error but I essentially just did `model.pressures.pNHS ./ Δt` to the new output...

For reference here is the simulation before applying the fix:

https://github.com/user-attachments/assets/a800d2bb-6426-438e-a5b7-e81fb44f39f0

@glwagner @simone-silvestri interested in your thoughts!