### PR TITLE
Some more fixing for polar BC

### DIFF
--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -278,26 +278,24 @@ regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::Latitude
 
 function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ), default)
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
-    cca_loc = LX == Center && LY == Center # scalar
     default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
-    return φnorth ≈ 90 && cca_loc ? PolarBoundaryCondition(grid, :north, LY(), LZ) : default_bc
+    return φnorth ≈ 90 && cca_loc ? maybe_polar_boundary_condition(grid, :north, LY(), LZ) : default_bc
 end
 
 function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ), default)    
     φsouth = @allowscalar φnode(1, grid, Face()) 
-    cca_loc = LZ == Center && LY == Center # scalar
     default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
-    return φsouth ≈ -90 && cca_loc ? PolarBoundaryCondition(grid, :south, LY(), LZ) : default_bc
+    return φsouth ≈ -90 && cca_loc ? maybe_polar_boundary_condition(grid, :south, LY, LZ) : default_bc
 end
 
 function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ))
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
     default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY())
-    return φnorth ≈ 90 ? PolarBoundaryCondition(grid, :north, LY(), LZ) : default_bc
+    return φnorth ≈ 90 ? maybe_polar_boundary_condition(grid, :north, LY, LZ) : default_bc
 end
 
 function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ))
     φsouth = @allowscalar φnode(1, grid, Face()) 
     default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY())
-    return φsouth ≈ -90 ? PolarBoundaryCondition(grid, :south, LY(), LZ) : default_bc
+    return φsouth ≈ -90 ? maybe_polar_boundary_condition(grid, :south, LY, LZ) : default_bc
 end

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -279,13 +279,13 @@ regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::Latitude
 function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ), default)
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
     default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
-    return φnorth ≈ 90 && cca_loc ? maybe_polar_boundary_condition(grid, :north, LY(), LZ) : default_bc
+    return φnorth ≈ 90 ? maybe_polar_boundary_condition(grid, :north, LY(), LZ) : default_bc
 end
 
 function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ), default)    
     φsouth = @allowscalar φnode(1, grid, Face()) 
     default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
-    return φsouth ≈ -90 && cca_loc ? maybe_polar_boundary_condition(grid, :south, LY, LZ) : default_bc
+    return φsouth ≈ -90 ? maybe_polar_boundary_condition(grid, :south, LY, LZ) : default_bc
 end
 
 function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ))

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -277,43 +277,27 @@ regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::Latitude
     regularize_boundary_condition(default_prognostic_bc(grid, Val(:south), loc, bc), grid, loc, args...)
 
 function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ), default)
-    if LY == Nothing
-        return nothing
-    end
-
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
     cca_loc = LX == Center && LY == Center # scalar
     default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
-    return φnorth ≈ 90 && cca_loc ? PolarBoundaryCondition(grid, :north, LZ) : default_bc
+    return φnorth ≈ 90 && cca_loc ? PolarBoundaryCondition(grid, :north, LY(), LZ()) : default_bc
 end
 
-function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ), default)
-    if LY == Nothing
-        return nothing
-    end
-    
+function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ), default)    
     φsouth = @allowscalar φnode(1, grid, Face()) 
     cca_loc = LZ == Center && LY == Center # scalar
     default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
-    return φsouth ≈ -90 && cca_loc ? PolarBoundaryCondition(grid, :south, LZ) : default_bc
+    return φsouth ≈ -90 && cca_loc ? PolarBoundaryCondition(grid, :south, LY(), LZ) : default_bc
 end
 
 function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ))
-    if LY == Nothing
-        return nothing
-    end
-
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
     default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY())
-    return φnorth ≈ 90 ? PolarBoundaryCondition(grid, :north, LZ) : default_bc
+    return φnorth ≈ 90 ? PolarBoundaryCondition(grid, :north, LY(), LZ()) : default_bc
 end
 
 function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ))
-    if LY == Nothing
-        return nothing
-    end
-
     φsouth = @allowscalar φnode(1, grid, Face()) 
     default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY())
