### PR TITLE
Fix incorrect type parameter count in ConformalCubedSpherePanel and ConformalCubedSpherePanelGrid definitions

### DIFF
--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -131,7 +131,6 @@ include("input_validation.jl")
 include("grid_generation.jl")
 include("rectilinear_grid.jl")
 include("orthogonal_spherical_shell_grid.jl")
-include("conformal_cubed_sphere_panel.jl")
 include("latitude_longitude_grid.jl")
 
 end # module

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -10,7 +10,6 @@ export XFlatGrid, YFlatGrid, ZFlatGrid
 export XRegularRG, YRegularRG, ZRegularRG, XYRegularRG, XYZRegularRG
 export LatitudeLongitudeGrid, XRegularLLG, YRegularLLG, ZRegularLLG
 export OrthogonalSphericalShellGrid, ConformalCubedSphereGrid, ZRegOrthogonalSphericalShellGrid
-export conformal_cubed_sphere_panel
 export MutableVerticalDiscretization
 export node, nodes
 export ξnode, ηnode, rnode

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -9,7 +9,7 @@ export AbstractCurvilinearGrid, AbstractHorizontallyCurvilinearGrid
 export XFlatGrid, YFlatGrid, ZFlatGrid
 export XRegularRG, YRegularRG, ZRegularRG, XYRegularRG, XYZRegularRG
 export LatitudeLongitudeGrid, XRegularLLG, YRegularLLG, ZRegularLLG
-export OrthogonalSphericalShellGrid, ConformalCubedSphereGrid, ZRegOrthogonalSphericalShellGrid
+export OrthogonalSphericalShellGrid, ZRegOrthogonalSphericalShellGrid
 export MutableVerticalDiscretization
 export node, nodes
 export ξnode, ηnode, rnode

--- a/src/Grids/conformal_cubed_sphere_panel.jl
+++ b/src/Grids/conformal_cubed_sphere_panel.jl
@@ -33,17 +33,6 @@ function Adapt.adapt_structure(to, conformal_mapping::CubedSphereConformalMappin
         adapt(to, conformal_mapping.ηᵃᶜᵃ))
 end
 
-# TODO: this belongs elsewhere.
-const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, FullyConnected, FullyConnected,
-                                                               <:Any, <:Any, <:CubedSphereConformalMapping}
-
-const ConformalCubedSpherePanelGrid = OrthogonalSphericalShellGrid{<:Any,
-                                                                   <:Any,
-                                                                   <:Any,
-                                                                   <:Any,
-                                                                   <:Any,
-                                                                   <:CubedSphereConformalMapping}
-
 # architecture = CPU() by default, assuming that a DataType positional arg is specifying the floating point type.
 conformal_cubed_sphere_panel(FT::DataType; kwargs...) = conformal_cubed_sphere_panel(CPU(), FT; kwargs...)
 

--- a/src/Grids/conformal_cubed_sphere_panel.jl
+++ b/src/Grids/conformal_cubed_sphere_panel.jl
@@ -35,11 +35,9 @@ end
 
 # TODO: this belongs elsewhere.
 const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, FullyConnected, FullyConnected,
