### PR TITLE
Fix indexing issues for `FieldTimeSeries`

### DIFF
--- a/src/OutputReaders/set_field_time_series.jl
+++ b/src/OutputReaders/set_field_time_series.jl
@@ -10,7 +10,7 @@ iterations_from_file(file) = parse.(Int, keys(file["timeseries/t"]))
 function find_time_index(time::Number, file_times, Δt)
     # Accommodate round-off discrepancies between the FTS times and file times
     # (see https://github.com/CliMA/Oceananigans.jl/pull/4505)
-    ϵ = 100 * eps(eltype(file_times))
+    ϵ = 100 * eps(Δt)
     return findfirst(t -> isapprox(t, time, atol=ϵ*Δt), file_times)
 end
 

--- a/src/OutputReaders/set_field_time_series.jl
+++ b/src/OutputReaders/set_field_time_series.jl
@@ -10,8 +10,8 @@ iterations_from_file(file) = parse.(Int, keys(file["timeseries/t"]))
 function find_time_index(time::Number, file_times, Δt)
     # Accommodate round-off discrepancies between the FTS times and file times
     # (see https://github.com/CliMA/Oceananigans.jl/pull/4505)
-    ϵ = 100 * eps(Δt)
-    return findfirst(t -> isapprox(t, time, atol=ϵ*Δt), file_times)
+    ϵ = sqrt(eps(Δt))
+    return findfirst(t -> isapprox(t, time; rtol=ϵ), file_times)
 end
 
 find_time_index(time::AbstractTime, file_times, Δt) = findfirst(t -> t == time, file_times)


### PR DESCRIPTION
I think this is the formulation we want because it is the absolute tolerance relative to the dt used.
In main, if dt is too small, multiplying the `ϵ` times dt might result in an absolute tolerance lower than machine precision.

I am not sure what tests were performed on #4505 to test that the new formulation worked but the previous not did not, so I will try to produce some tests with different precisions and dt size to make sure this is the tolerance we want