-    return φsouth ≈ -90 ? PolarBoundaryCondition(grid, :south, LZ) : default_bc
+    return φsouth ≈ -90 ? PolarBoundaryCondition(grid, :south, LY(), LZ) : default_bc
 end

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -276,28 +276,44 @@ regularize_north_boundary_condition(bc::DefaultBoundaryCondition, grid::Latitude
 regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) = 
     regularize_boundary_condition(default_prognostic_bc(grid, Val(:south), loc, bc), grid, loc, args...)
 
-function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, loc, default)
+function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ), default)
+    if LY == Nothing
+        return nothing
+    end
+
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
-    cca_loc = loc[1] == Center && loc[2] == Center # scalar
-    default_bc = default_prognostic_bc(topology(grid, 2)(), loc[2](), default)
-    return φnorth ≈ 90 && cca_loa ? PolarBoundaryCondition(grid, :north, loc[3]) : default_bc
+    cca_loc = LX == Center && LY == Center # scalar
+    default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
+    return φnorth ≈ 90 && cca_loc ? PolarBoundaryCondition(grid, :north, LZ) : default_bc
 end
 
-function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, loc, default)
+function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ), default)
+    if LY == Nothing
+        return nothing
+    end
+    
     φsouth = @allowscalar φnode(1, grid, Face()) 
-    cca_loc = loc[1] == Center && loc[2] == Center # scalar
-    default_bc = default_prognostic_bc(topology(grid, 2)(), loc[2](), default)
-    return φsouth ≈ -90 && cca_loa ? PolarBoundaryCondition(grid, :south, loc[3]) : default_bc
+    cca_loc = LZ == Center && LY == Center # scalar
+    default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
+    return φsouth ≈ -90 && cca_loc ? PolarBoundaryCondition(grid, :south, LZ) : default_bc
 end
 
-function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, loc)
+function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ))
+    if LY == Nothing
+        return nothing
+    end
+
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
-    default_bc = _default_auxiliary_bc(topology(grid, 2)(), loc[2]())
-    return φnorth ≈ 90 ? PolarBoundaryCondition(grid, :north, loc[3]) : default_bc
+    default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY())
+    return φnorth ≈ 90 ? PolarBoundaryCondition(grid, :north, LZ) : default_bc
 end
 
-function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, loc)
+function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ))
+    if LY == Nothing
+        return nothing
+    end
+
     φsouth = @allowscalar φnode(1, grid, Face()) 
-    default_bc = _default_auxiliary_bc(topology(grid, 2)(), loc[2]())
-    return φsouth ≈ -90 ? PolarBoundaryCondition(grid, :south, loc[3]) : default_bc
+    default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY())
+    return φsouth ≈ -90 ? PolarBoundaryCondition(grid, :south, LZ) : default_bc
 end

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -280,7 +280,7 @@ function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, 
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
     cca_loc = LX == Center && LY == Center # scalar
     default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
-    return φnorth ≈ 90 && cca_loc ? PolarBoundaryCondition(grid, :north, LY(), LZ()) : default_bc
+    return φnorth ≈ 90 && cca_loc ? PolarBoundaryCondition(grid, :north, LY(), LZ) : default_bc
 end
 
 function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ), default)    
@@ -293,7 +293,7 @@ end
 function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ))
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
     default_bc = _default_auxiliary_bc(topology(grid, 2)(), LY())
-    return φnorth ≈ 90 ? PolarBoundaryCondition(grid, :north, LY(), LZ()) : default_bc
+    return φnorth ≈ 90 ? PolarBoundaryCondition(grid, :north, LY(), LZ) : default_bc
 end
 
 function default_auxiliary_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ))

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -279,7 +279,7 @@ regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::Latitude
 function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (LX, LY, LZ), default)
     φnorth = @allowscalar φnode(grid.Ny+1, grid, Face()) 
     default_bc = default_prognostic_bc(topology(grid, 2)(), LY(), default)
-    return φnorth ≈ 90 ? maybe_polar_boundary_condition(grid, :north, LY(), LZ) : default_bc
+    return φnorth ≈ 90 ? maybe_polar_boundary_condition(grid, :north, LY, LZ) : default_bc
 end
 
 function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:south}, (LX, LY, LZ), default)    

--- a/src/BoundaryConditions/polar_boundary_condition.jl
+++ b/src/BoundaryConditions/polar_boundary_condition.jl
@@ -7,17 +7,31 @@ end
 
 Adapt.adapt_structure(to, pv::PolarValue) = PolarValue(Adapt.adapt(to, pv.data), nothing)
 
