### PR TITLE
Remove shift in `FFTBasedPoissonSolver` and multiply by negative one in preconditioning for `Conjugate GradientPoissonSolver`

### DIFF
--- a/src/Solvers/conjugate_gradient_poisson_solver.jl
+++ b/src/Solvers/conjugate_gradient_poisson_solver.jl
@@ -127,9 +127,7 @@ const FFTBasedPreconditioner = Union{FFTBasedPoissonSolver, FourierTridiagonalPo
 
 function precondition!(p, preconditioner::FFTBasedPreconditioner, r, args...)
     compute_preconditioner_rhs!(preconditioner, r)
-    shift = - sqrt(eps(eltype(r))) # to make the operator strictly negative definite
-    solve!(p, preconditioner, preconditioner.storage, shift)
-    p .*= -1
+    solve!(p, preconditioner, preconditioner.storage)
     return p
 end
 


### PR DESCRIPTION
Closes https://github.com/CliMA/Oceananigans.jl/issues/4581, and details of the origin of this can also be found https://github.com/CliMA/Oceananigans.jl/pull/4539.

@glwagner @tomchor @amontoison 