### PR TITLE
Refactor hydrostatic free surface names

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl
@@ -86,6 +86,15 @@ Return a flattened `NamedTuple` of the fields in `model.velocities`, `model.free
           model.auxiliary_fields,
           biogeochemical_auxiliary_fields(model.biogeochemistry))
 
+velocity_names(user_velocities) = (:u, :v, :w)
+
+constructor_field_names(user_velocities, user_tracers, user_free_surface, auxiliary_fields, biogeochemistry, grid) =
+    tuple(velocity_names(user_velocities)...,
+          tracernames(user_tracers)...,
+          free_surface_names(user_free_surface, user_velocities, grid)...,
+          keys(auxiliary_fields)..., 
+          keys(biogeochemical_auxiliary_fields(biogeochemistry))...)
+
 """
     prognostic_fields(model::HydrostaticFreeSurfaceModel)
 
@@ -94,45 +103,25 @@ Return a flattened `NamedTuple` of the prognostic fields associated with `Hydros
 @inline prognostic_fields(model::HydrostaticFreeSurfaceModel) =
     hydrostatic_prognostic_fields(model.velocities, model.free_surface, model.tracers)
 
-@inline hydrostatic_prognostic_fields(velocities, free_surface, tracers) = merge((u = velocities.u,
-                                                                                  v = velocities.v,
-                                                                                  η = free_surface.η),
-                                                                                  tracers)
+@inline horizontal_velocities(velocities) = (u=velocities.u, v=velocities.v)
 
-@inline hydrostatic_prognostic_fields(velocities, free_surface::SplitExplicitFreeSurface, tracers) = merge((u = velocities.u,
-                                                                                                            v = velocities.v,
-                                                                                                            η = free_surface.η,
-                                                                                                            U = free_surface.barotropic_velocities.U,
-                                                                                                            V = free_surface.barotropic_velocities.V),
-                                                                                                            tracers)
+# Note: we do not distinguish between prognostic and auxiliary free surface fields
+# even though arguably the "filtered state" is an auxiliary part of the free surface state.
+@inline free_surface_names(free_surface, velocities, grid) = tuple(:η)
+@inline free_surface_names(free_surface::SplitExplicitFreeSurface, velocities, grid) = (:η, :U, :V)
 
-@inline hydrostatic_prognostic_fields(velocities, ::Nothing, tracers) = merge((u = velocities.u,
-                                                                               v = velocities.v),
-                                                                               tracers)
-                                               
-@inline hydrostatic_fields(velocities, free_surface, tracers) = merge((u = velocities.u,
-                                                                       v = velocities.v,
-                                                                       w = velocities.w),
-                                                                       tracers,
-                                                                       (; η = free_surface.η,
-                                                                          U = nothing,
-                                                                          V = nothing))
+@inline free_surface_fields(free_surface) = (; η=free_surface.η)
+@inline free_surface_fields(::Nothing) = NamedTuple()
+@inline free_surface_fields(free_surface::SplitExplicitFreeSurface) = (η = free_surface.η,
+                                                                       U = free_surface.barotropic_velocities.U,
+                                                                       V = free_surface.barotropic_velocities.V)
 
-@inline hydrostatic_fields(velocities, free_surface::SplitExplicitFreeSurface, tracers) = merge((u = velocities.u,
-                                                                                                 v = velocities.v,
-                                                                                                 w = velocities.w),
-                                                                                                 tracers,
-                                                                                                 (; η = free_surface.η,
-                                                                                                    U = free_surface.barotropic_velocities.U,
-                                                                                                    V = free_surface.barotropic_velocities.V))
+@inline hydrostatic_prognostic_fields(velocities, free_surface, tracers) =
+    merge(horizontal_velocities(velocities), tracers, free_surface_fields(free_surface))
 
-@inline hydrostatic_fields(velocities, ::Nothing, tracers) = merge((u = velocities.u,
-                                                                    v = velocities.v,
-                                                                    w = velocities.w),
-                                                                    tracers,
-                                                                    (; η = nothing, 
-                                                                       U = nothing,
-                                                                       V = nothing))
+# Include vertical velocity
+@inline hydrostatic_fields(velocities, free_surface, tracers) =
+    merge(velocities, tracers, free_surface_fields(free_surface))
 
 displacement(free_surface) = free_surface.η
 displacement(::Nothing) = nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl
@@ -121,7 +121,9 @@ Return a flattened `NamedTuple` of the prognostic fields associated with `Hydros
 
 # Include vertical velocity
 @inline hydrostatic_fields(velocities, free_surface, tracers) =
-    merge(velocities, tracers, free_surface_fields(free_surface))
+    merge((u=velocities.u, v=velocities.v, w=velocities.w),
+          tracers,
+          free_surface_fields(free_surface))
 
 displacement(free_surface) = free_surface.η
 displacement(::Nothing) = nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -28,24 +28,24 @@ const AbstractBGCOrNothing = Union{Nothing, AbstractBiogeochemistry}
 mutable struct HydrostaticFreeSurfaceModel{TS, E, A<:AbstractArchitecture, S,
                                            G, T, V, B, R, F, P, BGC, U, C, Φ, K, AF, Z} <: AbstractModel{TS, A}
 
-                architecture :: A        # Computer `Architecture` on which `Model` is run
-                        grid :: G        # Grid of physical points on which `Model` is solved
-                       clock :: Clock{T} # Tracks iteration number and simulation time of `Model`
-                   advection :: V        # Advection scheme for tracers
-                    buoyancy :: B        # Set of parameters for buoyancy model
-                    coriolis :: R        # Set of parameters for the background rotation rate of `Model`
-                free_surface :: S        # Free surface parameters and fields
-                     forcing :: F        # Container for forcing functions defined by the user
-                     closure :: E        # Diffusive 'turbulence closure' for all model fields
-                   particles :: P        # Particle set for Lagrangian tracking
-             biogeochemistry :: BGC      # Biogeochemistry for Oceananigans tracers
-                  velocities :: U        # Container for velocity fields `u`, `v`, and `w`
-                     tracers :: C        # Container for tracer fields
-                    pressure :: Φ        # Container for hydrostatic pressure
-          diffusivity_fields :: K        # Container for turbulent diffusivities
-                 timestepper :: TS       # Object containing timestepper fields and parameters
-            auxiliary_fields :: AF       # User-specified auxiliary fields for forcing functions and boundary conditions
-         vertical_coordinate :: Z        # Rulesets that define the time-evolution of the grid
+    architecture :: A           # Computer `Architecture` on which `Model` is run
+    grid :: G                   # Grid of physical points on which `Model` is solved
+    clock :: Clock{T}           # Tracks iteration number and simulation time of `Model`
+    advection :: V              # Advection scheme for tracers
+    buoyancy :: B               # Set of parameters for buoyancy model
+    coriolis :: R               # Set of parameters for the background rotation rate of `Model`
+    free_surface :: S           # Free surface parameters and fields
+    forcing :: F                # Container for forcing functions defined by the user
+    closure :: E                # Diffusive 'turbulence closure' for all model fields
+    particles :: P              # Particle set for Lagrangian tracking
+    biogeochemistry :: BGC      # Biogeochemistry for Oceananigans tracers
+    velocities :: U             # Container for velocity fields `u`, `v`, and `w`
+    tracers :: C                # Container for tracer fields
+    pressure :: Φ               # Container for hydrostatic pressure
+    diffusivity_fields :: K     # Container for turbulent diffusivities
+    timestepper :: TS           # Object containing timestepper fields and parameters
+    auxiliary_fields :: AF      # User-specified auxiliary fields for forcing functions and boundary conditions
+    vertical_coordinate :: Z    # Rulesets that define the time-evolution of the grid
 end
 
 default_free_surface(grid::XYRegularRG; gravitational_acceleration=g_Earth) =

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -166,7 +166,7 @@ function HydrostaticFreeSurfaceModel(; grid,
                                          extract_boundary_conditions(diffusivity_fields))
 
     # Next, we form a list of default boundary conditions:
-    field_names = constructor_field_names(velocities, tracers, auxiliary_fields, biogeochemistry, grid)
+    field_names = constructor_field_names(velocities, tracers, free_surface, auxiliary_fields, biogeochemistry, grid)
     default_boundary_conditions = NamedTuple{field_names}(Tuple(FieldBoundaryConditions()
                                                           for name in field_names))
 

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -166,10 +166,7 @@ function HydrostaticFreeSurfaceModel(; grid,
                                          extract_boundary_conditions(diffusivity_fields))
 
     # Next, we form a list of default boundary conditions:
-    field_names = (:u, :v, :w, tracernames(tracers)..., :η, :U, :V, 
-                   keys(auxiliary_fields)..., 
-                   keys(biogeochemical_auxiliary_fields(biogeochemistry))...)
-                   
+    field_names = constructor_field_names(velocities, tracers, auxiliary_fields, biogeochemistry, grid)
     default_boundary_conditions = NamedTuple{field_names}(Tuple(FieldBoundaryConditions()
                                                           for name in field_names))
 

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -75,6 +75,9 @@ end
 hydrostatic_tendency_fields(::PrescribedVelocityFields, free_surface, grid, tracer_names) = 
     merge((u=nothing, v=nothing), TracerFields(tracer_names, grid))
 
+free_surface_names(free_surface, ::PrescribedVelocityFields, grid) = tuple()
+velocity_names(::PrescribedVelocityFields) = tuple()
+
 @inline fill_halo_regions!(::PrescribedVelocityFields, args...) = nothing
 @inline fill_halo_regions!(::FunctionField, args...) = nothing
 

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -76,7 +76,6 @@ hydrostatic_tendency_fields(::PrescribedVelocityFields, free_surface, grid, trac
     merge((u=nothing, v=nothing), TracerFields(tracer_names, grid))
 
 free_surface_names(free_surface, ::PrescribedVelocityFields, grid) = tuple()
-velocity_names(::PrescribedVelocityFields) = tuple()
 
 @inline fill_halo_regions!(::PrescribedVelocityFields, args...) = nothing
 @inline fill_halo_regions!(::FunctionField, args...) = nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -76,6 +76,7 @@ hydrostatic_tendency_fields(::PrescribedVelocityFields, free_surface, grid, trac
     merge((u=nothing, v=nothing), TracerFields(tracer_names, grid))
 
 free_surface_names(free_surface, ::PrescribedVelocityFields, grid) = tuple()
+free_surface_names(::SplitExplicitFreeSurface, ::PrescribedVelocityFields, grid) = tuple()
 
 @inline fill_halo_regions!(::PrescribedVelocityFields, args...) = nothing
 @inline fill_halo_regions!(::FunctionField, args...) = nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/single_column_model_mode.jl
@@ -25,12 +25,19 @@ const SingleColumnGrid = AbstractGrid{<:AbstractFloat, <:Flat, <:Flat, <:Bounded
 #####
 
 PressureField(arch, ::SingleColumnGrid) = (pHY′ = nothing,)
-materialize_free_surface(free_surface::ExplicitFreeSurface{Nothing}, velocities,                 ::SingleColumnGrid) = nothing
-materialize_free_surface(free_surface::ImplicitFreeSurface{Nothing}, velocities,                 ::SingleColumnGrid) = nothing
-materialize_free_surface(free_surface::SplitExplicitFreeSurface,     velocities,                 ::SingleColumnGrid) = nothing
-materialize_free_surface(free_surface::ExplicitFreeSurface{Nothing}, ::PrescribedVelocityFields, ::SingleColumnGrid) = nothing
-materialize_free_surface(free_surface::ImplicitFreeSurface{Nothing}, ::PrescribedVelocityFields, ::SingleColumnGrid) = nothing
-materialize_free_surface(free_surface::SplitExplicitFreeSurface,     ::PrescribedVelocityFields, ::SingleColumnGrid) = nothing
+materialize_free_surface(::ExplicitFreeSurface{Nothing}, velocities,                 ::SingleColumnGrid) = nothing
+materialize_free_surface(::ImplicitFreeSurface{Nothing}, velocities,                 ::SingleColumnGrid) = nothing
+materialize_free_surface(::SplitExplicitFreeSurface,     velocities,                 ::SingleColumnGrid) = nothing
+materialize_free_surface(::ExplicitFreeSurface{Nothing}, ::PrescribedVelocityFields, ::SingleColumnGrid) = nothing
+materialize_free_surface(::ImplicitFreeSurface{Nothing}, ::PrescribedVelocityFields, ::SingleColumnGrid) = nothing
+materialize_free_surface(::SplitExplicitFreeSurface,     ::PrescribedVelocityFields, ::SingleColumnGrid) = nothing
+
+free_surface_names(::ExplicitFreeSurface{Nothing}, velocities,                 ::SingleColumnGrid) = tuple()
+free_surface_names(::ImplicitFreeSurface{Nothing}, velocities,                 ::SingleColumnGrid) = tuple()
+free_surface_names(::SplitExplicitFreeSurface,     velocities,                 ::SingleColumnGrid) = tuple()
+free_surface_names(::ExplicitFreeSurface{Nothing}, ::PrescribedVelocityFields, ::SingleColumnGrid) = tuple()
+free_surface_names(::ImplicitFreeSurface{Nothing}, ::PrescribedVelocityFields, ::SingleColumnGrid) = tuple()
+free_surface_names(::SplitExplicitFreeSurface,     ::PrescribedVelocityFields, ::SingleColumnGrid) = tuple()
 
 function hydrostatic_velocity_fields(::Nothing, grid::SingleColumnGrid, clock, bcs=NamedTuple())
     u = XFaceField(grid, boundary_conditions=bcs.u)


### PR DESCRIPTION
This PR refactors `Oceananigans.fields(::HydrostaticFreeSurfaceModel)` so that it only contains non-nothing fields. To do this we add a function `constructor_field_names` which basically returns the same thing as `keys(fields(model))`, but before the model is constructed.