-                                                               <:Any, <:Any, <:Any,
-                                                               <:CubedSphereConformalMapping}
+                                                               <:Any, <:Any, <:CubedSphereConformalMapping}
 
 const ConformalCubedSpherePanelGrid = OrthogonalSphericalShellGrid{<:Any,
-                                                                   <:Any,
                                                                    <:Any,
                                                                    <:Any,
                                                                    <:Any,

--- a/src/MultiRegion/cubed_sphere_grid.jl
+++ b/src/MultiRegion/cubed_sphere_grid.jl
@@ -12,16 +12,6 @@ using Distances
 import Oceananigans.Grids: grid_name
 import Oceananigans.BoundaryConditions: fill_halo_regions!
 
-const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, FullyConnected, FullyConnected,
-                                                               <:Any, <:Any, <:CubedSphereConformalMapping}
-
-const ConformalCubedSpherePanelGrid = OrthogonalSphericalShellGrid{<:Any,
-                                                                   <:Any,
-                                                                   <:Any,
-                                                                   <:Any,
-                                                                   <:Any,
-                                                                   <:CubedSphereConformalMapping}
-
 const ConformalCubedSphereGrid{FT, TX, TY, TZ, CZ} = MultiRegionGrid{FT, TX, TY, TZ, CZ, <:CubedSpherePartition}
 
 """

--- a/src/MultiRegion/cubed_sphere_grid.jl
+++ b/src/MultiRegion/cubed_sphere_grid.jl
@@ -1,12 +1,13 @@
 using Oceananigans.Architectures: architecture
-using Oceananigans.Grids: conformal_cubed_sphere_panel,
-                          R_Earth,
+using Oceananigans.Grids: R_Earth,
                           halo_size,
                           size_summary,
                           total_length,
                           topology
 
 using CubedSphere
+using Oceananigans.OrthogonalSphericalShellGrids: conformal_cubed_sphere_panel
+
 using Distances
 
 import Oceananigans.Grids: grid_name

--- a/src/MultiRegion/cubed_sphere_grid.jl
+++ b/src/MultiRegion/cubed_sphere_grid.jl
@@ -6,7 +6,7 @@ using Oceananigans.Grids: R_Earth,
                           topology
 
 using CubedSphere
-using Oceananigans.OrthogonalSphericalShellGrids: conformal_cubed_sphere_panel
+using Oceananigans.OrthogonalSphericalShellGrids: ConformalCubedSpherePanelGrid
 
 using Distances
 
@@ -30,7 +30,7 @@ const ConformalCubedSphereGrid{FT, TX, TY, TZ, CZ} = MultiRegionGrid{FT, TX, TY,
                              partition = CubedSpherePartition(; R = 1),
                              devices = nothing)
 
-Return a `ConformalCubedSphereGrid` that comprises of six [`conformal_cubed_sphere_panel`](@ref) grids; we refer to each
+Return a `ConformalCubedSphereGrid` that comprises of six [`ConformalCubedSpherePanelGrid`](@ref)s; we refer to each
 of these grids as a "panel". Each panel corresponds to a face of the cube.
 
 The keyword arguments prescribe the properties of each of the panels. Only the topology in the vertical direction can be
@@ -232,7 +232,7 @@ function ConformalCubedSphereGrid(arch::AbstractArchitecture=CPU(),
     region_rotation = Iterate(region_rotation)
 
     # As mentioned above, construct the grid on CPU and convert to user-prescribed architecture later...
-    region_grids = construct_regionally(conformal_cubed_sphere_panel, CPU(), FT;
+    region_grids = construct_regionally(ConformalCubedSpherePanelGrid, CPU(), FT;
                                         size = region_size,
                                         z,
                                         topology = region_topology,
@@ -399,7 +399,7 @@ function ConformalCubedSphereGrid(filepath::AbstractString,
     region_Nz = MultiRegionObject(Tuple(repeat([Nz], length(partition))), devices)
     region_panels = Iterate(Array(1:length(partition)))
 
-    region_grids = construct_regionally(conformal_cubed_sphere_panel, filepath, arch, FT;
+    region_grids = construct_regionally(ConformalCubedSpherePanelGrid, filepath, arch, FT;
                                         panel = region_panels,
                                         Nz = region_Nz,
                                         z,

--- a/src/MultiRegion/cubed_sphere_grid.jl
+++ b/src/MultiRegion/cubed_sphere_grid.jl
@@ -12,6 +12,16 @@ using Distances
 import Oceananigans.Grids: grid_name
 import Oceananigans.BoundaryConditions: fill_halo_regions!
 
+const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, FullyConnected, FullyConnected,
+                                                               <:Any, <:Any, <:CubedSphereConformalMapping}
+
+const ConformalCubedSpherePanelGrid = OrthogonalSphericalShellGrid{<:Any,
+                                                                   <:Any,
+                                                                   <:Any,
+                                                                   <:Any,
+                                                                   <:Any,
+                                                                   <:CubedSphereConformalMapping}
+
 const ConformalCubedSphereGrid{FT, TX, TY, TZ, CZ} = MultiRegionGrid{FT, TX, TY, TZ, CZ, <:CubedSpherePartition}
 
 """

--- a/src/Operators/vorticity_operators.jl
+++ b/src/Operators/vorticity_operators.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Grids: ConformalCubedSpherePanel
+using Oceananigans.MultiRegion: ConformalCubedSpherePanel
 
 """ Vertical circulation associated with horizontal velocities u, v. """
 @inline Γᶠᶠᶜ(i, j, k, grid, u, v) = δxᶠᶠᶜ(i, j, k, grid, Δy_qᶜᶠᶜ, v) - δyᶠᶠᶜ(i, j, k, grid, Δx_qᶠᶜᶜ, u)

--- a/src/Operators/vorticity_operators.jl
+++ b/src/Operators/vorticity_operators.jl
@@ -1,5 +1,3 @@
-using Oceananigans.OrthogonalSphericalShellGrids: ConformalCubedSpherePanel
-
 """ Vertical circulation associated with horizontal velocities u, v. """
 @inline Γᶠᶠᶜ(i, j, k, grid, u, v) = δxᶠᶠᶜ(i, j, k, grid, Δy_qᶜᶠᶜ, v) - δyᶠᶠᶜ(i, j, k, grid, Δx_qᶠᶜᶜ, u)
 
