### PR TITLE
Enforce mass-conservation inside domains with Radiation OpenBoundaryConditions

### DIFF
--- a/src/Models/NonhydrostaticModels/pressure_correction.jl
+++ b/src/Models/NonhydrostaticModels/pressure_correction.jl
@@ -1,4 +1,118 @@
 import Oceananigans.TimeSteppers: compute_pressure_correction!, make_pressure_correction!
+using Oceananigans.AbstractOperations: Average
+using Oceananigans.Fields: Field
+using Oceananigans.BoundaryConditions: PerturbationAdvection, PerturbationAdvectionOpenBoundaryCondition
+using Oceananigans.ImmersedBoundaries: immersed_inactive_node
+
+const PAOBC = BoundaryCondition{<:Open{<:PerturbationAdvection}}
+const c = Center()
+const f = Face()
+
+# Left boundary averages for normal velocity components
+west_average(u)   = Field(Average(view(u, 1, :, :), dims=(2, 3)))[]
+south_average(v)  = Field(Average(view(v, :, 1, :), dims=(1, 3)))[]
+bottom_average(w) = Field(Average(view(w, :, :, 1), dims=(1, 2)))[]
+
+# Right boundary averages for normal velocity components
+east_average(u)   = Field(Average(view(u, u.grid.Nx + 1, :, :), dims=(2, 3)))[]
+north_average(v)  = Field(Average(view(v, :, v.grid.Ny + 1, :), dims=(1, 3)))[]
+top_average(w)    = Field(Average(view(w, :, :, w.grid.Nz + 1), dims=(1, 2)))[]
+
+function gather_boundary_fluxes(model::NonhydrostaticModel)
+
+    velocities = model.velocities
+    grid = model.grid
+
+    # Get the boundary conditions for the velocities
+    u_bcs = velocities.u.boundary_conditions
+    v_bcs = velocities.v.boundary_conditions
+    w_bcs = velocities.w.boundary_conditions
+
+    # Collect left and right PAOBC boundary conditions into separate lists
+    left_bcs = Symbol[]
+    right_bcs = Symbol[]
+
+    # Initialize fluxes to zero
+    left_flux = zero(grid)
+    right_flux = zero(grid)
+
+    # Calculate flux through left boundaries
+    if u_bcs.west isa PAOBC
+        left_flux += west_average(velocities.u)
+        push!(left_bcs, :west)
+    end
+    if v_bcs.south isa PAOBC
+        left_flux += south_average(velocities.v)
+        push!(left_bcs, :south)
+    end
+    if w_bcs.bottom isa PAOBC
+        left_flux += bottom_average(velocities.w)
+        push!(left_bcs, :bottom)
+    end
+
+    # Calculate flux through right boundaries
+    if u_bcs.east isa PAOBC
+        right_flux += east_average(velocities.u)
+        push!(right_bcs, :east)
+    end
+    if v_bcs.north isa PAOBC
+        right_flux += north_average(velocities.v)
+        push!(right_bcs, :north)
+    end
+    if w_bcs.top isa PAOBC
+        right_flux += top_average(velocities.w)
+        push!(right_bcs, :top)
+    end
+
+    # Calculate total flux (positive means net inflow)
+    total_flux = left_flux - right_flux
+
+    return total_flux, left_bcs, right_bcs
+end
+
+
+
+
+"""
+correct_boundary_mass_flux!(model::NonhydrostaticModel)
+
+Correct boundary mass fluxes for perturbation advection boundary conditions to ensure
+zero net mass flux through each boundary.
+"""
+function correct_boundary_mass_flux!(model::NonhydrostaticModel)
+    velocities = model.velocities
+    grid = model.grid
+
+    total_flux, left_bcs, right_bcs = gather_boundary_fluxes(model)
+
+    # Calculate flux correction per boundary
+    flux_correction_per_boundary = -total_flux / (length(left_bcs) + length(right_bcs))
+
+    # Subtract correction from left boundaries to reduce inflow
+
+    for bc in left_bcs
+        if bc == :west
+            velocities.u[1, :, :] = velocities.u[1, :, :] .- flux_correction_per_boundary
+        elseif bc == :south  
+            velocities.v[:, 1, :] = velocities.v[:, 1, :] .- flux_correction_per_boundary
+        elseif bc == :bottom
+            velocities.w[:, :, 1] = velocities.w[:, :, 1] .- flux_correction_per_boundary
+        end
+    end
+
+    # Add correction to right boundaries to increase outflow
+    for bc in right_bcs
+        if bc == :east
+            velocities.u[size(grid, 1) + 1, :, :] = velocities.u[size(grid, 1) + 1, :, :] .+ flux_correction_per_boundary
+        elseif bc == :north
+            velocities.v[:, size(grid, 2) + 1, :] = velocities.v[:, size(grid, 2) + 1, :] .+ flux_correction_per_boundary
+        elseif bc == :top
+            velocities.w[:, :, size(grid, 3) + 1] = velocities.w[:, :, size(grid, 3) + 1] .+ flux_correction_per_boundary
+        end
+    end
+end
+
+
 
 """
     compute_pressure_correction!(model::NonhydrostaticModel, Δt)
@@ -10,6 +124,9 @@ function compute_pressure_correction!(model::NonhydrostaticModel, Δt)
     # Mask immersed velocities
     foreach(mask_immersed_field!, model.velocities)
     fill_halo_regions!(model.velocities, model.clock, fields(model))
+
+    correct_boundary_mass_flux!(model)
+
     solve_for_pressure!(model.pressures.pNHS, model.pressure_solver, Δt, model.velocities)
     fill_halo_regions!(model.pressures.pNHS)
 

--- a/src/Models/NonhydrostaticModels/pressure_correction.jl
+++ b/src/Models/NonhydrostaticModels/pressure_correction.jl
@@ -98,11 +98,11 @@ function correct_boundary_mass_flux!(model::NonhydrostaticModel)
     # Add extra flux to right boundaries to increase outflow
     for bc in right_bcs
         if bc == :east
-            velocities.u[size(grid, 1) + 1, :, :] = velocities.u[size(grid, 1) + 1, :, :] .+ extra_flux_per_boundary
+            velocities.u[grid.Nx + 1, :, :] = velocities.u[grid.Nx + 1, :, :] .+ extra_flux_per_boundary
         elseif bc == :north
-            velocities.v[:, size(grid, 2) + 1, :] = velocities.v[:, size(grid, 2) + 1, :] .+ extra_flux_per_boundary
+            velocities.v[:, grid.Ny + 1, :] = velocities.v[:, grid.Ny + 1, :] .+ extra_flux_per_boundary
         elseif bc == :top
-            velocities.w[:, :, size(grid, 3) + 1] = velocities.w[:, :, size(grid, 3) + 1] .+ extra_flux_per_boundary
+            velocities.w[:, :, grid.Nz + 1] = velocities.w[:, :, grid.Nz + 1] .+ extra_flux_per_boundary
         end
     end
 end

--- a/src/Models/NonhydrostaticModels/pressure_correction.jl
+++ b/src/Models/NonhydrostaticModels/pressure_correction.jl
@@ -5,8 +5,6 @@ using Oceananigans.BoundaryConditions: PerturbationAdvection, PerturbationAdvect
 using Oceananigans.ImmersedBoundaries: immersed_inactive_node
 
 const PAOBC = BoundaryCondition{<:Open{<:PerturbationAdvection}}
-const c = Center()
-const f = Face()
 
 # Left boundary averages for normal velocity components
 west_average(u)   = Field(Average(view(u, 1, :, :), dims=(2, 3)))[]
@@ -69,8 +67,6 @@ function gather_boundary_fluxes(model::NonhydrostaticModel)
 
     return total_flux, left_bcs, right_bcs
 end
-
-
 
 
 """