-const PolarBoundaryCondition{V} = BoundaryCondition{<:Value, <:PolarValue}
+const PolarValueBoundaryCondition{V} = BoundaryCondition{<:Value, <:PolarValue}
+const PolarOpenBoundaryCondition{V}  = BoundaryCondition{<:Open,  <:PolarValue}
 
-function PolarBoundaryCondition(grid, side, zloc)
+function PolarValueBoundaryCondition(grid, side, LZ)
     FT   = eltype(grid)
-    loc  = (Nothing, Nothing, zloc)
+    loc  = (Nothing, Nothing, LZ)
     data = new_data(FT, grid, loc)
     return ValueBoundaryCondition(PolarValue(data, side))
 end
 
+function PolarOpenBoundaryCondition(grid, side, LZ)
+    FT   = eltype(grid)
+    loc  = (Nothing, Nothing, LZ)
+    data = new_data(FT, grid, loc)
+    return OpenBoundaryCondition(PolarValue(data, side))
+end
+
+const PolarBoundaryCondition = Union{PolarValueBoundaryCondition, PolarOpenBoundaryCondition}
+
+PolarBoundaryCondition(grid, size, ::Nothing, LZ) = nothing
+PolarBoundaryCondition(grid, size, ::Center, LZ)  = PolarValueBoundaryCondition(grid, size, LZ)
+PolarBoundaryCondition(grid, size, ::Face,   LZ)  = PolarOpenBoundaryCondition(grid, size, LZ)
+
 # Just a column
-@inline getbc(pv::BC{<:Value, <:PolarValue}, i, k, args...) = @inbounds pv.condition.data[1, 1, k]
+@inline getbc(pv::BC{<:Any, <:PolarValue}, i, k, args...) = @inbounds pv.condition.data[1, 1, k]
 
 @kernel function _average_pole_value!(data, c, j, grid, loc)
     i′, j′, k = @index(Global, NTuple)
@@ -40,31 +54,31 @@ function update_pole_value!(bc::PolarValue, c, grid, loc)
     return nothing
 end
 
-function fill_south_halo!(c, bc::PolarBoundaryCondition, size, offset, loc, arch, grid, args...; only_local_halos = false, kwargs...)
+function fill_south_halo!(c, bc::PolarBoundaryCondition, size, offset, loc, arch, grid, args...; only_local_halos=false, kwargs...)
     update_pole_value!(bc.condition, c, grid, loc)
     return launch!(arch, grid, KernelParameters(size, offset),
                    _fill_only_south_halo!, c, bc, loc, grid, Tuple(args); kwargs...)
 end
 
-function fill_north_halo!(c, bc::PolarBoundaryCondition, size, offset, loc, arch, grid, args...; only_local_halos = false, kwargs...)
+function fill_north_halo!(c, bc::PolarBoundaryCondition, size, offset, loc, arch, grid, args...; only_local_halos=false, kwargs...)
     update_pole_value!(bc.condition, c, grid, loc)
     return launch!(arch, grid, KernelParameters(size, offset),
                    _fill_only_north_halo!, c, bc, loc, grid, Tuple(args); kwargs...)
 end
 
-function fill_south_and_north_halo!(c, south_bc::PolarBoundaryCondition, north_bc, size, offset, loc, arch, grid, args...; only_local_halos = false, kwargs...)
+function fill_south_and_north_halo!(c, south_bc::PolarBoundaryCondition, north_bc, size, offset, loc, arch, grid, args...; only_local_halos=false, kwargs...)
     update_pole_value!(south_bc.condition, c, grid, loc)
     return launch!(arch, grid, KernelParameters(size, offset),
                    _fill_south_and_north_halo!, c, south_bc, north_bc, loc, grid, Tuple(args); kwargs...)
 end
 
-function fill_south_and_north_halo!(c, south_bc, north_bc::PolarBoundaryCondition, size, offset, loc, arch, grid, args...; only_local_halos = false, kwargs...)
+function fill_south_and_north_halo!(c, south_bc, north_bc::PolarBoundaryCondition, size, offset, loc, arch, grid, args...; only_local_halos=false, kwargs...)
     update_pole_value!(north_bc.condition, c, grid, loc)
     return launch!(arch, grid, KernelParameters(size, offset),
                    _fill_south_and_north_halo!, c, south_bc, north_bc, loc, grid, Tuple(args); kwargs...)
 end
 
