### PR TITLE
Add a constructor for LatitudeLongitudeGrid from RectilinearGrid

### DIFF
--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -672,11 +672,11 @@ end
 @inline φspacings(grid::LLG, ℓy) = φspacings(grid, nothing, ℓy, nothing)
 
 """
-    LatitudeLongitudeGrid(rectilinear_grid::RectilinearGrid; radius=R_Earth, origin=(0,0))
+    LatitudeLongitudeGrid(rectilinear_grid::RectilinearGrid; radius=R_Earth, origin=(0, 0))
 
 Construct a `LatitudeLongitudeGrid` from a `RectilinearGrid`. The horizontal coordinates of the
 rectilinear grid are transformed to longitude-latitude coordinates in degrees, accounting for
-spherical Earth geometry.
+spherical Earth geometry. The longitudes are computed approximately using the latitudinal origin.
 
 The vertical coordinate and architecture are inherited from the input grid.
 

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -670,3 +670,60 @@ end
 
 @inline λspacings(grid::LLG, ℓx) = λspacings(grid, ℓx, nothing, nothing)
 @inline φspacings(grid::LLG, ℓy) = φspacings(grid, nothing, ℓy, nothing)
+
+"""
+    LatitudeLongitudeGrid(rectilinear_grid::RectilinearGrid; radius=R_Earth, origin=(0,0))
+
+Construct a `LatitudeLongitudeGrid` from a `RectilinearGrid`. The horizontal coordinates of the
+rectilinear grid are transformed to longitude-latitude coordinates in degrees, accounting for
+spherical Earth geometry.
+
+The vertical coordinate and architecture are inherited from the input grid.
+
+Keyword Arguments
+================ 
+- `radius`: The radius of the sphere, defaults to Earth's mean radius (≈ 6371 km)
+- `origin`: Tuple of (longitude, latitude) in degrees specifying the origin of the rectilinear grid
+"""
+function LatitudeLongitudeGrid(rectilinear_grid::RectilinearGrid; radius=R_Earth, origin=(0, 0))
+    arch = architecture(rectilinear_grid)
+    @show Nx, Ny, Nz = size(rectilinear_grid)
+    Hx, Hy, Hz = halo_size(rectilinear_grid)
+    
+    λ₀, φ₀ = origin
+
+    TX, TY, TZ = topology(rectilinear_grid)
+    tx, ty, tz = TX(), TY(), TZ()
+    triply_bounded = tx isa Bounded && ty isa Bounded && tz isa Bounded
+    if !triply_bounded
+        msg = string("The source RectilinearGrid for constructing LatitudeLongitudeGrid ",
+                     "must be triply-bounded, but has topology=($tx, $ty, $tz)!")
+        throw(ArgumentError(msg))
+    end
+
+    # Get face coordinates from rectilinear grid
+    xᶠ = xnodes(rectilinear_grid, Face())
+    yᶠ = ynodes(rectilinear_grid, Face())
+
+    xᶠ = on_architecture(CPU(), xᶠ)
+    yᶠ = on_architecture(CPU(), yᶠ)
+
+    @show xᶠ
+    @show yᶠ
+    
+    # Convert y coordinates to latitudes
+    R = radius
+    φᶠ = @. φ₀ + 180 / π * yᶠ / R
+    
+    # Convert x to longitude, using the origin as a reference
+    λᶠ = @. λ₀ + 180 / π * xᶠ / (R * cosd(φ₀))
+
+    z = cpu_face_constructor_z(rectilinear_grid)
+
+    return LatitudeLongitudeGrid(arch, eltype(rectilinear_grid); z, radius,
+                                 topology = (Bounded, Bounded, Bounded),
+                                 size = (Nx, Ny, Nz),
+                                 halo = (Hx, Hy, Hz),
+                                 longitude = λᶠ,
+                                 latitude = φᶠ)
+end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -985,6 +985,51 @@ end
             cpu_grid_again = on_architecture(CPU(), grid)
             @test cpu_grid_again == cpu_grid
         end
+
+        for arch in archs
+            for FT in float_types
+                @info " Testing construction of LatitudeLongitudeGrid from RectilinearGrid..."
+                Nx = 4
+                Ny = 5
+                Nz = 6
+                Lx = Ly = 2π / 180
+                rectilinear_grid = RectilinearGrid(arch, FT, size=(Nx, Ny, Nz), x=(-Lx/2, Lx/2), y=(-Ly/2, Ly/2), z=(0, 1), topology=(Bounded, Bounded, Bounded))
+                lat_lon_grid = LatitudeLongitudeGrid(rectilinear_grid, radius=1, origin=(0, 0))
+                λ = λnodes(lat_lon_grid, Face())
+                φ = φnodes(lat_lon_grid, Face())
+                @test λ[1]  == -1
+                @test λ[Nx+1] == +1
+                @test φ[1]  == -1
+                @test φ[Ny+1] == +1
+                @test znodes(rectilinear_grid, Center()) == znodes(lat_lon_grid, Center())
+                @test znodes(rectilinear_grid, Face()) == znodes(lat_lon_grid, Face())
+
+                lat_lon_grid = LatitudeLongitudeGrid(rectilinear_grid, radius=1, origin=(273, 0))
+                λ = λnodes(lat_lon_grid, Face())
+                φ = φnodes(lat_lon_grid, Face())
+                @test λ[1]  == 272
+                @test λ[Nx+1] == 274
+                @test φ[1]  == -1
+                @test φ[Ny+1] == +1
+                @test znodes(rectilinear_grid, Center()) == znodes(lat_lon_grid, Center())
+                @test znodes(rectilinear_grid, Face()) == znodes(lat_lon_grid, Face())
+
+
+                Lx = 2π / 180 * cosd(45)
+                Ly = 2π / 180
+                rectilinear_grid = RectilinearGrid(arch, FT, size=(Nx, Ny, Nz), x=(-Lx/2, Lx/2), y=(-Ly/2, Ly/2), z=(0, 1), topology=(Bounded, Bounded, Bounded))
+                lat_lon_grid = LatitudeLongitudeGrid(rectilinear_grid, radius=1, origin=(0, 45))
+
+                λ = λnodes(lat_lon_grid, Face())
+                φ = φnodes(lat_lon_grid, Face())
+                @test λ[1]  == -1
+                @test λ[Nx+1] == +1
+                @test φ[1]  == 44
+                @test φ[Ny+1] == 46
+                @test znodes(rectilinear_grid, Center()) == znodes(lat_lon_grid, Center())
+                @test znodes(rectilinear_grid, Face()) == znodes(lat_lon_grid, Face())
+            end
+        end
     end
 
     @testset "Single column grids" begin


### PR DESCRIPTION
This might prove useful for building bathymetry on RectilinearGrids for a particular place on the Earth, using ClimaOcean's metadata features to automate the process. For example we would do something like

```julia
grid = RectilinearGrid(etc...)
corresponding_lat_lon = LatitudeLongitudeGrid(grid, origin=(210, 45))
bottom_height = ClimaOcean.regrid_bathymetry(corresponding_lat_lon)
ibg = ImmersedBoundaryGrid(grid, GridFittedBottom(bottom_height))
```

I could also see us building this into ClimaOcean's Metadata utilities directly, eg so we can also initialize T, S from datasets. 

cc @tomchor 

Also I just realized that we can construct the _exact_ grid for `OrthogonalSphericalShellGrid` (here, we have to make an approximation when computing the longitudes).

I think this is useful and we have the tests, so I'll put off the corresponding OrthogonalSphericalShellGrid implementation for a future PR.