@@ -9,31 +7,3 @@ using Oceananigans.OrthogonalSphericalShellGrids: ConformalCubedSpherePanel
 The vertical vorticity associated with horizontal velocities ``u`` and ``v``.
 """
 @inline ζ₃ᶠᶠᶜ(i, j, k, grid, u, v) = Γᶠᶠᶜ(i, j, k, grid, u, v) * Az⁻¹ᶠᶠᶜ(i, j, k, grid)
-
-# South-west, south-east, north-west, north-east corners
-@inline on_south_west_corner(i, j, grid) = (i == 1) & (j == 1)
-@inline on_south_east_corner(i, j, grid) = (i == grid.Nx+1) & (j == 1)
-@inline on_north_east_corner(i, j, grid) = (i == grid.Nx+1) & (j == grid.Ny+1)
-@inline on_north_west_corner(i, j, grid) = (i == 1) & (j == grid.Ny+1)
-
-#####
-##### Vertical circulation at the corners of the cubed sphere needs to treated in a special manner.
-##### See: https://github.com/CliMA/Oceananigans.jl/issues/1584
-#####
-
-"""
-    Γᶠᶠᶜ(i, j, k, grid, u, v)
-
-The vertical circulation associated with horizontal velocities ``u`` and ``v``.
-"""
-@inline function Γᶠᶠᶜ(i, j, k, grid::ConformalCubedSpherePanel, u, v)
-    Hx, Hy = grid.Hx, grid.Hy
-    Γ = ifelse(on_south_west_corner(i, j, grid) | on_north_west_corner(i, j, grid),
-               Δy_qᶜᶠᶜ(i, j, k, grid, v) - Δx_qᶠᶜᶜ(i, j, k, grid, u) + Δx_qᶠᶜᶜ(i, j-1, k, grid, u),
-               ifelse(on_south_east_corner(i, j, grid) | on_north_east_corner(i, j, grid),
-                      - Δy_qᶜᶠᶜ(i-1, j, k, grid, v) + Δx_qᶠᶜᶜ(i, j-1, k, grid, u) - Δx_qᶠᶜᶜ(i, j, k, grid, u),
-                      δxᶠᶠᶜ(i, j, k, grid, Δy_qᶜᶠᶜ, v) - δyᶠᶠᶜ(i, j, k, grid, Δx_qᶠᶜᶜ, u)
-                     )
-              )
-    return Γ
-end

--- a/src/Operators/vorticity_operators.jl
+++ b/src/Operators/vorticity_operators.jl
@@ -1,4 +1,4 @@
-using Oceananigans.MultiRegion: ConformalCubedSpherePanel
+using Oceananigans.OrthogonalSphericalShellGrids: ConformalCubedSpherePanel
 
 """ Vertical circulation associated with horizontal velocities u, v. """
 @inline Γᶠᶠᶜ(i, j, k, grid, u, v) = δxᶠᶠᶜ(i, j, k, grid, Δy_qᶜᶠᶜ, v) - δyᶠᶠᶜ(i, j, k, grid, Δx_qᶠᶜᶜ, u)

--- a/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
+++ b/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
@@ -1,8 +1,7 @@
 module OrthogonalSphericalShellGrids
 
 # The only thing we need!
-export TripolarGrid, RotatedLatitudeLongitudeGrid, ConformalCubedSpherePanel, ConformalCubedSpherePanelGrid
-export conformal_cubed_sphere_panel
+export TripolarGrid, RotatedLatitudeLongitudeGrid, ConformalCubedSpherePanelGrid
 
 import Oceananigans
 import Oceananigans.Architectures: on_architecture

--- a/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
+++ b/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
@@ -1,7 +1,7 @@
 module OrthogonalSphericalShellGrids
 
 # The only thing we need!
-export TripolarGrid, RotatedLatitudeLongitudeGrid
+export TripolarGrid, RotatedLatitudeLongitudeGrid, ConformalCubedSpherePanel, ConformalCubedSpherePanelGrid
 
 import Oceananigans
 
@@ -33,6 +33,7 @@ include("generate_tripolar_coordinates.jl")
 include("tripolar_grid.jl")
 include("tripolar_field_extensions.jl")
 include("rotated_latitude_longitude_grid.jl")
+include("conformal_cubed_sphere_panel.jl")
 
 # Distributed computations on a tripolar grid
 include("distributed_tripolar_grid.jl")

--- a/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
+++ b/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
@@ -18,7 +18,7 @@ using Oceananigans.Grids: RightConnected
 using Oceananigans.Grids: R_Earth,
                           halo_size, spherical_area_quadrilateral,
                           lat_lon_to_cartesian, generate_coordinate, topology
-using Oceananigans.Grids: add_halos, fill_metric_halo_regions!
+using Oceananigans.Grids: add_halos
 
 using Oceananigans.Operators
 using Oceananigans.Utils: get_cartesian_nodes_and_vertices

--- a/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
+++ b/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
@@ -18,7 +18,7 @@ using Oceananigans.Grids: RightConnected
 using Oceananigans.Grids: R_Earth,
                           halo_size, spherical_area_quadrilateral,
                           lat_lon_to_cartesian, generate_coordinate, topology
-using Oceananigans.Grids: add_halos
+using Oceananigans.Grids: add_halos, fill_metric_halo_regions!
 
 using Oceananigans.Operators
 using Oceananigans.Utils: get_cartesian_nodes_and_vertices

--- a/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
+++ b/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
@@ -18,7 +18,7 @@ using Oceananigans.Grids: RightConnected
 using Oceananigans.Grids: R_Earth,
                           halo_size, spherical_area_quadrilateral,
                           lat_lon_to_cartesian, generate_coordinate, topology
-using Oceananigans.Grids: add_halos, fill_metric_halo_regions!
+using Oceananigans.Grids: total_length, add_halos, fill_metric_halo_regions!
 
 using Oceananigans.Operators
 using Oceananigans.Utils: get_cartesian_nodes_and_vertices

--- a/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
+++ b/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
@@ -2,8 +2,10 @@ module OrthogonalSphericalShellGrids
 
 # The only thing we need!
 export TripolarGrid, RotatedLatitudeLongitudeGrid, ConformalCubedSpherePanel, ConformalCubedSpherePanelGrid
+export conformal_cubed_sphere_panel
 
 import Oceananigans
+import Oceananigans.Architectures: on_architecture
 
 using Oceananigans
 using Oceananigans.Grids
@@ -17,6 +19,7 @@ using Oceananigans.Grids: RightConnected
 using Oceananigans.Grids: R_Earth,
                           halo_size, spherical_area_quadrilateral,
                           lat_lon_to_cartesian, generate_coordinate, topology
+using Oceananigans.Grids: add_halos, fill_metric_halo_regions!
 
 using Oceananigans.Operators
 using Oceananigans.Utils: get_cartesian_nodes_and_vertices

--- a/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
+++ b/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
@@ -235,7 +235,7 @@ Examples
 * The default conformal cubed sphere panel grid with `Float64` type:
 
 ```jldoctest
-julia> using Oceananigans, Oceananigans.Grids
+julia> using Oceananigans, Oceananigans.OrthogonalSphericalShellGrids
 
 julia> grid = ConformalCubedSpherePanelGrid(size=(36, 34, 25), z=(-1000, 0))
 36×34×25 OrthogonalSphericalShellGrid{Float64, Bounded, Bounded, Bounded} on CPU with 1×1×1 halo and with precomputed metrics
@@ -248,7 +248,7 @@ julia> grid = ConformalCubedSpherePanelGrid(size=(36, 34, 25), z=(-1000, 0))
 * The conformal cubed sphere panel that includes the South Pole with `Float32` type:
 
 ```jldoctest
-julia> using Oceananigans, Oceananigans.Grids, Rotations
+julia> using Oceananigans, Oceananigans.OrthogonalSphericalShellGrids, Rotations
 
 julia> grid = ConformalCubedSpherePanelGrid(Float32, size=(36, 34, 25), z=(-1000, 0), rotation=RotY(π))
 36×34×25 OrthogonalSphericalShellGrid{Float32, Bounded, Bounded, Bounded} on CPU with 1×1×1 halo and with precomputed metrics

--- a/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
+++ b/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
@@ -33,6 +33,16 @@ function Adapt.adapt_structure(to, conformal_mapping::CubedSphereConformalMappin
         adapt(to, conformal_mapping.ηᵃᶜᵃ))
 end
 
+const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, FullyConnected, FullyConnected,
+                                                               <:Any, <:Any, <:CubedSphereConformalMapping}
+
+const ConformalCubedSpherePanelGrid = OrthogonalSphericalShellGrid{<:Any,
+                                                                   <:Any,
+                                                                   <:Any,
+                                                                   <:Any,
+                                                                   <:Any,
+                                                                   <:CubedSphereConformalMapping}
+
 # architecture = CPU() by default, assuming that a DataType positional arg is specifying the floating point type.
 conformal_cubed_sphere_panel(FT::DataType; kwargs...) = conformal_cubed_sphere_panel(CPU(), FT; kwargs...)
 

--- a/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
+++ b/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
@@ -1,3 +1,5 @@
+using CubedSphere
+
 struct CubedSphereConformalMapping{Rotation, F, C}
     rotation :: Rotation
     ξᶠᵃᵃ :: F
@@ -736,4 +738,31 @@ function conformal_cubed_sphere_panel(architecture::AbstractArchitecture = CPU()
                                                     conformal_mapping)
 
     return grid
+end
+
+#####
+##### Vertical circulation at the corners of the cubed sphere needs to treated in a special manner.
+##### See: https://github.com/CliMA/Oceananigans.jl/issues/1584
+#####
+
+# South-west, south-east, north-west, north-east corners
+@inline on_south_west_corner(i, j, grid) = (i == 1) & (j == 1)
+@inline on_south_east_corner(i, j, grid) = (i == grid.Nx+1) & (j == 1)
+@inline on_north_east_corner(i, j, grid) = (i == grid.Nx+1) & (j == grid.Ny+1)
+@inline on_north_west_corner(i, j, grid) = (i == 1) & (j == grid.Ny+1)
+
+"""
+    Γᶠᶠᶜ(i, j, k, grid, u, v)
+
+The vertical circulation associated with horizontal velocities ``u`` and ``v``.
+"""
+@inline function Γᶠᶠᶜ(i, j, k, grid::ConformalCubedSpherePanel, u, v)
+    Γ = ifelse(on_south_west_corner(i, j, grid) | on_north_west_corner(i, j, grid),
+               Δy_qᶜᶠᶜ(i, j, k, grid, v) - Δx_qᶠᶜᶜ(i, j, k, grid, u) + Δx_qᶠᶜᶜ(i, j-1, k, grid, u),
+               ifelse(on_south_east_corner(i, j, grid) | on_north_east_corner(i, j, grid),
+                      - Δy_qᶜᶠᶜ(i-1, j, k, grid, v) + Δx_qᶠᶜᶜ(i, j-1, k, grid, u) - Δx_qᶠᶜᶜ(i, j, k, grid, u),
+                      δxᶠᶠᶜ(i, j, k, grid, Δy_qᶜᶠᶜ, v) - δyᶠᶠᶜ(i, j, k, grid, Δx_qᶠᶜᶜ, u)
+                     )
+              )
+    return Γ
 end

--- a/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
+++ b/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
@@ -1,4 +1,5 @@
 using CubedSphere
+using JLD2
 
 struct CubedSphereConformalMapping{Rotation, F, C}
     rotation :: Rotation

--- a/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
+++ b/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
@@ -35,18 +35,11 @@ function Adapt.adapt_structure(to, conformal_mapping::CubedSphereConformalMappin
         adapt(to, conformal_mapping.ηᵃᶜᵃ))
 end
 
-const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, FullyConnected, FullyConnected,
-                                                               <:Any, <:Any, <:CubedSphereConformalMapping}
-
-const ConformalCubedSpherePanelGrid = OrthogonalSphericalShellGrid{<:Any,
-                                                                   <:Any,
-                                                                   <:Any,
-                                                                   <:Any,
-                                                                   <:Any,
-                                                                   <:CubedSphereConformalMapping}
+const ConformalCubedSpherePanelGrid{FT, TX, TY, TZ, CZ, CC, FC, CF, FF, Arch} = 
+    OrthogonalSphericalShellGrid{FT, TX, TY, TZ, CZ, <:CubedSphereConformalMapping, CC, FC, CF, FF, Arch}
 
 # architecture = CPU() by default, assuming that a DataType positional arg is specifying the floating point type.
-conformal_cubed_sphere_panel(FT::DataType; kwargs...) = conformal_cubed_sphere_panel(CPU(), FT; kwargs...)
+ConformalCubedSpherePanelGrid(FT::DataType; kwargs...) = ConformalCubedSpherePanelGrid(CPU(), FT; kwargs...)
 
 function load_and_offset_cubed_sphere_data(file, FT, arch, field_name, loc, topo, N, H)
     data = on_architecture(arch, file[field_name])
@@ -55,12 +48,12 @@ function load_and_offset_cubed_sphere_data(file, FT, arch, field_name, loc, topo
     return offset_data(data, loc[1:2], topo[1:2], N[1:2], H[1:2])
 end
 
-function conformal_cubed_sphere_panel(filepath::AbstractString, architecture = CPU(), FT = Float64;
-                                      panel, Nz, z,
-                                      topology = (FullyConnected, FullyConnected, Bounded),
-                                        radius = R_Earth,
-                                          halo = (4, 4, 4),
-                                      rotation = nothing)
+function ConformalCubedSpherePanelGrid(filepath::AbstractString, architecture = CPU(), FT = Float64;
+                                       panel, Nz, z,
+                                       topology = (FullyConnected, FullyConnected, Bounded),
+                                         radius = R_Earth,
+                                           halo = (4, 4, 4),
+                                       rotation = nothing)
 
     TX, TY, TZ = topology
     Hx, Hy, Hz = halo
@@ -159,31 +152,31 @@ function with_halo(new_halo, old_grid::OrthogonalSphericalShellGrid; arch=archit
 
     provided_conformal_mapping = old_grid.conformal_mapping
 
-    new_grid = conformal_cubed_sphere_panel(arch, eltype(old_grid);
-                                            size, z, ξ, η,
-                                            topology = topo,
-                                            radius = old_grid.radius,
-                                            halo = new_halo,
-                                            rotation,
-                                            provided_conformal_mapping)
+    new_grid = ConformalCubedSpherePanelGrid(arch, eltype(old_grid);
+                                             size, z, ξ, η,
+                                             topology = topo,
+                                             radius = old_grid.radius,
+                                             halo = new_halo,
+                                             rotation,
+                                             provided_conformal_mapping)
 
     return new_grid
 end
 
 """
