### PR TITLE
Drop TimesDates from direct dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [weakdeps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"


### PR DESCRIPTION
I didn't see this used anywhere in the src code

