### PR TITLE
Bugfix BC default

### DIFF
--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -283,7 +283,7 @@ function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, loc, 
 
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
     cca_loc = loc[1] == Center && loc[2] == Center # scalar
-    default_bc = _default_prognostic_bc(topology(grid, 2)(), loc[2](), default)
+    default_bc = default_prognostic_bc(topology(grid, 2)(), loc[2](), default)
     return φnorth ≈ 90 && cca_loa ? PolarBoundaryCondition(grid, :north, loc[3]) : default_bc
 end
 
@@ -294,7 +294,7 @@ function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, loc, 
     
     φsouth = @allowscalar φnode(1, grid, Face()) 
     cca_loc = loc[1] == Center && loc[2] == Center # scalar
-    default_bc = _default_prognostic_bc(topology(grid, 2)(), loc[2](), default)
+    default_bc = default_prognostic_bc(topology(grid, 2)(), loc[2](), default)
     return φsouth ≈ -90 && cca_loa ? PolarBoundaryCondition(grid, :south, loc[3]) : default_bc
 end
 

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -276,44 +276,44 @@ regularize_north_boundary_condition(bc::DefaultBoundaryCondition, grid::Latitude
 regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) = 
     regularize_boundary_condition(default_prognostic_bc(grid, Val(:south), loc, bc), grid, loc, args...)
 
-function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, loc, default)
-    if loc[2] == Nothing
+function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ), default)
+    if LY == Nothing
         return nothing
     end
 
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
-    cca_loc = loc[1] == Center && loc[2] == Center # scalar
-    default_bc = default_prognostic_bc(topology(grid, 2)(), loc[2](), default)
-    return φnorth ≈ 90 && cca_loa ? PolarBoundaryCondition(grid, :north, loc[3]) : default_bc
+    cca_loc = LX == Center && LY == Center # scalar
+    default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
+    return φnorth ≈ 90 && cca_loc ? PolarBoundaryCondition(grid, :north, LZ) : default_bc
 end
 
-function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, loc, default)
-    if loc[2] == Nothing
+function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ), default)
+    if LY == Nothing
         return nothing
     end
     
     φsouth = @allowscalar φnode(1, grid, Face()) 
-    cca_loc = loc[1] == Center && loc[2] == Center # scalar
-    default_bc = default_prognostic_bc(topology(grid, 2)(), loc[2](), default)
-    return φsouth ≈ -90 && cca_loa ? PolarBoundaryCondition(grid, :south, loc[3]) : default_bc
+    cca_loc = LZ == Center && LY == Center # scalar
+    default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
+    return φsouth ≈ -90 && cca_loc ? PolarBoundaryCondition(grid, :south, LZ) : default_bc
 end
 
-function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, loc)
-    if loc[2] == Nothing
+function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ))
+    if LY == Nothing
         return nothing
     end
 
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
-    default_bc = _default_auxiliary_bc(topology(grid, 2)(), loc[2]())
-    return φnorth ≈ 90 ? PolarBoundaryCondition(grid, :north, loc[3]) : default_bc
+    default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY[2]())
+    return φnorth ≈ 90 ? PolarBoundaryCondition(grid, :north, LZ) : default_bc
 end
 
-function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, loc)
-    if loc[2] == Nothing
+function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ))
+    if LY == Nothing
         return nothing
     end
 
     φsouth = @allowscalar φnode(1, grid, Face()) 
-    default_bc = _default_auxiliary_bc(topology(grid, 2)(), loc[2]())
-    return φsouth ≈ -90 ? PolarBoundaryCondition(grid, :south, loc[3]) : default_bc
+    default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY())
+    return φsouth ≈ -90 ? PolarBoundaryCondition(grid, :south, LZ) : default_bc
 end

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -304,7 +304,7 @@ function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, L
     end
 
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
-    default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY[2]())
+    default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY())
     return φnorth ≈ 90 ? PolarBoundaryCondition(grid, :north, LZ) : default_bc
 end
 

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -276,14 +276,6 @@ regularize_north_boundary_condition(bc::DefaultBoundaryCondition, grid::Latitude
 regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) = 
     regularize_boundary_condition(default_prognostic_bc(grid, Val(:south), loc, bc), grid, loc, args...)
 
-
-# Fallback for `Nothing` locations
-default_prognostic_bc(::LatitudeLongitudeGrid, ::Val{:north}, ::Nothing, default) = nothing
-default_prognostic_bc(::LatitudeLongitudeGrid, ::Val{:south}, ::Nothing, default) = nothing
-
-default_auxiliary_bc(::LatitudeLongitudeGrid, ::Val{:north}, ::Nothing) = nothing
-default_auxiliary_bc(::LatitudeLongitudeGrid, ::Val{:south}, ::Nothing) = nothing
-
 function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, loc, default)
     if loc[2] == Nothing
         return nothing

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -1,6 +1,6 @@
 include("dependencies_for_runtests.jl")
 
