### PR TITLE
Fix `summary()` for `ConjugateGradientPoissonSolver`

### DIFF
--- a/src/Solvers/conjugate_gradient_poisson_solver.jl
+++ b/src/Solvers/conjugate_gradient_poisson_solver.jl
@@ -45,6 +45,18 @@ end
 
 struct DefaultPreconditioner end
 
+"""
+    ConjugateGradientPoissonSolver(grid;
+                                   preconditioner = DefaultPreconditioner(),
+                                   reltol = sqrt(eps(grid)),
+                                   abstol = sqrt(eps(grid)),
+                                   kw...)
+
+Creates a `ConjugateGradientPoissonSolver` on `grid` using a `preconditioner`.
+`ConjugateGradientPoissonSolver` is iterative, and will stop when both the relative error in the
+pressure solution is smaller than `reltol` and the absolute error is smaller than `abstol`. Other
+keyword arguments are passed to `ConjugateGradientSolver`.
+"""
 function ConjugateGradientPoissonSolver(grid;
                                         preconditioner = DefaultPreconditioner(),
                                         reltol = sqrt(eps(grid)),

--- a/src/Solvers/conjugate_gradient_poisson_solver.jl
+++ b/src/Solvers/conjugate_gradient_poisson_solver.jl
@@ -16,7 +16,7 @@ architecture(solver::ConjugateGradientPoissonSolver) = architecture(cgps.grid)
 iteration(cgps::ConjugateGradientPoissonSolver) = iteration(cgps.conjugate_gradient_solver)
 
 Base.summary(ips::ConjugateGradientPoissonSolver) =
-    summary("ConjugateGradientPoissonSolver on ", summary(ips.grid))
+    "ConjugateGradientPoissonSolver with $(summary(ips.conjugate_gradient_solver.preconditioner)) on $(summary(ips.grid))"
 
 function Base.show(io::IO, ips::ConjugateGradientPoissonSolver)
     A = architecture(ips.grid)


### PR DESCRIPTION
This fixes a bug in the `summary` method for `ConjugateGradientPoissonSolver`. It also adds a docstring. @xkykai I believe you coded this, right? Can you take a look at the docstring to make sure it's okay?