-function fill_south_and_north_halo!(c, south_bc::PolarBoundaryCondition, north_bc::PolarBoundaryCondition, size, offset, loc, arch, grid, args...; only_local_halos = false, kwargs...)
+function fill_south_and_north_halo!(c, south_bc::PolarBoundaryCondition, north_bc::PolarBoundaryCondition, size, offset, loc, arch, grid, args...; only_local_halos=false, kwargs...)
     update_pole_value!(south_bc.condition, c, grid, loc)
     update_pole_value!(north_bc.condition, c, grid, loc)
     return launch!(arch, grid, KernelParameters(size, offset),

--- a/src/BoundaryConditions/polar_boundary_condition.jl
+++ b/src/BoundaryConditions/polar_boundary_condition.jl
@@ -26,9 +26,9 @@ end
 
 const PolarBoundaryCondition = Union{PolarValueBoundaryCondition, PolarOpenBoundaryCondition}
 
-maybe_polar_boundary_condition(grid, size, ::Tyep{Nothing}, LZ) = nothing
-maybe_polar_boundary_condition(grid, size, ::Tyep{Center},  LZ) = PolarValueBoundaryCondition(grid, size, LZ)
-maybe_polar_boundary_condition(grid, size, ::Tyep{Face},    LZ) = PolarOpenBoundaryCondition(grid, size, LZ)
+maybe_polar_boundary_condition(grid, size, ::Type{Nothing}, LZ) = nothing
+maybe_polar_boundary_condition(grid, size, ::Type{Center},  LZ) = PolarValueBoundaryCondition(grid, size, LZ)
+maybe_polar_boundary_condition(grid, size, ::Type{Face},    LZ) = PolarOpenBoundaryCondition(grid, size, LZ)
 
 # Just a column
 @inline getbc(pv::BC{<:Any, <:PolarValue}, i, k, args...) = @inbounds pv.condition.data[1, 1, k]

--- a/src/BoundaryConditions/polar_boundary_condition.jl
+++ b/src/BoundaryConditions/polar_boundary_condition.jl
@@ -26,9 +26,9 @@ end
 
 const PolarBoundaryCondition = Union{PolarValueBoundaryCondition, PolarOpenBoundaryCondition}
 
-PolarBoundaryCondition(grid, size, ::Nothing, LZ) = nothing
-PolarBoundaryCondition(grid, size, ::Center, LZ)  = PolarValueBoundaryCondition(grid, size, LZ)
-PolarBoundaryCondition(grid, size, ::Face,   LZ)  = PolarOpenBoundaryCondition(grid, size, LZ)
+maybe_polar_boundary_condition(grid, size, ::Tyep{Nothing}, LZ) = nothing
+maybe_polar_boundary_condition(grid, size, ::Tyep{Center},  LZ) = PolarValueBoundaryCondition(grid, size, LZ)
+maybe_polar_boundary_condition(grid, size, ::Tyep{Face},    LZ) = PolarOpenBoundaryCondition(grid, size, LZ)
 
 # Just a column
 @inline getbc(pv::BC{<:Any, <:PolarValue}, i, k, args...) = @inbounds pv.condition.data[1, 1, k]

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -1,6 +1,6 @@
 include("dependencies_for_runtests.jl")
 
-using Oceananigans.BoundaryConditions: PBC, ZFBC, VBC, OBC, ContinuousBoundaryFunction, DiscreteBoundaryFunction, regularize_field_boundary_conditions
+using Oceananigans.BoundaryConditions: PBC, ZFBC, VBC, OBC, Zipper, ContinuousBoundaryFunction, DiscreteBoundaryFunction, regularize_field_boundary_conditions
 using Oceananigans.Fields: Face, Center
 
 simple_bc(ξ, η, t) = exp(ξ) * cos(η) * sin(t)
@@ -17,6 +17,33 @@ end
 
 @testset "Boundary conditions" begin
     @info "Testing boundary conditions..."
+
+    @testset "Default serial boundary conditions" begin
+        @info "  Testing default boundary conditions..."
+        loc  = (Center, Center, Center)
+        grid = RectilinearGrid(size=(10, 10), x=(0, 1), y=(0, 1), topology=(Periodic, Bounded, Flat))
+        default_bcs = FieldBoundaryConditions(grid, loc)
+
+        @test default_bcs.east  isa PBC
+        @test default_bcs.west  isa PBC
+        @test default_bcs.north isa ZFBC
+        @test default_bcs.south isa ZFBC
+        @test default_bcs.top    isa Nothing
+        @test default_bcs.bottom isa Nothing
+
+        grid = LatitudeLongitudeGrid(size=(10, 10, 10), latitude=(-90, 90), longitude=(-10, 10), z = (0, 1))
+        default_bcs = FieldBoundaryConditions(grid, loc)
+        
+        @test default_bcs.east  isa ZFBC
+        @test default_bcs.west  isa ZFBC
+        @test default_bcs.north isa VBC
+        @test default_bcs.south isa VBC
+
+        grid = TripolarGrid(size=(10, 10, 10), z = (0, 1))
+        default_bcs = FieldBoundaryConditions(grid, loc)
+        @test default_bcs.north.classification isa Zipper
+        @test default_bcs.south isa ZFBC        
+    end
 
     @testset "Boundary condition instantiation" begin
         @info "  Testing boundary condition instantiation..."

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -43,14 +43,14 @@ end
         @test default_bcs_C.north isa VBC
         @test default_bcs_C.south isa VBC
 
-        @test default_bcs_C.north.condition isa Oceananigans.BoundaryCondition.PolarValue
-        @test default_bcs_C.south.condition isa Oceananigans.BoundaryCondition.PolarValue
+        @test default_bcs_C.north.condition isa Oceananigans.BoundaryConditions.PolarValue
+        @test default_bcs_C.south.condition isa Oceananigans.BoundaryConditions.PolarValue
 
         @test default_bcs_F.north isa OBC
         @test default_bcs_F.south isa OBC
 
-        @test default_bcs_F.north.condition isa Oceananigans.BoundaryCondition.PolarValue
-        @test default_bcs_F.south.condition isa Oceananigans.BoundaryCondition.PolarValue
+        @test default_bcs_F.north.condition isa Oceananigans.BoundaryConditions.PolarValue
+        @test default_bcs_F.south.condition isa Oceananigans.BoundaryConditions.PolarValue
 
         @test default_bcs_N.north isa Nothing
         @test default_bcs_N.south isa Nothing

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -32,12 +32,28 @@ end
         @test default_bcs.bottom isa Nothing
 
         grid = LatitudeLongitudeGrid(size=(10, 10, 10), latitude=(-90, 90), longitude=(-10, 10), z = (0, 1))
-        default_bcs = FieldBoundaryConditions(grid, loc)
-        
-        @test default_bcs.east  isa ZFBC
-        @test default_bcs.west  isa ZFBC
-        @test default_bcs.north isa VBC
-        @test default_bcs.south isa VBC
+        locC  = (Center, Center,  Center)
+        locF  = (Center, Face,    Center)
+        locN  = (Center, Nothing, Center)
+
+        default_bcs_C = FieldBoundaryConditions(grid, locC)
+        default_bcs_F = FieldBoundaryConditions(grid, locF)
+        default_bcs_N = FieldBoundaryConditions(grid, locN)
+
+        @test default_bcs_C.north isa VBC
+        @test default_bcs_C.south isa VBC
+
+        @test default_bcs_C.north.condition isa Oceananigans.BoundaryCondition.PolarValue
+        @test default_bcs_C.south.condition isa Oceananigans.BoundaryCondition.PolarValue
+
+        @test default_bcs_F.north isa OBC
+        @test default_bcs_F.south isa OBC
+
+        @test default_bcs_F.north.condition isa Oceananigans.BoundaryCondition.PolarValue
+        @test default_bcs_F.south.condition isa Oceananigans.BoundaryCondition.PolarValue
+
+        @test default_bcs_N.north isa Nothing
+        @test default_bcs_N.south isa Nothing
 
         grid = TripolarGrid(size=(10, 10, 10), z = (0, 1))
         default_bcs = FieldBoundaryConditions(grid, loc)
@@ -292,11 +308,11 @@ end
         @test all(f.data[1:10, 0,  1:10] .== f.data[1:10, 1, 1:10])
         @test all(f.data[1:10, 11, 1:10] .== f.data[1:10, 10, 1:10])
 
-        # Minimal test for PolarBoundaryCondition
+        # Minimal test for PolarValueBoundaryCondition
         polar_grid = LatitudeLongitudeGrid(size=(10, 10, 10), latitude=(-90, 90), longitude=(0, 360), z = (0, 1))
         c = CenterField(polar_grid)
-        @test c.boundary_conditions.north isa Oceananigans.BoundaryConditions.PolarBoundaryCondition
-        @test c.boundary_conditions.south isa Oceananigans.BoundaryConditions.PolarBoundaryCondition
+        @test c.boundary_conditions.north isa Oceananigans.BoundaryConditions.PolarValueBoundaryCondition
+        @test c.boundary_conditions.south isa Oceananigans.BoundaryConditions.PolarValueBoundaryCondition
 
         set!(c, (x, y, z) -> x)
         fill_halo_regions!(c)


### PR DESCRIPTION
In #4457 we forgot `Face` fields that do not allow `ValueBoundaryConditions`. This PR introduces an equivalent `PolarOpenBoundaryCondition` for fields with `LY == Face` (and a couple more tests).

for reference on main:
```julia
julia> grid = LatitudeLongitudeGrid(size=(10, 10, 10), latitude=(-90, 90), longitude=(-10, 10), z = (0, 1))
10×10×10 LatitudeLongitudeGrid{Float64, Bounded, Bounded, Bounded} on CPU with 3×3×3 halo and with precomputed metrics
├── longitude: Bounded  λ ∈ [-10.0, 10.0] regularly spaced with Δλ=2.0
├── latitude:  Bounded  φ ∈ [-90.0, 90.0] regularly spaced with Δφ=18.0
└── z:         Bounded  z ∈ [0.0, 1.0]    regularly spaced with Δz=0.1

julia> v = YFaceField(grid)
ERROR: ArgumentError: Cannot specify north boundary condition ValueBoundaryCondition: Oceananigans.BoundaryConditions.PolarValue{OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, Symbol} on a field at Face()!
Stacktrace:
  [1] validate_boundary_condition_location(bc::BoundaryCondition{…}, loc::Face, side::Symbol)
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:57
  [2] validate_boundary_conditions(loc::Tuple{…}, grid::LatitudeLongitudeGrid{…}, bcs::FieldBoundaryConditions{…})
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:76
  [3] #apply_regionally!#58
    @ ~/development/Oceananigans.jl/src/Utils/multi_region_transformation.jl:121 [inlined]
  [4] apply_regionally!
    @ ~/development/Oceananigans.jl/src/Utils/multi_region_transformation.jl:118 [inlined]
  [5] macro expansion
    @ ~/development/Oceananigans.jl/src/Utils/multi_region_transformation.jl:206 [inlined]
  [6] Field(loc::Tuple{…}, grid::LatitudeLongitudeGrid{…}, data::OffsetArrays.OffsetArray{…}, bcs::FieldBoundaryConditions{…}, indices::Tuple{…}, op::Nothing, status::Nothing)
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:101
  [7] Field(loc::Tuple{…}, grid::LatitudeLongitudeGrid{…}, T::DataType; indices::Tuple{…}, data::OffsetArrays.OffsetArray{…}, boundary_conditions::FieldBoundaryConditions{…}, operand::Nothing, status::Nothing)
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:194
  [8] Field(loc::Tuple{…}, grid::LatitudeLongitudeGrid{…}, T::DataType)
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:185
  [9] YFaceField
    @ ~/development/Oceananigans.jl/src/Fields/field.jl:222 [inlined]
 [10] YFaceField(grid::LatitudeLongitudeGrid{…})
    @ Oceananigans.Fields ~/development/Oceananigans.jl/src/Fields/field.jl:222
 [11] top-level scope
    @ REPL[4]:1
Some type information was truncated. Use `show(err)` to see complete types.
```