### PR TITLE
Adds `DroguedBuoyDynamics` for lagrangian particles

### DIFF
--- a/src/Models/LagrangianParticleTracking/LagrangianParticleTracking.jl
+++ b/src/Models/LagrangianParticleTracking/LagrangianParticleTracking.jl
@@ -1,6 +1,6 @@
 module LagrangianParticleTracking
 
-export LagrangianParticles
+export LagrangianParticles, DroguedBuoyDynamics
 
 using Printf
 using Adapt
@@ -129,6 +129,7 @@ end
 
 include("update_lagrangian_particle_properties.jl")
 include("lagrangian_particle_advection.jl")
+include("drogued_dynamics.jl")
 
 step_lagrangian_particles!(::Nothing, model, Δt) = nothing
 

--- a/src/Models/LagrangianParticleTracking/drogued_dynamics.jl
+++ b/src/Models/LagrangianParticleTracking/drogued_dynamics.jl
@@ -1,0 +1,47 @@
+"""
+    DroguedBuoyDynamics(drogue_depths)
+
+`DroguedBuoyDynamics` goes in the `dynamics` slot of `LagrangianParticles` 
+and modifies their behaviour to mimic the behaviour of bouys which are 
+drogued at `drogue_depths`. The particles remain at the their `z` position
+so the "measurment depth can be set", and then are advected in the `x` and `y`
+directions according to the velocity field at `drogue_depths`.
+
+`drogue_depths` should be an array of length `length(particles)`.
+"""
+struct DroguedBuoyDynamics{DD}
+    drogue_depths :: DD
+end
+
+@inline (::DroguedBuoyDynamics)(args...) = nothing
+
+const DroguedBuoyParticle = LagrangianParticles{<:Any, <:Any, <:Any, <:DroguedBuoyDynamics}
+
+function advect_lagrangian_particles!(particles::DroguedBuoyParticle, model, Δt)
+    grid = model.grid
+    arch = architecture(grid)
+    parameters = KernelParameters(1:length(particles))
+
+    launch!(arch, grid, parameters,
+            _advect_drogued_particles!,
+            particles.properties, particles.restitution, model.grid, Δt, total_velocities(model), particles.dynamics.drogue_depths)
+
+    return nothing
+end
+
+@kernel function _advect_drogued_particles!(properties, restitution, grid, Δt, velocities, drogue_depths)
+    p = @index(Global)
+
+    @inbounds begin
+        x = properties.x[p]
+        y = properties.y[p]
+        z = drogue_depths[p]
+    end
+
+    x⁺, y⁺, _ = advect_particle((x, y, z), properties, p, restitution, grid, Δt, velocities)
+
+    @inbounds begin
+        properties.x[p] = x⁺
+        properties.y[p] = y⁺
+    end
+end

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -6,7 +6,7 @@ export
     HydrostaticFreeSurfaceModel, ZStar, ZCoordinate,
     ExplicitFreeSurface, ImplicitFreeSurface, SplitExplicitFreeSurface,
     PrescribedVelocityFields, PressureField,
-    LagrangianParticles,
+    LagrangianParticles, DroguedBuoyDynamics,
     BoundaryConditionOperation, ForcingOperation,
     seawater_density
 

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -75,7 +75,7 @@ export
     viscosity, diffusivity,
 
     # Lagrangian particle tracking
-    LagrangianParticles,
+    LagrangianParticles, DroguedBuoyDynamics,
 
     # Models
     NonhydrostaticModel, HydrostaticFreeSurfaceModel, ShallowWaterModel,

