### PR TITLE
Use a default active cells map for kernel launching

### DIFF
--- a/src/Grids/abstract_grid.jl
+++ b/src/Grids/abstract_grid.jl
@@ -1,3 +1,5 @@
+import Oceananigans.Utils: get_active_cells_map
+
 """
     AbstractGrid{FT, TX, TY, TZ}
 

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -16,6 +16,8 @@ import Base
 
 struct KernelParameters{S, O} end
 
+get_active_cells_map(grid, any_map_type) = nothing
+
 """
     KernelParameters(size, offsets)
 
@@ -247,7 +249,7 @@ the architecture `arch`.
                                   exclude_periphery = false,
                                   reduced_dimensions = (),
                                   location = nothing,
-                                  active_cells_map = nothing)
+                                  active_cells_map = get_active_cells_map(grid, Val(:interior)))
 
 
     if !isnothing(active_cells_map) # everything else is irrelevant


### PR DESCRIPTION
Curious about the performance implications of this.

I think it is better to do the same thing re: active cells for every kernel, rather than picking and choosing.

The main advantage is the simplicity of the algorithm.

Ultimately I think that the active cells should be part of the KernelParameters. It doesn't make sense to think of the kernel parameters and active map as separate concepts.

It should be automatically computed for the majority of kernels, and only changed for edge cases. I am not sure why there are edge cases, but it seems they exist for halo filling?

cc @simone-silvestri can you help improve this design? Perhaps we can discuss here.

Ironing out these issues will become crucial if we want to use Oceananigans finite volume engine for implementing additional models. I also think a distributed algo refactor needs to come at some point, and this is perhaps the first step. 