### PR TITLE
Use Makie extension in Kelvin-Helmholtz example

### DIFF
--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -307,7 +307,7 @@ n = Observable(1)
 
 fig = Figure(size=(800, 600))
 
-kwargs = (xlabel="x", ylabel="z", limits = ((xω[1], xω[end]), (zω[1], zω[end])), aspect=1,)
+kwargs = (xlabel="x", ylabel="z", limits = ((-5, 5), (-5, 5)), aspect=1)
 
 ω_title(t) = t === nothing ? @sprintf("vorticity") : @sprintf("vorticity at t = %.2f", t)
 b_title(t) = t === nothing ? @sprintf("buoyancy")  : @sprintf("buoyancy at t = %.2f", t)
@@ -410,8 +410,8 @@ t_final = times[end]
 
 n = Observable(1)
 
-ωₙ = @lift interior(ω_timeseries, :, 1, :, $n)
-bₙ = @lift interior(b_timeseries, :, 1, :, $n)
+ωₙ = @lift view(ω_timeseries[$n], :, 1, :)
+bₙ = @lift view(b_timeseries[$n], :, 1, :)
 
 fig = Figure(size=(800, 600))
 
@@ -430,13 +430,13 @@ ax_KE = Axis(fig[3, :];
 
 fig[1, :] = Label(fig, title, fontsize=24, tellwidth=false)
 
-ω_lims = @lift (-maximum(abs, interior(ω_timeseries, :, 1, :, $n)) - 1e-16, maximum(abs, interior(ω_timeseries, :, 1, :, $n)) + 1e-16)
-b_lims = @lift (-maximum(abs, interior(b_timeseries, :, 1, :, $n)) - 1e-16, maximum(abs, interior(b_timeseries, :, 1, :, $n)) + 1e-16)
+ω_lims = @lift (-maximum(abs, ω_timeseries[$n]) - 1e-16, maximum(abs, ω_timeseries[$n]) + 1e-16)
+b_lims = @lift (-maximum(abs, b_timeseries[$n]) - 1e-16, maximum(abs, b_timeseries[$n]) + 1e-16)
 
-hm_ω = heatmap!(ax_ω, xω, zω, ωₙ; colorrange = ω_lims, colormap = :balance)
+hm_ω = heatmap!(ax_ω, ωₙ; colorrange = ω_lims, colormap = :balance)
 Colorbar(fig[2, 2], hm_ω)
 
-hm_b = heatmap!(ax_b, xb, zb, bₙ; colorrange = b_lims, colormap = :balance)
+hm_b = heatmap!(ax_b, bₙ; colorrange = b_lims, colormap = :balance)
 Colorbar(fig[2, 4], hm_b)
 
 tₙ = @lift times[1:$n]
@@ -469,12 +469,12 @@ nothing #hide
 # And then the same for total vorticity & buoyancy of the fluid.
 n = Observable(1)
 
-Ωₙ = @lift interior(Ω_timeseries, :, 1, :, $n)
-Bₙ = @lift interior(B_timeseries, :, 1, :, $n)
+Ωₙ = @lift view(Ω_timeseries[$n], :, 1, :)
+Bₙ = @lift view(B_timeseries[$n], :, 1, :)
 
 fig = Figure(size=(800, 600))
 
-kwargs = (xlabel="x", ylabel="z", limits = ((xω[1], xω[end]), (zω[1], zω[end])), aspect=1,)
+kwargs = (xlabel="x", ylabel="z", limits = ((-5, 5), (-5, 5)), aspect=1)
 
 title = @lift @sprintf("t = %.2f", times[$n])
 
@@ -489,10 +489,10 @@ ax_KE = Axis(fig[3, :];
 
 fig[1, :] = Label(fig, title, fontsize=24, tellwidth=false)
 
-hm_Ω = heatmap!(ax_Ω, xω, zω, Ωₙ; colorrange = (-1, 1), colormap = :balance)
+hm_Ω = heatmap!(ax_Ω, Ωₙ; colorrange = (-1, 1), colormap = :balance)
 Colorbar(fig[2, 2], hm_Ω)
 
-hm_B = heatmap!(ax_B, xb, zb, Bₙ; colorrange = (-0.05, 0.05), colormap = :balance)
+hm_B = heatmap!(ax_B, Bₙ; colorrange = (-0.05, 0.05), colormap = :balance)
 Colorbar(fig[2, 4], hm_B)
 
 tₙ = @lift times[1:$n]

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -318,8 +318,8 @@ bₙ = @lift power_method_data[$n].b
 
 σₙ = @lift [(i-1, i==1 ? NaN : growth_rates[i-1]) for i in 1:$n]
 
-ω_lims = @lift (-maximum(abs, power_method_data[$n].ω) - 1e-16, maximum(abs, power_method_data[$n].ω) + 1e-16)
-b_lims = @lift (-maximum(abs, power_method_data[$n].b) - 1e-16, maximum(abs, power_method_data[$n].b) + 1e-16)
+ω_lims = @lift (-maximum(abs, power_method_data[$n].ω), maximum(abs, power_method_data[$n].ω))
+b_lims = @lift (-maximum(abs, power_method_data[$n].b), maximum(abs, power_method_data[$n].b))
 
 hm_ω = heatmap!(ax_ω, ωₙ; colorrange = ω_lims, colormap = :balance)
 Colorbar(fig[2, 2], hm_ω)
@@ -427,8 +427,8 @@ ax_KE = Axis(fig[3, :];
 
 fig[1, :] = Label(fig, title, fontsize=24, tellwidth=false)
 
-ω_lims = @lift (-maximum(abs, ω_timeseries[$n]) - 1e-16, maximum(abs, ω_timeseries[$n]) + 1e-16)
-b_lims = @lift (-maximum(abs, b_timeseries[$n]) - 1e-16, maximum(abs, b_timeseries[$n]) + 1e-16)
+ω_lims = @lift (-maximum(abs, ω_timeseries[$n]), maximum(abs, ω_timeseries[$n]))
+b_lims = @lift (-maximum(abs, b_timeseries[$n]), maximum(abs, b_timeseries[$n]))
 
 hm_ω = heatmap!(ax_ω, ωₙ; colorrange = ω_lims, colormap = :balance)
 Colorbar(fig[2, 2], hm_ω)

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -251,7 +251,7 @@ function estimate_growth_rate(simulation, energy, ω, b; convergence_criterion=1
     σ = []
     power_method_data = []
     compute!(ω)
-    push!(power_method_data, (ω=deepcopy(view(ω, :, 1, :)), b=deepcopy(view(b, :, 1, :)), σ=deepcopy(σ)))
+    push!(power_method_data, (ω=deepcopy(ω), b=deepcopy(b), σ=deepcopy(σ)))
 
     while convergence(σ) > convergence_criterion
         compute!(energy)
@@ -265,7 +265,7 @@ function estimate_growth_rate(simulation, energy, ω, b; convergence_criterion=1
 
         compute!(ω)
         rescale!(simulation.model, energy)
-        push!(power_method_data, (ω=deepcopy(view(ω, :, 1, :)), b=deepcopy(view(b, :, 1, :)), σ=deepcopy(σ)))
+    push!(power_method_data, (ω=deepcopy(ω), b=deepcopy(b), σ=deepcopy(σ)))
     end
 
     return σ, power_method_data
@@ -407,8 +407,8 @@ t_final = times[end]
 
 n = Observable(1)
 
-ωₙ = @lift view(ω_timeseries[$n], :, 1, :)
-bₙ = @lift view(b_timeseries[$n], :, 1, :)
+ωₙ = @lift ω_timeseries[$n]
+bₙ = @lift b_timeseries[$n]
 
 fig = Figure(size=(800, 600))
 
@@ -466,8 +466,8 @@ nothing #hide
 # And then the same for total vorticity & buoyancy of the fluid.
 n = Observable(1)
 
-Ωₙ = @lift view(Ω_timeseries[$n], :, 1, :)
-Bₙ = @lift view(B_timeseries[$n], :, 1, :)
+Ωₙ = @lift Ω_timeseries[$n]
+Bₙ = @lift B_timeseries[$n]
 
 fig = Figure(size=(800, 600))
 

--- a/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
+++ b/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
@@ -11,7 +11,8 @@ using Oceananigans.Fields: Field, VelocityFields
 using Oceananigans.Operators
 using Oceananigans.BoundaryConditions
 using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper,
-                                 RungeKutta3TimeStepper
+                                 RungeKutta3TimeStepper, 
+                                 SplitRungeKutta3TimeStepper
 
 using Oceananigans.TurbulenceClosures: viscosity,
                                        diffusivity,

--- a/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
+++ b/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
@@ -10,8 +10,8 @@ using Oceananigans.Fields
 using Oceananigans.Fields: Field, VelocityFields
 using Oceananigans.Operators
 using Oceananigans.BoundaryConditions
-using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper, 
-                                 RungeKutta3TimeStepper, 
+using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper,
+                                 RungeKutta3TimeStepper,
                                  SplitRungeKutta3TimeStepper
 
 using Oceananigans.TurbulenceClosures: viscosity,
@@ -80,7 +80,7 @@ Keyword Arguments
 - `Uⁿ`: The velocity field at the current time step. Default: `VelocityFields(grid)`.
 
 !!! compat "Time stepper compatibility"
-    At the moment, the variance dissipation diagnostic is supported only for a [`QuasiAdamsBashforth2TimeStepper`](@ref) 
+    At the moment, the variance dissipation diagnostic is supported only for a [`QuasiAdamsBashforth2TimeStepper`](@ref)
     and a [`SplitRungeKutta3TimeStepper`](@ref).
 """
 function VarianceDissipation(tracer_name, grid;

--- a/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
+++ b/src/Models/VarianceDissipationComputations/VarianceDissipationComputations.jl
@@ -11,8 +11,7 @@ using Oceananigans.Fields: Field, VelocityFields
 using Oceananigans.Operators
 using Oceananigans.BoundaryConditions
 using Oceananigans.TimeSteppers: QuasiAdamsBashforth2TimeStepper,
-                                 RungeKutta3TimeStepper,
-                                 SplitRungeKutta3TimeStepper
+                                 RungeKutta3TimeStepper
 
 using Oceananigans.TurbulenceClosures: viscosity,
                                        diffusivity,

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -3,7 +3,6 @@ module TimeSteppers
 export
     QuasiAdamsBashforth2TimeStepper,
     RungeKutta3TimeStepper,
-    SplitRungeKutta3TimeStepper,
     time_step!,
     Clock,
     tendencies

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -3,6 +3,7 @@ module TimeSteppers
 export
     QuasiAdamsBashforth2TimeStepper,
     RungeKutta3TimeStepper,
+    SplitRungeKutta3TimeStepper,
     time_step!,
     Clock,
     tendencies


### PR DESCRIPTION
This PR changes the Kelvin-Helmholtz example to plot Oceananigans fields instead of Arrays and thus utilize the OceananigansMakieExt.

https://clima.github.io/OceananigansDocumentation/previews/PR4569/literated/kelvin_helmholtz_instability/