### PR TITLE
Support assignment `a = b` in `@apply_regionally`

### DIFF
--- a/src/Utils/multi_region_transformation.jl
+++ b/src/Utils/multi_region_transformation.jl
@@ -215,6 +215,11 @@ macro apply_regionally(expr)
             Nret = length(expr.args[1].args)
         end
         exp = expr.args[2]
+        if exp isa Symbol # It is not a function call! Just a variable assignment
+            return quote
+                $ret = $(esc(exp))
+            end
+        end
         func = exp.args[1]
         args = exp.args[2:end]
         multi_region = quote

--- a/test/test_multi_region_unit.jl
+++ b/test/test_multi_region_unit.jl
@@ -3,6 +3,21 @@ include("dependencies_for_runtests.jl")
 devices(::CPU, num) = nothing
 devices(::GPU, num) = Tuple(0 for i in 1:num)
 
+# To be extended as we find new use cases
+@testset "Test @apply_regionally macro" begin
+    a = 1
+    b = 2
+    @apply_regionally a = b + 1
+
+    @test a == 3
+    
+    a = MultiRegionObject((1, 2, 3))
+    b = MultiRegionObject((4, 5, 6))
+
+    @apply_regionally a = b + 1
+    @test a == MultiRegionObject((5, 6, 7))
+end
+
 @testset "Testing multi region grids" begin
     for arch in archs
 


### PR DESCRIPTION
which was not supported before, only function calls were supported.
I am also adding a simple test for `@apply_regionally` since it looks like we are missing tests for it. We should populate the tests as we find new bugs.