--- a/validation/lagrangian_particles/drogued_buoy.jl
+++ b/validation/lagrangian_particles/drogued_buoy.jl
@@ -1,0 +1,112 @@
+using Oceananigans, Oceananigans.Units, StructArrays
+
+using Oceananigans.Models.LagrangianParticleTracking: DroguedBuoyDynamics
+
+grid = RectilinearGrid(size = (32, 32, 16), x = (-100, 100), y = (-100, 100), z = (-25, 0))
+
+struct CTrackingParticle{T}
+    x :: T
+    y :: T
+    z :: T
+    c :: T
+end
+
+n_particles = 41
+
+drogue_depths = -20:20/(n_particles-1):0
+
+c = CenterField(grid)
+
+particle_properties = StructArray{CTrackingParticle}((zeros(n_particles), 
+                                                      zeros(n_particles), 
+                                                      zeros(n_particles), 
+                                                      zeros(n_particles)))
+
+particles = LagrangianParticles(particle_properties; dynamics = DroguedBuoyDynamics(drogue_depths), tracked_fields = (; c))
+
+ρₒ = 1024
+u₁₀ = 10    # m s⁻¹, average wind velocity 10 meters above the ocean
+cᴰ = 2.5e-3 # dimensionless drag coefficient
+ρₐ = 1.225  # kg m⁻³, average density of air at sea-levelOce
+
+τx = - ρₐ / ρₒ * cᴰ * u₁₀ * abs(u₁₀) # m² s⁻²
+
+u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(τx))
+
+coriolis = FPlane(latitude = 45)
+closure = ScalarDiffusivity(κ = 1e-4, ν = 1e-4)
+advection = UpwindBiased()
+
+model = NonhydrostaticModel(; grid, particles, boundary_conditions = (; u = u_bcs), coriolis, closure, advection, tracers = (; c))
+
+# Random noise damped at top and bottom
+Ξ(z) = randn() * z / model.grid.Lz * (1 + z / model.grid.Lz) # noise
+
+# Velocity initial condition: random noise scaled by the friction velocity.
+uᵢ(x, y, z) = sqrt(abs(τx)) * 1e-3 * Ξ(z)
+
+set!(model, u = uᵢ)
+
+simulation = Simulation(model, Δt = 10, stop_time = 4hours)
+
+conjure_time_step_wizard!(simulation, IterationInterval(100), cfl = 0.5, diffusive_cfl = 0.5)
+
+simulation.output_writers[:velocities] = JLD2Writer(model, model.velocities;
+                                                    overwrite_existing = true, 
+                                                    filename = "drogued_velocities.jld2", 
+                                                    schedule = TimeInterval(10minutes))
+
+prog(sim) = @info prettytime(sim) * " in " * prettytime(sim.run_wall_time) * " with Δt = " * prettytime(sim.Δt)
+
+add_callback!(simulation, prog, IterationInterval(50))
+
+run!(simulation)
+
+simulation.output_writers[:particles] = JLD2Writer(model, (; particles);
+                                                   overwrite_existing = true, 
+                                                   filename = "drogued_particles.jld2", 
+                                                   schedule = TimeInterval(0.1minutes))
+simulation.output_writers[:tracer] = JLD2Writer(model, model.tracers;
+                                                overwrite_existing = true, 
+                                                filename = "drogued_tracer.jld2", 
+                                                schedule = TimeInterval(0.1minutes))
+
+particles.properties.x .= 0 
+particles.properties.y .= 0 
+
+simulation.stop_time += 0.2hours
+
+set!(model, c = (x, y, z) -> exp(-(x^2+y^2)/(2π * 10^2)) * max(0, 1+z/10))
+
+run!(simulation)
+
+c = FieldTimeSeries("drogued_tracer.jld2", "c");
+
+using JLD2, CairoMakie
+
+file = jldopen("drogued_particles.jld2")
+
+iterations = keys(file["timeseries/particles"])[2:end]
+
+n = Observable(1)
+
+fig = Figure(size=(1000, 1200));
+
+ax = Axis(fig[1:4, 1], ylabel = "y (m)", aspect = DataAspect(), title = (@lift "Surface tracer concentration " *  prettytime(c.times[$n])))
+ax2 = Axis(fig[5, 1], xlabel = "x (m)", ylabel = "z (m)",  aspect = DataAspect(), title = "Maximum tracer concentration")
+
+c_plt = @lift interior(c[$n], :, :, grid.Nz)
+c_slice_plt = @lift maximum(c[$n], dims = 2)[1:grid.Nx, 1, 1:grid.Nz]
+
+x_plt = @lift file["timeseries/particles/$(iterations[$n])"].x
+y_plt = @lift file["timeseries/particles/$(iterations[$n])"].y
+particle_c_plt = @lift file["timeseries/particles/$(iterations[$n])"].c
+
+heatmap!(ax, xnodes(c), ynodes(c), c_plt, colorrange = (0, 1), alpha = 0.5)
+
+scatter!(ax, x_plt, y_plt, color = particle_c_plt, colorrange = (0, 1))
+
+heatmap!(ax2, xnodes(c), znodes(c), c_slice_plt, alpha = 0.5, colorrange = (0, 1))
+
+scatter!(ax2, x_plt, drogue_depths, color = particle_c_plt, colorrange = (0, 1))
+


### PR DESCRIPTION
This PR adds `DroguedBuoyDynamics` which goes in the `dynamics` slot for `LagrangianParticles` and makes them move in the x/y directions according to the velocity field at fixed `drogue_depths` as if to mimic the movement of a buoy with a drogue at a fixed depth. This could be used to produce more realistic simulations of observations from buoys.

https://github.com/user-attachments/assets/2c78d968-be4a-4acd-9667-fefe09af634d

CC: @johnryantaylor 