### PR TITLE
tick! does that; no need to repeat

### DIFF
--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -125,7 +125,6 @@ function time_step!(model::AbstractModel{<:SplitRungeKutta3TimeStepper}, Δt; ca
     step_lagrangian_particles!(model, Δt)
 
     tick!(model.clock, Δt)
-    model.clock.last_Δt = Δt
 
     return nothing
 end


### PR DESCRIPTION
This PR removes a redundant step after ticking the clock for the SplitExplicitRK3 timestepper which, after #4637, is done via `tick!(clock)` method.