-using Oceananigans.BoundaryConditions: PBC, ZFBC, VBC, OBC, ContinuousBoundaryFunction, DiscreteBoundaryFunction, regularize_field_boundary_conditions
+using Oceananigans.BoundaryConditions: PBC, ZFBC, VBC, OBC, Zipper, ContinuousBoundaryFunction, DiscreteBoundaryFunction, regularize_field_boundary_conditions
 using Oceananigans.Fields: Face, Center
 
 simple_bc(ξ, η, t) = exp(ξ) * cos(η) * sin(t)
@@ -17,6 +17,33 @@ end
 
 @testset "Boundary conditions" begin
     @info "Testing boundary conditions..."
+
+    @testset "Default serial boundary conditions" begin
+        @info "  Testing default boundary conditions..."
+        loc  = (Center, Center, Center)
+        grid = RectilinearGrid(size=(10, 10), x=(0, 1), y=(0, 1), topology=(Periodic, Bounded, Flat))
+        default_bcs = FieldBoundaryConditions(grid, loc)
+
+        @test default_bcs.east  isa PBC
+        @test default_bcs.west  isa PBC
+        @test default_bcs.north isa ZFBC
+        @test default_bcs.south isa ZFBC
+        @test default_bcs.top    isa Nothing
+        @test default_bcs.bottom isa Nothing
+
+        grid = LatitudeLongitudeGrid(size=(10, 10, 10), latitude=(-90, 90), longitude=(-10, 10), z = (0, 1))
+        default_bcs = FieldBoundaryConditions(grid, loc)
+        
+        @test default_bcs.east  isa ZFBC
+        @test default_bcs.west  isa ZFBC
+        @test default_bcs.north isa VBC
+        @test default_bcs.south isa VBC
+
+        grid = TripolarGrid(size=(10, 10, 10), z = (0, 1))
+        default_bcs = FieldBoundaryConditions(grid, loc)
+        @test default_bcs.north.classification isa Zipper
+        @test default_bcs.south isa ZFBC        
+    end
 
     @testset "Boundary condition instantiation" begin
         @info "  Testing boundary condition instantiation..."


### PR DESCRIPTION
for `LatitudeLongitudeGrid`s spanning -90:90 with a `Nothing` location in the latitude direction.

For reference on main:
```julia
julia> grid = LatitudeLongitudeGrid(size = (600, 100, 1), latitude = (-90, 90), longitude = (0, 360), z = (0, 1))
600×100×1 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×1 halo and with precomputed metrics
├── longitude: Periodic λ ∈ [0.0, 360.0)  regularly spaced with Δλ=0.6
├── latitude:  Bounded  φ ∈ [-90.0, 90.0] regularly spaced with Δφ=1.8
└── z:         Bounded  z ∈ [0.0, 1.0]    regularly spaced with Δz=1.0

julia> minimum_xspacing(grid)
ERROR: ArgumentError: Cannot specify north boundary condition ValueBoundaryCondition: Oceananigans.BoundaryConditions.PolarValue{OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, Symbol} on a field at nothing!
Stacktrace:
  [1] validate_boundary_condition_location(bc::BoundaryCondition{…}, loc::Nothing, side::Symbol)
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:57
  [2] validate_boundary_conditions(loc::Tuple{…}, grid::LatitudeLongitudeGrid{…}, bcs::FieldBoundaryConditions{…})
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:76
  [3] #apply_regionally!#58
    @ ~/development/Oceananigans.jl/src/Utils/multi_region_transformation.jl:121 [inlined]
  [4] apply_regionally!
    @ ~/development/Oceananigans.jl/src/Utils/multi_region_transformation.jl:118 [inlined]
  [5] macro expansion
    @ ~/development/Oceananigans.jl/src/Utils/multi_region_transformation.jl:206 [inlined]
  [6] Field(loc::Tuple{…}, grid::LatitudeLongitudeGrid{…}, data::OffsetArrays.OffsetArray{…}, bcs::FieldBoundaryConditions{…}, indices::Tuple{…}, op::Nothing, status::Nothing)
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:101
  [7] Field(loc::Tuple{…}, grid::LatitudeLongitudeGrid{…}, T::DataType; indices::Tuple{…}, data::OffsetArrays.OffsetArray{…}, boundary_conditions::FieldBoundaryConditions{…}, operand::Nothing, status::Nothing)
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:194
  [8] minimum(f::Function, c::KernelFunctionOperation{…}; condition::Nothing, mask::Float64, dims::Function)
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:710
  [9] minimum
    @ ~/development/Oceananigans.jl/src/Fields/field.jl:701 [inlined]
 [10] minimum
    @ ~/development/Oceananigans.jl/src/Fields/field.jl:721 [inlined]
 [11] minimum_xspacing(grid::LatitudeLongitudeGrid{…})
    @ Oceananigans.Grids ~/development/Oceananigans.jl/src/Grids/nodes_and_spacings.jl:160
 [12] top-level scope
    @ REPL[17]:1
Some type information was truncated. Use `show(err)` to see complete types.

julia>
```