### PR TITLE
Reduced KernelFunctionOperations

### DIFF
--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -162,6 +162,10 @@ for arch in archs
             less_trivial_kernel_function(i, j, k, grid, u, v) = @inbounds u[i, j, k] * ℑxyᶠᶜᵃ(i, j, k, grid, v)
             op = KernelFunctionOperation{Face, Center, Center}(less_trivial_kernel_function, grid, u, v)
             @test op isa KernelFunctionOperation
+
+            reduced_kernel_function(i, j, grid, u, v) = @inbounds u[i, j, 1] * ℑxyᶠᶜᵃ(i, j, 1, grid, v)
+            op = KernelFunctionOperation{Face, Center, Nothing}(less_trivial_kernel_function, grid, u, v)
+            @test op isa KernelFunctionOperation
         end
 
         @testset "Fidelity of simple binary operations" begin

--- a/test/test_computed_field.jl
+++ b/test/test_computed_field.jl
@@ -321,7 +321,7 @@ function compute_tuples_and_namedtuples(model)
     ten_c_field = Field(ten_c_op)
     compute!(ten_c_field)
 
-    at_ijk(i, j, grid, nt::NamedTuple) = nt.field[i, j, 1]
+    at_ij(i, j, grid, nt::NamedTuple) = nt.field[i, j, 1]
     reduced_ten_c_op = KernelFunctionOperation{Center, Center, Nothing}(at_ij, model.grid, ten_c)
     reduced_ten_c_field = Field(reduced_ten_c_op)
     compute!(reduced_ten_c_field)


### PR DESCRIPTION
These may be useful for capturing discrete-form boundary conditions. 