### PR TITLE
Remove more splatting

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_ab2_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_ab2_step.jl
@@ -94,13 +94,13 @@ function ab2_step_tracers!(tracers, model, Δt, χ)
             FT = eltype(grid)
             launch!(architecture(grid), grid, :xyz, _ab2_step_tracer_field!, tracer_field, grid, convert(FT, Δt), χ, Gⁿ, G⁻)
 
-            implicit_step!(tracer_field,
-                           model.timestepper.implicit_solver,
-                           closure,
-                           model.diffusivity_fields,
-                           Val(tracer_index),
-                           model.clock,
-                           Δt)
+            # implicit_step!(tracer_field,
+            #                model.timestepper.implicit_solver,
+            #                closure,
+            #                model.diffusivity_fields,
+            #                Val(tracer_index),
+            #                model.clock,
+            #                Δt)
         end
     end
 

--- a/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
@@ -224,8 +224,8 @@ const VITD = VerticallyImplicitTimeDiscretization
 @inline ivd_viscous_flux_vz(i, j, k, grid, closure::AVD, K, clock, fields, b) = zero(grid)
 
 # General functions (eg for vertically periodic)
-@inline viscous_flux_uz(i, j, k, grid,  ::VITD, closure::AIDorAVD, args...) = ivd_viscous_flux_uz(i, j, k, grid, closure, args...)
-@inline viscous_flux_vz(i, j, k, grid,  ::VITD, closure::AIDorAVD, args...) = ivd_viscous_flux_vz(i, j, k, grid, closure, args...)
+@inline viscous_flux_uz(i, j, k, grid,  ::VITD, closure::AIDorAVD, K, clock, fields, b) = ivd_viscous_flux_uz(i, j, k, grid, closure, K, clock, fields, b)
+@inline viscous_flux_vz(i, j, k, grid,  ::VITD, closure::AIDorAVD, K, clock, fields, b) = ivd_viscous_flux_vz(i, j, k, grid, closure, K, clock, fields, b)
 @inline viscous_flux_wz(i, j, k, grid,  ::VITD, closure::AIDorAVD, args...) = zero(grid)
 @inline diffusive_flux_z(i, j, k, grid, ::VITD, closure::AIDorAVD, args...) = zero(grid)
 
@@ -237,27 +237,27 @@ const VITD = VerticallyImplicitTimeDiscretization
 # of boundary contributions (eg boundary contributions must be moved to the right
 # hand side of the tridiagonal system).
 
-@inline function viscous_flux_uz(i, j, k, grid::VerticallyBoundedGrid, ::VITD, closure::AIDorAVD, args...)
+@inline function viscous_flux_uz(i, j, k, grid::VerticallyBoundedGrid, ::VITD, closure::AIDorAVD,  K, clock, fields, b)
     return ifelse((k == 1) | (k == grid.Nz+1),
-                  viscous_flux_uz(i, j, k, grid, ExplicitTimeDiscretization(), closure, args...),
-                  ivd_viscous_flux_uz(i, j, k, grid, closure, args...))
+                  viscous_flux_uz(i, j, k, grid, ExplicitTimeDiscretization(), closure, K, clock, fields, b),
+                  ivd_viscous_flux_uz(i, j, k, grid, closure, K, clock, fields, b))
 end
 
-@inline function viscous_flux_vz(i, j, k, grid::VerticallyBoundedGrid, ::VITD, closure::AIDorAVD, args...)
+@inline function viscous_flux_vz(i, j, k, grid::VerticallyBoundedGrid, ::VITD, closure::AIDorAVD, K, clock, fields, b)
     return ifelse((k == 1) | (k == grid.Nz+1),
-                  viscous_flux_vz(i, j, k, grid, ExplicitTimeDiscretization(), closure, args...),
-                  ivd_viscous_flux_vz(i, j, k, grid, closure, args...))
+                  viscous_flux_vz(i, j, k, grid, ExplicitTimeDiscretization(), closure, K, clock, fields, b),
+                  ivd_viscous_flux_vz(i, j, k, grid, closure, K, clock, fields, b))
 end
 
-@inline function viscous_flux_wz(i, j, k, grid::VerticallyBoundedGrid, ::VITD, closure::AIDorAVD, args...)
+@inline function viscous_flux_wz(i, j, k, grid::VerticallyBoundedGrid, ::VITD, closure::AIDorAVD,  K, clock, fields, b)
     return ifelse((k == 1) | (k == grid.Nz+1),
-                  viscous_flux_wz(i, j, k, grid, ExplicitTimeDiscretization(), closure, args...),
+                  viscous_flux_wz(i, j, k, grid, ExplicitTimeDiscretization(), closure, K, clock, fields, b),
                   zero(grid))
 end
 