--- a/src/Models/NonhydrostaticModels/pressure_correction.jl
+++ b/src/Models/NonhydrostaticModels/pressure_correction.jl
@@ -86,28 +86,27 @@ function correct_boundary_mass_flux!(model::NonhydrostaticModel)
     total_flux, left_bcs, right_bcs = gather_boundary_fluxes(model)
 
     # Calculate flux correction per boundary
-    flux_correction_per_boundary = -total_flux / (length(left_bcs) + length(right_bcs))
+    extra_flux_per_boundary = total_flux / (length(left_bcs) + length(right_bcs))
 
-    # Subtract correction from left boundaries to reduce inflow
-
+    # Subtract extra flux from left boundaries to reduce inflow
     for bc in left_bcs
         if bc == :west
-            velocities.u[1, :, :] = velocities.u[1, :, :] .- flux_correction_per_boundary
+            velocities.u[1, :, :] = velocities.u[1, :, :] .- extra_flux_per_boundary
         elseif bc == :south  
-            velocities.v[:, 1, :] = velocities.v[:, 1, :] .- flux_correction_per_boundary
+            velocities.v[:, 1, :] = velocities.v[:, 1, :] .- extra_flux_per_boundary
         elseif bc == :bottom
-            velocities.w[:, :, 1] = velocities.w[:, :, 1] .- flux_correction_per_boundary
+            velocities.w[:, :, 1] = velocities.w[:, :, 1] .- extra_flux_per_boundary
         end
     end
 
