### PR TITLE
Add validation for `condition` kwarg in `ConditionalOperation` for immersed boundary grids

### DIFF
--- a/src/AbstractOperations/conditional_operations.jl
+++ b/src/AbstractOperations/conditional_operations.jl
@@ -19,6 +19,7 @@ struct ConditionalOperation{LX, LY, LZ, F, C, O, G, M, T} <: AbstractOperation{L
         if func === Base.identity
             func = nothing
         end
+        condition = validate_condition(condition, operand)
         T = eltype(operand)
         F = typeof(func)
         return new{LX, LY, LZ, F, C, O, G, M, T}(operand, func, grid, condition, mask)
@@ -95,8 +96,6 @@ function ConditionalOperation(operand::AbstractField;
                               func = nothing,
                               condition = nothing,
                               mask = zero(eltype(operand)))
-
-    condition = validate_condition(condition, operand)
 
     LX, LY, LZ = location(operand)
     return ConditionalOperation{LX, LY, LZ}(operand, func, operand.grid, condition, mask)

--- a/src/AbstractOperations/conditional_operations.jl
+++ b/src/AbstractOperations/conditional_operations.jl
@@ -101,7 +101,9 @@ function ConditionalOperation(operand::AbstractField;
     return ConditionalOperation{LX, LY, LZ}(operand, func, operand.grid, condition, mask)
 end
 
-validate_condition(cond, ::AbstractField) = cond # fallback
+# fallbacks
+validate_condition(cond, ::AbstractField) = cond
+validate_condition(cond::AbstractArray, ::OneField) = cond
 
 function validate_condition(cond::AbstractArray, operand::AbstractField)
     if size(cond) !== size(operand)

--- a/src/AbstractOperations/conditional_operations.jl
+++ b/src/AbstractOperations/conditional_operations.jl
@@ -19,7 +19,6 @@ struct ConditionalOperation{LX, LY, LZ, F, C, O, G, M, T} <: AbstractOperation{L
         if func === Base.identity
             func = nothing
         end
-        condition = validate_condition(condition, operand)
         T = eltype(operand)
         F = typeof(func)
         return new{LX, LY, LZ, F, C, O, G, M, T}(operand, func, grid, condition, mask)
@@ -96,7 +95,7 @@ function ConditionalOperation(operand::AbstractField;
                               func = nothing,
                               condition = nothing,
                               mask = zero(eltype(operand)))
-
+    condition = validate_condition(condition, operand)
     LX, LY, LZ = location(operand)
     return ConditionalOperation{LX, LY, LZ}(operand, func, operand.grid, condition, mask)
 end
@@ -116,6 +115,7 @@ function ConditionalOperation(c::ConditionalOperation;
                               func = c.func,
                               condition = c.condition,
                               mask = c.mask)
+    condition = validate_condition(condition, operand)
     LX, LY, LZ = location(c)
     compined_func = func ∘ c.func
 
@@ -126,6 +126,7 @@ function ConditionalOperation(c::NoFuncCO;
                               func = c.func,
                               condition = c.condition,
                               mask = c.mask)
+    condition = validate_condition(condition, operand)
     LX, LY, LZ = location(c)
     return ConditionalOperation{LX, LY, LZ}(c.operand, func, c.grid, condition, mask)
 end
@@ -165,6 +166,7 @@ end
 @inline condition_operand(op::ConditionalOperation, condition, mask) = error("not supported")
 
 @inline function condition_operand(func, operand::AbstractField, condition::AbstractArray, mask)
+    condition = validate_condition(condition, operand)
     condition = on_architecture(architecture(operand.grid), condition)
     return ConditionalOperation(operand; func, condition, mask)
 end

--- a/src/AbstractOperations/conditional_operations.jl
+++ b/src/AbstractOperations/conditional_operations.jl
@@ -197,7 +197,10 @@ end
 end
 
 @inline conditional_length(c::ConditionalOperation) = sum(conditional_one(c, 0))
-@inline conditional_length(c::ConditionalOperation, dims) = sum(conditional_one(c, 0); dims = dims)
+@inline conditional_length(c::ConditionalOperation, dims) = sum(conditional_one(c, 0); dims)
+
+compute_at!(c::ConditionalOperation, time) = compute_at!(c.operand, time)
+indices(c::ConditionalOperation) = indices(c.operand)
 
 Adapt.adapt_structure(to, c::ConditionalOperation{LX, LY, LZ}) where {LX, LY, LZ} =
     ConditionalOperation{LX, LY, LZ}(adapt(to, c.operand),
@@ -213,10 +216,8 @@ on_architecture(to, c::ConditionalOperation{LX, LY, LZ}) where {LX, LY, LZ} =
                                      on_architecture(to, c.condition),
                                      on_architecture(to, c.mask))
 
-Base.summary(c::ConditionalOperation) = string("ConditionalOperation of ", summary(c.operand), " with condition ", summary(c.condition))
-
-compute_at!(c::ConditionalOperation, time) = compute_at!(c.operand, time)
-indices(c::ConditionalOperation) = indices(c.operand)
+Base.summary(c::ConditionalOperation) =
+    string("ConditionalOperation of ", summary(c.operand), " with condition ", summary(c.condition))
 
 Base.show(io::IO, operation::ConditionalOperation) =
     print(io, "ConditionalOperation at $(location(operation))", '\n',

--- a/src/ImmersedBoundaries/immersed_reductions.jl
+++ b/src/ImmersedBoundaries/immersed_reductions.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Fields: AbstractField, indices
+using Oceananigans.Fields: AbstractField, OneField, indices
 using Oceananigans.AbstractOperations: KernelFunctionOperation
 
 import Oceananigans.AbstractOperations: ConditionalOperation, evaluate_condition, validate_condition
@@ -30,6 +30,8 @@ NotImmersed() = NotImmersed(nothing)
 Base.summary(::NotImmersed{Nothing}) = "NotImmersed()"
 Base.summary(ni::NotImmersed) = string("NotImmersed(", summary(ni.condition), ")")
 Base.size(ni::NotImmersed{<:AbstractArray}) = size(ni.condition)
+
+validate_condition(cond::NotImmersed{<:AbstractArray}, ::OneField) = cond
 
 function validate_condition(cond::NotImmersed{<:AbstractArray}, operand::AbstractField)
     if size(cond) !== size(operand)

--- a/src/ImmersedBoundaries/immersed_reductions.jl
+++ b/src/ImmersedBoundaries/immersed_reductions.jl
@@ -33,12 +33,8 @@ Base.size(ni::NotImmersed{<:AbstractArray}) = size(ni.condition)
 
 validate_condition(cond::NotImmersed{<:AbstractArray}, ::OneField) = cond
 
-function validate_condition(cond::NotImmersed{<:AbstractArray}, operand::AbstractField)
-    if size(cond) !== size(operand)
-        throw(ArgumentError("The keyword argument condition::AbstractArray requires size $(size(operand))"))
-    end
-    return cond
-end
+validate_condition(cond::NotImmersed{<:AbstractArray}, operand::AbstractField) =
+    validate_condition(cond.condition, operand)
 
 "Adapt `NotImmersed` to work on the GPU via CUDAnative and CUDAdrv."
 Adapt.adapt_structure(to, ni::NotImmersed) = NotImmersed(Adapt.adapt(to, ni.condition))

--- a/src/ImmersedBoundaries/immersed_reductions.jl
+++ b/src/ImmersedBoundaries/immersed_reductions.jl
@@ -51,6 +51,8 @@ function ConditionalOperation(operand::IF;
                               condition = nothing,
                               mask = zero(eltype(operand)))
 
+    condition = validate_condition(condition, operand)
+
     if condition isa NotImmersed || condition isa NotImmersedColumn
         immersed_condition = condition # it's immersed enough
     elseif operand isa IRF

--- a/test/test_field_scans.jl
+++ b/test/test_field_scans.jl
@@ -404,7 +404,7 @@ interior_array(a, i, j, k) = Array(interior(a, i, j, k))
             w_ibg = ZFaceField(grid)
             w_noibg = ZFaceField(grid.underlying_grid)
 
-            condition = trues(size(grid))
+            condition = trues(size(grid)) # should work for Periodic but not for Bounded directions
 
             ∫u_ibg = Integral(u_ibg; dims=1, condition)
             @test ∫u_ibg isa Reduction{<:Any, <:Any, <:ConditionalOperation}

--- a/test/test_field_scans.jl
+++ b/test/test_field_scans.jl
@@ -404,6 +404,8 @@ interior_array(a, i, j, k) = Array(interior(a, i, j, k))
             w_ibg = ZFaceField(grid)
             w_noibg = ZFaceField(grid.underlying_grid)
 
+            condition = trues(size(grid))
+
             ∫u_ibg = Integral(u_ibg; dims=1, condition)
             @test ∫u_ibg isa Reduction{<:Any, <:Any, <:ConditionalOperation}
             ∫u_noibg = Integral(u_noibg; dims=1, condition)

--- a/test/test_field_scans.jl
+++ b/test/test_field_scans.jl
@@ -397,13 +397,29 @@ interior_array(a, i, j, k) = Array(interior(a, i, j, k))
 
             grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bump))
 
+            u_ibg = XFaceField(grid)
+            u_noibg = XFaceField(grid.underlying_grid)
+            v_ibg = YFaceField(grid)
+            v_noibg = YFaceField(grid.underlying_grid)
             w_ibg = ZFaceField(grid)
             w_noibg = ZFaceField(grid.underlying_grid)
 
-            condition = trues(size(grid)...)
-
+            ∫u_ibg = Integral(u_ibg; dims=1, condition)
+            @test ∫u_ibg isa Reduction{<:Any, <:Any, <:ConditionalOperation}
+            ∫u_noibg = Integral(u_noibg; dims=1, condition)
+            @test ∫u_noibg isa Reduction{<:Any, <:Any, <:ConditionalOperation}
+            @test_throws ArgumentError ∫v_ibg = Integral(v_ibg; dims=1, condition)
+            @test_throws ArgumentError ∫v_noibg = Integral(v_noibg; dims=1, condition)
             @test_throws ArgumentError ∫w_ibg = Integral(w_ibg; dims=1, condition)
             @test_throws ArgumentError ∫w_noibg = Integral(w_noibg; dims=1, condition)
+            ∫v_ibg = Integral(v_ibg; dims=1, condition=trues(size(v_ibg)))
+            @test ∫v_ibg isa Reduction{<:Any, <:Any, <:ConditionalOperation}
+            ∫v_noibg = Integral(v_noibg; dims=1, condition=trues(size(v_noibg)))
+            @test ∫v_noibg isa Reduction{<:Any, <:Any, <:ConditionalOperation}
+            ∫w_ibg = Integral(w_ibg; dims=1, condition=trues(size(w_ibg)))
+            @test ∫w_ibg isa Reduction{<:Any, <:Any, <:ConditionalOperation}
+            ∫w_noibg = Integral(w_noibg; dims=1, condition=trues(size(w_noibg)))
+            @test ∫w_noibg isa Reduction{<:Any, <:Any, <:ConditionalOperation}
         end
     end
 end


### PR DESCRIPTION
This PR adds validation for NotImmersed conditions that are Arrays. Continuation from #4266. 