-@inline function diffusive_flux_z(i, j, k, grid::VerticallyBoundedGrid, ::VITD, closure::AIDorAVD, args...)
+@inline function diffusive_flux_z(i, j, k, grid::VerticallyBoundedGrid, ::VITD, closure::AIDorAVD, K, id, clock, fields, b)
     return ifelse((k == 1) | (k == grid.Nz+1),
-                  diffusive_flux_z(i, j, k, grid, ExplicitTimeDiscretization(), closure, args...),
+                  diffusive_flux_z(i, j, k, grid, ExplicitTimeDiscretization(), closure, K, id, clock, fields, b),
                   zero(grid))
 end
 

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -30,10 +30,10 @@ const F = Face
 @inline implicit_linear_coefficient(i, j, k, grid, args...) = zero(grid)
 
 # General implementation
-@inline νzᶠᶜᶠ(i, j, k, grid, closure, K, args...) = zero(grid)
-@inline νzᶜᶠᶠ(i, j, k, grid, closure, K, args...) = zero(grid)
-@inline νzᶜᶜᶜ(i, j, k, grid, closure, K, args...) = zero(grid)
-@inline κzᶜᶜᶠ(i, j, k, grid, closure, K, args...) = zero(grid)
+@inline νzᶠᶜᶠ(i, j, k, grid, closure, K, id, clock) = zero(grid)
+@inline νzᶜᶠᶠ(i, j, k, grid, closure, K, id, clock) = zero(grid)
+@inline νzᶜᶜᶜ(i, j, k, grid, closure, K, id, clock) = zero(grid)
+@inline κzᶜᶜᶠ(i, j, k, grid, closure, K, id, clock) = zero(grid)
 
 # Vertical momentum diffusivities: u, v, w
 @inline ivd_diffusivity(i, j, k, grid, ::F, ::C, ::F, clo, K, id, clock) = νzᶠᶜᶠ(i, j, k, grid, clo, K, id, clock) * !inactive_node(i, j, k, grid, f, c, f)
@@ -41,7 +41,7 @@ const F = Face
 @inline ivd_diffusivity(i, j, k, grid, ::C, ::C, ::C, clo, K, id, clock) = νzᶜᶜᶜ(i, j, k, grid, clo, K, id, clock) * !inactive_node(i, j, k, grid, c, c, c)
 
 # Tracer diffusivity
-@inline ivd_diffusivity(i, j, k, grid, ::C, ::C, ::F, args...) = κzᶜᶜᶠ(i, j, k, grid, args...) * !inactive_node(i, j, k, grid, c, c, f)
+@inline ivd_diffusivity(i, j, k, grid, ::C, ::C, ::F, clo, K, id, clock) = κzᶜᶜᶠ(i, j, k, grid, clo, K, id, clock) * !inactive_node(i, j, k, grid, c, c, f)
 
 #####
 ##### Batched Tridiagonal solver for implicit diffusion
@@ -113,9 +113,8 @@ end
 
 @inline ivd_diagonal(i, j, k, grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) =
     one(grid) - Δt * _implicit_linear_coefficient(i, j, k,   grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) -
-                               _ivd_upper_diagonal(i, j, k,   grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) -
-                               _ivd_lower_diagonal(i, j, k-1, grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock)
-
+                              _ivd_upper_diagonal(i, j, k,   grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) -
+                              _ivd_lower_diagonal(i, j, k-1, grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock)
 
 @inline _implicit_linear_coefficient(args...) = implicit_linear_coefficient(args...)
 @inline _ivd_upper_diagonal(args...) = ivd_upper_diagonal(args...)
@@ -163,9 +162,14 @@ end
 
 # Extend `get_coefficient` to retrieve `ivd_diagonal`, `_ivd_lower_diagonal` and `_ivd_upper_diagonal`.
 # Note that we use the "periphery-aware" upper and lower diagonals
-@inline get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionLowerDiagonal, p, ::ZDirection, args...) = _ivd_lower_diagonal(i, j, k, grid, args...)
-@inline get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionUpperDiagonal, p, ::ZDirection, args...) = _ivd_upper_diagonal(i, j, k, grid, args...)
-@inline get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionDiagonal,      p, ::ZDirection, args...) = ivd_diagonal(i, j, k, grid, args...)
+@inline get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionLowerDiagonal, p, ::ZDirection, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) = 
+    _ivd_lower_diagonal(i, j, k, grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock)
+
+@inline get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionUpperDiagonal, p, ::ZDirection, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) = 
+    _ivd_upper_diagonal(i, j, k, grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock)
+
+@inline get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionDiagonal, p, ::ZDirection, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) =        
+           ivd_diagonal(i, j, k, grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock)
 
 #####
 ##### Implicit step functions


### PR DESCRIPTION
splatting seems to be a very large penalty when done with many different arguments, this PR fixes more performance issue with implicit solvers that seems to depend on the splitting of the arguments inside the flux calculation