-    conformal_cubed_sphere_panel(architecture::AbstractArchitecture = CPU(),
-                                 FT::DataType = Float64;
-                                 size,
-                                 z,
-                                 topology = (Bounded, Bounded, Bounded),
-                                 ξ = (-1, 1),
-                                 η = (-1, 1),
-                                 radius = R_Earth,
-                                 halo = (1, 1, 1),
-                                 rotation = nothing,
-                                 non_uniform_conformal_mapping = false,
-                                 spacing_type = "geometric",
-                                 provided_conformal_mapping = nothing)
+    ConformalCubedSpherePanelGrid(architecture::AbstractArchitecture = CPU(),
+                                  FT::DataType = Float64;
+                                  size,
+                                  z,
+                                  topology = (Bounded, Bounded, Bounded),
+                                  ξ = (-1, 1),
+                                  η = (-1, 1),
+                                  radius = R_Earth,
+                                  halo = (1, 1, 1),
+                                  rotation = nothing,
+                                  non_uniform_conformal_mapping = false,
+                                  spacing_type = "geometric",
+                                  provided_conformal_mapping = nothing)
 
 Create a `OrthogonalSphericalShellGrid` that represents a section of a sphere after it has been conformally mapped from
 the face of a cube. The cube's coordinates are `ξ` and `η` (which, by default, both take values in the range
