### PR TITLE
Warn if using a `Distributed` architecture using a single rank

### DIFF
--- a/src/DistributedComputations/distributed_architectures.jl
+++ b/src/DistributedComputations/distributed_architectures.jl
@@ -264,6 +264,11 @@ function Distributed(child_architecture = CPU();
     ranks = Rx, Ry, Rz = size(partition)
     partition_ranks = Rx * Ry * Rz
 
+    if partition_ranks == 1
+        @warn "The script has been launched using a single MPI rank. \n
+               This might not be intended but a result of an incorrect MPI configuration."
+    end
+
     # TODO: make this error refer to `partition` (user input) rather than `ranks`
     if partition_ranks != mpi_ranks
         throw(ArgumentError("Partition($Rx, $Ry, $Rz) [$partition_ranks ranks] inconsistent " *

--- a/src/DistributedComputations/distributed_architectures.jl
+++ b/src/DistributedComputations/distributed_architectures.jl
@@ -265,8 +265,8 @@ function Distributed(child_architecture = CPU();
     partition_ranks = Rx * Ry * Rz
 
     if partition_ranks == 1
-        @warn "The script has been launched using a single MPI rank. \n" *
-              "This might not be intended but a result of an incorrect MPI configuration."
+        @warn "We are building a Distributed architecture on a single MPI rank. \n" *
+              "This can occur when MPI is incorrectly configured."
     end
 
     # TODO: make this error refer to `partition` (user input) rather than `ranks`

--- a/src/DistributedComputations/distributed_architectures.jl
+++ b/src/DistributedComputations/distributed_architectures.jl
@@ -266,7 +266,8 @@ function Distributed(child_architecture = CPU();
 
     if partition_ranks == 1
         @warn "We are building a Distributed architecture on a single MPI rank. \n" *
-              "This can occur when MPI is incorrectly configured."
+              "This can occur when MPI is incorrectly configured. \n" *
+              "See https://juliaparallel.org/MPI.jl/stable/configuration/ for more details."
     end
 
     # TODO: make this error refer to `partition` (user input) rather than `ranks`

--- a/src/DistributedComputations/distributed_architectures.jl
+++ b/src/DistributedComputations/distributed_architectures.jl
@@ -265,8 +265,8 @@ function Distributed(child_architecture = CPU();
     partition_ranks = Rx * Ry * Rz
 
     if partition_ranks == 1
-        @warn "The script has been launched using a single MPI rank. \n
-               This might not be intended but a result of an incorrect MPI configuration."
+        @warn "The script has been launched using a single MPI rank. \n" *
+              "This might not be intended but a result of an incorrect MPI configuration."
     end
 
     # TODO: make this error refer to `partition` (user input) rather than `ranks`


### PR DESCRIPTION
@tomchor this might help catching incorrectly configured MPI, see #4483 