### PR TITLE
Use polar criteria to build PolarBoundaryCondition

### DIFF
--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -259,12 +259,13 @@ regularize_field_boundary_conditions(boundary_conditions::NamedTuple, grid::Abst
 ##### Special behavior for LatitudeLongitudeGrid
 #####
 
+# TODO: these may be incorrect because we have not defined behavior for prognostic fields (which are
+# treated by `regularize`).
 regularize_north_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) = 
     regularize_boundary_condition(latitude_north_auxiliary_bc(grid, loc, bc), grid, loc, args...)
 
 regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) = 
     regularize_boundary_condition(latitude_south_auxiliary_bc(grid, loc, bc), grid, loc, args...)
-
 
 function FieldBoundaryConditions(grid::LatitudeLongitudeGrid, location, indices=(:, :, :);
                                  west     = default_auxiliary_bc(topology(grid, 1)(), location[1]()),
@@ -275,17 +276,13 @@ function FieldBoundaryConditions(grid::LatitudeLongitudeGrid, location, indices=
                                  top      = default_auxiliary_bc(topology(grid, 3)(), location[3]()),
                                  immersed = NoFluxBoundaryCondition())
 
+    # TODO: define special behavior for prognostic fields.
     north = latitude_north_auxiliary_bc(grid, location, north)
     south = latitude_south_auxiliary_bc(grid, location, south)
 
     return FieldBoundaryConditions(indices, west, east, south, north, bottom, top, immersed)
 end
 
-# TODO: vectors should have a different treatment since vector components should account for the frame of reference.
-# For the moment, the `PolarBoundaryConditions` is implemented only for fields that have `loc[1] == loc[2] == Center()`, which
-# we assume are not components of horizontal vectors that would require rotation. (The `w` velocity if not a tracer, but it does
-# not require rotation since it is a scalar field.)
-# North - South flux boundary conditions are not valid on a Latitude-Longitude grid if the last / first rows represent the poles
 function latitude_north_auxiliary_bc(grid, loc, default_bc=DefaultBoundaryCondition()) 
     # Check if the halo lies beyond the north pole
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
@@ -302,7 +299,6 @@ function latitude_north_auxiliary_bc(grid, loc, default_bc=DefaultBoundaryCondit
     return bc
 end
 
-# North - South flux boundary conditions are not valid on a Latitude-Longitude grid if the last / first rows represent the poles
 function latitude_south_auxiliary_bc(grid, loc, default_bc=DefaultBoundaryCondition()) 
     # Check if the halo lies beyond the south pole
     φsouth = @allowscalar φnode(1, grid, Face()) 

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -1,4 +1,6 @@
 using Oceananigans.Operators: assumed_field_location
+using Oceananigans.Grids: YFlatGrid
+using CUDA: @allowscalar
 
 #####
 ##### Default boundary conditions
@@ -290,7 +292,7 @@ function latitude_north_auxiliary_bc(grid, loc, default_bc=DefaultBoundaryCondit
     # Assumption: fields at `Center`s in x and y are not vector components
     cca_loc = loc[1] != Center || loc[2] != Center
 
-    if φmax ≈ 90 && cca_loc
+    if φnorth ≈ 90 && cca_loc
         bc = PolarBoundaryCondition(grid, :north, loc[3])
     else
         bc = default_bc

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -290,7 +290,7 @@ function latitude_north_auxiliary_bc(grid, loc, default_bc=DefaultBoundaryCondit
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
     
     # Assumption: fields at `Center`s in x and y are not vector components
-    cca_loc = loc[1] != Center || loc[2] != Center
+    cca_loc = loc[1] == Center && loc[2] == Center
 
     if φnorth ≈ 90 && cca_loc
         bc = PolarBoundaryCondition(grid, :north, loc[3])
@@ -306,7 +306,7 @@ function latitude_south_auxiliary_bc(grid, loc, default_bc=DefaultBoundaryCondit
     φsouth = @allowscalar φnode(1, grid, Face()) 
 
     # Assumption: fields at `Center`s in x and y are not vector components
-    cca_loc = loc[1] != Center || loc[2] != Center
+    cca_loc = loc[1] == Center && loc[2] == Center
 
     if φsouth ≈ -90 && cca_loc
         bc = PolarBoundaryCondition(grid, :south, loc[3])

--- a/src/BoundaryConditions/polar_boundary_condition.jl
+++ b/src/BoundaryConditions/polar_boundary_condition.jl
@@ -1,5 +1,4 @@
-using Oceananigans.Grids: inactive_node, new_data, YFlatGrid
-using CUDA: @allowscalar
+using Oceananigans.Grids: inactive_node, new_data
 
 struct PolarValue{D, S}
     data :: D

--- a/src/BoundaryConditions/polar_boundary_condition.jl
+++ b/src/BoundaryConditions/polar_boundary_condition.jl
@@ -20,52 +20,6 @@ end
 # Just a column
 @inline getbc(pv::BC{<:Value, <:PolarValue}, i, k, args...) = @inbounds pv.condition.data[1, 1, k]
 
-# YFlat grids do not have boundary conditions!
-latitude_north_auxiliary_bc(::YFlatGrid, args...) = nothing
-latitude_south_auxiliary_bc(::YFlatGrid, args...) = nothing
-
-# TODO: vectors should have a different treatment since vector components should account for the frame of reference.
-# For the moment, the `PolarBoundaryConditions` is implemented only for fields that have `loc[1] == loc[2] == Center()`, which
-# we assume are not components of horizontal vectors that would require rotation. (The `w` velocity if not a tracer, but it does
-# not require rotation since it is a scalar field.)
-# North - South flux boundary conditions are not valid on a Latitude-Longitude grid if the last / first rows represent the poles
-function latitude_north_auxiliary_bc(grid, loc, default_bc=DefaultBoundaryCondition()) 
-    # Check if the halo lies beyond the north pole
-    φmax = @allowscalar φnode(grid.Ny+1, grid, Center()) 
-    
-    # Assumption: fields at `Center`s in x and y are not vector components
-    rotated_field = loc[1] != Center || loc[2] != Center
-
-    # No problem!
-    if φmax < 90 || rotated_field
-        return default_bc
-    end
-
-    return PolarBoundaryCondition(grid, :north, loc[3])
-end
-
-# North - South flux boundary conditions are not valid on a Latitude-Longitude grid if the last / first rows represent the poles
-function latitude_south_auxiliary_bc(grid, loc, default_bc=DefaultBoundaryCondition()) 
-    # Check if the halo lies beyond the south pole
-    φmin = @allowscalar φnode(0, grid, Face()) 
-
-    # Assumption: fields at `Center`s in x and y are not vector components
-    rotated_field = loc[1] != Center || loc[2] != Center
-
-    # No problem!
-    if φmin > -90 || rotated_field
-        return default_bc
-    end
-
-    return PolarBoundaryCondition(grid, :south, loc[3])
-end
-
-regularize_north_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) = 
-    regularize_boundary_condition(latitude_north_auxiliary_bc(grid, loc, bc), grid, loc, args...)
-
-regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) = 
-    regularize_boundary_condition(latitude_south_auxiliary_bc(grid, loc, bc), grid, loc, args...)
-
 @kernel function _average_pole_value!(data, c, j, grid, loc)
     i′, j′, k = @index(Global, NTuple)
     c̄ = zero(grid)
@@ -118,18 +72,4 @@ function fill_south_and_north_halo!(c, south_bc::PolarBoundaryCondition, north_b
                    _fill_south_and_north_halo!, c, south_bc, north_bc, loc, grid, Tuple(args); kwargs...)
 end
 
-# If it is a LatitudeLongitudeGrid, we include the PolarBoundaryConditions
-function FieldBoundaryConditions(grid::LatitudeLongitudeGrid, location, indices=(:, :, :);
-                                 west     = default_auxiliary_bc(topology(grid, 1)(), location[1]()),
-                                 east     = default_auxiliary_bc(topology(grid, 1)(), location[1]()),
-                                 south    = default_auxiliary_bc(topology(grid, 2)(), location[2]()),
-                                 north    = default_auxiliary_bc(topology(grid, 2)(), location[2]()),
-                                 bottom   = default_auxiliary_bc(topology(grid, 3)(), location[3]()),
-                                 top      = default_auxiliary_bc(topology(grid, 3)(), location[3]()),
-                                 immersed = NoFluxBoundaryCondition())
 
-    north = latitude_north_auxiliary_bc(grid, location, north)
-    south = latitude_south_auxiliary_bc(grid, location, south)
-
-    return FieldBoundaryConditions(indices, west, east, south, north, bottom, top, immersed)
-end

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -256,8 +256,8 @@ end
         grid = LatitudeLongitudeGrid(size=(10, 10, 10), latitude=(-85, 85), longitude=(0, 360), z = (0, 1))
         f = CenterField(grid)
 
-        @test f.boundary_conditions.north isa VBC
-        @test f.boundary_conditions.south isa VBC
+        @test f.boundary_conditions.north isa ZFBC
+        @test f.boundary_conditions.south isa ZFBC
 
         set!(f, (x, y, z) -> x)
         fill_halo_regions!(f)

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -214,12 +214,12 @@ end
         grid = bbb_grid
         
         T_bcs = FieldBoundaryConditions(grid, (Center, Center, Center),
-                                                   east = ValueBoundaryCondition(simple_bc),
-                                                   west = ValueBoundaryCondition(simple_bc),
-                                                 bottom = ValueBoundaryCondition(simple_bc),
-                                                    top = ValueBoundaryCondition(simple_bc),
-                                                  north = ValueBoundaryCondition(simple_bc),
-                                                  south = ValueBoundaryCondition(simple_bc))
+                                        east = ValueBoundaryCondition(simple_bc),
+                                        west = ValueBoundaryCondition(simple_bc),
+                                        bottom = ValueBoundaryCondition(simple_bc),
+                                        top = ValueBoundaryCondition(simple_bc),
+                                        north = ValueBoundaryCondition(simple_bc),
+                                        south = ValueBoundaryCondition(simple_bc))
 
         @test T_bcs.east.condition isa ContinuousBoundaryFunction
         @test T_bcs.west.condition isa ContinuousBoundaryFunction 
@@ -237,12 +237,12 @@ end
 
         one_bc = BoundaryCondition(Value(), 1.0)
 
-        T_bcs = FieldBoundaryConditions(   east = one_bc,
-                                           west = one_bc,
-                                         bottom = one_bc,
-                                            top = one_bc,
-                                          north = one_bc,
-                                          south = one_bc)
+        T_bcs = FieldBoundaryConditions(east = one_bc,
+                                        west = one_bc,
+                                        bottom = one_bc,
+                                        top = one_bc,
+                                        north = one_bc,
+                                        south = one_bc)
 
         T_bcs = regularize_field_boundary_conditions(T_bcs, grid, :T)
 
@@ -262,13 +262,19 @@ end
         set!(f, (x, y, z) -> x)
         fill_halo_regions!(f)
 
-        @test all(f.data[1:10, 0,  1:10] .== 2 * mean(f.data[1:10, 1,  1:10]) .- f.data[1:10, 1,  1:10])
-        @test all(f.data[1:10, 11, 1:10] .== 2 * mean(f.data[1:10, 10, 1:10]) .- f.data[1:10, 10, 1:10])
+        @test all(f.data[1:10, 0,  1:10] .== f.data[1:10, 1, 1:10])
+        @test all(f.data[1:10, 11, 1:10] .== f.data[1:10, 10, 1:10])
 
         # Minimal test for PolarBoundaryCondition
         polar_grid = LatitudeLongitudeGrid(size=(10, 10, 10), latitude=(-90, 90), longitude=(0, 360), z = (0, 1))
         c = CenterField(polar_grid)
         @test c.boundary_conditions.north isa Oceananigans.BoundaryConditions.PolarBoundaryCondition
         @test c.boundary_conditions.south isa Oceananigans.BoundaryConditions.PolarBoundaryCondition
+
+        set!(c, (x, y, z) -> x)
+        fill_halo_regions!(c)
+
+        @test all(c.data[1:10, 0,  1:10] .== 2 * mean(c.data[1:10, 1,  1:10]) .- c.data[1:10, 1,  1:10])
+        @test all(c.data[1:10, 11, 1:10] .== 2 * mean(c.data[1:10, 10, 1:10]) .- c.data[1:10, 10, 1:10])
     end
 end

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -253,7 +253,7 @@ end
         @test T_bcs.top    === one_bc
         @test T_bcs.bottom === one_bc
 
-        grid = LatitudeLongitudeGrid(size=(10, 10, 10), latitude=(-90, 90), longitude=(0, 360), z = (0, 1))
+        grid = LatitudeLongitudeGrid(size=(10, 10, 10), latitude=(-85, 85), longitude=(0, 360), z = (0, 1))
         f = CenterField(grid)
 
         @test f.boundary_conditions.north isa VBC

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -264,5 +264,11 @@ end
 
         @test all(f.data[1:10, 0,  1:10] .== 2 * mean(f.data[1:10, 1,  1:10]) .- f.data[1:10, 1,  1:10])
         @test all(f.data[1:10, 11, 1:10] .== 2 * mean(f.data[1:10, 10, 1:10]) .- f.data[1:10, 10, 1:10])
+
+        # Minimal test for PolarBoundaryCondition
+        polar_grid = LatitudeLongitudeGrid(size=(10, 10, 10), latitude=(-90, 90), longitude=(0, 360), z = (0, 1))
+        c = CenterField(polar_grid)
+        @test c.boundary_conditions.north isa Oceananigans.BoundaryConditions.PolarBoundaryCondition
+        @test c.boundary_conditions.south isa Oceananigans.BoundaryConditions.PolarBoundaryCondition
     end
 end


### PR DESCRIPTION
This PR changes the criteria for `PolarBoundaryCondition` to check whether the north/south end of the grid is at the pole. Previously, it checked whether the _center of the first halo_ was "beyond the pole". This "non-polar" criteria produces undesirable behavior; for example, whether or not the polar boundary condition would be applied depended on resolution.

It also reorganizes code so that `polar_boundary_condition.jl` only contains code relevant to applying the `PolarBoundaryCondition`, and `FieldBoundaryCondition` stuff resides in `field_boundary_condition.jl`.