### PR TITLE
Fix a memory allocation issues

### DIFF
--- a/src/BoundaryConditions/update_boundary_conditions.jl
+++ b/src/BoundaryConditions/update_boundary_conditions.jl
@@ -1,6 +1,6 @@
 using Oceananigans: boundary_conditions
 
-@inline update_boundary_condition!(bc, args...) = nothing
+@inline update_boundary_condition!(bc, side, field, model) = nothing
 
 function update_boundary_condition!(bcs::FieldBoundaryConditions, field, model)
     update_boundary_condition!(bcs.west, Val(:west), field, model)
@@ -16,9 +16,7 @@ end
 update_boundary_condition!(fields::NamedTuple, model) = update_boundary_condition!(values(fields), model)
 
 function update_boundary_condition!(fields::Tuple, model)
-    N = length(fields)
-    ntuple(Val(N)) do n
-        field = fields[n]
+    for field in fields
         bcs = boundary_conditions(field)
         update_boundary_condition!(bcs, field, model)
     end

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/step_split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/step_split_explicit_free_surface.jl
@@ -8,23 +8,25 @@ using Oceananigans.ImmersedBoundaries: MutableGridOfSomeKind
 # the free surface field η and its average η̄ are located on `Face`s at the surface (grid.Nz +1). All other intermediate variables
 # (U, V, Ū, V̄) are barotropic fields (`ReducedField`) for which a k index is not defined
 
-@kernel function _split_explicit_free_surface!(grid, Δτ, η, U, V, timestepper)
+@kernel function _split_explicit_free_surface!(η_args)
     i, j = @index(Global, NTuple)
-    k_top = grid.Nz+1
-    
+
+    # Unpack tupled arguments
+    grid, Δτ, η, U, V, timestepper = η_args
+
+    k_top = size(grid, 3) + 1
     cache_previous_free_surface!(timestepper, i, j, k_top, η)
     @inbounds  η[i, j, k_top] -= Δτ * (δxTᶜᵃᵃ(i, j, grid.Nz, grid, Δy_qᶠᶜᶠ, U★, timestepper, U) +
                                        δyTᵃᶜᵃ(i, j, grid.Nz, grid, Δx_qᶜᶠᶠ, U★, timestepper, V)) / Azᶜᶜᶠ(i, j, k_top, grid)
 end
 
-@kernel function _split_explicit_barotropic_velocity!(averaging_weight, grid, Δτ, 
-                                                      η, U, V, 
-                                                      η̅, U̅, V̅, 
-                                                      Gᵁ, Gⱽ, g, 
-                                                      timestepper)
+@kernel function _split_explicit_barotropic_velocity!(averaging_weight, U_args)
     i, j = @index(Global, NTuple)
-    k_top = grid.Nz+1
 
+    # Unpack the tupled arguments
+    grid, Δτ, η, U, V, η̅, U̅, V̅, Gᵁ, Gⱽ, g, timestepper = U_args
+    
+    k_top = size(grid, 3) + 1
     cache_previous_velocities!(timestepper, i, j, 1, U)
     cache_previous_velocities!(timestepper, i, j, 1, V)
 
@@ -58,7 +60,7 @@ const MINIMUM_SUBSTEPS = 5
 @inline calculate_adaptive_settings(substepping::FTS, substeps) = weights_from_substeps(eltype(substepping.Δt_barotropic),
                                                                                         substeps, substepping.averaging_kernel)
 
-function iterate_split_explicit!(free_surface, grid, GUⁿ, GVⁿ, Δτᴮ, weights, ::Val{Nsubsteps}) where Nsubsteps
+function iterate_split_explicit!(free_surface, grid, GUⁿ, GVⁿ, Δτᴮ, weights, Nsubsteps) 
     arch = architecture(grid)
 
     η           = free_surface.η