-    # Add correction to right boundaries to increase outflow
+    # Add extra flux to right boundaries to increase outflow
     for bc in right_bcs
         if bc == :east
-            velocities.u[size(grid, 1) + 1, :, :] = velocities.u[size(grid, 1) + 1, :, :] .+ flux_correction_per_boundary
+            velocities.u[size(grid, 1) + 1, :, :] = velocities.u[size(grid, 1) + 1, :, :] .+ extra_flux_per_boundary
         elseif bc == :north
-            velocities.v[:, size(grid, 2) + 1, :] = velocities.v[:, size(grid, 2) + 1, :] .+ flux_correction_per_boundary
+            velocities.v[:, size(grid, 2) + 1, :] = velocities.v[:, size(grid, 2) + 1, :] .+ extra_flux_per_boundary
         elseif bc == :top
-            velocities.w[:, :, size(grid, 3) + 1] = velocities.w[:, :, size(grid, 3) + 1] .+ flux_correction_per_boundary
+            velocities.w[:, :, size(grid, 3) + 1] = velocities.w[:, :, size(grid, 3) + 1] .+ extra_flux_per_boundary
         end
     end
 end

--- a/test/test_mass_conservation.jl
+++ b/test/test_mass_conservation.jl
@@ -1,0 +1,39 @@
+using Oceananigans
+using Oceananigans.BoundaryConditions: PerturbationAdvectionOpenBoundaryCondition
+using Oceananigans.Diagnostics: AdvectiveCFL
+using Printf
+using Random: seed!
+seed!(156)
+
+Δx = Δz = 0.05
+Nx = Nz = round(Int, 2 / Δx)
+grid = RectilinearGrid(size = (Nx, Nz), halo = (4, 4), extent = (1, 1),
+                       topology = (Bounded, Flat, Bounded))
+
+U₀ = 1.0
+inflow_timescale = 1e-1
+outflow_timescale = Inf
+u_boundary_conditions = FieldBoundaryConditions(west = PerturbationAdvectionOpenBoundaryCondition(U₀; inflow_timescale, outflow_timescale),
+                                                east = PerturbationAdvectionOpenBoundaryCondition(U₀; inflow_timescale, outflow_timescale))
+boundary_conditions = (; u = u_boundary_conditions,)
+
+model = NonhydrostaticModel(; grid, boundary_conditions,
+                            timestepper = :RungeKutta3,)
+
+uᵢ(x, z) = U₀ + 1e-4 * rand()
+fill!(model.velocities.u, U₀)
+set!(model, u=uᵢ)
+simulation = Simulation(model; Δt=0.1Δx/U₀, stop_time=1, verbose=false)
+
+cfl_calculator = AdvectiveCFL(simulation.Δt)
+function progress(sim)
+    u, v, w = model.velocities
+    cfl_value = cfl_calculator(model)
+    west_mass_flux = Field(Average(view(u, 1, :, :)))[]
+    east_mass_flux = Field(Average(view(u, grid.Nx+1, :, :)))[]
+    net_mass_flux = east_mass_flux - west_mass_flux
+    @info @sprintf("time: %.3f, max|u|: %.3f, CFL: %.2f, west mass flux: %.6e, east mass flux: %.6e, Net mass flux: %.4e",
+                   time(sim), maximum(abs, u), cfl_value, west_mass_flux, east_mass_flux, net_mass_flux)
+end
+add_callback!(simulation, progress, IterationInterval(20))
+run!(simulation)

