### PR TITLE
Improve and test error handling for vertical level specification in grid construction

### DIFF
--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -135,15 +135,13 @@ function validate_dimension_specification(T, ξ::AbstractVector, dir, N, FT)
 
     ξ[end] ≥ ξ[1] || throw(ArgumentError("$dir=$ξ should have increasing values."))
 
-    # Validate the length of ξ: error is ξ is too short, warn if ξ is too long.
+    # Validate the length of ξ: error is ξ is too short, error if ξ is too long.
     Nξ = length(ξ)
     N⁺¹ = N + 1
     if Nξ < N⁺¹
         throw(ArgumentError("length($dir) = $Nξ has too few interfaces for the dimension size $(N)!"))
     elseif Nξ > N⁺¹
-        msg = "length($dir) = $Nξ is greater than $N+1, where $N was passed to `size`.\n" *
-              "$dir cell interfaces will be constructed from $dir[1:$N⁺¹]."
-        @warn msg
+        throw(ArgumentError("length($dir) = $Nξ has too many interfaces for the dimension size $(N)!"))
     end
 
     return ξ

--- a/src/OrthogonalSphericalShellGrids/tripolar_grid.jl
+++ b/src/OrthogonalSphericalShellGrids/tripolar_grid.jl
@@ -1,7 +1,7 @@
 using Oceananigans.BoundaryConditions: ZipperBoundaryCondition
 using Oceananigans.Grids: architecture, cpu_face_constructor_z
 
-import Oceananigans.Grids: with_halo
+import Oceananigans.Grids: with_halo, validate_dimension_specification
 
 """
     struct Tripolar{N, F, S}
@@ -92,6 +92,8 @@ function TripolarGrid(arch = CPU(), FT::DataType = Float64;
     # but for the φ coordinate we need to remove one point at the north
     # because the the north pole is a `Center`point, not on `Face` point...
     topology  = (Periodic, RightConnected, Bounded)
+    TZ = topology[3]
+    z = validate_dimension_specification(TZ, z, :z, Nz, FT)
 
     Lx, λᶠᵃᵃ, λᶜᵃᵃ, Δλᶠᵃᵃ, Δλᶜᵃᵃ = generate_coordinate(FT, topology, size, halo, longitude, :longitude, 1, CPU())
     Lz, z                        = generate_coordinate(FT, topology, size, halo, z,         :z,         3, CPU())

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -281,6 +281,9 @@ function test_regular_rectilinear_constructor_errors(FT)
     @test_throws ArgumentError RectilinearGrid(CPU(), FT, topology=(Flat, Flat, Periodic), size=(16, 16), extent=1)
 
     @test_throws ArgumentError RectilinearGrid(CPU(), FT, topology=(Flat, Flat, Flat), size=16, extent=1)
+    
+    @test_throws ArgumentError RectilinearGrid(CPU(), FT, size=(4, 4, 4), x=(0, 1), y=(0, 1), z=[-50.0, -30.0, -20.0, 0.0]) # too few z-faces
+    @test_throws ArgumentError RectilinearGrid(CPU(), FT, size=(4, 4, 4), x=(0, 1), y=(0, 1), z=[-2000.0, -1000.0, -50.0, -30.0, -20.0, 0.0]) # too many z-faces
 
     return nothing
 end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -915,6 +915,13 @@ end
     end
 
     @testset "Latitude-longitude grid" begin
+        @info "  Testing latitude-longitude grid construction errors..."
+
+	for FT in float_types
+	    @test_throws ArgumentError LatitudeLongitudeGrid(CPU(), FT, size=(10, 10, 4), longitude=(-180, 180), latitude=(-80, 80), z=[-50.0, -30.0, -20.0, 0.0]) # too few z-faces
+	    @test_throws ArgumentError LatitudeLongitudeGrid(CPU(), FT, size=(10, 10, 4), longitude=(-180, 180), latitude=(-80, 80), z=[-2000.0, -1000.0, -50.0, -30.0, -20.0, 0.0]) # too many z-faces
+	end
+
         @info "  Testing general latitude-longitude grid..."
 
         for FT in float_types

--- a/test/test_tripolar_grid.jl
+++ b/test/test_tripolar_grid.jl
@@ -106,6 +106,13 @@ end
     end
 end
 
+@testset "Grid construction error tests..." begin
+    for FT in float_types
+        @test_throws ArgumentError TripolarGrid(CPU(), FT, size=(10, 10, 4), z=[-50.0, -30.0, -20.0, 0.0]) # too few z-faces
+        @test_throws ArgumentError TripolarGrid(CPU(), FT, size=(10, 10, 4), z=[-2000.0, -1000.0, -50.0, -30.0, -20.0, 0.0]) # too many z-faces
+    end
+end
+
 @testset "Orthogonality of family of ellipses and hyperbolae..." begin
     for arch in archs
         # Test the orthogonality of a tripolar grid based on the orthogonality of a


### PR DESCRIPTION
## Summary of this PR

- Converts the warning about providing too many vertical interfaces (`z` faces) into an error.
- Ensures that this error is properly triggered during the creation of a `TripolarGrid`.
- Adds tests verifying that an error is raised when too many or few `z` faces are passed to:
  - `RectilinearGrid`
  - `LatitudeLongitudeGrid`
  - `TripolarGrid`