### PR TITLE
Correct diffusion with a non-linear free surface

### DIFF
--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -54,18 +54,12 @@ implicit_diffusion_solver(::ExplicitTimeDiscretization, args...; kwargs...) = no
 ##### Note: "ivd" stands for implicit vertical diffusion.
 #####
 
-# The vertical spacing used here is Δz for velocities and Δr for tracers, since the
-# implicit solver operator is applied to the scaled tracer σθ instead of just θ
-
-@inline rcp_vertical_spacing(i, j, k, grid, ℓx, ℓy, ℓz) = Δz⁻¹(i, j, k, grid, ℓx, ℓy, ℓz)
-@inline rcp_vertical_spacing(i, j, k, grid, ::Center, ::Center, ℓz) = Δr⁻¹(i, j, k, grid, c, c, ℓz)
-
 # Tracers and horizontal velocities at cell centers in z
 @inline function ivd_upper_diagonal(i, j, k, grid, closure, K, id, ℓx, ℓy, ::Center, Δt, clock)
     closure_ij = getclosure(i, j, closure)
     κᵏ⁺¹     = ivd_diffusivity(i, j, k+1, grid, ℓx, ℓy, f, closure_ij, K, id, clock)
-    Δz⁻¹ᶜₖ   = rcp_vertical_spacing(i, j, k,   grid, ℓx, ℓy, c)
-    Δz⁻¹ᶠₖ₊₁ = rcp_vertical_spacing(i, j, k+1, grid, ℓx, ℓy, f)
+    Δz⁻¹ᶜₖ   = Δz⁻¹(i, j, k,   grid, ℓx, ℓy, c)
+    Δz⁻¹ᶠₖ₊₁ = Δz⁻¹(i, j, k+1, grid, ℓx, ℓy, f)
     du       = - Δt * κᵏ⁺¹ * (Δz⁻¹ᶜₖ * Δz⁻¹ᶠₖ₊₁)
     # This conditional ensures the diagonal is correct
     return du * !peripheral_node(i, j, k+1, grid, ℓx, ℓy, f)
@@ -75,8 +69,8 @@ end
     k = k′ + 1 # Shift index to match LinearAlgebra.Tridiagonal indexing convenction
     closure_ij = getclosure(i, j, closure)
     κᵏ     = ivd_diffusivity(i, j, k, grid, ℓx, ℓy, f, closure_ij, K, id, clock)
-    Δz⁻¹ᶜₖ = rcp_vertical_spacing(i, j, k, grid, ℓx, ℓy, c)
-    Δz⁻¹ᶠₖ = rcp_vertical_spacing(i, j, k, grid, ℓx, ℓy, f)
+    Δz⁻¹ᶜₖ = Δz⁻¹(i, j, k, grid, ℓx, ℓy, c)
+    Δz⁻¹ᶠₖ = Δz⁻¹(i, j, k, grid, ℓx, ℓy, f)
     dl     = - Δt * κᵏ * (Δz⁻¹ᶜₖ * Δz⁻¹ᶠₖ)
 
     # This conditional ensures the diagonal is correct. (Note we use LinearAlgebra.Tridiagonal
@@ -93,8 +87,8 @@ end
 @inline function ivd_upper_diagonal(i, j, k, grid, closure, K, id, ℓx, ℓy, ::Face, Δt, clock)
     closure_ij = getclosure(i, j, closure)
     νᵏ   = ivd_diffusivity(i, j, k, grid, ℓx, ℓy, c, closure_ij, K, id, clock)
-    Δz⁻¹ᶜₖ = rcp_vertical_spacing(i, j, k, grid, ℓx, ℓy, c)
-    Δz⁻¹ᶠₖ = rcp_vertical_spacing(i, j, k, grid, ℓx, ℓy, f)
+    Δz⁻¹ᶜₖ = Δz⁻¹(i, j, k, grid, ℓx, ℓy, c)
+    Δz⁻¹ᶠₖ = Δz⁻¹(i, j, k, grid, ℓx, ℓy, f)
     du   = - Δt * νᵏ * (Δz⁻¹ᶜₖ * Δz⁻¹ᶠₖ)
     return du * !peripheral_node(i, j, k, grid, ℓx, ℓy, c)
 end
@@ -103,8 +97,8 @@ end
     k′ = k + 2 # Shift to adjust for Tridiagonal indexing convention
     closure_ij = getclosure(i, j, closure)
     νᵏ⁻¹     = ivd_diffusivity(i, j, k′-1, grid, ℓx, ℓy, c, closure_ij, K, id, clock)
-    Δz⁻¹ᶜₖ   = rcp_vertical_spacing(i, j, k′,   grid, ℓx, ℓy, c)
-    Δz⁻¹ᶠₖ₋₁ = rcp_vertical_spacing(i, j, k′-1, grid, ℓx, ℓy, f)
+    Δz⁻¹ᶜₖ   = Δz⁻¹(i, j, k′,   grid, ℓx, ℓy, c)
+    Δz⁻¹ᶠₖ₋₁ = Δz⁻¹(i, j, k′-1, grid, ℓx, ℓy, f)
     dl       = - Δt * νᵏ⁻¹ * (Δz⁻¹ᶜₖ * Δz⁻¹ᶠₖ₋₁)
     return dl * !peripheral_node(i, j, k, grid, ℓx, ℓy, c)
 end

