### PR TITLE
Add a warning if trying to launch a kernel with workspec `()` instead of throwing an error

### DIFF
--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -298,6 +298,12 @@ keyword arguments `kw`.
     return nothing
 end
 
+# launching with an empty tuple has no effect
+@inline function launch!(arch, grid, workspec_tuple::Tuple{}, kernel, args...; kwargs...)
+    @warn "trying to launch kernel $kernel! with workspec == (). The kernel will not be launched."
+    return nothing
+end
+
 # When dims::Val
 @inline launch!(arch, grid, ::Val{workspec}, args...; kw...) where workspec =
     _launch!(arch, grid, workspec, args...; kw...)


### PR DESCRIPTION
This was the error hit in #4483.
The fact that MPI was not correctly configured was leading to a distributed grid with only one rank. 
This triggers a launch with a zero-tuple, which is the intended behavior in the case we launch a distributed architecture with 1 rank only. 
Generally speaking, launching a kernel with a zero-tuple should be possible but might be an indication that there might be something wrong, so it is good to spit out a warning.