### PR TITLE
Switch default behavior of `Distributed` architecture

### DIFF
--- a/src/DistributedComputations/distributed_architectures.jl
+++ b/src/DistributedComputations/distributed_architectures.jl
@@ -318,16 +318,16 @@ convert_to_device(arch::Distributed, arg)  = convert_to_device(child_architectur
 
 # Switch to a synchronized architecture
 synchronized(arch) = arch
-synchronized(arch::AsynchronousDistributed) = Distributed{true}(child_architecture(arch),
-                                                                arch.partition,
-                                                                arch.ranks,
-                                                                arch.local_rank,
-                                                                arch.local_index,
-                                                                arch.connectivity,
-                                                                arch.communicator,
-                                                                arch.mpi_requests,
-                                                                arch.mpi_tag,
-                                                                arch.devices)
+synchronized(arch::Distributed) = Distributed{true}(child_architecture(arch),
+                                                    arch.partition,
+                                                    arch.ranks,
+                                                    arch.local_rank,
+                                                    arch.local_index,
+                                                    arch.connectivity,
+                                                    arch.communicator,
+                                                    arch.mpi_requests,
+                                                    arch.mpi_tag,
+                                                    arch.devices)
 
 cpu_architecture(arch::DistributedCPU) = arch
 cpu_architecture(arch::Distributed{A, S}) where {A, S} = 

--- a/src/DistributedComputations/distributed_architectures.jl
+++ b/src/DistributedComputations/distributed_architectures.jl
@@ -300,6 +300,7 @@ const DistributedCPU = Distributed{CPU}
 const DistributedGPU = Distributed{GPU}
 
 const SynchronizedDistributed = Distributed{<:Any, true}
+const AsynchronousDistributed = Distributed{<:Any, false}
 
 #####
 ##### All the architectures
@@ -317,17 +318,16 @@ convert_to_device(arch::Distributed, arg)  = convert_to_device(child_architectur
 
 # Switch to a synchronized architecture
 synchronized(arch) = arch
-synchronized(arch::SynchronizedDistributed) = arch
-synchronized(arch::Distributed) = Distributed{true}(child_architecture(arch),
-                                                     arch.partition,
-                                                     arch.ranks,
-                                                     arch.local_rank,
-                                                     arch.local_index,
-                                                     arch.connectivity,
-                                                     arch.communicator,
-                                                     arch.mpi_requests,
-                                                     arch.mpi_tag,
-                                                     arch.devices)
+synchronized(arch::AsynchronousDistributed) = Distributed{true}(child_architecture(arch),
+                                                                arch.partition,
+                                                                arch.ranks,
+                                                                arch.local_rank,
+                                                                arch.local_index,
+                                                                arch.connectivity,
+                                                                arch.communicator,
+                                                                arch.mpi_requests,
+                                                                arch.mpi_tag,
+                                                                arch.devices)
 
 cpu_architecture(arch::DistributedCPU) = arch
 cpu_architecture(arch::Distributed{A, S}) where {A, S} = 

--- a/src/DistributedComputations/distributed_immersed_boundaries.jl
+++ b/src/DistributedComputations/distributed_immersed_boundaries.jl
@@ -123,7 +123,7 @@ function build_active_cells_map(grid::DistributedGrid, ib)
 
     # If we using a synchronized architecture, nothing
     # changes with serial execution.
-    if arch isa SynchronizedDistributed
+    if !(arch isa AsynchronousDistributed)
         return serially_build_active_cells_map(grid, ib; parameters=:xyz)
     end
 

--- a/src/DistributedComputations/halo_communication.jl
+++ b/src/DistributedComputations/halo_communication.jl
@@ -148,7 +148,7 @@ end
 
     # Overlapping communication and computation, store requests in a `MPI.Request`
     # pool to be waited upon later on when halos are required.
-    if async && !(arch isa SynchronizedDistributed)
+    if async && (arch isa AsynchronousDistributed)
         push!(arch.mpi_requests, requests...)
         return nothing
     end

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -535,7 +535,7 @@ function nodes(grid::OSSG, ℓx, ℓy, ℓz; reshape=false, with_halos=false)
     if reshape
         # λ and φ are 2D arrays
         N = (size(λ)..., size(z)...)
-        λ = Base.reshape(λ, N[1], Ν[2], 1)
+        λ = Base.reshape(λ, N[1], N[2], 1)
         φ = Base.reshape(φ, N[1], N[2], 1)
         z = Base.reshape(z, 1, 1, N[3])
     end

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/distributed_split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/distributed_split_explicit_free_surface.jl
@@ -1,5 +1,5 @@
 using Oceananigans.DistributedComputations: DistributedField
-using Oceananigans.DistributedComputations: SynchronizedDistributed, synchronize_communication!
+using Oceananigans.DistributedComputations: AsynchronousDistributed, synchronize_communication!
 
 const DistributedSplitExplicit = SplitExplicitFreeSurface{<:DistributedField}
 

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/distributed_split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/distributed_split_explicit_free_surface.jl
@@ -4,9 +4,8 @@ using Oceananigans.DistributedComputations: SynchronizedDistributed, synchronize
 const DistributedSplitExplicit = SplitExplicitFreeSurface{<:DistributedField}
 
 wait_free_surface_communication!(free_surface, model, arch) = nothing
-wait_free_surface_communication!(::DistributedSplitExplicit, model, ::SynchronizedDistributed) = nothing
     
-function wait_free_surface_communication!(free_surface::DistributedSplitExplicit, model, arch)
+function wait_free_surface_communication!(free_surface::DistributedSplitExplicit, model, ::AsynchronousDistributed)
     
     barotropic_velocities = free_surface.barotropic_velocities
 

--- a/src/Models/interleave_communication_and_computation.jl
+++ b/src/Models/interleave_communication_and_computation.jl
@@ -4,9 +4,9 @@ using Oceananigans.Utils: KernelParameters
 using Oceananigans.Grids: halo_size, topology, architecture
 using Oceananigans.DistributedComputations
 using Oceananigans.DistributedComputations: DistributedGrid
-using Oceananigans.DistributedComputations: synchronize_communication!, SynchronizedDistributed
+using Oceananigans.DistributedComputations: synchronize_communication!, SynchronizedDistributed, AsynchronousDistributed
 
-function complete_communication_and_compute_buffer!(model, ::DistributedGrid, arch)
+function complete_communication_and_compute_buffer!(model, ::DistributedGrid, ::AsynchronousDistributed)
 
     # Iterate over the fields to clear _ALL_ possible architectures
     for field in prognostic_fields(model)
@@ -20,16 +20,13 @@ function complete_communication_and_compute_buffer!(model, ::DistributedGrid, ar
 end
 
 # Fallback
-complete_communication_and_compute_buffer!(model, ::DistributedGrid, ::SynchronizedDistributed) = nothing
 complete_communication_and_compute_buffer!(model, grid, arch) = nothing
-
 compute_buffer_tendencies!(model) = nothing
 
 """ Kernel parameters for computing interior tendencies. """
 interior_tendency_kernel_parameters(arch, grid) = :xyz # fallback
-interior_tendency_kernel_parameters(::SynchronizedDistributed, grid) = :xyz
 
-function interior_tendency_kernel_parameters(arch::Distributed, grid)
+function interior_tendency_kernel_parameters(arch::AsynchronousDistributed, grid)
     Rx, Ry, _ = arch.ranks
     Hx, Hy, _ = halo_size(grid)
     Tx, Ty, _ = topology(grid)

--- a/src/Models/interleave_communication_and_computation.jl
+++ b/src/Models/interleave_communication_and_computation.jl
@@ -4,7 +4,7 @@ using Oceananigans.Utils: KernelParameters
 using Oceananigans.Grids: halo_size, topology, architecture
 using Oceananigans.DistributedComputations
 using Oceananigans.DistributedComputations: DistributedGrid
-using Oceananigans.DistributedComputations: synchronize_communication!, SynchronizedDistributed, AsynchronousDistributed
+using Oceananigans.DistributedComputations: synchronize_communication!, AsynchronousDistributed
 
 function complete_communication_and_compute_buffer!(model, ::DistributedGrid, ::AsynchronousDistributed)
 


### PR DESCRIPTION
in main, the default behavior is defined for an asynchronous distributed architecture and methods are further specialized for a synchronized architecture

in light of #4301, it is a better pattern to have the default behavior being the one of a synchronized architecture and specialize the methods for an asynchronous architecture...