### PR TITLE
Allow reductions with dims kwarg work for `FieldTimeSeries`

### DIFF
--- a/src/OutputReaders/field_time_series_reductions.jl
+++ b/src/OutputReaders/field_time_series_reductions.jl
@@ -1,4 +1,7 @@
 using Statistics
+
+using Oceananigans.Fields: reduced_location, filltype
+
 import Oceananigans.Fields: conditional_length
 
 @inline conditional_length(fts::FieldTimeSeries) = length(fts) * conditional_length(fts[1])
@@ -30,7 +33,7 @@ for reduction in (:sum, :maximum, :minimum, :all, :any, :prod)
                 T = filltype(Base.$(reduction!), fts)
                 loc = LX, LY, LZ = reduced_location(location(fts); dims)
                 times = fts.times
-                rts = FieldTimeSeries{LX, LY, LZ}(grid, times, T; indices=fts.indices)
+                rts = FieldTimeSeries{LX, LY, LZ}(fts.grid, times, T; indices=fts.indices)
                 return Base.$(reduction!)(f, rts, fts; kw...)
             end
         end


### PR DESCRIPTION
At the moment, reductions of FieldTimeSeries work _if we don't provide `dims` kwarg_ but seem to be broken when we provide `dims`.

I fixed a few obvious bugs. But I am a bit unsure how to proceed.

```Julia
using Oceananigans

grid = RectilinearGrid(size=(2, 3, 4), extent=(1, 1, 1))
times = 0:0.1:3

sinf(t) = sin(2π * t / 3)

fts = FieldTimeSeries{Center, Center, Center}(grid, times; backend=OnDisk(), path="test.jld2", name="f")

f = CenterField(grid)
for (i, time) in enumerate(fts.times)
    set!(f, (x, y, z) -> sinf(time))
    set!(fts, f, i)
end

@info "mean(fts)"
@show mean(fts)

@info "mean(fts, dims=4)"
@show mean(fts, dims=4)
```

```Julia
julia> include("mwe_fts.jl")
[ Info: mean(fts)
mean(fts) = -1.2676099885359938e-17
[ Info: mean(fts, dims=4)
ERROR: LoadError: MethodError: no method matching (FieldTimeSeries{…})(::RectilinearGrid{…}, ::StepRangeLen{…}, ::Type{…}; indices::Tuple{…})

Closest candidates are:
  (FieldTimeSeries{LX, LY, LZ})(::D, ::G, ::K, ::B, ::I, ::Any, ::Any, ::Any, ::Any, ::Any) where {LX, LY, LZ, K, D, G, B, I} got unsupported keyword argument "indices"
   @ Oceananigans ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/Oceananigans.jl-v2/src/OutputReaders/field_time_series.jl:231
  (FieldTimeSeries{LX, LY, LZ})(::Oceananigans.Grids.AbstractGrid, ::Any; kwargs...) where {LX, LY, LZ}
   @ Oceananigans ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/Oceananigans.jl-v2/src/OutputReaders/field_time_series.jl:438
  (FieldTimeSeries{LX, LY, LZ})(::Oceananigans.Grids.AbstractGrid; ...) where {LX, LY, LZ}
   @ Oceananigans ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/Oceananigans.jl-v2/src/OutputReaders/field_time_series.jl:438

Stacktrace:
 [1] sum(f::Function, fts::FieldTimeSeries{…}; dims::Int64, kw::@Kwargs{})
   @ Oceananigans.OutputReaders ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/Oceananigans.jl-v2/src/OutputReaders/field_time_series_reductions.jl:36
 [2] sum(fts::FieldTimeSeries{…}; kw::@Kwargs{…})
   @ Oceananigans.OutputReaders ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/Oceananigans.jl-v2/src/OutputReaders/field_time_series_reductions.jl:41
 [3] _mean(f::Function, c::FieldTimeSeries{…}, dims::Int64; condition::Nothing)
   @ Oceananigans.OutputReaders ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/Oceananigans.jl-v2/src/OutputReaders/field_time_series_reductions.jl:66
 [4] mean(c::FieldTimeSeries{…}; condition::Nothing, dims::Int64)
   @ Oceananigans.Fields ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/Oceananigans.jl-v2/src/Fields/field.jl:727
 [5] macro expansion
   @ show.jl:1181 [inlined]
 [6] top-level scope
   @ ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/Oceananigans.jl-v2/mwe_fts.jl:21
 [7] include(fname::String)
   @ Base.MainInclude ./client.jl:494
 [8] top-level scope
   @ REPL[151]:1
in expression starting at /Users/navid/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/Oceananigans.jl-v2/mwe_fts.jl:21
Some type information was truncated. Use `show(err)` to see complete types.
```

It's a bit tricky, in the sense if the reduction is over `dims=4` then should it return a Field? or a FieldTimeSeries?