--- a/test/test_mass_conservation.jl
+++ b/test/test_mass_conservation.jl
@@ -15,12 +15,16 @@ inflow_timescale = 1e-1
 outflow_timescale = Inf
 u_boundary_conditions = FieldBoundaryConditions(west = PerturbationAdvectionOpenBoundaryCondition(U₀; inflow_timescale, outflow_timescale),
                                                 east = PerturbationAdvectionOpenBoundaryCondition(U₀; inflow_timescale, outflow_timescale))
-boundary_conditions = (; u = u_boundary_conditions,)
+v_boundary_conditions = FieldBoundaryConditions(south = PerturbationAdvectionOpenBoundaryCondition(0; inflow_timescale, outflow_timescale),
+                                                north = PerturbationAdvectionOpenBoundaryCondition(0; inflow_timescale, outflow_timescale))
+w_boundary_conditions = FieldBoundaryConditions(bottom = PerturbationAdvectionOpenBoundaryCondition(0; inflow_timescale, outflow_timescale),
+                                                top = PerturbationAdvectionOpenBoundaryCondition(0; inflow_timescale, outflow_timescale))
+boundary_conditions = (; u = u_boundary_conditions)
 
 model = NonhydrostaticModel(; grid, boundary_conditions,
-                            timestepper = :RungeKutta3,)
+                              timestepper = :RungeKutta3,)
 
-uᵢ(x, z) = U₀ + 1e-4 * rand()
+uᵢ(x, z) = U₀ + 1e-2 * rand()
 fill!(model.velocities.u, U₀)
 set!(model, u=uᵢ)
 simulation = Simulation(model; Δt=0.1Δx/U₀, stop_time=1, verbose=false)
@@ -29,11 +33,9 @@ cfl_calculator = AdvectiveCFL(simulation.Δt)
 function progress(sim)
     u, v, w = model.velocities
     cfl_value = cfl_calculator(model)
-    west_mass_flux = Field(Average(view(u, 1, :, :)))[]
-    east_mass_flux = Field(Average(view(u, grid.Nx+1, :, :)))[]
-    net_mass_flux = east_mass_flux - west_mass_flux
-    @info @sprintf("time: %.3f, max|u|: %.3f, CFL: %.2f, west mass flux: %.6e, east mass flux: %.6e, Net mass flux: %.4e",
-                   time(sim), maximum(abs, u), cfl_value, west_mass_flux, east_mass_flux, net_mass_flux)
+    net_mass_flux2 = ∫∇u = Field(Integral(∂x(u) + ∂z(w)))[]
+    @info @sprintf("time: %.3f, max|u|: %.3f, CFL: %.2f, Net2: %.4e",
+                   time(sim), maximum(abs, u), cfl_value, net_mass_flux2)
 end
 add_callback!(simulation, progress, IterationInterval(20))
 run!(simulation)


