### PR TITLE
Updating barotropic gyre validation script to run with current package interface

### DIFF
--- a/validation/barotropic_gyre/barotropic_gyre.jl
+++ b/validation/barotropic_gyre/barotropic_gyre.jl
@@ -5,16 +5,9 @@ using Oceananigans.Grids
 
 using Oceananigans.Advection: EnergyConserving, EnstrophyConserving
 
-using Oceananigans.Models.HydrostaticFreeSurfaceModels:
-    HydrostaticFreeSurfaceModel,
-    VectorInvariant,
-    ExplicitFreeSurface,
-    ImplicitFreeSurface
-
 using Oceananigans.Units
 
 using Statistics
-using JLD2
 using Printf
 
 Nx = 60
@@ -37,7 +30,7 @@ free_surface = ImplicitFreeSurface(gravitational_acceleration=0.1)
 
 coriolis = HydrostaticSphericalCoriolis(scheme = EnstrophyConserving())
 
-@show surface_wind_stress_parameters = (τ₀ = 1e-4,
+@show surface_wind_stress_parameters = (τ₀ = 1e-2,
                                         Lφ = grid.Ly,
                                         φ₀ = 15)
 
@@ -71,10 +64,8 @@ v_bcs = FieldBoundaryConditions(bottom = v_bottom_drag_bc)
 variable_horizontal_diffusivity = HorizontalScalarDiffusivity(ν = νh)
 constant_horizontal_diffusivity = HorizontalScalarDiffusivity(ν = νh₀)
 
-model = HydrostaticFreeSurfaceModel(grid = grid,
+model = HydrostaticFreeSurfaceModel(; grid, free_surface, coriolis,
                                     momentum_advection = VectorInvariant(),
-                                    free_surface = free_surface,
-                                    coriolis = coriolis,
                                     boundary_conditions = (u=u_bcs, v=v_bcs),
                                     closure = constant_horizontal_diffusivity,
                                     #closure = variable_horizontal_diffusivity,
@@ -96,7 +87,7 @@ end
 function (p::Progress)(sim)
     wall_time = (time_ns() - p.interval_start_time) * 1e-9
 
-    @info @sprintf("Time: %s, iteration: %d, max(u): %.2e m s⁻¹, wall time: %s",
+    @info @sprintf("time: %s, iteration: %d, max(u): %.2e m s⁻¹, wall time: %s",
                    prettytime(sim.model.clock.time),
                    sim.model.clock.iteration,
                    maximum(sim.model.velocities.u),
@@ -109,16 +100,16 @@ end
 
 simulation = Simulation(model,
                         Δt = 3600,
-                        stop_time = 365days)
+                        stop_time = 2 * 365days)
 
-simulation.callbacks[:progress] = Callback(Progress(time_ns()), IterationInterval(20))
+simulation.callbacks[:progress] = Callback(Progress(time_ns()), IterationInterval(24*50))
 
 output_fields = merge(model.velocities, (η=model.free_surface.η,))
 
 output_prefix = "barotropic_gyre_Nx$(grid.Nx)_Ny$(grid.Ny)"
 
 simulation.output_writers[:fields] = JLD2Writer(model, output_fields,
-                                                schedule = TimeInterval(10day),
+                                                schedule = TimeInterval(5day),
                                                 filename = output_prefix,
                                                 overwrite_existing = true)
 

--- a/validation/barotropic_gyre/visualize_barotropic_gyre.jl
+++ b/validation/barotropic_gyre/visualize_barotropic_gyre.jl
@@ -26,7 +26,6 @@ function geographic2cartesian(λ, φ, r=1)
 end
 
 function visualize_barotropic_gyre(filepath)
-
     file = jldopen(filepath)
 
     Nx = file["grid/Nx"]
@@ -69,7 +68,7 @@ function visualize_barotropic_gyre(filepath)
 
     supertitle = fig[0, :] = Label(fig, plot_title, fontsize=50)
 
-    record(fig, output_prefix * ".mp4", iterations, framerate=30) do i
+    record(fig, output_prefix * ".mp4", iterations, framerate=18) do i
         @info "Animating iteration $i/$(iterations[end])..."
         iter[] = i
     end


### PR DESCRIPTION
When trying to run the barotropic gyre validation example script with a recent version of Oceananigans package (v0.96.32) I got a series of errors due to changes in Oceananigans interface since the script was written. Specifically

- Import of `years` from `Oceananigans.Units` and `Oceananigans.Utils` fails due to `years` having being removed in #3059.
- Call signature of `xnodes` and `ynodes` changed in #2842 resulting in `MethodError` in current calls.
- `show_axis` not a valid argument to `wireframe!` in current (GL)Makie (v0.11.11).

This PR updates the scripts so that they run for me locally (in Julia v1.11.4 with Oceananigcans v0.96.32, GLMakie v0.11.11, JLD2 v0.5.13) and successfully outputs the animated visualisation of the simulated fields.