### PR TITLE
Add `PiecewiseLinearMask`

### DIFF
--- a/src/Forcings/Forcings.jl
+++ b/src/Forcings/Forcings.jl
@@ -1,6 +1,6 @@
 module Forcings
 
-export Forcing, ContinuousForcing, DiscreteForcing, Relaxation, GaussianMask, LinearTarget, AdvectiveForcing
+export Forcing, ContinuousForcing, DiscreteForcing, Relaxation, GaussianMask, PiecewiseLinearMask, LinearTarget, AdvectiveForcing
 
 using Oceananigans.Fields
 using Oceananigans.OutputReaders: FlavorOfFTS

--- a/src/Forcings/relaxation.jl
+++ b/src/Forcings/relaxation.jl
@@ -129,8 +129,11 @@ Example
 
 Create a Gaussian mask centered on `z=0` with width `1` meter.
 
-```julia
+```jldoctest
+julia> using Oceananigans
+
 julia> mask = GaussianMask{:z}(center=0, width=1)
+GaussianMask{:z, Int64}(0, 1)
 ```
 """
 struct GaussianMask{D, T}
@@ -153,6 +156,63 @@ show_exp_arg(D, c) = c == 0 ? "$D^2" :
 
 Base.summary(g::GaussianMask{D}) where D =
     "exp(-$(show_exp_arg(D, g.center)) / (2 * $(g.width)^2))"
+
+
+"""
+    PiecewiseLinearMask{D}(center, width)
+
+Callable object that returns a piecewise linear masking function centered on
+`center`, with `width`, and varying along direction `D`. The mask is:
+- 0 when |D - center| > width
+- 1 when D = center
+- Linear interpolation between 0 and 1 when |D - center| ≤ width
+
+Example
+=======
+
+Create a piecewise linear mask centered on `z=0` with width `1` meter.
+
+```jldoctest
+julia> using Oceananigans
+
+julia> mask = PiecewiseLinearMask{:z}(center=0, width=1)
+PiecewiseLinearMask{:z, Int64}(0, 1)
+
+julia> mask(0, 0, 0) == 1
+true
+
+julia> mask(0, 0, 1) == mask(0, 0, -1) == 0
+true
+```
+"""
+struct PiecewiseLinearMask{D, T}
+    center :: T
+     width :: T
+
+    function PiecewiseLinearMask{D}(; center, width) where D
+        T = promote_type(typeof(center), typeof(width))
+        return new{D, T}(center, width)
+    end
+end
+
+@inline function (p::PiecewiseLinearMask{:x})(x, y, z)
+    d = abs(x - p.center)
+    return d > p.width ? 0.0 : 1.0 - d/p.width
+end
+
+@inline function (p::PiecewiseLinearMask{:y})(x, y, z)
+    d = abs(y - p.center)
+    return d > p.width ? 0.0 : 1.0 - d/p.width
+end
+
+@inline function (p::PiecewiseLinearMask{:z})(x, y, z)
+    d = abs(z - p.center)
+    return d > p.width ? 0.0 : 1.0 - d/p.width
+end
+
+Base.summary(p::PiecewiseLinearMask{D}) where D =
+    "piecewise_linear($D, center=$(p.center), width=$(p.width))"
+
 
 #####
 ##### Linear target functions

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -42,7 +42,7 @@ export
     interior, set!, compute!, regrid!,
 
     # Forcing functions
-    Forcing, Relaxation, LinearTarget, GaussianMask, AdvectiveForcing,
+    Forcing, Relaxation, LinearTarget, GaussianMask, PiecewiseLinearMask, AdvectiveForcing,
 
     # Coriolis forces
     FPlane, ConstantCartesianCoriolis, BetaPlane, NonTraditionalBetaPlane,

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -140,14 +140,14 @@ function time_step_with_field_time_series_forcing(arch)
     return true
 end
 
-function relaxed_time_stepping(arch)
-    x_relax = Relaxation(rate = 1/60,   mask = GaussianMask{:x}(center=0.5, width=0.1),
+function relaxed_time_stepping(arch, mask_type)
+    x_relax = Relaxation(rate = 1/60,   mask = mask_type{:x}(center=0.5, width=0.1),
                                       target = LinearTarget{:x}(intercept=π, gradient=ℯ))
 
-    y_relax = Relaxation(rate = 1/60,   mask = GaussianMask{:y}(center=0.5, width=0.1),
+    y_relax = Relaxation(rate = 1/60,   mask = mask_type{:y}(center=0.5, width=0.1),
                                       target = LinearTarget{:y}(intercept=π, gradient=ℯ))
 
-    z_relax = Relaxation(rate = 1/60,   mask = GaussianMask{:z}(center=0.5, width=0.1),
+    z_relax = Relaxation(rate = 1/60,   mask = mask_type{:z}(center=0.5, width=0.1),
                                       target = π)
 
     grid = RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 1, 1))
@@ -273,7 +273,8 @@ end
 
             @testset "Relaxation forcing functions [$A]" begin
                 @info "      Testing relaxation forcing functions [$A]..."
-                @test relaxed_time_stepping(arch)
+                @test relaxed_time_stepping(arch, GaussianMask)
+                @test relaxed_time_stepping(arch, PiecewiseLinearMask)
             end
 
             @testset "Advective and multiple forcing [$A]" begin


### PR DESCRIPTION
This PR adds `PiecewiseLinearMask` to the `Forcings` module.

One advantage of `PiecewiseLinearMask` over the existing `GaussianMask` is that it has a well-defined region of action, as opposed to `GaussianMask` which decays smoothly and it's up to the user to decide where the mask is small enough that it doesn't affect the solution. Another advantage is that it's probably faster than `GaussianMask`, although I haven't really tested that.