### PR TITLE
Mask implicit linear coefficient if inside an immersed boundary

### DIFF
--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
@@ -168,7 +168,7 @@ end
     @inbounds begin
         total_Gⁿe = slow_Gⁿe[i, j, k] + fast_Gⁿe
         e[i, j, k] += Δτ * (α * total_Gⁿe - β * G⁻e[i, j, k]) * active
-        G⁻e[i, j, k] = total_Gⁿe * mask
+        G⁻e[i, j, k] = total_Gⁿe * active
     end
 end
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
@@ -119,7 +119,7 @@ end
     #       Lᵂ = - Cᵂϵ * √e / Δz.
 
     on_bottom = !inactive_cell(i, j, k, grid) & inactive_cell(i, j, k-1, grid)
-    mask = !inactive_cell(i, j, k, grid)
+    active = !inactive_cell(i, j, k, grid)
     Δz = Δzᶜᶜᶜ(i, j, k, grid)
     Cᵂϵ = closure_ij.turbulent_kinetic_energy_equation.Cᵂϵ
     e⁺ = clip(eⁱʲᵏ)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
@@ -119,6 +119,7 @@ end
     #       Lᵂ = - Cᵂϵ * √e / Δz.
 
     on_bottom = !inactive_cell(i, j, k, grid) & inactive_cell(i, j, k-1, grid)
+    mask = !inactive_cell(i, j, k, grid)
     Δz = Δzᶜᶜᶜ(i, j, k, grid)
     Cᵂϵ = closure_ij.turbulent_kinetic_energy_equation.Cᵂϵ
     e⁺ = clip(eⁱʲᵏ)
@@ -141,7 +142,7 @@ end
     #
     # where ω = ϵ / e ∼ √e / ℓ.
 
-    @inbounds Le[i, j, k] = wb⁻_e - ω + div_Jᵉ_e
+    @inbounds Le[i, j, k] = (wb⁻_e - ω + div_Jᵉ_e ) * mask
 
     # Compute fast TKE RHS
     u⁺ = next_velocities.u
@@ -163,7 +164,6 @@ end
     # See below.
     α = convert(FT, 1.5) + χ
     β = convert(FT, 0.5) + χ
-    mask = !inactive_cell(i, j, k, grid)
     
     @inbounds begin
         total_Gⁿe = slow_Gⁿe[i, j, k] + fast_Gⁿe

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
@@ -142,7 +142,7 @@ end
     #
     # where ω = ϵ / e ∼ √e / ℓ.
 
-    @inbounds Le[i, j, k] = (wb⁻_e - ω + div_Jᵉ_e) * mask
+    @inbounds Le[i, j, k] = (wb⁻_e - ω + div_Jᵉ_e) * active
 
     # Compute fast TKE RHS
     u⁺ = next_velocities.u

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
@@ -167,7 +167,7 @@ end
     
     @inbounds begin
         total_Gⁿe = slow_Gⁿe[i, j, k] + fast_Gⁿe
-        e[i, j, k] += Δτ * (α * total_Gⁿe - β * G⁻e[i, j, k]) * mask
+        e[i, j, k] += Δτ * (α * total_Gⁿe - β * G⁻e[i, j, k]) * active
         G⁻e[i, j, k] = total_Gⁿe * mask
     end
 end

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
@@ -142,7 +142,7 @@ end
     #
     # where ω = ϵ / e ∼ √e / ℓ.
 
-    @inbounds Le[i, j, k] = (wb⁻_e - ω + div_Jᵉ_e ) * mask
+    @inbounds Le[i, j, k] = (wb⁻_e - ω + div_Jᵉ_e) * mask
 
     # Compute fast TKE RHS
     u⁺ = next_velocities.u

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -113,8 +113,8 @@ end
 
 @inline ivd_diagonal(i, j, k, grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) =
     one(grid) - Δt * _implicit_linear_coefficient(i, j, k,   grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) -
-                               _ivd_upper_diagonal(i, j, k,   grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) -
-                               _ivd_lower_diagonal(i, j, k-1, grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock)
+                              _ivd_upper_diagonal(i, j, k,   grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock) -
+                              _ivd_lower_diagonal(i, j, k-1, grid, closure, K, id, ℓx, ℓy, ℓz, Δt, clock)
 
 
 @inline _implicit_linear_coefficient(args...) = implicit_linear_coefficient(args...)


### PR DESCRIPTION
Inside immersed boundaries we should have the diagonal term equal to 1. For this reason, the implicit linear coefficient should be masked