### PR TITLE
Add constructor for missing FieldBoundaryConditions

### DIFF
--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -69,6 +69,7 @@ FieldBoundaryConditions(indices::Tuple, bcs::FieldBoundaryConditions) =
     FieldBoundaryConditions(indices, (getproperty(bcs, side) for side in propertynames(bcs))...)
 
 FieldBoundaryConditions(indices::Tuple, ::Nothing) = nothing
+FieldBoundaryConditions(indices::Tuple, ::Missing) = nothing
 
 # return boundary conditions only if the field is not windowed!
 window_boundary_conditions(::UnitRange,  left, right) = nothing, nothing


### PR DESCRIPTION
This code needs to be cleaned up (constructors for objects should not return `nothing`) but in the interim, this may fix the issue on #4547 