### PR TITLE
Add a `RightFolded` topology

### DIFF
--- a/ext/OceananigansReactantExt/Grids/Grids.jl
+++ b/ext/OceananigansReactantExt/Grids/Grids.jl
@@ -8,7 +8,7 @@ using Oceananigans
 using Oceananigans: Distributed
 using Oceananigans.Architectures: ReactantState, CPU
 using Oceananigans.Grids: AbstractGrid, AbstractUnderlyingGrid, StaticVerticalDiscretization, MutableVerticalDiscretization
-using Oceananigans.Grids: Center, Face, RightConnected, LeftConnected, Periodic, Bounded, Flat
+using Oceananigans.Grids: Center, Face, RightConnected, LeftConnected, Periodic, Bounded, Flat, RightFolded
 using Oceananigans.Fields: Field
 using Oceananigans.ImmersedBoundaries: GridFittedBottom, AbstractImmersedBoundary
 

--- a/ext/OceananigansReactantExt/Grids/sharded_grids.jl
+++ b/ext/OceananigansReactantExt/Grids/sharded_grids.jl
@@ -195,7 +195,7 @@ function TripolarGrid(arch::ShardedDistributed,
     # ``1'' here is the maximum number of dimensions of the fields of ``z''
     replicate = Sharding.NamedSharding(arch.connectivity, ntuple(Returns(nothing), 1)) 
 
-    grid = OrthogonalSphericalShellGrid{Periodic,RightConnected,Bounded}(arch,
+    grid = OrthogonalSphericalShellGrid{Periodic, RightFolded, Bounded}(arch,
         global_size...,
         halo...,
         convert(FT, global_grid.Lz),

--- a/ext/OceananigansReactantExt/OceananigansReactantExt.jl
+++ b/ext/OceananigansReactantExt/OceananigansReactantExt.jl
@@ -7,7 +7,7 @@ using OffsetArrays
 using Oceananigans: Distributed, DistributedComputations, ReactantState, CPU,
                     OrthogonalSphericalShellGrids
 using Oceananigans.Architectures: on_architecture
-using Oceananigans.Grids: Bounded, Periodic, RightConnected
+using Oceananigans.Grids: Bounded, Periodic, RightConnected, RightFolded
 
 deconcretize(obj) = obj # fallback
 deconcretize(a::OffsetArray) = OffsetArray(Array(a.parent), a.offsets...)

--- a/src/Advection/topologically_conditional_interpolation.jl
+++ b/src/Advection/topologically_conditional_interpolation.jl
@@ -14,13 +14,15 @@ using Oceananigans.Grids: AbstractUnderlyingGrid,
                           Bounded, 
                           RightConnected, 
                           LeftConnected, 
+                          RightFolded,
                           topology,
                           architecture
 
 const AUG = AbstractUnderlyingGrid
 
 # topologies bounded at least on one side
-const BT = Union{Bounded, RightConnected, LeftConnected}
+const BT = Union{Bounded, RightConnected, LeftConnected, RightFolded}
+const RightTopology = Union{RightConnected, RightFolded}
 
 # Bounded underlying Grids
 const AUGX   = AUG{<:Any, <:BT}
@@ -52,13 +54,13 @@ for dir in (:x, :y, :z)
                                                                     (i >= $required_halo_size(adv) - 1) & (i <= N + 1 - $required_halo_size(adv))          # Right bias
 
         # Right connected topologies (only test the left side, i.e. the bounded side)
-        @inline $outside_symmetric_haloᶠ(i, ::Type{RightConnected}, N, adv) = i >= $required_halo_size(adv) + 1
-        @inline $outside_symmetric_haloᶜ(i, ::Type{RightConnected}, N, adv) = i >= $required_halo_size(adv)
+        @inline $outside_symmetric_haloᶠ(i, ::Type{RightTopology}, N, adv) = i >= $required_halo_size(adv) + 1
+        @inline $outside_symmetric_haloᶜ(i, ::Type{RightTopology}, N, adv) = i >= $required_halo_size(adv)
 
-        @inline $outside_biased_haloᶠ(i, ::Type{RightConnected}, N, adv) = (i >= $required_halo_size(adv) + 1) &  # Left bias
-                                                                           (i >= $required_halo_size(adv))        # Right bias
-        @inline $outside_biased_haloᶜ(i, ::Type{RightConnected}, N, adv) = (i >= $required_halo_size(adv))     &  # Left bias
-                                                                           (i >= $required_halo_size(adv) - 1)    # Right bias
+        @inline $outside_biased_haloᶠ(i, ::Type{RightTopology}, N, adv) = (i >= $required_halo_size(adv) + 1) &  # Left bias
+                                                                          (i >= $required_halo_size(adv))        # Right bias
+        @inline $outside_biased_haloᶜ(i, ::Type{RightTopology}, N, adv) = (i >= $required_halo_size(adv))     &  # Left bias
+                                                                          (i >= $required_halo_size(adv) - 1)    # Right bias
 
         # Left bounded topologies (only test the right side, i.e. the bounded side)
         @inline $outside_symmetric_haloᶠ(i, ::Type{LeftConnected}, N, adv) = (i <= N + 1 - $required_halo_size(adv))

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -16,22 +16,24 @@ default_prognostic_bc(::Flat,           loc,      default)  = nothing
 default_prognostic_bc(::Bounded,        ::Center, default)  = default.boundary_condition
 default_prognostic_bc(::LeftConnected,  ::Center, default)  = default.boundary_condition
 default_prognostic_bc(::RightConnected, ::Center, default)  = default.boundary_condition
+default_prognostic_bc(::RightFolded,    ::Center, default)  = default.boundary_condition
 
 # TODO: make model constructors enforce impenetrability on velocity components to simplify this code
 default_prognostic_bc(::Bounded,        ::Face, default)    = ImpenetrableBoundaryCondition()
 default_prognostic_bc(::LeftConnected,  ::Face, default)    = ImpenetrableBoundaryCondition()
 default_prognostic_bc(::RightConnected, ::Face, default)    = ImpenetrableBoundaryCondition()
+default_prognostic_bc(::RightFolded,    ::Face, default)    = ImpenetrableBoundaryCondition()
 
 default_prognostic_bc(::Bounded,        ::Nothing, default) = nothing
 default_prognostic_bc(::Flat,           ::Nothing, default) = nothing
 default_prognostic_bc(::Grids.Periodic, ::Nothing, default) = nothing
 default_prognostic_bc(::FullyConnected, ::Nothing, default) = nothing
 default_prognostic_bc(::LeftConnected,  ::Nothing, default) = nothing
-default_prognostic_bc(::RightConnected, ::Nothing, default) = nothing
+default_prognostic_bc(::RightFolded,    ::Nothing, default) = nothing
 
 default_auxiliary_bc(topo, loc) = default_prognostic_bc(topo, loc, DefaultBoundaryCondition())
 default_auxiliary_bc(::Bounded, ::Face)        = nothing
-default_auxiliary_bc(::RightConnected, ::Face) = nothing
+default_auxiliary_bc(::RightFolded, ::Face)    = nothing
 default_auxiliary_bc(::LeftConnected,  ::Face) = nothing
 
 #####

--- a/src/DistributedComputations/distributed_architectures.jl
+++ b/src/DistributedComputations/distributed_architectures.jl
@@ -381,7 +381,7 @@ Generate a `NeighboringRanks` object that holds the MPI ranks of the neighboring
 NeighboringRanks(; east, west, north, south, southwest, southeast, northwest, northeast) =
     NeighboringRanks(east, west, north, south, southwest, southeast, northwest, northeast)
 
-# The "Periodic" topologies are `Periodic`, `FullyConnected` and `RightConnected`
+# The "Periodic" topologies are `Periodic`, `RightFolded` and `FullyConnected`, and `RightConnected`
 # The "Bounded" topologies are `Bounded` and `LeftConnected`
 function increment_index(i, R)
     R == 1 && return nothing

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -107,6 +107,13 @@ Grid topology for dimensions that are connected to other models or domains only 
 """
 struct RightConnected <: AbstractTopology end
 
+"""
+    RightFolded
+
+Grid topology for dimensions that are folded onto each other on the right (the other direction is bounded).
+"""
+struct RightFolded <: AbstractTopology end
+
 #####
 ##### Directions (for tilted domains)
 #####

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -286,6 +286,7 @@ function domain_summary(topo, name, (left, right))
 
     topo_string = topo isa Periodic ? "Periodic " :
                   topo isa Bounded ? "Bounded  " :
+                  topo isa RightFolded ? "RightFolded " :
                   topo isa FullyConnected ? "FullyConnected " :
                   topo isa LeftConnected ? "LeftConnected  " :
                   topo isa RightConnected ? "RightConnected  " :

--- a/src/Grids/inactive_node.jl
+++ b/src/Grids/inactive_node.jl
@@ -17,7 +17,7 @@ function build_condition(Topo, side, dim, array::Bool)
         else
             return :(($side > grid.$dim))
         end
-    else # RightConnected
+    else # RightConnected and RightFolded
         if array
             return :((ReactantCore.materialize_traced_array($side) .< 1))
         else
@@ -36,7 +36,7 @@ end
 Return `true` when the tracer cell at `i, j, k` is "external" to the domain boundary.
 
 `inactive_cell`s include halo cells in `Bounded` directions, right halo cells in
-`LeftConnected` directions, left halo cells in `RightConnected` directions, and cells
+`LeftConnected` directions, left halo cells in `RightFolded` and `RightConnected` directions, and cells
 within an immersed boundary. Cells that are staggered with respect to tracer cells and
 which lie _on_ the boundary are considered active.
 """
@@ -45,11 +45,11 @@ which lie _on_ the boundary are considered active.
 
 # We use metaprogramming to handle all the permutations between
 # Bounded, LeftConnected, and RightConnected topologies.
-# Note that LeftConnected is equivalent to "RightBounded" and
-# RightConnected is equivalent to "LeftBounded".
-# So LeftConnected and RightConnected are "half Bounded" topologies.
+# Note that LeftConnected is equivalent to "RightBounded" while
+# RightFolded and RightConnected are equivalent to "LeftBounded".
+# So RightFolded, LeftConnected and RightConnected are "half Bounded" topologies.
 
-Topos = (:Bounded, :LeftConnected, :RightConnected)
+Topos = (:Bounded, :RightFolded, :LeftConnected, :RightConnected)
 
 for PrimaryTopo in Topos
 

--- a/src/Operators/topology_aware_operators.jl
+++ b/src/Operators/topology_aware_operators.jl
@@ -2,11 +2,13 @@ using Oceananigans.Grids: AbstractUnderlyingGrid
 
 const AGXB = AbstractUnderlyingGrid{FT, Bounded} where FT
 const AGXP = AbstractUnderlyingGrid{FT, Periodic} where FT
+const AGXF = AbstractUnderlyingGrid{FT, RightFolded} where FT
 const AGXR = AbstractUnderlyingGrid{FT, RightConnected} where FT
 const AGXL = AbstractUnderlyingGrid{FT, LeftConnected} where FT
 
 const AGYB = AbstractUnderlyingGrid{FT, <:Any, Bounded} where FT
 const AGYP = AbstractUnderlyingGrid{FT, <:Any, Periodic} where FT
+const AGYF = AbstractUnderlyingGrid{FT, <:Any, RightFolded} where FT
 const AGYR = AbstractUnderlyingGrid{FT, <:Any, RightConnected} where FT
 const AGYL = AbstractUnderlyingGrid{FT, <:Any, LeftConnected} where FT
 
@@ -40,6 +42,9 @@ const AGYL = AbstractUnderlyingGrid{FT, <:Any, LeftConnected} where FT
 @inline δxTᶠᵃᵃ(i, j, k, grid::AGXB{FT}, f::Function, args...) where FT = ifelse(i == 1, zero(FT), δxᶠᵃᵃ(i, j, k, grid, f, args...))
 @inline δyTᵃᶠᵃ(i, j, k, grid::AGYB{FT}, f::Function, args...) where FT = ifelse(j == 1, zero(FT), δyᵃᶠᵃ(i, j, k, grid, f, args...))
 
+@inline δxTᶠᵃᵃ(i, j, k, grid::AGXF{FT}, f::Function, args...) where FT = ifelse(i == 1, zero(FT), δxᶠᵃᵃ(i, j, k, grid, f, args...))
+@inline δyTᵃᶠᵃ(i, j, k, grid::AGYF{FT}, f::Function, args...) where FT = ifelse(j == 1, zero(FT), δyᵃᶠᵃ(i, j, k, grid, f, args...))
+
 @inline δxTᶠᵃᵃ(i, j, k, grid::AGXR{FT}, f::Function, args...) where FT = ifelse(i == 1, zero(FT), δxᶠᵃᵃ(i, j, k, grid, f, args...))
 @inline δyTᵃᶠᵃ(i, j, k, grid::AGYR{FT}, f::Function, args...) where FT = ifelse(j == 1, zero(FT), δyᵃᶠᵃ(i, j, k, grid, f, args...))
 
@@ -58,8 +63,8 @@ const AGYL = AbstractUnderlyingGrid{FT, <:Any, LeftConnected} where FT
 @inline δxTᶜᵃᵃ(i, j, k, grid::AGXL, f::Function, args...) = ifelse(i == grid.Nx, - f(i, j, k, grid, args...), δxᶜᵃᵃ(i, j, k, grid, f, args...))
 @inline δyTᵃᶜᵃ(i, j, k, grid::AGYL, f::Function, args...) = ifelse(j == grid.Ny, - f(i, j, k, grid, args...), δyᵃᶜᵃ(i, j, k, grid, f, args...))
 
-@inline δxTᶜᵃᵃ(i, j, k, grid::AGXR, f::Function, args...) = ifelse(i == 1, f(2, j, k, grid, args...), δxᶜᵃᵃ(i, j, k, grid, f, args...))
-@inline δyTᵃᶜᵃ(i, j, k, grid::AGYR, f::Function, args...) = ifelse(j == 1, f(i, 2, k, grid, args...), δyᵃᶜᵃ(i, j, k, grid, f, args...))
+@inline δxTᶜᵃᵃ(i, j, k, grid::AGXF, f::Function, args...) = ifelse(i == grid.Nx, f(2, j, k, grid, args...), δxᶜᵃᵃ(i, j, k, grid, f, args...))
+@inline δyTᵃᶜᵃ(i, j, k, grid::AGYF, f::Function, args...) = ifelse(j == grid.Ny, f(i, 2, k, grid, args...), δyᵃᶜᵃ(i, j, k, grid, f, args...))
 
 # Derivative operators
 


### PR DESCRIPTION
this topology, for the moment, is particular to the tripolar grid. It works in the same exact way as a `RightConnected` topology except for two differences:

- the topology-aware operators (used for the split explicit free surface) are different because they encode the fold in the operator
- the right boundary conditions associated with a `RightFolded` are `ZipperBoundaryConditions`