@@ -91,11 +93,10 @@ function iterate_split_explicit!(free_surface, grid, GUⁿ, GVⁿ, Δτᴮ, weig
         converted_η_args = convert_to_device(arch, η_args)
         converted_U_args = convert_to_device(arch, U_args)
 
-        @unroll for substep in 1:Nsubsteps
-            Base.@_inline_meta
+        for substep in 1:Nsubsteps
             averaging_weight = weights[substep]
-            free_surface_kernel!(converted_η_args...)
-            barotropic_velocity_kernel!(averaging_weight, converted_U_args...)
+            free_surface_kernel!(converted_η_args)
+            barotropic_velocity_kernel!(averaging_weight, converted_U_args)
         end
     end
 
@@ -154,7 +155,7 @@ function step_free_surface!(free_surface::SplitExplicitFreeSurface, model, baroc
     # reset free surface averages
     @apply_regionally begin
         # Solve for the free surface at tⁿ⁺¹
-        iterate_split_explicit!(free_surface, free_surface_grid, GUⁿ, GVⁿ, Δτᴮ, weights, Val(Nsubsteps))
+        iterate_split_explicit!(free_surface, free_surface_grid, GUⁿ, GVⁿ, Δτᴮ, weights, Nsubsteps)
         
         # Update eta and velocities for the next timestep
         # The halos are updated in the `update_state!` function

--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -1,38 +1,40 @@
 using Oceananigans.AbstractOperations: AbstractOperation
-using Oceananigans.Fields: flattened_unique_values
+using Oceananigans.Fields: flattened_unique_values, Field
+using Oceananigans.Grids: AbstractGrid
 
 #####
 ##### Utility for "extracting" FieldTimeSeries from large nested objects (eg models)
 #####
 
-extract_field_time_series(t1, tn...) = extract_field_time_series(tuple(t1, tn...))
+extract_field_time_series(args...) = ()
 
-# Utility used to extract field time series from a type through recursion
-function extract_field_time_series(t) 
-    prop = propertynames(t)
-    if isempty(prop)
-        return nothing
-    end
+# extract_field_time_series(t1, tn...) = extract_field_time_series(tuple(t1, tn...))
 
-    extracted = Tuple(extract_field_time_series(getproperty(t, p)) for p in prop)
-    flattened = flattened_unique_values(extracted)
+# # Utility used to extract field time series from a type through recursion
+# function extract_field_time_series(t) 
+#     prop = propertynames(t)
+#     if isempty(prop)
+#         return nothing
+#     end
 
-    return flattened
-end
+#     extracted = Tuple(extract_field_time_series(getproperty(t, p)) for p in prop)
+#     flattened = flattened_unique_values(extracted)
 
-# Termination (move all here when we switch the code up)
-extract_field_time_series(f::FieldTimeSeries) = f
+#     return flattened
+# end
 
-# For types that do not contain `FieldTimeSeries`, halt the recursion
-CannotPossiblyContainFTS = (:Number, :AbstractArray)
+# # Termination (move all here when we switch the code up)
+# extract_field_time_series(f::FieldTimeSeries) = f
 
-for T in CannotPossiblyContainFTS
-    @eval extract_field_time_series(::$T) = nothing
-end
+# # For types that do not contain `FieldTimeSeries`, halt the recursion
+# CannotPossiblyContainFTS = (:Number, :AbstractArray, :AbstractGrid, :Field)
 
-# Special recursion rules for `Tuple` and `Field` types
-extract_field_time_series(t::AbstractField)     = Tuple(extract_field_time_series(getproperty(t, p)) for p in propertynames(t))
-extract_field_time_series(t::AbstractOperation) = Tuple(extract_field_time_series(getproperty(t, p)) for p in propertynames(t))
+# for T in CannotPossiblyContainFTS
+#     @eval extract_field_time_series(::$T) = nothing
+# end
 
-extract_field_time_series(t::Union{Tuple, NamedTuple}) = map(extract_field_time_series, t)
+# # Special recursion rules for `Tuple` and `Field` types
+# extract_field_time_series(t::AbstractField)     = Tuple(extract_field_time_series(getproperty(t, p)) for p in propertynames(t))
+# extract_field_time_series(t::AbstractOperation) = Tuple(extract_field_time_series(getproperty(t, p)) for p in propertynames(t))
+# extract_field_time_series(t::Union{Tuple, NamedTuple}) = map(extract_field_time_series, t)
 

--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -6,35 +6,35 @@ using Oceananigans.Grids: AbstractGrid
 ##### Utility for "extracting" FieldTimeSeries from large nested objects (eg models)
 #####
 
-extract_field_time_series(args...) = ()
+# extract_field_time_series(args...) = ()
 
-# extract_field_time_series(t1, tn...) = extract_field_time_series(tuple(t1, tn...))
+extract_field_time_series(t1, tn...) = extract_field_time_series(tuple(t1, tn...))
 
-# # Utility used to extract field time series from a type through recursion
-# function extract_field_time_series(t) 
-#     prop = propertynames(t)
-#     if isempty(prop)
-#         return nothing
-#     end
+# Utility used to extract field time series from a type through recursion
+function extract_field_time_series(t) 
+    prop = propertynames(t)
+    if isempty(prop)
+        return nothing
+    end
 
-#     extracted = Tuple(extract_field_time_series(getproperty(t, p)) for p in prop)
-#     flattened = flattened_unique_values(extracted)
+    extracted = Tuple(extract_field_time_series(getproperty(t, p)) for p in prop)
+    flattened = flattened_unique_values(extracted)
 
-#     return flattened
-# end
+    return flattened
+end
 
-# # Termination (move all here when we switch the code up)
-# extract_field_time_series(f::FieldTimeSeries) = f
+# Termination (move all here when we switch the code up)
+extract_field_time_series(f::FieldTimeSeries) = f
 
-# # For types that do not contain `FieldTimeSeries`, halt the recursion
-# CannotPossiblyContainFTS = (:Number, :AbstractArray, :AbstractGrid, :Field)
+# For types that do not contain `FieldTimeSeries`, halt the recursion
+CannotPossiblyContainFTS = (:Number, :AbstractArray, :AbstractGrid, :Field)
 
-# for T in CannotPossiblyContainFTS
-#     @eval extract_field_time_series(::$T) = nothing
-# end
+for T in CannotPossiblyContainFTS
+    @eval extract_field_time_series(::$T) = nothing
+end
 
-# # Special recursion rules for `Tuple` and `Field` types
-# extract_field_time_series(t::AbstractField)     = Tuple(extract_field_time_series(getproperty(t, p)) for p in propertynames(t))
-# extract_field_time_series(t::AbstractOperation) = Tuple(extract_field_time_series(getproperty(t, p)) for p in propertynames(t))
-# extract_field_time_series(t::Union{Tuple, NamedTuple}) = map(extract_field_time_series, t)
+# Special recursion rules for `Tuple` and `Field` types
+extract_field_time_series(t::AbstractField)     = Tuple(extract_field_time_series(getproperty(t, p)) for p in propertynames(t))
+extract_field_time_series(t::AbstractOperation) = Tuple(extract_field_time_series(getproperty(t, p)) for p in propertynames(t))
+extract_field_time_series(t::Union{Tuple, NamedTuple}) = map(extract_field_time_series, t)
 

--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -6,8 +6,6 @@ using Oceananigans.Grids: AbstractGrid
 ##### Utility for "extracting" FieldTimeSeries from large nested objects (eg models)
 #####
 
-# extract_field_time_series(args...) = ()
-
 extract_field_time_series(t1, tn...) = extract_field_time_series(tuple(t1, tn...))
 
 # Utility used to extract field time series from a type through recursion

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -341,24 +341,24 @@ end
 @inline getrange(::OffsetStaticSize{S}) where {S} = worksize(S), offsets(S)
 @inline getrange(::Type{OffsetStaticSize{S}}) where {S} = worksize(S), offsets(S)
 
-@inline offsets(ranges::Tuple{Vararg{UnitRange}}) = Tuple(r.start - 1 for r in ranges)
+@inline offsets(ranges::NTuple{N, UnitRange}) where N = Tuple(r.start - 1 for r in ranges)::NTuple{N}
 
 @inline worksize(t::Tuple) = map(worksize, t)
 @inline worksize(sz::Int) = sz
 @inline worksize(r::AbstractUnitRange) = length(r)
 
 """a type used to store offsets in `NDRange` types"""
-struct KernelOffsets{O}
-    offsets :: O
+struct KernelOffsets{N, I}
+    offsets :: NTuple{N, I}
 end
 
 Base.getindex(o::KernelOffsets, args...) = getindex(o.offsets, args...)
 
-const OffsetNDRange{N} = NDRange{N, <:StaticSize, <:StaticSize, <:Any, <:KernelOffsets} where N
+const OffsetNDRange8{N} = NDRange{N, <:StaticSize, <:StaticSize, <:Any, <:KernelOffsets{N, I}} where {N, I}
 
 # NDRange has been modified to have offsets in place of workitems: Remember, dynamic offset kernels are not possible with this extension!!
 # TODO: maybe don't do this
-@inline function expand(ndrange::OffsetNDRange{N}, groupidx::CartesianIndex{N}, idx::CartesianIndex{N}) where {N}
+@inline function expand(ndrange::OffsetNDRange8{N}, groupidx::CartesianIndex{N}, idx::CartesianIndex{N}) where {N}
     nI = ntuple(Val(N)) do I
         Base.@_inline_meta
         offsets = workitems(ndrange)


### PR DESCRIPTION
which are deriving mainly from a dynamic dispatch caused by offset kernel objects not being able to infer the type of `KernelOffsets` which was bloating up the memory on kernel launch. This effect is much more evident when using a `SplitExplicitFreeSurface` where we launch a lot of kernels all at the same time.

I have also simplified the recursion for `extract_field_time_series!` to exclude `AbstractGrid`s and `Field`s to simplify the recursion and it seems to help.

This is the difference in a (fairly complicated) lop for the HydrostaticFreeSurface model on main
<img width="1210" alt="Untitled 2" src="https://github.com/user-attachments/assets/70784a31-a528-4584-ac96-4a80be43b8a9" />
where all the spaces indicate GC activity, and on this PR where all those white spaces (indicating an idle GPU) are absent
<img width="1228" alt="Untitled" src="https://github.com/user-attachments/assets/bbb2e685-a604-468c-8299-72ad5aa8204d" />

