### PR TITLE
Add extrema(c::AbstractField)

### DIFF
--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -722,6 +722,10 @@ for reduction in (:sum, :maximum, :minimum, :all, :any, :prod)
     end
 end
 
+# Improve me! We can should both the extrama in one single reduction instead of two
+Base.extrema(c::AbstractField; kwargs...) = (minimum(c; kwargs...), maximum(c; kwargs...))
+Base.extrema(f, c::AbstractField; kwargs...) = (minimum(f, c; kwargs...), maximum(f, c; kwargs...))
+
 function Statistics._mean(f, c::AbstractField, ::Colon; condition = nothing, mask = 0)
     operator = condition_operand(f, c, condition, mask)
     return sum(operator) / conditional_length(operator)

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -92,6 +92,9 @@ function run_field_reduction_tests(FT, arch)
         @test maximum(abs, ϕ) ≈ maximum(abs, ϕ_vals) atol=ε
         @test mean(abs2, ϕ) ≈ mean(abs2, ϕ) atol=ε
 
+        @test extrema(ϕ) == (minimum(ϕ), maximum(ϕ))
+        @test extrema(∛, ϕ) == (minimum(∛, ϕ), maximum(∛, ϕ))
+
         for dims in dims_to_test
             @test all(isapprox(minimum(ϕ, dims=dims), minimum(ϕ_vals, dims=dims), atol=4ε))
             @test all(isapprox(maximum(ϕ, dims=dims), maximum(ϕ_vals, dims=dims), atol=4ε))


### PR DESCRIPTION
Currently, `extrema(field)` fails with scalar indexing on CUDA. The reason for this is that `extrema(c::AbstractField)` is not defined, so we fall back to `extrema(a::AbstractArray; dims, kw...)`.

This commit adds `extrema(field)` by calling `minimum(field)` and `maximum(field)` separately. Note that there's an opportunity for optimization here, where both the extrama are found in the same reduction.

