### PR TITLE
Fix warning message for set timestepper

### DIFF
--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -261,7 +261,9 @@ end
 
 function set_time_stepper_tendencies!(timestepper, file, model_fields, addr)
     for name in propertynames(model_fields)
-        if string(name) ∈ keys(file["$addr/timestepper/Gⁿ"]) # Test if variable tendencies exist in checkpoint
+        tendency_in_model = hasproperty(timestepper.Gⁿ, name) 
+        tendency_in_checkpoint = string(name) ∈ keys(file["$addr/timestepper/Gⁿ"])
+        if tendency_in_model && tendency_in_checkpoint
             # Tendency "n"
             parent_data = file["$addr/timestepper/Gⁿ/$name/data"]
 
@@ -273,7 +275,7 @@ function set_time_stepper_tendencies!(timestepper, file, model_fields, addr)
 
             tendency⁻_field = timestepper.G⁻[name]
             copyto!(tendency⁻_field.data.parent, parent_data)
-        else
+        elseif tendency_in_model && !tendency_in_checkpoint
             @warn "Tendencies for $name do not exist in checkpoint and could not be restored."
         end
     end


### PR DESCRIPTION
The warning message when setting the timestepper assumes that all prognostic fields require an associated tendency field.
However, not all prognostic fields need an associated tendency stored. An example is the free surface field using the `SplitExplicitFreeSurface` that evolves with $$\frac{\partial \eta}{\partial t} = - \nabla  \cdot \int_0^\eta u dz$$ where the tendency is simple enough to be computed on the fly inside the evolution kernel.
This PR updates the warning message to reflect the needs of the model.

Discussed in #4516 