### PR TITLE
Sb/cubed sphere integration

### DIFF
--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -20,9 +20,6 @@ using Oceananigans.Grids
 
 import Adapt: adapt_structure
 
-# Switch around halos for cubed sphere by exchanging buffer informations
-replace_horizontal_vector_halos!(velocities, grid::AbstractGrid; signed=true) = nothing
-
 include("boundary_condition_classifications.jl")
 include("boundary_condition.jl")
 include("discrete_boundary_function.jl")

--- a/src/ImmersedBoundaries/immersed_boundary_grid.jl
+++ b/src/ImmersedBoundaries/immersed_boundary_grid.jl
@@ -78,7 +78,7 @@ end
 const IBG = ImmersedBoundaryGrid
 
 @inline Base.getproperty(ibg::IBG, property::Symbol) = get_ibg_property(ibg, Val(property))
-@inline get_ibg_property(ibg::IBG, ::Val{property}) where property = getfield(getfield(ibg, :underlying_grid), property)
+@inline get_ibg_property(ibg::IBG, ::Val{property}) where property = getproperty(getfield(ibg, :underlying_grid), property)
 @inline get_ibg_property(ibg::IBG, ::Val{:immersed_boundary})      = getfield(ibg, :immersed_boundary)
 @inline get_ibg_property(ibg::IBG, ::Val{:underlying_grid})        = getfield(ibg, :underlying_grid)
 @inline get_ibg_property(ibg::IBG, ::Val{:interior_active_cells})  = getfield(ibg, :interior_active_cells)

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/initialize_split_explicit_substepping.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/initialize_split_explicit_substepping.jl
@@ -20,6 +20,7 @@ function initialize_free_surface!(sefs::SplitExplicitFreeSurface, grid, velociti
                                                grid, u, v, sefs.η)
 
     fill_halo_regions!((barotropic_velocities.U, barotropic_velocities.V))
+    fill_halo_regions!(sefs.η)
 
     return nothing
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/pcg_implicit_free_surface_solver.jl
@@ -5,7 +5,7 @@ using Oceananigans.Architectures
 using Oceananigans.Grids: with_halo, isrectilinear, halo_size
 using Oceananigans.Architectures: device
 
