### PR TITLE
Flip location along accumulating dimension for `Accumulating` scans

### DIFF
--- a/src/Fields/scans.jl
+++ b/src/Fields/scans.jl
@@ -197,7 +197,15 @@ cumsum_c²[1:Nx, 1:Ny, 1:Nz]
 ```
 """
 Accumulation(accumulate!, operand; dims) = Scan(Accumulating(), accumulate!, operand, dims)
-location(a::Accumulation) = location(a.operand)
+
+flip(::Type{Face}) = Center
+flip(::Type{Center}) = Face
+            
+function location(a::Accumulation)
+    oloc = location(a.operand)
+    loc = Tuple(d ∈ a.dims ? flip(oloc[d]) : oloc[d] for d=1:3)
+    return loc
+end
 
 #####
 ##### Some custom scans


### PR DESCRIPTION
Addresses #4354 

Things to think about:

* does this apply to all accumulations?
* should we throw an error when you try to accumulate along an already-reduced dimension (eg the location is `Nothing`)
* can we test this? maybe a simple unit test is enough but it would also be nice to know if this is "correct" somehow
* other concerns I didn't think of

cc @tomchor 