### PR TITLE
Export `@compute` at the top level

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -39,7 +39,7 @@ export
     # Fields and field manipulation
     Field, CenterField, XFaceField, YFaceField, ZFaceField,
     Average, Integral, CumulativeIntegral, Reduction, Accumulation, BackgroundField,
-    interior, set!, compute!, regrid!,
+    interior, set!, compute!, @compute, regrid!,
 
     # Forcing functions
     Forcing, Relaxation, LinearTarget, GaussianMask, AdvectiveForcing,


### PR DESCRIPTION
I wonder what people think of this. I find this macro really useful and always find myself using it, getting an error that `@compute` is not defined, and then (properly) `using` it!