### PR TITLE
Require `interval::Int` in IterationInterval?

### DIFF
--- a/src/Utils/schedules.jl
+++ b/src/Utils/schedules.jl
@@ -108,7 +108,7 @@ For example,
 * `IterationInterval(100)` actuates at iterations `[100, 200, 300, ...]`.
 * `IterationInterval(100, offset=-1)` actuates at iterations `[99, 199, 299, ...]`.
 """
-IterationInterval(interval; offset=0) = IterationInterval(interval, offset)
+IterationInterval(interval::Int; offset=0) = IterationInterval(interval, offset)
 (schedule::IterationInterval)(model) = (model.clock.iteration - schedule.offset) % schedule.interval == 0
 
 next_actuation_time(schedule::IterationInterval) = Inf


### PR DESCRIPTION
Resolves https://github.com/CliMA/Oceananigans.jl/issues/4369

I am curious what others think. The reason why 86400.0 is valid is because it can be converted to `Int` (which happens under the hood). So if users do math on their iteration interval they will have to manually convert it to `Int`.