### PR TITLE
Fix `VarianceDissipation` docstring links

### DIFF
--- a/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
+++ b/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
@@ -73,7 +73,7 @@ Keyword Arguments
 - `Uⁿ⁻¹`: The velocity field at the previous time step. Default: `VelocityFields(grid)`.
 - `Uⁿ`: The velocity field at the current time step. Default: `VelocityFields(grid)`.
 
-!!! compat "Only compatible with QuasiAdamsBashforth2TimeStepper"
+!!! compat "Time stepper compatibility"
     At the moment, the variance dissipation diagnostic is supported only for [`QuasiAdamsBashforth2TimeStepper`](@ref).
 """
 function VarianceDissipation(tracer_name, grid;

--- a/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
+++ b/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
@@ -2,13 +2,14 @@ module VarianceDissipationComputations
 
 export VarianceDissipation, flatten_dissipation_fields
 
+using Oceananigans.Advection
+using Oceananigans.BoundaryConditions
 using Oceananigans.Grids: architecture
 using Oceananigans.Utils
-using Oceananigans.TimeSteppers
 using Oceananigans.Fields
 using Oceananigans.Fields: Field, VelocityFields
 using Oceananigans.Operators
-using Oceananigans.BoundaryConditions
+using Oceananigans.TimeSteppers
 using Oceananigans.TurbulenceClosures: viscosity,
                                        diffusivity,
                                        ScalarDiffusivity,
@@ -56,13 +57,14 @@ These include the numerical dissipation implicit to the advection scheme and the
 dissipation associated to closures.
 
 This diagnostic is especially useful for models that use a dissipative advection scheme
-like [`WENO`](@ref) or [`UpwindBiased`](@ref).
+like [`WENO`](@ref Oceananigans.Advection.WENO) or [`UpwindBiased`](@ref Oceananigans.Advection.UpwindBiased).
 
 Arguments
 =========
 
-- `tracer_name`: The name of the tracer for which variance dissipation is computed. This should be a `Symbol`.
-                 When calling `ϵ::VarianceDissipation` on the model, this name is used to identify the tracer in the model's state.
+- `tracer_name`: The name of the tracer for which variance dissipation is computed. This should
+                 be a `Symbol`. When calling `ϵ::VarianceDissipation` on the model, this name is
+                 used to identify the tracer in the model's state.
 - `grid`: The grid on which the tracer is defined.
 
 Keyword Arguments
@@ -71,9 +73,8 @@ Keyword Arguments
 - `Uⁿ⁻¹`: The velocity field at the previous time step. Default: `VelocityFields(grid)`.
 - `Uⁿ`: The velocity field at the current time step. Default: `VelocityFields(grid)`.
 
-!!! Note
-    At the moment, the variance dissipation diagnostic is supported only
-    for [`QuasiAdamsBashforth2TimeStepper`](@ref Oceananigans.TimeSteppers.QuasiAdamsBashforth2TimeStepper).
+!!! compat "Only compatible with QuasiAdamsBashforth2TimeStepper"
+    The variance dissipation diagnostic is supported only for [`QuasiAdamsBashforth2TimeStepper`](@ref).
 """
 function VarianceDissipation(tracer_name, grid;
                              Uⁿ⁻¹ = VelocityFields(grid),

--- a/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
+++ b/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
@@ -74,7 +74,7 @@ Keyword Arguments
 - `Uⁿ`: The velocity field at the current time step. Default: `VelocityFields(grid)`.
 
 !!! compat "Only compatible with QuasiAdamsBashforth2TimeStepper"
-    The variance dissipation diagnostic is supported only for [`QuasiAdamsBashforth2TimeStepper`](@ref).
+    At the moment, the variance dissipation diagnostic is supported only for [`QuasiAdamsBashforth2TimeStepper`](@ref).
 """
 function VarianceDissipation(tracer_name, grid;
                              Uⁿ⁻¹ = VelocityFields(grid),

--- a/src/Models/VarianceDissipationComputations/compute_dissipation.jl
+++ b/src/Models/VarianceDissipationComputations/compute_dissipation.jl
@@ -8,18 +8,18 @@
 Compute the numerical dissipation for tracer `tracer_name`, from the previously calculated advective and diffusive fluxes, 
 the formulation is:
 
-A = 2 * δc★ * F - U δc²  # For advective dissipation 
-D = 2 * δc★ * F          # For diffusive dissipation
+    A = 2 * δc★ * F - U δc²  # For advective dissipation 
+    D = 2 * δc★ * F          # For diffusive dissipation
 
 Where ``F'' is the flux associated with the particular process,``U'' is the adecting velocity,
 while ``c★'' and ``c²'' are functions defined above.
 Note that ``F'' and ``U'' need to be numerically accurate for the budgets to close,
 i.e. for and AB2 scheme:
 
-F = 1.5 Fⁿ - 0.5 Fⁿ⁻¹
-U = 1.5 Uⁿ - 0.5 Uⁿ⁻¹
+    F = 1.5 Fⁿ - 0.5 Fⁿ⁻¹
+    U = 1.5 Uⁿ - 0.5 Uⁿ⁻¹
 
-For an RK3 method (not implemented at the moment), the whole substepping procedure needs to be accounted for.
+For a RK3 method (not implemented at the moment), the whole substepping procedure needs to be accounted for.
 """
 function compute_dissipation!(dissipation, model, tracer_name::Symbol)
     

--- a/src/Models/VarianceDissipationComputations/flatten_dissipation_fields.jl
+++ b/src/Models/VarianceDissipationComputations/flatten_dissipation_fields.jl
@@ -1,11 +1,11 @@
 """
-    flatten_dissipation_fields(t::VarianceDissipation, tracer_name)
+    flatten_dissipation_fields(t::VarianceDissipation)
 
-Flattens the dissipation fields of a `VarianceDissipation` object into a named tuple containing:
+Flatten the dissipation fields of a `VarianceDissipation` object into a named tuple containing:
 
 - The dissipation associated with the advection scheme in fields named `A-tracername-dir`
 - The dissipation associated with the closures in fields names `D-tracername-dir`
-- The squared gradients (necessary for computing an ``effective diffusivity'') in fields named `G-tracername-dir`
+- The squared gradients (necessary for computing an "effective diffusivity") in fields named `G-tracername-dir`
 """
 function flatten_dissipation_fields(t::VarianceDissipation) 
     A = t.advective_production


### PR DESCRIPTION
Docs have been built and the preview shows that the links now work; see https://clima.github.io/OceananigansDocumentation/previews/PR4537/appendix/library/#VarianceDissipationComputations

I suggest we merge this without requiring the rest of the CI to pass (for economy of resources)