### PR TITLE
Fix computation of bottom height for GridFittedBottom

### DIFF
--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -118,7 +118,7 @@ compute_numerical_bottom_height!(bottom_field, grid, ib) =
     zb★ = ifelse(zb ≥ zᶜ, zᶠ⁺, zb)
 
     # So if zb < zᶜ (bottom height below cell center), we snap down to zᶠ⁻.
-    zb★ = ifelse(zb < zᶜ, zᶠ⁻, zb)
+    zb★ = ifelse(zb < zᶜ, zᶠ⁻, zb★)
 
     # Only adjust bottom_heights that lie within this cell.
     # Note, don't include interfaces, so the heights are adjusted only once.


### PR DESCRIPTION
This PR fixes how we compute the bottom height for GridFittedBottom.

I have to confess that I did not completely understand what the code was trying to do prior to this PR. Our objective is to change the bottom height so that it exactly corresponds to what the model "sees". This is useful for computing statistics of the bathymetry, etc.

This might change results --- so we may need to bump the minor version.

@NoraLoose may have an MWE where the previous code was causing an issue (and hopefully this fixes it).