### PR DESCRIPTION
Recently (I think in https://github.com/CliMA/Oceananigans.jl/pull/4578) we found that mass wasn't being exactly conserved whenever PerturbationAdvection was used as an open boundary condition. This PR (which is a draft for now) explores adding a correction to normal velocities at the boundaries right before `solve_for_pressure!()` is called which enforces that no net mass enters or leaves the domain.

At the moment the algorithm is not optimized (suggestions on how to do that are welcome) but it works by:

1. Calculating the net mass (really, momentum) flux into the domain by integrating the velocities at the boundaries (only for boundaries with an OpenBoundaryCondition with a matching scheme)
2. Dividing the correction equally between all the aforementioned boundaries
3. Adding/subtracting the same correction constant to left/right open boundaries

A [MWE measuring the net mass flux](https://github.com/CliMA/Oceananigans.jl/blob/tc/mass-flux-correction/test/test_mass_conservation.jl) into the domain produces this result without the correction:

```julia
[ Info: time: 0.000, max|u|: 1.011, CFL: 0.20, Net flux: 1.9306e-03
[ Info: time: 0.100, max|u|: 1.010, CFL: 0.20, Net flux: 4.1407e-03
[ Info: time: 0.200, max|u|: 1.009, CFL: 0.20, Net flux: 4.6124e-03
[ Info: time: 0.300, max|u|: 1.009, CFL: 0.20, Net flux: 4.4737e-03
[ Info: time: 0.400, max|u|: 1.008, CFL: 0.20, Net flux: 4.1404e-03
[ Info: time: 0.500, max|u|: 1.008, CFL: 0.20, Net flux: 3.7634e-03
[ Info: time: 0.600, max|u|: 1.008, CFL: 0.20, Net flux: 3.3962e-03
[ Info: time: 0.700, max|u|: 1.007, CFL: 0.20, Net flux: 3.0557e-03
[ Info: time: 0.800, max|u|: 1.006, CFL: 0.20, Net flux: 2.7461e-03
[ Info: time: 0.900, max|u|: 1.007, CFL: 0.20, Net flux: 2.4666e-03
[ Info: time: 1.000, max|u|: 1.006, CFL: 0.20, Net flux: 2.2152e-03
```

and this result with the correction:

```julia
[ Info: time: 0.000, max|u|: 1.011, CFL: 0.20, Net flux: 3.8326e-16
[ Info: time: 0.100, max|u|: 1.008, CFL: 0.20, Net flux: -2.7974e-18
[ Info: time: 0.200, max|u|: 1.007, CFL: 0.20, Net flux: 3.4705e-16
[ Info: time: 0.300, max|u|: 1.007, CFL: 0.20, Net flux: 5.3560e-16
[ Info: time: 0.400, max|u|: 1.006, CFL: 0.20, Net flux: -1.0820e-16
[ Info: time: 0.500, max|u|: 1.006, CFL: 0.20, Net flux: -1.6355e-16
[ Info: time: 0.600, max|u|: 1.006, CFL: 0.20, Net flux: -4.9130e-16
[ Info: time: 0.700, max|u|: 1.006, CFL: 0.20, Net flux: 2.5534e-16
[ Info: time: 0.800, max|u|: 1.005, CFL: 0.20, Net flux: -3.0518e-16
[ Info: time: 0.900, max|u|: 1.005, CFL: 0.20, Net flux: 4.2174e-16
[ Info: time: 1.000, max|u|: 1.005, CFL: 0.20, Net flux: 1.2774e-16
```

Notes:

1. This came about in the context of immersed boundaries, but no immersed boundary is necessary to produce these results. Flows with open (radiation) boundaries seem to be divergent even in regular grids, although the FFTSolver seems to handle this well enough that we haven't had problems.
2. @jagoosw I'm curious about your thoughts here. You mentioned before that this might be due to an asymmetry between left and right boundaries when time-stepping the code, but I don't see how the PerturbationAdvection matching scheme (where boundary velocities are computed locally) can be made to always provide velocities at the boundary that are consistent with zero mass flux without having some sort of nonlocal correction.

cc @glwagner @xkykai @ali-ramadhan 