### PR TITLE
Fix vector rotation operation

### DIFF
--- a/src/Operators/vector_rotation_operators.jl
+++ b/src/Operators/vector_rotation_operators.jl
@@ -80,8 +80,8 @@ _intrinsic_ coordinate systems are equivalent. However, for other grids (e.g., f
     cosθ = Rcosθ / R
     sinθ = Rsinθ / R
 
-    uᵢ =   u * cosθ + v * sinθ
-    vᵢ = - u * sinθ + v * cosθ
+    uᵢ = u * cosθ - v * sinθ
+    vᵢ = u * sinθ + v * cosθ
 
     return uᵢ, vᵢ
 end
@@ -121,8 +121,8 @@ end
     cosθ = Rcosθ / R
     sinθ = Rsinθ / R
 
-    uₑ = u * cosθ - v * sinθ
-    vₑ = u * sinθ + v * cosθ
+    uₑ = - u * cosθ + v * sinθ
+    vₑ = + u * sinθ + v * cosθ
 
     return uₑ, vₑ
 end


### PR DESCRIPTION
The rotation and inverse rotation matrix seem to be reversed, leading to the issue encountered in https://github.com/CliMA/ClimaOcean.jl/issues/549

I think I will add a couple of more tests here, since this operation seems to be quite elusive and a big source of error.