### PR TITLE
Refactor `getbc` interface

### DIFF
--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -109,18 +109,15 @@ DistributedCommunicationBoundaryCondition(val; kwargs...) = BoundaryCondition(Di
 #     * additional arguments to `fill_halo_regions` enter `getbc` after the `grid` argument:
 #           so `fill_halo_regions!(c, clock, fields)` translates to `getbc(bc, i, j, grid, clock, fields)`, etc.
 
-@inline getbc(bc, args...) = bc.condition(args...) # fallback!
+@inline getbc(bc::BoundaryCondition, args...) = getbc(bc.condition, args...) # unwrap
+@inline getbc(condition, args...) = condition(args...) # fallback!
 
-@inline getbc(::BC{<:Open, Nothing}, ::Integer, ::Integer, grid::AbstractGrid, args...) = zero(grid)
-@inline getbc(::BC{<:Flux, Nothing}, ::Integer, ::Integer, grid::AbstractGrid, args...) = zero(grid)
-@inline getbc(::Nothing,             ::Integer, ::Integer, grid::AbstractGrid, args...) = zero(grid)
+@inline getbc(::Nothing, ::Integer, ::Integer, grid::AbstractGrid, args...) = zero(grid)
 
-@inline getbc(bc::BC{<:Any, <:Number}, args...) = bc.condition
-@inline getbc(bc::BC{<:Any, <:AbstractArray}, i::Integer, j::Integer, grid::AbstractGrid, args...) = @inbounds bc.condition[i, j]
-
-# Support for Ref boundary conditions
 const NumberRef = Base.RefValue{<:Number}
-@inline getbc(bc::BC{<:Any, <:NumberRef}, args...) = bc.condition[]
+@inline getbc(condition::NumberRef, args...) = condition[]
+@inline getbc(condition::Number, args...) = condition
+@inline getbc(condition::AbstractArray, i::Integer, j::Integer, grid::AbstractGrid, args...) = @inbounds condition[i, j]
 
 #####
 ##### Validation with topology

--- a/src/BoundaryConditions/continuous_boundary_function.jl
+++ b/src/BoundaryConditions/continuous_boundary_function.jl
@@ -116,15 +116,14 @@ end
 @inline z_boundary_node(i, j, k, grid::YFlatGrid,  ℓx, ℓy) = tuple(ξnode(i, j, k, grid, ℓx, nothing, Face()))
 @inline z_boundary_node(i, j, k, grid::XYFlatGrid, ℓx, ℓy) = tuple()
 
-const XBoundaryFunction{LY, LZ, S} = BoundaryCondition{<:Any, <:ContinuousBoundaryFunction{Nothing, LY, LZ, S}} where {LY, LZ, S}
-const YBoundaryFunction{LX, LZ, S} = BoundaryCondition{<:Any, <:ContinuousBoundaryFunction{LX, Nothing, LZ, S}} where {LX, LZ, S}
-const ZBoundaryFunction{LX, LY, S} = BoundaryCondition{<:Any, <:ContinuousBoundaryFunction{LX, LY, Nothing, S}} where {LX, LY, S}
+const XBoundaryFunction{LY, LZ, S} = ContinuousBoundaryFunction{Nothing, LY, LZ, S} where {LY, LZ, S}
+const YBoundaryFunction{LX, LZ, S} = ContinuousBoundaryFunction{LX, Nothing, LZ, S} where {LX, LZ, S}
+const ZBoundaryFunction{LX, LY, S} = ContinuousBoundaryFunction{LX, LY, Nothing, S} where {LX, LY, S}
 
 # Return ContinuousBoundaryFunction on east or west boundaries.
-@inline function getbc(bc::XBoundaryFunction{LY, LZ, S}, j::Integer, k::Integer,
+@inline function getbc(cbf::XBoundaryFunction{LY, LZ, S}, j::Integer, k::Integer,
                        grid::AbstractGrid, clock, model_fields, args...) where {LY, LZ, S}
 
-    cbf = bc.condition
     i, i′ = domain_boundary_indices(S(), grid.Nx)
     args = user_function_arguments(i, j, k, grid, model_fields, cbf.parameters, cbf)
     X = x_boundary_node(i′, j, k, grid, LY(), LZ())
@@ -133,10 +132,9 @@ const ZBoundaryFunction{LX, LY, S} = BoundaryCondition{<:Any, <:ContinuousBounda
 end
 
 # Return ContinuousBoundaryFunction on south or north boundaries.
-@inline function getbc(bc::YBoundaryFunction{LX, LZ, S}, i::Integer, k::Integer,
+@inline function getbc(cbf::YBoundaryFunction{LX, LZ, S}, i::Integer, k::Integer,
                        grid::AbstractGrid, clock, model_fields, args...) where {LX, LZ, S}
 
-    cbf = bc.condition
     j, j′ = domain_boundary_indices(S(), grid.Ny)
     args = user_function_arguments(i, j, k, grid, model_fields, cbf.parameters, cbf)
     X = y_boundary_node(i, j′, k, grid, LX(), LZ())
@@ -145,10 +143,9 @@ end
 end
 
 # Return ContinuousBoundaryFunction on bottom or top boundaries.
-@inline function getbc(bc::ZBoundaryFunction{LX, LY, S}, i::Integer, j::Integer,
+@inline function getbc(cbf::ZBoundaryFunction{LX, LY, S}, i::Integer, j::Integer,
                        grid::AbstractGrid, clock, model_fields, args...) where {LX, LY, S}
 
-    cbf = bc.condition
     k, k′ = domain_boundary_indices(S(), grid.Nz)
     args = user_function_arguments(i, j, k, grid, model_fields, cbf.parameters, cbf)
     X = z_boundary_node(i, j, k′, grid, LX(), LY())
@@ -161,10 +158,9 @@ end
 #####
 
 # Return ContinuousBoundaryFunction on the east or west interface of a cell adjacent to an immersed boundary
-@inline function getbc(bc::XBoundaryFunction{LY, LZ, S}, i::Integer, j::Integer, k::Integer,
+@inline function getbc(cbf::XBoundaryFunction{LY, LZ, S}, i::Integer, j::Integer, k::Integer,
                        grid::AbstractGrid, clock, model_fields, args...) where {LY, LZ, S}
 
-    cbf = bc.condition
     i′ = cell_boundary_index(S(), i)
     args = user_function_arguments(i, j, k, grid, model_fields, cbf.parameters, cbf)
     X = node(i′, j, k, grid, Face(), LY(), LZ())
@@ -173,10 +169,9 @@ end
 end
 
 # Return ContinuousBoundaryFunction on the south or north interface of a cell adjacent to an immersed boundary
-@inline function getbc(bc::YBoundaryFunction{LX, LZ, S}, i::Integer, j::Integer, k::Integer,
+@inline function getbc(cbf::YBoundaryFunction{LX, LZ, S}, i::Integer, j::Integer, k::Integer,
                        grid::AbstractGrid, clock, model_fields, args...) where {LX, LZ, S}
 
-    cbf = bc.condition
     j′ = cell_boundary_index(S(), j)
     args = user_function_arguments(i, j, k, grid, model_fields, cbf.parameters, cbf)
     X = node(i, j′, k, grid, LX(), Face(), LZ())
@@ -185,10 +180,9 @@ end
 end
 
 # Return ContinuousBoundaryFunction on the bottom or top interface of a cell adjacent to an immersed boundary
-@inline function getbc(bc::ZBoundaryFunction{LX, LY, S}, i::Integer, j::Integer, k::Integer,
+@inline function getbc(cbf::ZBoundaryFunction{LX, LY, S}, i::Integer, j::Integer, k::Integer,
                        grid::AbstractGrid, clock, model_fields, args...) where {LX, LY, S}
 
-    cbf = bc.condition
     k′ = cell_boundary_index(S(), k)
     args = user_function_arguments(i, j, k, grid, model_fields, cbf.parameters, cbf)
     X = node(i, j, k′, grid, LX(), LY(), Face())

--- a/src/BoundaryConditions/discrete_boundary_function.jl
+++ b/src/BoundaryConditions/discrete_boundary_function.jl
@@ -32,21 +32,19 @@ struct DiscreteBoundaryFunction{P, F}
 end
 
 const UnparameterizedDBF = DiscreteBoundaryFunction{<:Nothing}
-const UnparameterizedDBFBC = BoundaryCondition{<:Any, <:UnparameterizedDBF}
-const DBFBC = BoundaryCondition{<:Any, <:DiscreteBoundaryFunction}
 
-@inline getbc(bc::UnparameterizedDBFBC, i::Integer, j::Integer, grid::AbstractGrid, clock, model_fields, args...) =
-    bc.condition.func(i, j, grid, clock, model_fields)
+@inline getbc(condition::UnparameterizedDBF, i::Integer, j::Integer, grid::AbstractGrid, clock, model_fields, args...) =
+    condition.func(i, j, grid, clock, model_fields)
 
-@inline getbc(bc::DBFBC, i::Integer, j::Integer, grid::AbstractGrid, clock, model_fields, args...) =
-    bc.condition.func(i, j, grid, clock, model_fields, bc.condition.parameters)
+@inline getbc(condition::DiscreteBoundaryFunction, i::Integer, j::Integer, grid::AbstractGrid, clock, model_fields, args...) =
+    condition.func(i, j, grid, clock, model_fields, bc.condition.parameters)
 
 # 3D function for immersed boundary conditions
-@inline getbc(bc::UnparameterizedDBFBC, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, model_fields, args...) =
-    bc.condition.func(i, j, k, grid, clock, model_fields)
+@inline getbc(condition::UnparameterizedDBF, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, model_fields, args...) =
+    condition.func(i, j, k, grid, clock, model_fields)
 
-@inline getbc(bc::DBFBC, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, model_fields, args...) =
-    bc.condition.func(i, j, k, grid, clock, model_fields, bc.condition.parameters)
+@inline getbc(condition::DiscreteBoundaryFunction, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, model_fields, args...) =
+    condition.func(i, j, k, grid, clock, model_fields, bc.condition.parameters)
 
 # Don't re-convert DiscreteBoundaryFunctions passed to BoundaryCondition constructor
 BoundaryCondition(Classification::DataType, condition::DiscreteBoundaryFunction) = BoundaryCondition(Classification(), condition)

--- a/src/BoundaryConditions/discrete_boundary_function.jl
+++ b/src/BoundaryConditions/discrete_boundary_function.jl
@@ -37,14 +37,14 @@ const UnparameterizedDBF = DiscreteBoundaryFunction{<:Nothing}
     condition.func(i, j, grid, clock, model_fields)
 
 @inline getbc(condition::DiscreteBoundaryFunction, i::Integer, j::Integer, grid::AbstractGrid, clock, model_fields, args...) =
-    condition.func(i, j, grid, clock, model_fields, bc.condition.parameters)
+    condition.func(i, j, grid, clock, model_fields, condition.parameters)
 
 # 3D function for immersed boundary conditions
 @inline getbc(condition::UnparameterizedDBF, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, model_fields, args...) =
     condition.func(i, j, k, grid, clock, model_fields)
 
 @inline getbc(condition::DiscreteBoundaryFunction, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, model_fields, args...) =
-    condition.func(i, j, k, grid, clock, model_fields, bc.condition.parameters)
+    condition.func(i, j, k, grid, clock, model_fields, condition.parameters)
 
 # Don't re-convert DiscreteBoundaryFunctions passed to BoundaryCondition constructor
 BoundaryCondition(Classification::DataType, condition::DiscreteBoundaryFunction) = BoundaryCondition(Classification(), condition)

--- a/src/BoundaryConditions/perturbation_advection_open_boundary_matching_scheme.jl
+++ b/src/BoundaryConditions/perturbation_advection_open_boundary_matching_scheme.jl
@@ -116,24 +116,19 @@ end
 @inline function step_right_boundary!(bc::FPAOBC, l, m, boundary_indices, boundary_adjacent_indices,
                                       grid, u, clock, model_fields, ΔX)
     Δt = clock.last_stage_Δt
-
     Δt = ifelse(isinf(Δt), 0, Δt)
 
     ūⁿ⁺¹ = getbc(bc, l, m, grid, clock, model_fields)
-
     uᵢⁿ     = @inbounds getindex(u, boundary_indices...)
     uᵢ₋₁ⁿ⁺¹ = @inbounds getindex(u, boundary_adjacent_indices...)
 
     U = max(0, min(1, Δt / ΔX * ūⁿ⁺¹))
-
     pa = bc.classification.matching_scheme
 
     τ = ifelse(ūⁿ⁺¹ >= 0, pa.outflow_timescale, pa.inflow_timescale)
-
     τ̃ = Δt / τ
 
     uᵢⁿ⁺¹ = uᵢⁿ + U * (uᵢ₋₁ⁿ⁺¹ - ūⁿ⁺¹) + (ūⁿ⁺¹ - uᵢⁿ) * τ̃
-
     @inbounds setindex!(u, uᵢⁿ⁺¹, boundary_indices...)
 
     return nothing
@@ -142,24 +137,19 @@ end
 @inline function step_left_boundary!(bc::FPAOBC, l, m, boundary_indices, boundary_adjacent_indices, boundary_secret_storage_indices,
                                      grid, u, clock, model_fields, ΔX)
     Δt = clock.last_stage_Δt
-
     Δt = ifelse(isinf(Δt), 0, Δt)
 
     ūⁿ⁺¹ = getbc(bc, l, m, grid, clock, model_fields)
-
     uᵢⁿ     = @inbounds getindex(u, boundary_secret_storage_indices...)
     uᵢ₋₁ⁿ⁺¹ = @inbounds getindex(u, boundary_adjacent_indices...)
 
     U = min(0, max(-1, Δt / ΔX * ūⁿ⁺¹))
-
     pa = bc.classification.matching_scheme
 
     τ = ifelse(ūⁿ⁺¹ <= 0, pa.outflow_timescale, pa.inflow_timescale)
-
     τ̃ = Δt / τ
 
     u₁ⁿ⁺¹ = uᵢⁿ - U * (uᵢ₋₁ⁿ⁺¹ - ūⁿ⁺¹) + (ūⁿ⁺¹ - uᵢⁿ) * τ̃
-
     @inbounds setindex!(u, u₁ⁿ⁺¹, boundary_indices...)
     @inbounds setindex!(u, u₁ⁿ⁺¹, boundary_secret_storage_indices...)
 
@@ -168,7 +158,6 @@ end
 
 @inline function _fill_east_halo!(j, k, grid, u, bc::PAOBC, ::Tuple{Face, Any, Any}, clock, model_fields)
     i = grid.Nx + 1
-
     boundary_indices = (i, j, k)
     boundary_adjacent_indices = (i-1, j, k)
 
@@ -193,7 +182,6 @@ end
 
 @inline function _fill_north_halo!(i, k, grid, u, bc::PAOBC, ::Tuple{Any, Face, Any}, clock, model_fields)
     j = grid.Ny + 1
-
     boundary_indices = (i, j, k)
     boundary_adjacent_indices = (i, j-1, k)
 
@@ -218,7 +206,6 @@ end
 
 @inline function _fill_top_halo!(i, j, grid, u, bc::PAOBC, ::Tuple{Any, Any, Face}, clock, model_fields)
     k = grid.Nz + 1
-
     boundary_indices = (i, j, k)
     boundary_adjacent_indices = (i, j, k-1)
 

--- a/src/BoundaryConditions/polar_boundary_condition.jl
+++ b/src/BoundaryConditions/polar_boundary_condition.jl
@@ -31,7 +31,7 @@ maybe_polar_boundary_condition(grid, side, ::Type{Center},  LZ) = PolarValueBoun
 maybe_polar_boundary_condition(grid, side, ::Type{Face},    LZ) = PolarOpenBoundaryCondition(grid, side, LZ)
 
 # Just a column
-@inline getbc(pv::BC{<:Any, <:PolarValue}, i, k, args...) = @inbounds pv.condition.data[1, 1, k]
+@inline getbc(pv::PolarValue, i, k, args...) = @inbounds pv.data[1, 1, k]
 
 @kernel function _average_pole_value!(data, c, j, grid, loc)
     i′, j′, k = @index(Global, NTuple)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -544,20 +544,15 @@ const ReducedField = Union{XReducedField,
 @propagate_inbounds Base.getindex(r::XYZReducedField, i, j, k) = getindex(r.data, 1, 1, 1)
 @propagate_inbounds Base.setindex!(r::XYZReducedField, v, i, j, k) = setindex!(r.data, v, 1, 1, 1)
 
-const XFieldBC = BoundaryCondition{<:Any, XReducedField}
-const YFieldBC = BoundaryCondition{<:Any, YReducedField}
-const ZFieldBC = BoundaryCondition{<:Any, ZReducedField}
-
 # Boundary conditions reduced in one direction --- drop boundary-normal index
-@inline getbc(bc::XFieldBC, j::Integer, k::Integer, grid::AbstractGrid, args...) = @inbounds bc.condition[1, j, k]
-@inline getbc(bc::YFieldBC, i::Integer, k::Integer, grid::AbstractGrid, args...) = @inbounds bc.condition[i, 1, k]
-@inline getbc(bc::ZFieldBC, i::Integer, j::Integer, grid::AbstractGrid, args...) = @inbounds bc.condition[i, j, 1]
+@inline getbc(condition::XReducedField, j::Integer, k::Integer, grid::AbstractGrid, args...) = @inbounds condition[1, j, k]
+@inline getbc(condition::YReducedField, i::Integer, k::Integer, grid::AbstractGrid, args...) = @inbounds condition[i, 1, k]
+@inline getbc(condition::ZReducedField, i::Integer, j::Integer, grid::AbstractGrid, args...) = @inbounds condition[i, j, 1]
 
 # Boundary conditions reduced in two directions are ambiguous, so that's hard...
 
 # 0D boundary conditions --- easy case
-const XYZFieldBC = BoundaryCondition{<:Any, XYZReducedField}
-@inline getbc(bc::XYZFieldBC, ::Integer, ::Integer, ::AbstractGrid, args...) = @inbounds bc.condition[1, 1, 1]
+@inline getbc(condition::XYZReducedField, ::Integer, ::Integer, ::AbstractGrid, args...) = @inbounds condition[1, 1, 1]
 
 # Preserve location when adapting fields reduced on one or more dimensions
 function Adapt.adapt_structure(to, reduced_field::ReducedField)

--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -35,6 +35,10 @@ end
 extract_field_time_series(t::AbstractOperation) = Tuple(extract_field_time_series(getproperty(t, p)) for p in propertynames(t))
 extract_field_time_series(t::Union{Tuple, NamedTuple}) = map(extract_field_time_series, t)
 
+const CPUFTSBC = BoundaryCondition{<:Any, <:FieldTimeSeries}
+const GPUFTSBC = BoundaryCondition{<:Any, <:GPUAdaptedFieldTimeSeries}
+const FTSBC = Union{CPUFTSBC, GPUFTSBC}
+
 # Special extract for Fields with FTSBC
 const WFTSBCS = FieldBoundaryConditions{<:FTSBC}
 const EFTSBCS = FieldBoundaryConditions{<:Any, <:FTSBC}

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -742,11 +742,7 @@ function interior(fts::FieldTimeSeries)
 end
 
 # FieldTimeSeries boundary conditions
-const CPUFTSBC = BoundaryCondition{<:Any, <:FieldTimeSeries}
-const GPUFTSBC = BoundaryCondition{<:Any, <:GPUAdaptedFieldTimeSeries}
-const FTSBC = Union{CPUFTSBC, GPUFTSBC}
-
-@inline getbc(bc::FTSBC, i::Int, j::Int, grid::AbstractGrid, clock, args...) = bc.condition[i, j, Time(clock.time)]
+@inline getbc(condition::Union{FTS, GPUFTS}, i::Int, j::Int, grid::AbstractGrid, clock, args...) = condition[i, j, Time(clock.time)]
 
 #####
 ##### Fill halo regions

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_top_boundary_condition.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_top_boundary_condition.jl
@@ -16,10 +16,10 @@ const TKEBoundaryFunction = DiscreteBoundaryFunction{<:TKETopBoundaryConditionPa
                                       on_architecture(to, p.top_velocity_boundary_conditions))
 
 @inline getbc(condition::TKEBoundaryFunction, i::Integer, j::Integer, grid::AbstractGrid, clock, fields, clo, buoyancy) =
-    condition.func(i, j, grid, clock, fields, bc.condition.parameters, clo, buoyancy)
+    condition.func(i, j, grid, clock, fields, condition.parameters, clo, buoyancy)
 
 @inline getbc(condition::TKEBoundaryFunction, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, fields, clo, buoyancy) =
-    condition.func(i, j, k, grid, clock, fields, bc.condition.parameters, clo, buoyancy)
+    condition.func(i, j, k, grid, clock, fields, condition.parameters, clo, buoyancy)
 
 """
     top_tke_flux(i, j, grid, clock, fields, parameters, closure, buoyancy)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_top_boundary_condition.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_top_boundary_condition.jl
@@ -6,7 +6,6 @@ struct TKETopBoundaryConditionParameters{C, U}
 end
 
 const TKEBoundaryFunction = DiscreteBoundaryFunction{<:TKETopBoundaryConditionParameters}
-const TKEBoundaryCondition = BoundaryCondition{<:Flux, <:TKEBoundaryFunction}
 
 @inline Adapt.adapt_structure(to, p::TKETopBoundaryConditionParameters) =
     TKETopBoundaryConditionParameters(adapt(to, p.top_tracer_boundary_conditions),
@@ -16,11 +15,11 @@ const TKEBoundaryCondition = BoundaryCondition{<:Flux, <:TKEBoundaryFunction}
     TKETopBoundaryConditionParameters(on_architecture(to, p.top_tracer_boundary_conditions),
                                       on_architecture(to, p.top_velocity_boundary_conditions))
 
-@inline getbc(bc::TKEBoundaryCondition, i::Integer, j::Integer, grid::AbstractGrid, clock, fields, clo, buoyancy) =
-    bc.condition.func(i, j, grid, clock, fields, bc.condition.parameters, clo, buoyancy)
+@inline getbc(condition::TKEBoundaryFunction, i::Integer, j::Integer, grid::AbstractGrid, clock, fields, clo, buoyancy) =
+    condition.func(i, j, grid, clock, fields, bc.condition.parameters, clo, buoyancy)
 
-@inline getbc(bc::TKEBoundaryCondition, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, fields, clo, buoyancy) =
-    bc.condition.func(i, j, k, grid, clock, fields, bc.condition.parameters, clo, buoyancy)
+@inline getbc(condition::TKEBoundaryFunction, i::Integer, j::Integer, k::Integer, grid::AbstractGrid, clock, fields, clo, buoyancy) =
+    condition.func(i, j, k, grid, clock, fields, bc.condition.parameters, clo, buoyancy)
 
 """
     top_tke_flux(i, j, grid, clock, fields, parameters, closure, buoyancy)


### PR DESCRIPTION
This PR refactors the `getbc` interface so that developers can implement methods to extend `bc.condition` directly, rather than having to extend `BoundaryCondition{<:Any, MyNewCondition}`. This simplifies the code and will allow more complex `getbc` cases to be expressed.