### PR TITLE
Improve benchmarks yml

### DIFF
--- a/.buildkite/pipeline-benchmarks.yml
+++ b/.buildkite/pipeline-benchmarks.yml
@@ -29,21 +29,6 @@ steps:
           limit: 1
 
   - wait
-
-  # Saving the latest build ID of the main branch for
-  # later comparison of the artifacts in PRs
-  - label: "💾 conditional metadata save" 
-    key: "save-metadata"
-    agents:
-      queue: Oceananigans-benchmarks
-    
-    command: |
-      if [ "$BUILDKITE_BRANCH" = "main" ]; then
-        echo "Saving build ID for main..."
-        buildkite-agent meta-data set "latest-main-build" "$BUILDKITE_BUILD_ID"
-      else
-        echo "Not on main, skipping metadata save."
-      fi
     
   - label: "🚀 Oceananigans GPU benchmarks"
     key: "benchmarks"
@@ -54,50 +39,38 @@ steps:
       # Instantiate
       $TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project --check-bounds=no -e 'using Pkg; Pkg.instantiate()'
 
-      # Run Periodic benchmarks
-      export BENCHMARK_GROUP="periodic"
-      $NSYS profile --output=periodic_output --trace=cuda $TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project --check-bounds=no test/benchmark_tests.jl
-      $NSYS stats periodic_output.nsys-rep > periodic_output.txt
+      # List of benchmark groups
+      BENCHMARK_GROUPS=(
+        "periodic"
+        "bounded"
+        "periodic_cheap_advection"
+        "bounded_cheap_advection"
+        "immersed"
+      )
 
-      # Remove generated output files
-      rm periodic_output.nsys-rep
-      rm periodic_output.sqlite
+      # Loop over each benchmark group
+      for BENCHMARK_GROUP in "\${BENCHMARK_GROUPS[@]}"; do
+        # Run benchmarks
+        export BENCHMARK_GROUP
+        OUTPUT_PREFIX="\${BENCHMARK_GROUP}_output"
 
-      # Run Bounded benchmarks
-      export BENCHMARK_GROUP="bounded"
-      $NSYS profile --output=bounded_output --trace=cuda $TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project --check-bounds=no test/benchmark_tests.jl
-      $NSYS stats bounded_output.nsys-rep > bounded_output.txt
+        $NSYS profile --output=\${OUTPUT_PREFIX} --trace=cuda $TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project --check-bounds=no test/benchmark_tests.jl
+        $NSYS stats \${OUTPUT_PREFIX}.nsys-rep > \${OUTPUT_PREFIX}.txt
 
-      # Remove generated output files
-      rm bounded_output.nsys-rep
-      rm bounded_output.sqlite
+        # Remove generated output files
+        rm \${OUTPUT_PREFIX}.nsys-rep
+        rm \${OUTPUT_PREFIX}.sqlite
+      done
 
-      # Run Periodic cheap advection benchmarks
-      export BENCHMARK_GROUP="periodic_cheap_advection"
-      $NSYS profile --output=periodic_cheap_advection_output --trace=cuda $TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project --check-bounds=no test/benchmark_tests.jl
-      $NSYS stats periodic_cheap_advection_output.nsys-rep > periodic_cheap_advection_output.txt
+      # Finally save job ID and build number to later use to retrieve the artifacts
 
-      # Remove generated output files
-      rm periodic_cheap_advection_output.nsys-rep
-      rm periodic_cheap_advection_output.sqlite
-
-      # Run Bounded cheap advection benchmarks
-      export BENCHMARK_GROUP="bounded_cheap_advection"
-      $NSYS profile --output=bounded_cheap_advection_output --trace=cuda $TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project --check-bounds=no test/benchmark_tests.jl
-      $NSYS stats bounded_cheap_advection_output.nsys-rep > bounded_cheap_advection_output.txt
-
-      # Remove generated output files
-      rm bounded_cheap_advection_output.nsys-rep
-      rm bounded_cheap_advection_output.sqlite
-
-      # Run Immersed benchmarks
-      export BENCHMARK_GROUP="immersed"
-      $NSYS profile --output=immersed_output --trace=cuda $TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project --check-bounds=no test/benchmark_tests.jl
-      $NSYS stats immersed_output.nsys-rep > immersed_output.txt
-
-      # Remove generated output files
-      rm immersed_output.nsys-rep
-      rm immersed_output.sqlite
+      if [ "$BUILDKITE_BRANCH" = "main" ]; then
+        echo "Saving build ID for main..."
+        buildkite-agent meta-data set "latest-main-build-number" "$BUILDKITE_BUILD_NUMBER"
+        buildkite-agent meta-data set "latest-main-job-id" "$BUILDKITE_JOB_ID"
+      else
+        echo "Not on main, skipping metadata save."
+      fi
 
     artifact_paths:
       - "periodic_output.txt"

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -43,10 +43,10 @@ function ocean_benchmark(arch, Nx, Ny, Nz, topology, immersed, tracer_advection=
     R = rand(size(model.grid))
 
     # initialize variables with randomish values
-    Tᵢ = 0.0001 .* R .+ 20
-    Sᵢ = 0.0001 .* R .+ 35
-    uᵢ = 0.0001 .* R
-    vᵢ = 0.0001 .* R
+    Tᵢ = 1e-4 .* R .+ 20
+    Sᵢ = 1e-4 .* R .+ 35
+    uᵢ = 1e-6 .* R
+    vᵢ = 1e-6 .* R
     
     set!(model, T=Tᵢ, S=Sᵢ, e=1e-6, u=uᵢ, v=vᵢ)
 
@@ -55,7 +55,7 @@ end
 
 function run_benchmark(model)
     for _ in 1:15
-        time_step!(model, 1.0)
+        time_step!(model, 0.001)
     end
 end
 


### PR DESCRIPTION
This PR tidies up a bit and puts the benchmarks in a loop.
Also it turns out that from the main branch pipeline we need to save the build number and the job ID if we later want to access them, not the build id. This has to be done in the specific pipeline (`steps`) that generates the artifacts.