### PR TITLE
Do not check if an `AbstractGrid` contains a function

### DIFF
--- a/src/OutputWriters/output_writer_utils.jl
+++ b/src/OutputWriters/output_writer_utils.jl
@@ -182,6 +182,9 @@ has_reference(::Type{T}, ::NTuple{N, <:T}) where {N, T} = true
 has_reference(T::Type{Function}, f::Field) =
     has_reference(T, f.data) || has_reference(T, f.boundary_conditions)
 
+# No functions in grids, so no need to check.
+has_reference(T::Type{Function}, f::AbstractGrid) = false
+
 """
     has_reference(has_type, obj)
 

--- a/src/OutputWriters/output_writer_utils.jl
+++ b/src/OutputWriters/output_writer_utils.jl
@@ -1,5 +1,5 @@
 using StructArrays: StructArray, replace_storage
-using Oceananigans.Grids: on_architecture, architecture
+using Oceananigans.Grids: on_architecture, architecture, AbstractGrid
 using Oceananigans.DistributedComputations
 using Oceananigans.DistributedComputations: DistributedGrid, Partition
 using Oceananigans.Fields: AbstractField, indices, boundary_conditions, instantiated_location

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -220,5 +220,21 @@ for arch in archs
         progress_cb = simulation.callbacks[:progress]
         progress_cb.schedule.first_actuation_time
         @test progress_cb.schedule.first_actuation_time == 4
+
+        @info "  Testing immmersed model checkpointer [$(typeof(arch))]..."
+        grid = RectilinearGrid(arch, size=(10, 10, 10), extent=(1, 1, 1))
+        grid = ImmersedBoundaryGrid(grid, GridFittedBottom((x, y) -> - 1 + 0.2 * rand()); active_cells_map=true)
+        model = HydrostaticFreeSurfaceModel(; grid)
+        simulation = Simulation(model, Δt=0.2, stop_iteration=6)
+
+        test_checkpointer = try 
+            simulation.output_writers[:checkpointer] = Checkpointer(model, schedule=IterationInterval(5))
+            run!(simulation)
+            true
+        catch e
+            false
+        end
+
+        @test test_checkpointer 
     end
 end

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -224,7 +224,8 @@ for arch in archs
         @info "  Testing immmersed model checkpointer [$(typeof(arch))]..."
         grid = RectilinearGrid(arch, size=(10, 10, 10), extent=(1, 1, 1))
         grid = ImmersedBoundaryGrid(grid, GridFittedBottom((x, y) -> - 1 + 0.2 * rand()); active_cells_map=true)
-        model = HydrostaticFreeSurfaceModel(; grid)
+        closure = ScalarDiffusivity(VerticallyImplicitTImeDiscretization(), ν=1e-2)
+        model = HydrostaticFreeSurfaceModel(; grid, timestepper=:SplitRungeKutta3, closure)
         simulation = Simulation(model, Δt=0.2, stop_iteration=6)
 
         test_checkpointer = try 


### PR DESCRIPTION
The `has_reference` function creates problems when trying to checkpoint a grid with an active map on GPU, because it is trying to access the elements of the active map array (which are `Tuple{<:Int, <:Int, <:Int}`), which lead me to find this check on the grid which is not required (grids do not contain functions since when we changed the immersed boundary to always be a `Field`).

I am not sure how this was working before though.