-import Oceananigans.Solvers: solve!, precondition!
+import Oceananigans.Solvers: solve!, precondition!, auxiliary_actions!
 import Oceananigans.Architectures: architecture
 
 """
@@ -50,7 +50,12 @@ function PCGImplicitFreeSurfaceSolver(grid::AbstractGrid, settings, gravitationa
     vertically_integrated_lateral_areas = (xᶠᶜᶜ = ∫ᶻ_Axᶠᶜᶜ, yᶜᶠᶜ = ∫ᶻ_Ayᶜᶠᶜ)
 
     @apply_regionally compute_vertically_integrated_lateral_areas!(vertically_integrated_lateral_areas)
-    fill_halo_regions!(vertically_integrated_lateral_areas)
+
+    u = vertically_integrated_lateral_areas.xᶠᶜᶜ
+    v = vertically_integrated_lateral_areas.yᶜᶠᶜ
+
+    grid isa ConformalCubedSphereGrid ? fill_halo_regions!((u, v); signed=false) :
+                                        fill_halo_regions!(vertically_integrated_lateral_areas)
 
     # Set some defaults
     settings = Dict{Symbol, Any}(settings)
@@ -134,15 +139,15 @@ function implicit_free_surface_linear_operation!(L_ηⁿ⁺¹, ηⁿ⁺¹, ∫�
     grid = L_ηⁿ⁺¹.grid
     arch = architecture(L_ηⁿ⁺¹)
 
-    # Note: because of `fill_halo_regions!` below, we cannot use `PCGImplicitFreeSurface` on a
-    # multi-region grid; `fill_halo_regions!` cannot be used within `@apply_regionally`
-    fill_halo_regions!(ηⁿ⁺¹)
-
     launch!(arch, grid, :xy, _implicit_free_surface_linear_operation!,
             L_ηⁿ⁺¹, grid,  ηⁿ⁺¹, ∫ᶻ_Axᶠᶜᶜ, ∫ᶻ_Ayᶜᶠᶜ, g, Δt)
 
     return nothing
 end
+
+ImplicitFreeSurfaceOperation = typeof(implicit_free_surface_linear_operation!)
+
+auxiliary_actions!(::ImplicitFreeSurfaceOperation, L_ηⁿ⁺¹, ηⁿ⁺¹, args...) = fill_halo_regions!(ηⁿ⁺¹)
 
 # Kernels that act on vertically integrated / surface quantities
 @inline ∫ᶻ_Ax_∂x_ηᶠᶜᶜ(i, j, k, grid, ∫ᶻ_Axᶠᶜᶜ, η) = @inbounds ∫ᶻ_Axᶠᶜᶜ[i, j, k] * ∂xᶠᶜᶠ(i, j, k, grid, η)

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -63,11 +63,8 @@ function hydrostatic_velocity_fields(velocities::PrescribedVelocityFields, grid,
     v = wrap_prescribed_field(Center, Face, Center, velocities.v, grid; clock, parameters)
     w = wrap_prescribed_field(Center, Center, Face, velocities.w, grid; clock, parameters)
 
-    fill_halo_regions!(u)
-    fill_halo_regions!(v)
+    fill_halo_regions!((u, v))
     fill_halo_regions!(w)
-    prescribed_velocities = (; u, v, w)
-    @apply_regionally replace_horizontal_vector_halos!(prescribed_velocities, grid)
 
     return PrescribedVelocityFields(u, v, w, parameters)
 end

--- a/src/MultiRegion/cubed_sphere_boundary_conditions.jl
+++ b/src/MultiRegion/cubed_sphere_boundary_conditions.jl
@@ -2,306 +2,679 @@ using Oceananigans.MultiRegion: number_of_regions
 
 import Oceananigans.BoundaryConditions: fill_halo_regions!
 
-function find_neighboring_panels(grid::ConformalCubedSphereGrid, region)
-    number_of_regions(grid) !== 6 && error("requires cubed sphere grids with 1 region per panel")
-
-    if isodd(region)
-        region_E = mod(region + 0, 6) + 1
-        region_N = mod(region + 1, 6) + 1
-        region_W = mod(region + 3, 6) + 1
-        region_S = mod(region + 4, 6) + 1
-    elseif iseven(region)
-        region_E = mod(region + 1, 6) + 1
-        region_N = mod(region + 0, 6) + 1
-        region_W = mod(region + 4, 6) + 1
-        region_S = mod(region + 3, 6) + 1
-    end
-
-    return (; region_E, region_N, region_W, region_S)
-end
-
 function fill_halo_regions!(field::CubedSphereField{<:Center, <:Center})
     grid = field.grid
+    Nz_grid = grid.Nz
 
-    Nx, Ny, Nz = size(grid)
-    Hx, Hy, Hz = halo_size(grid)
+    Nx, Ny, Nz = size(field)
+    Hx, Hy, _ = halo_size(grid)
 
-    Nx == Ny || error("horizontal grid size Nx and Ny must be the same")
-    Nc = Nx
+    # Remember that for a cubed sphere grid, `Nx == Ny` and `Hx == Hy`.
+    Nc, Hc = Nx, Hx
 
-    Hx == Hy || error("horizontal halo size Hx and Hy must be the same")
-    Hc = Hx
+    if Nz == 1 && first.(axes(field[1].data))[3] == Nz_grid + 1 # take ssh into consideration
+        kernel_parameters = KernelParameters((Nc, 1), (0, Nz_grid))
+    else
+        kernel_parameters = KernelParameters((Nc, Nz), (0, 0))
+    end
 
-    #-- one pass: only use interior-point values:
-    for region in 1:6
+    multiregion_field = Reference(field.data.regional_objects)
+    region = Iterate(1:6)
 
-        region_E, region_N, region_W, region_S = find_neighboring_panels(grid, region)
+    @apply_regionally begin
+        launch!(grid.architecture, grid, kernel_parameters,
+                _fill_cubed_sphere_center_center_field_east_west_halo_regions!, field, multiregion_field, region,
+                grid.connectivity.connections, Nc, Hc)
+    end
 
-        if isodd(region)
-            #- odd face number (1, 3, 5):
-            for k in -Hz+1:Nz+Hz
-                #- E + W Halo for field:
-                field[region][Nc+1:Nc+Hc, 1:Nc, k] .=         field[region_E][1:Hc, 1:Nc, k]
-                field[region][1-Hc:0, 1:Nc, k]     .= reverse(field[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)'
-                #- N + S Halo for field:
-                field[region][1:Nc, Nc+1:Nc+Hc, k] .= reverse(field[region_N][1:Hc, 1:Nc, k], dims=2)'
-                field[region][1:Nc, 1-Hc:0, k]     .=         field[region_S][1:Nc, Nc+1-Hc:Nc, k]
-            end
-        elseif iseven(region)
-            #- even face number (2, 4, 6):
-            for k in -Hz+1:Nz+Hz
-                #- E + W Halo for field:
-                field[region][Nc+1:Nc+Hc, 1:Nc, k] .= reverse(field[region_E][1:Nc, 1:Hc, k], dims=1)'
-                field[region][1-Hc:0, 1:Nc, k]     .=         field[region_W][Nc+1-Hc:Nc, 1:Nc, k]
-                #- N + S Halo for field:
-                field[region][1:Nc, Nc+1:Nc+Hc, k] .=         field[region_N][1:Nc, 1:Hc, k]
-                field[region][1:Nc, 1-Hc:0, k]     .= reverse(field[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)'
-            end
-        end
+    @apply_regionally begin
+        launch!(grid.architecture, grid, kernel_parameters,
+                _fill_cubed_sphere_center_center_field_north_south_halo_regions!, field, multiregion_field, region,
+                grid.connectivity.connections, Nc, Hc)
     end
 
     return nothing
+end
+
+@kernel function _fill_cubed_sphere_center_center_field_east_west_halo_regions!(field, multiregion_field, region,
+                                                                                connections, Nc, Hc)
+    j, k = @index(Global, NTuple)
+    region_E = connections.east.from_rank
+    region_W = connections.west.from_rank
+
+    #- E + W Halo for field:
+    for i in 1:Hc
+        if isodd(region)
+            @inbounds begin
+                #=
+                field[region][Nc+1:Nc+Hc, 1:Nc, k] .=         field[region_E][1:Hc, 1:Nc, k]
+                field[region][1-Hc:0, 1:Nc, k]     .= reverse(field[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)'
+                =#
+                field[Nc+i, j, k] = multiregion_field[region_E][i, j, k]
+                field[i-Hc, j, k] = multiregion_field[region_W][Nc+1-j, Nc+i-Hc, k]
+            end
+        elseif iseven(region)
+            @inbounds begin
+                #=
+                field[region][Nc+1:Nc+Hc, 1:Nc, k] .= reverse(field[region_E][1:Nc, 1:Hc, k], dims=1)'
+                field[region][1-Hc:0, 1:Nc, k]     .=         field[region_W][Nc+1-Hc:Nc, 1:Nc, k]
+                =#
+                field[Nc+i, j, k] = multiregion_field[region_E][Nc+1-j, i, k]
+                field[i-Hc, j, k] = multiregion_field[region_W][Nc+i-Hc, j, k]
+            end
+        end
+    end
+end
+
+@kernel function _fill_cubed_sphere_center_center_field_north_south_halo_regions!(field, multiregion_field, region,
+                                                                                  connections, Nc, Hc)
+    i, k = @index(Global, NTuple)
+    region_N = connections.north.from_rank
+    region_S = connections.south.from_rank
+
+    #- N + S Halo for field:
+    for j in 1:Hc
+        if isodd(region)
+            @inbounds begin
+                #=
+                field[region][1:Nc, Nc+1:Nc+Hc, k] .= reverse(field[region_N][1:Hc, 1:Nc, k], dims=2)'
+                field[region][1:Nc, 1-Hc:0, k]     .=         field[region_S][1:Nc, Nc+1-Hc:Nc, k]
+                =#
+                field[i, Nc+j, k] = multiregion_field[region_N][j, Nc+1-i, k]
+                field[i, j-Hc, k] = multiregion_field[region_S][i, Nc+j-Hc, k]
+            end
+        elseif iseven(region)
+            @inbounds begin
+                #=
+                field[region][1:Nc, Nc+1:Nc+Hc, k] .=         field[region_N][1:Nc, 1:Hc, k]
+                field[region][1:Nc, 1-Hc:0, k]     .= reverse(field[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)'
+                =#
+                field[i, Nc+j, k] = multiregion_field[region_N][i, j, k]
+                field[i, j-Hc, k] = multiregion_field[region_S][Nc+j-Hc, Nc+1-i, k]
+            end
+        end
+    end
 end
 
 function fill_halo_regions!(field::CubedSphereField{<:Face, <:Face})
     grid = field.grid
 
-    Nx, Ny, Nz = size(grid)
-    Hx, Hy, Hz = halo_size(grid)
+    Nx, Ny, Nz = size(field)
+    Hx, Hy, _ = halo_size(grid)
 
-    Nx == Ny || error("horizontal grid size Nx and Ny must be the same")
-    Nc = Nx
+    # Remember that for a cubed sphere grid, `Nx == Ny` and `Hx == Hy`.
+    Nc, Hc = Nx, Hx
 
-    Hx == Hy || error("horizontal halo size Hx and Hy must be the same")
-    Hc = Hx
+    multiregion_field = Reference(field.data.regional_objects)
+    region = Iterate(1:6)
 
-    #-- one pass: only use interior-point values:
-    for region in 1:6
+    @apply_regionally begin
+        launch!(grid.architecture, grid, (Nc, Nz), _fill_cubed_sphere_face_face_field_east_west_halo_regions!, field,
+                multiregion_field, region, grid.connectivity.connections, Nc, Hc)
+    end
 
-        region_E, region_N, region_W, region_S = find_neighboring_panels(grid, region)
+    @apply_regionally begin
+        launch!(grid.architecture, grid, (Nc, Nz), _fill_cubed_sphere_face_face_field_north_south_halo_regions!, field,
+                multiregion_field, region, grid.connectivity.connections, Nc, Hc)
+    end
 
+    return nothing
+end
+
+@kernel function _fill_cubed_sphere_face_face_field_east_west_halo_regions!(field, multiregion_field, region,
+                                                                            connections, Nc, Hc)
+    j, k = @index(Global, NTuple)
+    region_E = connections.east.from_rank
+    region_W = connections.west.from_rank
+    region_S = connections.south.from_rank
+
+    #- E + W Halo for field:
+    for i in 1:Hc
         if isodd(region)
-            #- odd face number (1, 3, 5):
-            for k in -Hz+1:Nz+Hz
-                #- E + W Halo for field:
+            @inbounds begin
+                #=
                 field[region][Nc+1:Nc+Hc, 1:Nc, k]   .=         field[region_E][1:Hc, 1:Nc, k]
                 field[region][1-Hc:0, 2:Nc+1, k]     .= reverse(field[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)'
                 field[region][1-Hc:0, 1, k]          .=         field[region_S][1, Nc+1-Hc:Nc, k]
-                #- N + S Halo for field:
-                field[region][2:Nc+1, Nc+1:Nc+Hc, k] .= reverse(field[region_N][1:Hc, 1:Nc, k], dims=2)'
-                if Hc > 1
-                    field[region][1, Nc+2:Nc+Hc, k]  .= reverse(field[region_W][1, Nc+2-Hc:Nc, k])'
-                end
-                # Note that the halo corresponding to the "missing" north-west corner of odd panels, specifically
-                # field[region][1, Nc+1, k], remains unfilled.
-                field[region][1:Nc, 1-Hc:0, k]       .=         field[region_S][1:Nc, Nc+1-Hc:Nc, k]
-                field[region][Nc+1, 1-Hc:0, k]       .= reverse(field[region_E][2:Hc+1, 1, k])'
+                =#
+                field[Nc+i, j, k]   = multiregion_field[region_E][i, j, k]
+                field[i-Hc, j+1, k] = multiregion_field[region_W][Nc+1-j, Nc+i-Hc, k]
+                field[i-Hc, 1, k]   = multiregion_field[region_S][1, Nc+i-Hc, k]
             end
         elseif iseven(region)
-            #- even face number (2, 4, 6):
-            for k in -Hz+1:Nz+Hz
-                #- E + W Halo for field:
+            @inbounds begin
+                #=
                 field[region][Nc+1:Nc+Hc, 2:Nc, k]   .= reverse(field[region_E][2:Nc, 1:Hc, k], dims=1)'
                 if Hc > 1
                     field[region][Nc+2:Nc+Hc, 1, k]  .= reverse(field[region_S][Nc+2-Hc:Nc, 1, k])
                 end
-                # Note that the halo corresponding to the "missing" south-east corner of even panels, specifically
-                # field[region][Nc+1, 1, k], remains unfilled.
+                Note that the halo corresponding to the "missing" south-east corner of even panels, specifically
+                field[region][Nc+1, 1, k], remains unfilled.
+                =#
+                j > 1 && (field[Nc+i, j, k] = multiregion_field[region_E][Nc+2-j, i, k])
+                (Hc > 1 && i > 1) && (field[Nc+i, 1, k] = multiregion_field[region_S][Nc+2-i, 1, k])
+                #=
                 field[region][1-Hc:0, 1:Nc, k]       .=         field[region_W][Nc+1-Hc:Nc, 1:Nc, k]
-                #- N + S Halo for field:
+                =#
+                field[i-Hc, j, k] = multiregion_field[region_W][Nc+i-Hc, j, k]
+            end
+        end
+    end
+end
+
+@kernel function _fill_cubed_sphere_face_face_field_north_south_halo_regions!(field, multiregion_field, region,
+                                                                              connections, Nc, Hc)
+    i, k = @index(Global, NTuple)
+    region_E = connections.east.from_rank
+    region_N = connections.north.from_rank
+    region_W = connections.west.from_rank
+    region_S = connections.south.from_rank
+
+    #- N + S Halo for field:
+    for j in 1:Hc
+        if isodd(region)
+            @inbounds begin
+                #=
+                field[region][2:Nc+1, Nc+1:Nc+Hc, k] .= reverse(field[region_N][1:Hc, 1:Nc, k], dims=2)'
+                if Hc > 1
+                    field[region][1, Nc+2:Nc+Hc, k]  .= reverse(field[region_W][1, Nc+2-Hc:Nc, k])'
+                end
+                Note that the halo corresponding to the "missing" north-west corner of odd panels, specifically
+                field[region][1, Nc+1, k], remains unfilled.
+                =#
+                field[i+1, Nc+j, k] = multiregion_field[region_N][j, Nc+1-i, k]
+                (Hc > 1 && j > 1) && (field[1, Nc+j, k] = multiregion_field[region_W][1, Nc+2-j, k])
+                #=
+                field[region][1:Nc, 1-Hc:0, k]       .=         field[region_S][1:Nc, Nc+1-Hc:Nc, k]
+                field[region][Nc+1, 1-Hc:0, k]       .= reverse(field[region_E][2:Hc+1, 1, k])'
+                =#
+                field[i, j-Hc, k] = multiregion_field[region_S][i, Nc+j-Hc, k]
+                field[Nc+1, j-Hc, k] = multiregion_field[region_E][Hc+2-j, 1, k]
+            end
+        elseif iseven(region)
+            @inbounds begin
+                #=
                 field[region][1:Nc, Nc+1:Nc+Hc, k]   .=         field[region_N][1:Nc, 1:Hc, k]
                 field[region][Nc+1, Nc+1:Nc+Hc, k]   .=         field[region_E][1, 1:Hc, k]'
                 field[region][2:Nc+1, 1-Hc:0, k]     .= reverse(field[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)'
                 field[region][1, 1-Hc:0, k]          .=         field[region_W][Nc+1-Hc:Nc, 1, k]'
+                =#
+                field[i, Nc+j, k] = multiregion_field[region_N][i, j, k]
+                field[Nc+1, Nc+j, k] = multiregion_field[region_E][1, j, k]
+                field[i+1, j-Hc, k] = multiregion_field[region_S][Nc+j-Hc, Nc+1-i, k]
+                field[1, j-Hc, k] = multiregion_field[region_W][Nc+j-Hc, 1, k]
             end
         end
+    end
+end
+
+fill_halo_regions!(fields::Tuple{CubedSphereField,CubedSphereField}; signed = true, kwargs...) = fill_halo_regions!(fields...; signed)
+
+function fill_halo_regions!(field_1::CubedSphereField{<:Center, <:Center},
+                            field_2::CubedSphereField{<:Center, <:Center}; signed = true)
+    grid = field_1.grid
+
+    Nx, Ny, Nz = size(field_1)
+    Hx, Hy, _ = halo_size(grid)
+
+    # Remember that for a cubed sphere grid, `Nx == Ny` and `Hx == Hy`.
+    Nc, Hc = Nx, Hx
+
+    signed ? plmn = -1 : plmn = 1
+
+    multiregion_field_1 = Reference(field_1.data.regional_objects)
+    multiregion_field_2 = Reference(field_2.data.regional_objects)
+    region = Iterate(1:6)
+
+    @apply_regionally begin
+        launch!(grid.architecture, grid, (Nc, Nz),
+                _fill_cubed_sphere_center_center_center_center_field_pairs_east_west_halo_regions!, field_1,
+                multiregion_field_1, field_2, multiregion_field_2, region, grid.connectivity.connections, Nc, Hc, plmn)
+    end
+
+    @apply_regionally begin
+        launch!(grid.architecture, grid, (Nc, Nz),
+                _fill_cubed_sphere_center_center_center_center_field_pairs_north_south_halo_regions!, field_1,
+                multiregion_field_1, field_2, multiregion_field_2, region, grid.connectivity.connections, Nc, Hc, plmn)
     end
 
     return nothing
 end
 
-fill_halo_regions!(fields::Tuple{CubedSphereField, CubedSphereField}; signed = true) = fill_halo_regions!(fields...; signed)
+@kernel function _fill_cubed_sphere_center_center_center_center_field_pairs_east_west_halo_regions!(
+field_1, multiregion_field_1, field_2, multiregion_field_2, region, connections, Nc, Hc, plmn)
+    j, k = @index(Global, NTuple)
+    region_E = connections.east.from_rank
+    region_W = connections.west.from_rank
 
-function fill_halo_regions!(field_1::CubedSphereField{<:Center, <:Center},
-                            field_2::CubedSphereField{<:Center, <:Center}; signed = true)
-
-    field_1.grid == field_2.grid || error("fields must be on the same grid")
-    grid = field_1.grid
-
-    Nx, Ny, Nz = size(grid)
-    Hx, Hy, Hz = halo_size(grid)
-    signed ? plmn = -1 : plmn = 1
-
-    Nx == Ny || error("horizontal grid size Nx and Ny must be the same")
-    Nc = Nx
-
-    Hx == Hy || error("horizontal halo size Hx and Hy must be the same")
-    Hc = Hx
-
-    #-- one pass: only use interior-point values:
-    for region in 1:6
-
-        region_E, region_N, region_W, region_S = find_neighboring_panels(grid, region)
-
+    #- E + W Halo for field:
+    for i in 1:Hc
         if isodd(region)
-            #- odd face number (1, 3, 5):
-            for k in -Hz+1:Nz+Hz
+            @inbounds begin
+                #=
                 #- E Halo:
                 field_1[region][Nc+1:Nc+Hc, 1:Nc, k] .=         field_1[region_E][1:Hc, 1:Nc, k]
                 field_2[region][Nc+1:Nc+Hc, 1:Nc, k] .=         field_2[region_E][1:Hc, 1:Nc, k]
+                =#
+                field_1[Nc+i, j, k] = multiregion_field_1[region_E][i, j, k]
+                field_2[Nc+i, j, k] = multiregion_field_2[region_E][i, j, k]
+                #=
                 #- W Halo:
                 field_1[region][1-Hc:0, 1:Nc, k]     .= reverse(field_2[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)'
                 field_2[region][1-Hc:0, 1:Nc, k]     .= reverse(field_1[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)' * plmn
-                #- N Halo:
-                field_1[region][1:Nc, Nc+1:Nc+Hc, k] .= reverse(field_2[region_N][1:Hc, 1:Nc, k], dims=2)' * plmn
-                field_2[region][1:Nc, Nc+1:Nc+Hc, k] .= reverse(field_1[region_N][1:Hc, 1:Nc, k], dims=2)'
-                #- S Halo:
-                field_1[region][1:Nc, 1-Hc:0, k]     .=         field_1[region_S][1:Nc, Nc+1-Hc:Nc, k]
-                field_2[region][1:Nc, 1-Hc:0, k]     .=         field_2[region_S][1:Nc, Nc+1-Hc:Nc, k]
+                =#
+                field_1[i-Hc, j, k] = multiregion_field_2[region_W][Nc+1-j, Nc+i-Hc, k]
+                field_2[i-Hc, j, k] = multiregion_field_1[region_W][Nc+1-j, Nc+i-Hc, k] * plmn
             end
         elseif iseven(region)
-            #- even face number (2, 4, 6):
-            for k in -Hz+1:Nz+Hz
+            @inbounds begin
+                #=
                 #- E Halo:
                 field_1[region][Nc+1:Nc+Hc, 1:Nc, k] .= reverse(field_2[region_E][1:Nc, 1:Hc, k], dims=1)'
                 field_2[region][Nc+1:Nc+Hc, 1:Nc, k] .= reverse(field_1[region_E][1:Nc, 1:Hc, k], dims=1)' * plmn
+                =#
+                field_1[Nc+i, j, k] = multiregion_field_2[region_E][Nc+1-j, i, k]
+                field_2[Nc+i, j, k] = multiregion_field_1[region_E][Nc+1-j, i, k] * plmn
+                #=
                 #- W Halo:
                 field_1[region][1-Hc:0, 1:Nc, k]     .=         field_1[region_W][Nc+1-Hc:Nc, 1:Nc, k]
                 field_2[region][1-Hc:0, 1:Nc, k]     .=         field_2[region_W][Nc+1-Hc:Nc, 1:Nc, k]
-                #- N Halo:
-                field_1[region][1:Nc, Nc+1:Nc+Hc, k] .=         field_1[region_N][1:Nc, 1:Hc, k]
-                field_2[region][1:Nc, Nc+1:Nc+Hc, k] .=         field_2[region_N][1:Nc, 1:Hc, k]
-                #- S Halo:
-                field_1[region][1:Nc, 1-Hc:0, k]     .= reverse(field_2[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)' * plmn
-                field_2[region][1:Nc, 1-Hc:0, k]     .= reverse(field_1[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)'
+                =#
+                field_1[i-Hc, j, k] = multiregion_field_1[region_W][Nc+i-Hc, j, k]
+                field_2[i-Hc, j, k] = multiregion_field_2[region_W][Nc+i-Hc, j, k]
             end
         end
     end
+end
 
-    return nothing
+@kernel function _fill_cubed_sphere_center_center_center_center_field_pairs_north_south_halo_regions!(
+field_1, multiregion_field_1, field_2, multiregion_field_2, region, connections, Nc, Hc, plmn)
+    i, k = @index(Global, NTuple)
+    region_N = connections.north.from_rank
+    region_S = connections.south.from_rank
+
+    #- N + S Halo for field:
+    for j in 1:Hc
+        if isodd(region)
+            @inbounds begin
+                #=
+                #- N Halo:
+                field_1[region][1:Nc, Nc+1:Nc+Hc, k] .= reverse(field_2[region_N][1:Hc, 1:Nc, k], dims=2)' * plmn
+                field_2[region][1:Nc, Nc+1:Nc+Hc, k] .= reverse(field_1[region_N][1:Hc, 1:Nc, k], dims=2)'
+                =#
+                field_1[i, Nc+j, k] = multiregion_field_2[region_N][j, Nc+1-i, k] * plmn
+                field_2[i, Nc+j, k] = multiregion_field_1[region_N][j, Nc+1-i, k]
+                #=
+                #- S Halo:
+                field_1[region][1:Nc, 1-Hc:0, k]     .=         field_1[region_S][1:Nc, Nc+1-Hc:Nc, k]
+                field_2[region][1:Nc, 1-Hc:0, k]     .=         field_2[region_S][1:Nc, Nc+1-Hc:Nc, k]
+                =#
+                field_1[i, j-Hc, k] = multiregion_field_1[region_S][i, Nc+j-Hc, k]
+                field_2[i, j-Hc, k] = multiregion_field_2[region_S][i, Nc+j-Hc, k]
+            end
+        elseif iseven(region)
+            @inbounds begin
+                #=
+                #- N Halo:
+                field_1[region][1:Nc, Nc+1:Nc+Hc, k] .=         field_1[region_N][1:Nc, 1:Hc, k]
+                field_2[region][1:Nc, Nc+1:Nc+Hc, k] .=         field_2[region_N][1:Nc, 1:Hc, k]
+                =#
+                field_1[i, Nc+j, k] = multiregion_field_1[region_N][i, j, k]
+                field_2[i, Nc+j, k] = multiregion_field_2[region_N][i, j, k]
+                #=
+                #- S Halo:
+                field_1[region][1:Nc, 1-Hc:0, k]     .= reverse(field_2[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)' * plmn
+                field_2[region][1:Nc, 1-Hc:0, k]     .= reverse(field_1[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)'
+                =#
+                field_1[i, j-Hc, k] = multiregion_field_2[region_S][Nc+j-Hc, Nc+1-i, k] * plmn
+                field_2[i, j-Hc, k] = multiregion_field_1[region_S][Nc+j-Hc, Nc+1-i, k]
+            end
+        end
+    end
 end
 
 function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Center},
                             field_2::CubedSphereField{<:Center, <:Face}; signed = true)
-
-    field_1.grid == field_2.grid || error("fields must be on the same grid")
     grid = field_1.grid
+    Nz_grid = grid.Nz
 
-    Nx, Ny, Nz = size(grid)
-    Hx, Hy, Hz = halo_size(grid)
+    Nx, Ny, Nz = size(field_1)
+    Hx, Hy, _ = halo_size(grid)
+
+    # Remember that for a cubed sphere grid, `Nx == Ny` and `Hx == Hy`.
+    Nc, Hc = Nx, Hx
+
     signed ? plmn = -1 : plmn = 1
 
-    Nx == Ny || error("horizontal grid size Nx and Ny must be the same")
-    Nc = Nx
+    multiregion_field_1 = Reference(field_1.data.regional_objects)
+    multiregion_field_2 = Reference(field_2.data.regional_objects)
+    region = Iterate(1:6)
 
-    Hx == Hy || error("horizontal halo size Hx and Hy must be the same")
-    Hc = Hx
+    if Nz == 1 && first.(axes(field_1[1].data))[3] == Nz_grid # take barotropic velocities into consideration
+        kernel_parameters = KernelParameters((Nc, 1), (0, Nz_grid-1))
+    else
+        kernel_parameters = KernelParameters((Nc, Nz), (0, 0))
+    end
 
-    #-- one pass: only use interior-point values:
-    for region in 1:6
+    @apply_regionally begin
+        launch!(grid.architecture, grid, kernel_parameters,
+                _fill_cubed_sphere_face_center_center_face_field_pairs_east_west_halo_regions!, field_1,
+                multiregion_field_1, field_2, multiregion_field_2, region, grid.connectivity.connections, Nc, Hc, plmn)
+    end
 
-        region_E, region_N, region_W, region_S = find_neighboring_panels(grid, region)
+    @apply_regionally begin
+        launch!(grid.architecture, grid, kernel_parameters,
+                _fill_cubed_sphere_face_center_center_face_field_pairs_north_south_halo_regions!, field_1,
+                multiregion_field_1, field_2, multiregion_field_2, region, grid.connectivity.connections, Nc, Hc, plmn)
+    end
 
+    #=
+    Add one valid field_1, field_2 value next to the corner, that allows us to compute vorticity on a wider stencil
+    (e.g., vort3(0,1) & (1,0)).
+    =#
+
+    if Nz == 1 && first.(axes(field_1[1].data))[3] == Nz_grid # take barotropic velocities into consideration
+        kernel_parameters = KernelParameters((1, 1), (Nz_grid-1, 0))
+    else
+        kernel_parameters = KernelParameters((Nz, 1), (0, 0))
+    end
+
+    if Hc > 1
+        @apply_regionally begin
+            launch!(grid.architecture, grid, kernel_parameters,
+                    _fill_cubed_sphere_face_center_field_corner_halo_regions!, field_1, field_2, Nc, Hc, plmn)
+        end
+        @apply_regionally begin
+            launch!(grid.architecture, grid, kernel_parameters,
+                    _fill_cubed_sphere_center_face_field_corner_halo_regions!, field_1, field_2, Nc, Hc, plmn)
+        end
+    end
+
+    return nothing
+end
+
+@kernel function _fill_cubed_sphere_face_center_center_face_field_pairs_east_west_halo_regions!(
+field_1, multiregion_field_1, field_2, multiregion_field_2, region, connections, Nc, Hc, plmn)
+    j, k = @index(Global, NTuple)
+
+    region_E = connections.east.from_rank
+    region_N = connections.north.from_rank
+    region_W = connections.west.from_rank
+    region_S = connections.south.from_rank
+
+    #- E + W Halo for field:
+    for i in 1:Hc
         if isodd(region)
-            #- odd face number (1, 3, 5):
-            for k in -Hz+1:Nz+Hz
+            @inbounds begin
+                #=
                 #- E + W Halo for field_1:
                 field_1[region][Nc+1:Nc+Hc, 1:Nc, k]   .=         field_1[region_E][1:Hc, 1:Nc, k]
                 field_1[region][1-Hc:0, 1:Nc, k]       .= reverse(field_2[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)'
-                #- N + S Halo for field_1:
-                field_1[region][2:Nc+1, Nc+1:Nc+Hc, k] .= reverse(field_2[region_N][1:Hc, 1:Nc, k], dims=2)' * plmn
-                field_1[region][1, Nc+1:Nc+Hc, k]      .= reverse(field_1[region_W][1, Nc+1-Hc:Nc, k])' * plmn
-                field_1[region][1:Nc, 1-Hc:0, k]       .=         field_1[region_S][1:Nc, Nc+1-Hc:Nc, k]
-                field_1[region][Nc+1, 1-Hc:0, k]       .= reverse(field_2[region_E][1:Hc, 1, k])'
+                =#
+                field_1[Nc+i, j, k] = multiregion_field_1[region_E][i, j, k]
+                field_1[i-Hc, j, k] = multiregion_field_2[region_W][Nc+1-j, Nc+i-Hc, k]
+                #=
                 #- E + W Halo for field_2:
                 field_2[region][Nc+1:Nc+Hc, 1:Nc, k]   .=         field_2[region_E][1:Hc, 1:Nc, k]
                 field_2[region][Nc+1:Nc+Hc, Nc+1, k]   .=         field_2[region_N][1:Hc, 1, k]
                 field_2[region][1-Hc:0, 2:Nc+1, k]     .= reverse(field_1[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)' * plmn
                 field_2[region][1-Hc:0, 1, k]          .=         field_1[region_S][1, Nc+1-Hc:Nc, k] * plmn
-                #- N + S Halo for field_2:
-                field_2[region][1:Nc, Nc+1:Nc+Hc, k]   .= reverse(field_1[region_N][1:Hc, 1:Nc, k], dims=2)'
-                field_2[region][1:Nc, 1-Hc:0, k]       .=         field_2[region_S][1:Nc, Nc+1-Hc:Nc, k]
+                =#
+                field_2[Nc+i, j, k] = multiregion_field_2[region_E][i, j, k]
+                field_2[Nc+i, Nc+1, k] = multiregion_field_2[region_N][i, 1, k]
+                field_2[i-Hc, j+1, k] = multiregion_field_1[region_W][Nc+1-j, Nc+i-Hc, k] * plmn
+                field_2[i-Hc, 1, k] = multiregion_field_1[region_S][1, Nc+i-Hc, k] * plmn
             end
         elseif iseven(region)
-            #- even face number (2, 4, 6):
-            for k in -Hz+1:Nz+Hz
+            @inbounds begin
+                #=
                 #- E + W Halo for field_1:
                 field_1[region][Nc+1:Nc+Hc, 1:Nc, k]   .= reverse(field_2[region_E][1:Nc, 1:Hc, k], dims=1)'
                 field_1[region][1-Hc:0, 1:Nc, k]       .=         field_1[region_W][Nc+1-Hc:Nc, 1:Nc, k]
-                #- N + S Halo for field_1:
-                field_1[region][1:Nc, Nc+1:Nc+Hc, k]   .=         field_1[region_N][1:Nc, 1:Hc, k]
-                field_1[region][Nc+1, Nc+1:Nc+Hc, k]   .=         field_1[region_E][1, 1:Hc, k]'
-                field_1[region][2:Nc+1, 1-Hc:0, k]     .= reverse(field_2[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)' * plmn
-                field_1[region][1, 1-Hc:0, k]          .=         field_2[region_W][Nc+1-Hc:Nc, 1, k]' * plmn
+                =#
+                field_1[Nc+i, j, k] = multiregion_field_2[region_E][Nc+1-j, i, k]
+                field_1[i-Hc, j, k] = multiregion_field_1[region_W][Nc+i-Hc, j, k]
+                #=
                 #- E + W Halo for field_2:
                 field_2[region][Nc+1:Nc+Hc, 2:Nc+1, k] .= reverse(field_1[region_E][1:Nc, 1:Hc, k], dims=1)' * plmn
                 field_2[region][Nc+1:Nc+Hc, 1, k]      .= reverse(field_2[region_S][Nc+1-Hc:Nc, 1, k]) * plmn
                 field_2[region][1-Hc:0, 1:Nc, k]       .=         field_2[region_W][Nc+1-Hc:Nc, 1:Nc, k]
                 field_2[region][1-Hc:0, Nc+1, k]       .= reverse(field_1[region_N][1, 1:Hc, k])
-                #- N + S Halo for field_2:
-                field_2[region][1:Nc, Nc+1:Nc+Hc, k]   .=         field_2[region_N][1:Nc, 1:Hc, k]
-                field_2[region][1:Nc, 1-Hc:0, k]       .= reverse(field_1[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)'
+                =#
+                field_2[Nc+i, j+1, k] = multiregion_field_1[region_E][Nc+1-j, i, k] * plmn
+                field_2[Nc+i, 1, k] = multiregion_field_2[region_S][Nc+1-i, 1, k] * plmn
+                field_2[i-Hc, j, k] = multiregion_field_2[region_W][Nc+i-Hc, j, k]
+                field_2[i-Hc, Nc+1, k] = multiregion_field_1[region_N][1, Hc+1-i, k]
             end
         end
     end
+end
 
-    #-- Add one valid field_1, field_2 value next to the corner, that allows to compute vorticity on a wider stencil
-    # (e.g., vort3(0,1) & (1,0)).
-    if Hc > 1
-        for region in 1:6
-            for k in -Hz+1:Nz+Hz
-                #- SW corner:
-                field_1[region][1-Hc:0, 0, k] .= field_2[region][1, 1-Hc:0, k]
-                field_2[region][0, 1-Hc:0, k] .= field_1[region][1-Hc:0, 1, k]'
-                #- NW corner:
-                field_1[region][2-Hc:0, Nc+1,  k]    .= reverse(field_2[region][1, Nc+2:Nc+Hc, k]) * plmn
-                field_2[region][0, Nc+2:Nc+Hc, k]    .= reverse(field_1[region][2-Hc:0, Nc, k])' * plmn
-                #- SE corner:
-                field_1[region][Nc+2:Nc+Hc, 0, k]    .= reverse(field_2[region][Nc, 2-Hc:0, k]) * plmn
-                field_2[region][Nc+1, 2-Hc:0,  k]    .= reverse(field_1[region][Nc+2:Nc+Hc, 1, k])' * plmn
-                #- NE corner:
-                field_1[region][Nc+2:Nc+Hc, Nc+1, k] .= field_2[region][Nc, Nc+2:Nc+Hc, k]
-                field_2[region][Nc+1, Nc+2:Nc+Hc, k] .= field_1[region][Nc+2:Nc+Hc, Nc, k]'
+@kernel function _fill_cubed_sphere_face_center_center_face_field_pairs_north_south_halo_regions!(
+field_1, multiregion_field_1, field_2, multiregion_field_2, region, connections, Nc, Hc, plmn)
+    i, k = @index(Global, NTuple)
+
+    region_E = connections.east.from_rank
+    region_N = connections.north.from_rank
+    region_W = connections.west.from_rank
+    region_S = connections.south.from_rank
+
+    #- N + S Halo for field:
+    for j in 1:Hc
+        if isodd(region)
+            @inbounds begin
+                #=
+                #- N + S Halo for field_1:
+                field_1[region][2:Nc+1, Nc+1:Nc+Hc, k] .= reverse(field_2[region_N][1:Hc, 1:Nc, k], dims=2)' * plmn
+                field_1[region][1, Nc+1:Nc+Hc, k]      .= reverse(field_1[region_W][1, Nc+1-Hc:Nc, k])' * plmn
+                field_1[region][1:Nc, 1-Hc:0, k]       .=         field_1[region_S][1:Nc, Nc+1-Hc:Nc, k]
+                field_1[region][Nc+1, 1-Hc:0, k]       .= reverse(field_2[region_E][1:Hc, 1, k])'
+                =#
+                field_1[i+1, Nc+j, k] = multiregion_field_2[region_N][j, Nc+1-i, k] * plmn
+                field_1[1, Nc+j, k] = multiregion_field_1[region_W][1, Nc+1-j, k] * plmn
+                field_1[i, j-Hc, k] = multiregion_field_1[region_S][i, Nc+j-Hc, k]
+                field_1[Nc+1, j-Hc, k] = multiregion_field_2[region_E][Hc+1-j, 1, k]
+                #=
+                #- N + S Halo for field_2:
+                field_2[region][1:Nc, Nc+1:Nc+Hc, k]   .= reverse(field_1[region_N][1:Hc, 1:Nc, k], dims=2)'
+                field_2[region][1:Nc, 1-Hc:0, k]       .=         field_2[region_S][1:Nc, Nc+1-Hc:Nc, k]
+                =#
+                field_2[i, Nc+j, k] = multiregion_field_1[region_N][j, Nc+1-i, k]
+                field_2[i, j-Hc, k] = multiregion_field_2[region_S][i, Nc+j-Hc, k]
+            end
+        elseif iseven(region)
+            @inbounds begin
+                #=
+                #- N + S Halo for field_1:
+                field_1[region][1:Nc, Nc+1:Nc+Hc, k]   .=         field_1[region_N][1:Nc, 1:Hc, k]
+                field_1[region][Nc+1, Nc+1:Nc+Hc, k]   .=         field_1[region_E][1, 1:Hc, k]'
+                field_1[region][2:Nc+1, 1-Hc:0, k]     .= reverse(field_2[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)' * plmn
+                field_1[region][1, 1-Hc:0, k]          .=         field_2[region_W][Nc+1-Hc:Nc, 1, k]' * plmn
+                =#
+                field_1[i, Nc+j, k] = multiregion_field_1[region_N][i, j, k]
+                field_1[Nc+1, Nc+j, k] = multiregion_field_1[region_E][1, j, k]
+                field_1[i+1, j-Hc, k] = multiregion_field_2[region_S][Nc+j-Hc, Nc+1-i, k] * plmn
+                field_1[1, j-Hc, k] = multiregion_field_2[region_W][Nc+j-Hc, 1, k] * plmn
+                #=
+                #- N + S Halo for field_2:
+                field_2[region][1:Nc, Nc+1:Nc+Hc, k]   .=         field_2[region_N][1:Nc, 1:Hc, k]
+                field_2[region][1:Nc, 1-Hc:0, k]       .= reverse(field_1[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)'
+                =#
+                field_2[i, Nc+j, k] = multiregion_field_2[region_N][i, j, k]
+                field_2[i, j-Hc, k] = multiregion_field_1[region_S][Nc+j-Hc, Nc+1-i, k]
             end
         end
+    end
+end
+
+@kernel function _fill_cubed_sphere_face_center_field_corner_halo_regions!(field_1, field_2, Nc, Hc, plmn)
+    k, _ = @index(Global, NTuple)
+
+    for i in 1:Hc
+        @inbounds begin
+            #=
+            #- SW corner:
+            field_1[region][1-Hc:0, 0, k] .= field_2[region][1, 1-Hc:0, k]
+            =#
+            field_1[i-Hc, 0, k] = field_2[1, i-Hc, k]
+            #=
+            #- NW corner:
+            field_1[region][2-Hc:0, Nc+1, k] .= reverse(field_2[region][1, Nc+2:Nc+Hc, k]) * plmn
+            =#
+            (i > 1) && (field_1[i-Hc, Nc+1, k] = field_2[1, Nc+Hc+2-i, k] * plmn)
+            #=
+            #- SE corner:
+            field_1[region][Nc+2:Nc+Hc, 0, k] .= reverse(field_2[region][Nc, 2-Hc:0, k]) * plmn
+            =#
+            (i > 1) && (field_1[Nc+i, 0, k] = field_2[Nc, 2-i, k] * plmn)
+            #=
+            #- NE corner:
+            field_1[region][Nc+2:Nc+Hc, Nc+1, k] .= field_2[region][Nc, Nc+2:Nc+Hc, k]
+            =#
+            (i > 1) && (field_1[Nc+i, Nc+1, k] = field_2[Nc, Nc+i, k])
+        end
+    end
+end
+
+@kernel function _fill_cubed_sphere_center_face_field_corner_halo_regions!(field_1, field_2, Nc, Hc, plmn)
+    k, _ = @index(Global, NTuple)
+
+    for j in 1:Hc
+        @inbounds begin
+            #=
+            #- SW corner:
+            field_2[region][0, 1-Hc:0, k] .= field_1[region][1-Hc:0, 1, k]'
+            =#
+            field_2[0, j-Hc, k] = field_1[j-Hc, 1, k]
+            #=
+            #- NW corner:
+            field_2[region][0, Nc+2:Nc+Hc, k] .= reverse(field_1[region][2-Hc:0, Nc, k])' * plmn
+            =#
+            (j > 1) && (field_2[0, Nc+j, k] = field_1[2-j, Nc, k] * plmn)
+            #=
+            #- SE corner:
+            field_2[region][Nc+1, 2-Hc:0, k] .= reverse(field_1[region][Nc+2:Nc+Hc, 1, k])' * plmn
+            =#
+            (j > 1) && (field_2[Nc+1, j-Hc, k] = field_1[Nc+Hc+2-j, 1, k] * plmn)
+            #=
+            #- NE corner:
+            field_2[region][Nc+1, Nc+2:Nc+Hc, k] .= field_1[region][Nc+2:Nc+Hc, Nc, k]'
+            =#
+            (j > 1) && (field_2[Nc+1, Nc+j, k] = field_1[Nc+j, Nc, k])
+        end
+    end
+end
+
+function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Face},
+                            field_2::CubedSphereField{<:Face, <:Face}; signed = true)
+    grid = field_1.grid
+
+    Nx, Ny, Nz = size(field_1)
+    Hx, Hy, _ = halo_size(grid)
+
+    # Remember that for a cubed sphere grid, `Nx == Ny` and `Hx == Hy`.
+    Nc, Hc = Nx, Hx
+
+    signed ? plmn = -1 : plmn = 1
+
+    multiregion_field_1 = Reference(field_1.data.regional_objects)
+    multiregion_field_2 = Reference(field_2.data.regional_objects)
+    region = Iterate(1:6)
+
+    @apply_regionally begin
+        launch!(grid.architecture, grid, (Nc, Nz),
+                _fill_cubed_sphere_face_face_face_face_field_pairs_east_west_halo_regions!, field_1,
+                multiregion_field_1, field_2, multiregion_field_2, region, grid.connectivity.connections, Nc, Hc, plmn)
+    end
+
+    @apply_regionally begin
+        launch!(grid.architecture, grid, (Nc, Nz),
+                _fill_cubed_sphere_face_face_face_face_field_pairs_north_south_halo_regions!, field_1,
+                multiregion_field_1, field_2, multiregion_field_2, region, grid.connectivity.connections, Nc, Hc, plmn)
     end
 
     return nothing
 end
 
-function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Face},
-                            field_2::CubedSphereField{<:Face, <:Face}; signed = true)
+@kernel function _fill_cubed_sphere_face_face_face_face_field_pairs_east_west_halo_regions!(
+field_1, multiregion_field_1, field_2, multiregion_field_2, region, connections, Nc, Hc, plmn)
+    j, k = @index(Global, NTuple)
 
-    field_1.grid == field_2.grid || error("fields must be on the same grid")
-    grid = field_1.grid
+    region_E = connections.east.from_rank
+    region_N = connections.north.from_rank
+    region_W = connections.west.from_rank
+    region_S = connections.south.from_rank
 
-    Nx, Ny, Nz = size(grid)
-    Hx, Hy, Hz = halo_size(grid)
-    signed ? plmn = -1 : plmn = 1
-
-    Nx == Ny || error("horizontal grid size Nx and Ny must be the same")
-    Nc = Nx
-
-    Hx == Hy || error("horizontal halo size Hx and Hy must be the same")
-    Hc = Hx
-
-    #-- one pass: only use interior-point values:
-    for region in 1:6
-
-        region_E, region_N, region_W, region_S = find_neighboring_panels(grid, region)
-
+    #- E + W Halo for field:
+    for i in 1:Hc
         if isodd(region)
-            #- odd face number (1, 3, 5):
-            for k in -Hz+1:Nz+Hz
+            @inbounds begin
+                #=
                 #- E Halo:
                 field_1[region][Nc+1:Nc+Hc, 1:Nc, k]   .=         field_1[region_E][1:Hc, 1:Nc, k]
                 field_2[region][Nc+1:Nc+Hc, 1:Nc, k]   .=         field_2[region_E][1:Hc, 1:Nc, k]
                 field_2[region][Nc+1:Nc+Hc, Nc+1, k]   .=         field_2[region_N][1:Hc, 1, k]
+                =#
+                field_1[Nc+i, j, k] = multiregion_field_1[region_E][i, j, k]
+                field_2[Nc+i, j, k] = multiregion_field_2[region_E][i, j, k]
+                field_2[Nc+i, Nc+1, k] = multiregion_field_2[region_N][i, 1, k]
+                #=
                 #- W Halo:
                 field_1[region][1-Hc:0, 2:Nc+1, k]     .= reverse(field_2[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)'
                 field_2[region][1-Hc:0, 2:Nc+1, k]     .= reverse(field_1[region_W][1:Nc, Nc+1-Hc:Nc, k], dims=1)' * plmn
                 field_1[region][1-Hc:0, 1, k]          .=         field_2[region_S][1, Nc+1-Hc:Nc, k]
                 field_2[region][1-Hc:0, 1, k]          .=         field_1[region_S][1, Nc+1-Hc:Nc, k] * plmn
+                =#
+                field_1[i-Hc, j+1, k] = multiregion_field_2[region_W][Nc+1-j, Nc+i-Hc, k]
+                field_2[i-Hc, j+1, k] = multiregion_field_1[region_W][Nc+1-j, Nc+i-Hc, k] * plmn
+                field_1[i-Hc, 1, k] = multiregion_field_2[region_S][1, Nc+i-Hc, k]
+                field_2[i-Hc, 1, k] = multiregion_field_1[region_S][1, Nc+i-Hc, k] * plmn
+            end
+        elseif iseven(region)
+            @inbounds begin
+                #=
+                #- E Halo:
+                field_1[region][Nc+1:Nc+Hc, 2:Nc, k]   .= reverse(field_2[region_E][2:Nc, 1:Hc, k], dims=1)'
+                field_2[region][Nc+1:Nc+Hc, 2:Nc+1, k] .= reverse(field_1[region_E][1:Nc, 1:Hc, k], dims=1)' * plmn
+                if Hc > 1
+                    field_1[region][Nc+2:Nc+Hc, 1, k]  .= reverse(field_1[region_S][Nc+2-Hc:Nc, 1, k]) * plmn
+                    field_2[region][Nc+2:Nc+Hc, 1, k]  .= reverse(field_2[region_S][Nc+2-Hc:Nc, 1, k]) * plmn
+                end
+                Note that the halos corresponding to the "missing" south-east corner of even panels, specifically
+                field_1[region][Nc+1, 1, k] and field_2[region][Nc+1, 1, k], remain unfilled.
+                =#
+                j > 1 && (field_1[Nc+i, j, k] = multiregion_field_2[region_E][Nc+2-j, i, k])
+                field_2[Nc+i, j+1, k] = multiregion_field_1[region_E][Nc+1-j, i, k] * plmn
+                (Hc > 1 && i > 1) && (field_1[Nc+i, 1, k] = multiregion_field_1[region_S][Nc+2-i, 1, k]) * plmn
+                (Hc > 1 && i > 1) && (field_2[Nc+i, 1, k] = multiregion_field_2[region_S][Nc+2-i, 1, k]) * plmn
+                #=
+                #- W Halo:
+                field_1[region][1-Hc:0, 1:Nc, k]       .=         field_1[region_W][Nc+1-Hc:Nc, 1:Nc, k]
+                field_2[region][1-Hc:0, 1:Nc, k]       .=         field_2[region_W][Nc+1-Hc:Nc, 1:Nc, k]
+                field_2[region][1-Hc:0, Nc+1, k]       .= reverse(field_1[region_N][1, 2:Hc+1, k])
+                =#
+                field_1[i-Hc, j, k] = multiregion_field_1[region_W][Nc+i-Hc, j, k]
+                field_2[i-Hc, j, k] = multiregion_field_2[region_W][Nc+i-Hc, j, k]
+                field_2[i-Hc, Nc+1, k] = multiregion_field_1[region_N][1, Hc+2-i, k]
+            end
+        end
+    end
+end
+
+@kernel function _fill_cubed_sphere_face_face_face_face_field_pairs_north_south_halo_regions!(
+field_1, multiregion_field_1, field_2, multiregion_field_2, region, connections, Nc, Hc, plmn)
+    i, k = @index(Global, NTuple)
+
+    region_E = connections.east.from_rank
+    region_N = connections.north.from_rank
+    region_W = connections.west.from_rank
+    region_S = connections.south.from_rank
+
+    #- N + S Halo for field:
+    for j in 1:Hc
+        if isodd(region)
+            @inbounds begin
+                #=
                 #- N Halo:
                 field_1[region][2:Nc+1, Nc+1:Nc+Hc, k] .= reverse(field_2[region_N][1:Hc, 1:Nc, k], dims=2)' * plmn
                 field_2[region][2:Nc, Nc+1:Nc+Hc, k]   .= reverse(field_1[region_N][1:Hc, 2:Nc, k], dims=2)'
@@ -311,39 +684,44 @@ function fill_halo_regions!(field_1::CubedSphereField{<:Face, <:Face},
                 end
                 # Note that the halos corresponding to the "missing" north-west corner of odd panels, specifically
                 # field_1[region][1, Nc+1, k] and field_2[region][1, Nc+1, k], remain unfilled.
+                =#
+                field_1[i+1, Nc+j, k] = multiregion_field_2[region_N][j, Nc+1-i, k] * plmn
+                (i > 1) && (field_2[i, Nc+j, k] = multiregion_field_1[region_N][j, Nc+2-i, k])
+                (Hc > 1 && j > 1) && (field_1[1, Nc+j, k] = multiregion_field_1[region_W][1, Nc+2-j, k]) * plmn
+                (Hc > 1 && j > 1) && (field_2[1, Nc+j, k] = multiregion_field_2[region_W][1, Nc+2-j, k]) * plmn
+                #=
                 #- S Halo:
                 field_1[region][1:Nc, 1-Hc:0, k]       .=         field_1[region_S][1:Nc, Nc+1-Hc:Nc, k]
                 field_2[region][1:Nc, 1-Hc:0, k]       .=         field_2[region_S][1:Nc, Nc+1-Hc:Nc, k]
                 field_1[region][Nc+1, 1-Hc:0, k]       .= reverse(field_2[region_E][2:Hc+1, 1, k])'
+                =#
+                field_1[i, j-Hc, k] = multiregion_field_1[region_S][i, Nc+j-Hc, k]
+                field_2[i, j-Hc, k] = multiregion_field_2[region_S][i, Nc+j-Hc, k]
+                field_1[Nc+1, j-Hc, k] = multiregion_field_2[region_E][Hc+2-j, 1, k]
             end
-        else
-            #- even face number (2, 4, 6):
-            for k in -Hz+1:Nz+Hz
-                #- E Halo:
-                field_1[region][Nc+1:Nc+Hc, 2:Nc, k]   .= reverse(field_2[region_E][2:Nc, 1:Hc, k], dims=1)'
-                field_2[region][Nc+1:Nc+Hc, 2:Nc+1, k] .= reverse(field_1[region_E][1:Nc, 1:Hc, k], dims=1)' * plmn
-                if Hc > 1
-                    field_1[region][Nc+2:Nc+Hc, 1, k]  .= reverse(field_1[region_S][Nc+2-Hc:Nc, 1, k]) * plmn
-                    field_2[region][Nc+2:Nc+Hc, 1, k]  .= reverse(field_2[region_S][Nc+2-Hc:Nc, 1, k]) * plmn
-                end
-                # Note that the halos corresponding to the "missing" south-east corner of even panels, specifically
-                # field_1[region][Nc+1, 1, k] and field_2[region][Nc+1, 1, k], remain unfilled.
-                #- W Halo:
-                field_1[region][1-Hc:0, 1:Nc, k]       .=         field_1[region_W][Nc+1-Hc:Nc, 1:Nc, k]
-                field_2[region][1-Hc:0, 1:Nc, k]       .=         field_2[region_W][Nc+1-Hc:Nc, 1:Nc, k]
-                field_2[region][1-Hc:0, Nc+1, k]       .= reverse(field_1[region_N][1, 2:Hc+1, k])
+        elseif iseven(region)
+            @inbounds begin
+                #=
                 #- N Halo:
                 field_1[region][1:Nc, Nc+1:Nc+Hc, k]   .=         field_1[region_N][1:Nc, 1:Hc, k]
                 field_2[region][1:Nc, Nc+1:Nc+Hc, k]   .=         field_2[region_N][1:Nc, 1:Hc, k]
                 field_1[region][Nc+1, Nc+1:Nc+Hc, k]   .=         field_1[region_E][1, 1:Hc, k]'
+                =#
+                field_1[i, Nc+j, k] = multiregion_field_1[region_N][i, j, k]
+                field_2[i, Nc+j, k] = multiregion_field_2[region_N][i, j, k]
+                field_1[Nc+1, Nc+j, k] = multiregion_field_1[region_E][1, j, k]
+                #=
                 #- S Halo:
                 field_1[region][2:Nc+1, 1-Hc:0, k]     .= reverse(field_2[region_S][Nc+1-Hc:Nc, 1:Nc, k], dims=2)' * plmn
                 field_2[region][2:Nc, 1-Hc:0, k]       .= reverse(field_1[region_S][Nc+1-Hc:Nc, 2:Nc, k], dims=2)'
                 field_1[region][1, 1-Hc:0, k]          .=         field_2[region_W][Nc+1-Hc:Nc, 1, k]' * plmn
                 field_2[region][1, 1-Hc:0, k]          .=         field_1[region_W][Nc+1-Hc:Nc, 1, k]'
+                =#
+                field_1[i+1, j-Hc, k] = multiregion_field_2[region_S][Nc+j-Hc, Nc+1-i, k] * plmn
+                (i > 1) && (field_2[i, j-Hc, k] = multiregion_field_1[region_S][Nc+j-Hc, Nc+2-i, k])
+                field_1[1, j-Hc, k] = multiregion_field_2[region_W][Nc+j-Hc, 1, k] * plmn
+                field_2[1, j-Hc, k] = multiregion_field_1[region_W][Nc+j-Hc, 1, k]
             end
         end
     end
-
-    return nothing
 end

--- a/src/MultiRegion/cubed_sphere_field.jl
+++ b/src/MultiRegion/cubed_sphere_field.jl
@@ -4,7 +4,9 @@ using Oceananigans.Fields: AbstractField, FunctionField
 # Flavors of CubedSphereField
 const CubedSphereField{LX, LY, LZ} =
     Union{Field{LX, LY, LZ, <:Nothing, <:ConformalCubedSphereGrid},
-        Field{LX, LY, LZ, <:AbstractOperation, <:ConformalCubedSphereGrid}}
+          Field{LX, LY, LZ, <:AbstractOperation, <:ConformalCubedSphereGrid},
+          Field{LX, LY, LZ, <:Nothing, <:ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:ConformalCubedSphereGrid}},
+          Field{LX, LY, LZ, <:AbstractOperation, <:ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:ConformalCubedSphereGrid}}}
 
 const CubedSphereFunctionField{LX, LY, LZ} =
     FunctionField{LX, LY, LZ, <:Any, <:Any, <:Any, <:ConformalCubedSphereGrid}

--- a/src/MultiRegion/multi_region_field.jl
+++ b/src/MultiRegion/multi_region_field.jl
@@ -25,7 +25,7 @@ const GriddedMultiRegionFieldTuple{N, T} = NTuple{N, T} where {N, T<:GriddedMult
 const GriddedMultiRegionFieldNamedTuple{S, N} = NamedTuple{S, N} where {S, N<:GriddedMultiRegionFieldTuple}
 
 # Utils
-Base.size(f::GriddedMultiRegionField) = size(getregion(f.grid, 1))
+Base.size(f::GriddedMultiRegionField) = size(getregion(f, 1))
 
 @inline isregional(f::GriddedMultiRegionField) = true
 @inline devices(f::GriddedMultiRegionField) = devices(f.grid)
@@ -142,7 +142,7 @@ end
 
 @inline hasnan(field::MultiRegionField) = (&)(construct_regionally(hasnan, field).regional_objects...)
 
-validate_indices(indices, loc, mrg::MultiRegionGrid) =
+validate_indices(indices, loc, mrg::MultiRegionGrids) =
     construct_regionally(validate_indices, indices, loc, mrg.region_grids)
 
 communication_buffers(grid::MultiRegionGrid, data, bcs) =
@@ -151,7 +151,10 @@ communication_buffers(grid::MultiRegionGrid, data, bcs) =
 communication_buffers(grid::MultiRegionGrid, data, ::Nothing) = nothing
 communication_buffers(grid::MultiRegionGrid, data, ::Missing) = nothing
 
-FieldBoundaryConditions(mrg::MultiRegionGrid, loc, indices; kwargs...) =
+FieldBoundaryBuffers(grid::MultiRegionGrids, args...; kwargs...) =
+    construct_regionally(FieldBoundaryBuffers, grid, args...; kwargs...)
+
+FieldBoundaryConditions(mrg::MultiRegionGrids, loc, indices; kwargs...) =
     construct_regionally(inject_regional_bcs, mrg, mrg.connectivity, Reference(loc), indices; kwargs...)
 
 function regularize_field_boundary_conditions(bcs::FieldBoundaryConditions,

--- a/src/MultiRegion/multi_region_grid.jl
+++ b/src/MultiRegion/multi_region_grid.jl
@@ -233,7 +233,7 @@ function with_halo(new_halo, mrg::MultiRegionGrid)
 end
 
 function on_architecture(::CPU, mrg::MultiRegionGrid{FT, TX, TY, TZ, CZ}) where {FT, TX, TY, TZ, CZ}
-    new_grids = construct_regionally(on_architecture, CPU(), mrg)
+    new_grids = on_architecture(CPU(), mrg.region_grids)
     devices   = Tuple(CPU() for i in 1:length(mrg))
     return MultiRegionGrid{FT, TX, TY, TZ, CZ}(CPU(), mrg.partition, mrg.connectivity, new_grids, devices)
 end

--- a/src/MultiRegion/multi_region_split_explicit_free_surface.jl
+++ b/src/MultiRegion/multi_region_split_explicit_free_surface.jl
@@ -60,6 +60,10 @@ end
 
 @inline multiregion_split_explicit_halos(old_halos, step_halo, ::XPartition) = (max(step_halo, old_halos[1]), old_halos[2], old_halos[3])
 @inline multiregion_split_explicit_halos(old_halos, step_halo, ::YPartition) = (old_halos[1], max(step_halo, old_halo[2]), old_halos[3])
+@inline multiregion_split_explicit_halos(old_halos, step_halo, ::CubedSpherePartition) = (max(step_halo, old_halos[1]), max(step_halo, old_halos[2]), old_halos[3])
+
+iterate_split_explicit!(free_surface, grid::MultiRegionGrids, GUⁿ, GVⁿ, Δτᴮ, weights, ::Val{Nsubsteps}) where Nsubsteps =
+    @apply_regionally iterate_split_explicit!(free_surface, grid, GUⁿ, GVⁿ, Δτᴮ, weights, Val(Nsubsteps))
 
 @inline augmented_kernel_size(grid, ::XPartition)           = (size(grid, 1) + 2halo_size(grid)[1]-2, size(grid, 2))
 @inline augmented_kernel_size(grid, ::YPartition)           = (size(grid, 1), size(grid, 2) + 2halo_size(grid)[2]-2)

--- a/src/MultiRegion/unified_implicit_free_surface_solver.jl
+++ b/src/MultiRegion/unified_implicit_free_surface_solver.jl
@@ -65,6 +65,8 @@ build_implicit_step_solver(::Val{:PreconditionedConjugateGradient}, grid::MultiR
     throw(ArgumentError("Cannot use PCG solver with Multi-region grids!! Select :Default or :HeptadiagonalIterativeSolver as solver_method"))
 build_implicit_step_solver(::Val{:Default}, grid::ConformalCubedSphereGrid, settings, gravitational_acceleration) =
     PCGImplicitFreeSurfaceSolver(grid, settings, gravitational_acceleration)
+build_implicit_step_solver(::Val{:PreconditionedConjugateGradient}, grid::ConformalCubedSphereGrid, settings, gravitational_acceleration) =
+    PCGImplicitFreeSurfaceSolver(grid, settings, gravitational_acceleration)
 build_implicit_step_solver(::Val{:HeptadiagonalIterativeSolver}, grid::ConformalCubedSphereGrid, settings, gravitational_acceleration) =
     throw(ArgumentError("Cannot use Matrix solvers with ConformalCubedSphereGrid!! Select :Default or :PreconditionedConjugateGradient as solver_method"))
 

--- a/src/Operators/difference_operators.jl
+++ b/src/Operators/difference_operators.jl
@@ -49,6 +49,48 @@ using Oceananigans.Grids: Flat
 @inline δzᵃᵃᶠ(i, j, k, grid::AG{FT, TX, TY, Flat}, f::F, args...) where {FT, TX, TY, F<:Function} = zero(FT)
 
 #####
+##### Support for aquaplanet simulations on conformal cubed sphere grids
+#####
+
+@inline δxᶠᶜᶜ(i, j, k, grid::OrthogonalSphericalShellGrid, c) =
+    @inbounds ifelse((i == 1) & (j < 1),               c[1, j, k]           - c[j, 1, k],
+              ifelse((i == grid.Nx+1) & (j < 1),       c[grid.Nx-j+1, 1, k] - c[grid.Nx, j, k],
+              ifelse((i == grid.Nx+1) & (j > grid.Ny), c[j, grid.Ny, k]     - c[grid.Nx, j, k],
+              ifelse((i == 1) & (j > grid.Ny),         c[1, j, k]           - c[grid.Ny-j+1, grid.Ny, k],
+                                                       c[i, j, k]           - c[i-1, j, k]))))
+
+@inline δxᶠᶜᶠ(i, j, k, grid::OrthogonalSphericalShellGrid, c) = δxᶠᶜᶜ(i, j, k, grid, c)
+
+@inline δyᶜᶠᶜ(i, j, k, grid::OrthogonalSphericalShellGrid, c) =
+    @inbounds ifelse((i < 1) & (j == 1),               c[i, 1, k]           - c[1, i, k],
+              ifelse((i > grid.Nx) & (j == 1),         c[i, 1, k]           - c[grid.Nx, grid.Ny+1-i, k],
+              ifelse((i > grid.Nx) & (j == grid.Ny+1), c[grid.Nx, i, k]     - c[i, grid.Ny, k],
+              ifelse((i < 1) & (j == grid.Ny+1),       c[1, grid.Ny-i+1, k] - c[i, grid.Ny, k],
+                                                       c[i, j, k]           - c[i, j-1, k]))))
+
+@inline δyᶜᶠᶠ(i, j, k, grid::OrthogonalSphericalShellGrid, c) = δyᶜᶠᶜ(i, j, k, grid, c)
+
+@inline δxᶠᶜᶜ(i, j, k, grid::OrthogonalSphericalShellGrid, f::F, args...) where F<:Function =
+    @inbounds ifelse((i == 1) & (j < 1),               f(1, j, k, grid, args...)           - f(j, 1, k, grid, args...),
+              ifelse((i == grid.Nx+1) & (j < 1),       f(grid.Nx-j+1, 1, k, grid, args...) - f(grid.Nx, j, k, grid, args...),
+              ifelse((i == grid.Nx+1) & (j > grid.Ny), f(j, grid.Ny, k, grid, args...)     - f(grid.Nx, j, k, grid, args...),
+              ifelse((i == 1) & (j > grid.Ny),         f(1, j, k, grid, args...)           - f(grid.Nx-j+1, grid.Ny, k, grid, args...),
+                                                       f(i, j, k, grid, args...)           - f(i-1, j, k, grid, args...)))))
+
+@inline δxᶠᶜᶠ(i, j, k, grid::OrthogonalSphericalShellGrid, f::F, args...) where F<:Function =
+    δxᶠᶜᶜ(i, j, k, grid, f, args...)
+
+@inline δyᶜᶠᶜ(i, j, k, grid::OrthogonalSphericalShellGrid, f::F, args...) where F<:Function =
+    @inbounds ifelse((i < 1) & (j == 1),               f(i, 1, k, grid, args...)           - f(1, i, k, grid, args...),
+              ifelse((i > grid.Nx) & (j == 1),         f(i, 1, k, grid, args...)           - f(grid.Nx, grid.Ny+1-i, k, grid, args...),
+              ifelse((i > grid.Nx) & (j == grid.Ny+1), f(grid.Nx, i, k, grid, args...)     - f(i, grid.Ny, k, grid, args...),
+              ifelse((i < 1) & (j == grid.Ny+1),       f(1, grid.Ny-i+1, k, grid, args...) - f(i, grid.Ny, k, grid, args...),
+                                                       f(i, j, k, grid, args...)           - f(i, j-1, k, grid, args...)))))
+
+@inline δyᶜᶠᶠ(i, j, k, grid::OrthogonalSphericalShellGrid, f::F, args...) where F<:Function =
+    δyᶜᶠᶜ(i, j, k, grid, f, args...)
+
+#####
 ##### 3D differences
 #####
 

--- a/src/Solvers/conjugate_gradient_solver.jl
+++ b/src/Solvers/conjugate_gradient_solver.jl
@@ -197,6 +197,10 @@ function iterate!(x, solver, b, args...)
 
     @apply_regionally perform_iteration!(q, p, ρ, z, solver, args...)
 
+    auxiliary_actions!(solver.linear_operation!, q, p, args...)
+
+    @apply_regionally solver.linear_operation!(q, p, args...)
+
     α = ρ / dot(p, q)
 
     @debug "ConjugateGradientSolver $(solver.iteration), |q|: $(norm(q))"
@@ -209,6 +213,8 @@ function iterate!(x, solver, b, args...)
 
     return nothing
 end
+
+auxiliary_actions!(args...) = nothing
 
 """ first iteration of the PCG """
 function initialize_solution!(q, x, b, solver, args...)

--- a/src/Utils/multi_region_transformation.jl
+++ b/src/Utils/multi_region_transformation.jl
@@ -1,6 +1,7 @@
 using CUDA: CuArray, CuDevice, CuContext, CuPtr, device, device!, synchronize
 using OffsetArrays
 using Oceananigans.Grids: AbstractGrid
+import Oceananigans.Architectures: on_architecture
 
 import Base: length
 
@@ -113,6 +114,15 @@ Base.length(mo::MultiRegionObject)               = Base.length(mo.regional_objec
 
 Base.similar(mo::MultiRegionObject) = construct_regionally(similar, mo)
 Base.parent(mo::MultiRegionObject) = construct_regionally(parent, mo)
+
+on_architecture(::CPU, mo::MultiRegionObject) = MultiRegionObject(on_architecture(CPU(), mo.regional_objects))
+
+# TODO: Properly define on_architecture(::GPU, mo::MultiRegionObject) to handle cases where MultiRegionObject can be
+# distributed across different devices. Currently, the implementation assumes that all regional objects reside on a
+# single GPU.
+on_architecture(::GPU, mo::MultiRegionObject) = (
+MultiRegionObject(on_architecture(GPU(), mo.regional_objects);
+                  devices = Tuple(CUDA.device() for i in 1:length(mo.regional_objects))))
 
 # For non-returning functions -> can we make it NON BLOCKING? This seems to be synchronous!
 @inline function apply_regionally!(regional_func!, args...; kwargs...)


### PR DESCRIPTION
This PR integrates the cubed sphere implementation into the main branch of Oceananigans. While grid generation was addressed in a previous PR (#4295, now closed), this PR focuses on accurately filling the halos of grid metrics and relevant fields---the most computationally challenging aspect of the implementation, and introduces numerous enhancements across several core components, including:

- MultiRegion grid and field infrastructure
- CubedSphere grid and field infrastructure
- Boundary condition handling
- Time-stepping methods (both implicit and split-explicit for the hydrostatic free surface model)
- Difference operators
- Conjugate gradient solver

and more. The goal is to enable seamless execution of cubed sphere simulations upon merging this PR. Note that I/O functionality (e.g., output writers, checkpointing, field time series) will be addressed in a subsequent PR.