### PR TITLE
Resolve ambiguity when setting MultiRegionField with a number

### DIFF
--- a/src/MultiRegion/multi_region_field.jl
+++ b/src/MultiRegion/multi_region_field.jl
@@ -120,6 +120,9 @@ end
 set!(mrf::MultiRegionField, v)  = apply_regionally!(set!,  mrf, v)
 fill!(mrf::MultiRegionField, v) = apply_regionally!(fill!, mrf, v)
 
+set!(mrf::MultiRegionField, a::Number)  = apply_regionally!(set!,  mrf, a)
+fill!(mrf::MultiRegionField, a::Number) = apply_regionally!(fill!, mrf, a)
+
 set!(mrf::MultiRegionField, f::Function) = apply_regionally!(set!, mrf, f)
 set!(u::MultiRegionField, v::MultiRegionField) = apply_regionally!(set!, u, v)
 compute!(mrf::GriddedMultiRegionField, time=nothing) = apply_regionally!(compute!, mrf, time)


### PR DESCRIPTION
This PR resolves a method ambiguity that arises when attempting to set a `MultiRegionField` using a scalar value.

Minimal Working Example:
```
grid = ConformalCubedSphereGrid(CPU(); panel_size=(4, 4, 1), z=(-1, 0), horizontal_direction_halo=2, radius=1)
u = XFaceField(grid)
set!(u, 1)
```
The above code throws the following error:
```
ERROR: MethodError: set!(::Field{...}, ::Int64) is ambiguous.
```

Root Cause: There is a method ambiguity between the following definitions:
```
set!(u::Field, a::Number) (defined in Fields/set!.jl)
set!(mrf::Field{...}, v) (defined in MultiRegion/multi_region_field.jl)
```
To resolve this, we define the following explicit methods:

```
set!(mrf::MultiRegionField, a::Number)  = apply_regionally!(set!,  mrf, a)
fill!(mrf::MultiRegionField, a::Number) = apply_regionally!(fill!, mrf, a)
```

Impact: This change ensures that scalar assignments like `set!(u, 1)` or `fill!(u, 1)` work seamlessly for `MultiRegionField`s without ambiguity errors.