@@ -243,7 +236,7 @@ Examples
 ```jldoctest
 julia> using Oceananigans, Oceananigans.Grids
 
-julia> grid = conformal_cubed_sphere_panel(size=(36, 34, 25), z=(-1000, 0))
+julia> grid = ConformalCubedSpherePanelGrid(size=(36, 34, 25), z=(-1000, 0))
 36×34×25 OrthogonalSphericalShellGrid{Float64, Bounded, Bounded, Bounded} on CPU with 1×1×1 halo and with precomputed metrics
 ├── centered at: North Pole, (λ, φ) = (0.0, 90.0)
 ├── longitude: Bounded  extent 90.0 degrees variably spaced with min(Δλ)=0.616164, max(Δλ)=2.58892
@@ -256,7 +249,7 @@ julia> grid = conformal_cubed_sphere_panel(size=(36, 34, 25), z=(-1000, 0))
 ```jldoctest
 julia> using Oceananigans, Oceananigans.Grids, Rotations
 
-julia> grid = conformal_cubed_sphere_panel(Float32, size=(36, 34, 25), z=(-1000, 0), rotation=RotY(π))
+julia> grid = ConformalCubedSpherePanelGrid(Float32, size=(36, 34, 25), z=(-1000, 0), rotation=RotY(π))
 36×34×25 OrthogonalSphericalShellGrid{Float32, Bounded, Bounded, Bounded} on CPU with 1×1×1 halo and with precomputed metrics
 ├── centered at: South Pole, (λ, φ) = (0.0, -90.0)
 ├── longitude: Bounded  extent 90.0 degrees variably spaced with min(Δλ)=0.616167, max(Δλ)=2.58891
