### PR TITLE
Making condition size mismatch error a bit more helpful

### DIFF
--- a/src/AbstractOperations/conditional_operations.jl
+++ b/src/AbstractOperations/conditional_operations.jl
@@ -106,7 +106,7 @@ validate_condition(cond::AbstractArray, ::OneField) = cond
 
 function validate_condition(cond::AbstractArray, operand::AbstractField)
     if size(cond) !== size(operand)
-        throw(ArgumentError("The keyword argument condition::AbstractArray requires size $(size(operand))"))
+        throw(ArgumentError("The keyword argument condition::AbstractArray requires size $(size(operand)) but has size $(size(cond))"))
     end
     return cond
 end


### PR DESCRIPTION
I've just modified the condition size check error to be a bit more helpful by outputting both the size of the operand and the size of the condition. 