--- a/test/test_zstar_coordinate.jl
+++ b/test/test_zstar_coordinate.jl
@@ -116,6 +116,8 @@ end
 @testset "ZStar diffusion test" begin
     @info "testing the ZStar diffusion in a HydrostaticFreeSurfaceModel"
     Random.seed!(1234)
+
+    # Build a stretched vertical coordinate
     z_static = [i + rand() for i in -15:0]
     z_static[1] = -15
     z_static[end] = 0

--- a/test/test_zstar_coordinate.jl
+++ b/test/test_zstar_coordinate.jl
@@ -115,17 +115,18 @@ end
 
 @testset "ZStar diffusion test" begin
     @info "testing the ZStar diffusion in a HydrostaticFreeSurfaceModel"
-
-    z_static = (-15, 0)
-    z_moving = MutableVerticalDiscretization((-10, 0))
+    Random.seed!(1234)
+    z_static = [i + rand() for i in -15:0]
+    z_static[1] = -15
+    z_static[end] = 0
+    z_moving = MutableVerticalDiscretization(z_static ./ 1.5)
     
     for arch in archs
         for TD in (ExplicitTimeDiscretization, VerticallyImplicitTimeDiscretization)
-            Random.seed!(1234)
-            c₀ = rand(20)
+            c₀ = rand(15)
 
-            grid_static = RectilinearGrid(arch; size=20, z=z_static, topology=(Flat, Flat, Bounded))
-            grid_moving = RectilinearGrid(arch; size=20, z=z_moving, topology=(Flat, Flat, Bounded))
+            grid_static = RectilinearGrid(arch; size=15, z=z_static, topology=(Flat, Flat, Bounded))
+            grid_moving = RectilinearGrid(arch; size=15, z=z_moving, topology=(Flat, Flat, Bounded))
 
             fill!(grid_moving.z.ηⁿ,   5)
             fill!(grid_moving.z.σᶜᶜ⁻, 1.5)


### PR DESCRIPTION
PR #4546 changed the implementation of zstar and a nonlinear free surface. In particular, before #4546 we were 
- 1. updating `σT`
- 2. performing implicit diffusion on `σT`
- 3. advancing `σ`
- 4. diagnosing `T` at the new timestep

PR#4546 changed this in
- 1. updating `σ`
- 2. computing directly `T` from updating `σT` and dividing by the new `σ`
- 3. implicit diffusion

After #4546, the diffusion is performed on `T` and not `σT`, but #4546 did not update the vertically implicit diffusion solver  (I also think there was a bug before), for this reason, the non linear free surface solution is way more diffusive now than the same solution with a static grid. This leads to SST increasing drastically using zstar compared to using a static vertical coordinate in ClimaOcean. 

This PR corrects the formulation and adds a very simple test, where if the free surface does not change, the results should be the same for static and moving grid `(H+η)_moving == H_static`.
If we run same test I added in this PR on main:
```julia
z_static = [i + rand() for i in -15:0]
z_static[1] = -15
z_static[end] = 0
z_moving = MutableVerticalDiscretization(z_static ./ 1.5)
    
c₀ = rand(15)

grid_static = RectilinearGrid(size=15, z=z_static, topology=(Flat, Flat, Bounded))
grid_moving = RectilinearGrid(size=15, z=z_moving, topology=(Flat, Flat, Bounded))

fill!(grid_moving.z.ηⁿ,   5)
fill!(grid_moving.z.σᶜᶜ⁻, 1.5)
fill!(grid_moving.z.σᶜᶜⁿ, 1.5)
fill!(grid_moving.z.σᶜᶠⁿ, 1.5)
fill!(grid_moving.z.σᶠᶠⁿ, 1.5)
fill!(grid_moving.z.σᶠᶜⁿ, 1.5)

model_static = HydrostaticFreeSurfaceModel(; grid = grid_static, 
                                            tracers = :c,
                                            closure = VerticalScalarDiffusivity(VerticallyImplicitTimeDiscretization(), κ=0.1))
                                                
model_moving = HydrostaticFreeSurfaceModel(; grid = grid_moving, 
                                            tracers = :c,
                                            closure = VerticalScalarDiffusivity(VerticallyImplicitTimeDiscretization(), κ=0.1))
                                        
set!(model_static, c = c₀)
set!(model_moving, c = c₀)

for _ in 1:1000
    time_step!(model_static, 1.0)
    time_step!(model_moving, 1.0)
end

lines(interior(model_static.tracers.c, 1, 1, :), label="Static Grid")
lines!(interior(model_moving.tracers.c, 1, 1, :), label="Moving Grid", linestyle=:dash)
axislegend()
```
we get 
## on main
![image](https://github.com/user-attachments/assets/4d5b2dc9-56cd-4ca9-949c-9186ebb2944e)

## on this PR
![image](https://github.com/user-attachments/assets/20d82a3d-2a72-49a0-a941-bf717da338ba)

The detailed formulation of the equations we solve is begin added in #4588 