@@ -264,19 +257,19 @@ julia> grid = conformal_cubed_sphere_panel(Float32, size=(36, 34, 25), z=(-1000,
 └── z:         Bounded  z ∈ [-1000.0, 0.0]  regularly spaced with Δz=40.0
 ```
 """
-function conformal_cubed_sphere_panel(architecture::AbstractArchitecture = CPU(),
-                                      FT::DataType = Oceananigans.defaults.FloatType;
-                                      size,
-                                      z,
-                                      topology = (Bounded, Bounded, Bounded),
-                                      ξ = (-1, 1),
-                                      η = (-1, 1),
-                                      radius = R_Earth,
-                                      halo = (1, 1, 1),
-                                      rotation = nothing,
-                                      non_uniform_conformal_mapping = false,
-                                      spacing_type = "geometric",
-                                      provided_conformal_mapping = nothing)
+function ConformalCubedSpherePanelGrid(architecture::AbstractArchitecture = CPU(),
+                                       FT::DataType = Oceananigans.defaults.FloatType;
+                                       size,
+                                       z,
+                                       topology = (Bounded, Bounded, Bounded),
+                                       ξ = (-1, 1),
+                                       η = (-1, 1),
+                                       radius = R_Earth,
+                                       halo = (1, 1, 1),
+                                       rotation = nothing,
+                                       non_uniform_conformal_mapping = false,
+                                       spacing_type = "geometric",
+                                       provided_conformal_mapping = nothing)
 
     radius = FT(radius)
     TX, TY, TZ = topology
@@ -756,7 +749,7 @@ end
 
 The vertical circulation associated with horizontal velocities ``u`` and ``v``.
 """
-@inline function Γᶠᶠᶜ(i, j, k, grid::ConformalCubedSpherePanel, u, v)
+@inline function Γᶠᶠᶜ(i, j, k, grid::ConformalCubedSpherePanelGrid, u, v)
     Γ = ifelse(on_south_west_corner(i, j, grid) | on_north_west_corner(i, j, grid),
                Δy_qᶜᶠᶜ(i, j, k, grid, v) - Δx_qᶠᶜᶜ(i, j, k, grid, u) + Δx_qᶠᶜᶜ(i, j-1, k, grid, u),
                ifelse(on_south_east_corner(i, j, grid) | on_north_east_corner(i, j, grid),

--- a/test/test_biogeochemistry.jl
+++ b/test/test_biogeochemistry.jl
@@ -5,6 +5,7 @@ using CUDA
 
 using Oceananigans.Fields: ConstantField, ZeroField
 using Oceananigans.Biogeochemistry: AbstractBiogeochemistry, AbstractContinuousFormBiogeochemistry
+using Oceananigans.OrthogonalSphericalShellGrids: ConformalCubedSpherePanelGrid
 
 import Oceananigans.Biogeochemistry:
        required_biogeochemical_tracers,

--- a/test/test_biogeochemistry.jl
+++ b/test/test_biogeochemistry.jl
@@ -134,7 +134,7 @@ end
         arch in archs,
         grid in (RectilinearGrid(arch; size = (2, 2, 2), extent = (2, 2, 2)),
                  LatitudeLongitudeGrid(arch; size = (5, 5, 5), longitude = (-180, 180), latitude = (-85, 85), z = (-2, 0)),
-                 conformal_cubed_sphere_panel(arch; size = (3, 3, 3), z = (-2, 0)))
+                 ConformalCubedSpherePanelGrid(arch; size = (3, 3, 3), z = (-2, 0)))
 
         if !((model == NonhydrostaticModel) && ((grid isa LatitudeLongitudeGrid) | (grid isa OrthogonalSphericalShellGrid)))
             @info "Testing $bgc in $model on $grid..."

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -744,7 +744,7 @@ end
 
 function test_orthogonal_shell_grid_array_sizes_and_spacings(FT)
 
-    grid = conformal_cubed_sphere_panel(CPU(), FT, size=(10, 10, 1), z=(0, 1))
+    grid = ConformalCubedSpherePanelGrid(CPU(), FT, size=(10, 10, 1), z=(0, 1))
 
     Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
     Hx, Hy, Hz = grid.Hx, grid.Hy, grid.Hz
@@ -1097,7 +1097,7 @@ end
         end
 
         # Testing show function
-        grid = conformal_cubed_sphere_panel(CPU(), size=(10, 10, 1), z=(0, 1))
+        grid = ConformalCubedSpherePanelGrid(CPU(), size=(10, 10, 1), z=(0, 1))
 
         @test try
             show(grid); println()
@@ -1130,7 +1130,7 @@ end
                 radius = 234.5e6
 
                 Nx, Ny = 10, 8
-                grid = conformal_cubed_sphere_panel(arch, FT, size=(Nx, Ny, 1); z, radius)
+                grid = ConformalCubedSpherePanelGrid(arch, FT, size=(Nx, Ny, 1); z, radius)
 
                 # the sum of area metrics Azᶜᶜᵃ is 1/6-th of the area of the sphere
                 @test sum(grid.Azᶜᶜᵃ[1:Nx, 1:Ny]) ≈ 4π * grid.radius^2 / 6
@@ -1140,16 +1140,16 @@ end
 
                 # (for odd number of grid points, the central grid points fall on great circles)
                 Nx, Ny = 11, 9
-                grid = conformal_cubed_sphere_panel(arch, FT, size=(Nx, Ny, 1); z, radius)
+                grid = ConformalCubedSpherePanelGrid(arch, FT, size=(Nx, Ny, 1); z, radius)
                 @test sum(grid.Δxᶜᶜᵃ[1:Nx, (Ny+1)÷2]) ≈ 2π * grid.radius / 4
                 @test sum(grid.Δyᶜᶜᵃ[(Nx+1)÷2, 1:Ny]) ≈ 2π * grid.radius / 4
 
                 Nx, Ny = 10, 9
-                grid = conformal_cubed_sphere_panel(arch, FT, size=(Nx, Ny, 1); z, radius)
+                grid = ConformalCubedSpherePanelGrid(arch, FT, size=(Nx, Ny, 1); z, radius)
                 @test sum(grid.Δxᶜᶜᵃ[1:Nx, (Ny+1)÷2]) ≈ 2π * grid.radius / 4
 
                 Nx, Ny = 11, 8
-                grid = conformal_cubed_sphere_panel(arch, FT, size=(Nx, Ny, 1); z, radius)
+                grid = ConformalCubedSpherePanelGrid(arch, FT, size=(Nx, Ny, 1); z, radius)
                 @test sum(grid.Δyᶜᶜᵃ[(Nx+1)÷2, 1:Ny]) ≈ 2π * grid.radius / 4
             end
         end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -6,7 +6,7 @@ using Oceananigans.Grids: total_extent, ColumnEnsembleSize,
                           xnode, ynode, znode, λnode, φnode,
                           λspacings, φspacings
 
-using Oceananigans.OrthogonalSphericalShellGrids: RotatedLatitudeLongitudeGrid
+using Oceananigans.OrthogonalSphericalShellGrids: RotatedLatitudeLongitudeGrid, ConformalCubedSpherePanelGrid
 
 using Oceananigans.Operators: Δx, Δy, Δz, Δλ, Δφ, Ax, Ay, Az, volume
 using Oceananigans.Operators: Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Δxᶜᶜᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, Azᶜᶜᵃ

--- a/test/test_multi_region_cubed_sphere.jl
+++ b/test/test_multi_region_cubed_sphere.jl
@@ -186,7 +186,7 @@ end
     cs32_filepath = datadep"cubed_sphere_32_grid/cubed_sphere_32_grid_with_4_halos.jld2"
 
     for panel in 1:6
-        grid = conformal_cubed_sphere_panel(cs32_filepath; panel, Nz, z)
+        grid = ConformalCubedSpherePanelGrid(cs32_filepath; panel, Nz, z)
         @test grid isa OrthogonalSphericalShellGrid
     end
 

--- a/test/test_multi_region_cubed_sphere.jl
+++ b/test/test_multi_region_cubed_sphere.jl
@@ -2,6 +2,7 @@ include("dependencies_for_runtests.jl")
 include("data_dependencies.jl")
 
 using Oceananigans.Grids: φnode, λnode, halo_size
+using Oceananigans.OrthogonalSphericalShellGrids: ConformalCubedSpherePanelGrid
 using Oceananigans.Utils: Iterate, getregion
 using Oceananigans.BoundaryConditions: replace_horizontal_vector_halos!
 using Oceananigans.MultiRegion: number_of_regions, fill_halo_regions!

--- a/validation/orthogonal_spherical_shell_grid/splash.jl
+++ b/validation/orthogonal_spherical_shell_grid/splash.jl
@@ -1,15 +1,15 @@
 using Oceananigans
-using.Oceananigans.Grids: conformal_cubed_sphere_panel
+using Oceananigans.OrthogonalSphericalShellGrids: ConformalCubedSpherePanelGrid
 using Oceananigans.Units
 
 using Printf, Rotations
 
 Nx, Ny, Nz = 64, 64, 2
 
-grid = conformal_cubed_sphere_panel(size = (Nx, Ny, Nz),
-                                    z = (-1000, 0),
-                                    topology=(Bounded, Bounded, Bounded),
-                                    rotation = RotY(π/2))
+grid = ConformalCubedSpherePanelGrid(size = (Nx, Ny, Nz),
+                                     z = (-1000, 0),
+                                     topology=(Bounded, Bounded, Bounded),
+                                     rotation = RotY(π/2))
 
 closure = ScalarDiffusivity(ν=2e-4, κ=2e-4)
 


### PR DESCRIPTION
This PR fixes a bug in the definitions of `ConformalCubedSpherePanel` and `ConformalCubedSpherePanelGrid` by removing an extra sixth `:Any` type parameter that does not belong in the `OrthogonalSphericalShellGrid` type.

Previously:
```
const ConformalCubedSpherePanel = OrthogonalSphericalShellGrid{<:Any, FullyConnected, FullyConnected,
                                                               <:Any, <:Any, <:Any,
                                                               <:CubedSphereConformalMapping}

const ConformalCubedSpherePanelGrid = OrthogonalSphericalShellGrid{<:Any,
                                                                   <:Any,
                                                                   <:Any,
                                                                   <:Any,
                                                                   <:Any,
                                                                   <:Any,
                                                                   <:CubedSphereConformalMapping}
```
The sixth `:<Any` parameter was unnecessary and did not correspond to any field in the underlying `OrthogonalSphericalShellGrid` type. This PR removes that extraneous type to ensure correctness and proper method dispatch.