### PR TITLE
Add `using CUDA` in benchmark tests + remove extra CUDA-specific methods from tests

### DIFF
--- a/.buildkite/pipeline-benchmarks.yml
+++ b/.buildkite/pipeline-benchmarks.yml
@@ -1,5 +1,5 @@
 env:
-  JULIA_VERSION: "1.10.9"
+  JULIA_VERSION: "1.10.10"
   JULIA_MINOR_VERSION: "1.10"
   TARTARUS_HOME: "/storage5/buildkite-agent"
   JULIA_DEPOT_PATH: "$TARTARUS_HOME/.julia-$BUILDKITE_BUILD_NUMBER"
@@ -29,7 +29,7 @@ steps:
           limit: 1
 
   - wait
-    
+
   - label: "🚀 Oceananigans GPU benchmarks"
     key: "benchmarks"
     agents:
@@ -47,7 +47,7 @@ steps:
         "bounded_cheap_advection"
         "immersed"
       )
-      
+
       # Profile each benchmark group, save output in txt and remove profiles
       for BENCHMARK_GROUP in "\${BENCHMARK_GROUPS[@]}"; do
         # Run benchmarks

--- a/.buildkite/pipeline-benchmarks.yml
+++ b/.buildkite/pipeline-benchmarks.yml
@@ -37,7 +37,7 @@ steps:
 
     command: |
       # Instantiate
-      $TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project --check-bounds=no -e 'using Pkg; Pkg.instantiate()'
+      $TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project --check-bounds=no -e 'using Pkg; Pkg.add("CUDA"); Pkg.instantiate()'
 
       # List of benchmark groups
       BENCHMARK_GROUPS=(

--- a/.buildkite/pipeline-benchmarks.yml
+++ b/.buildkite/pipeline-benchmarks.yml
@@ -77,7 +77,7 @@ steps:
       queue: "Oceananigans-benchmarks"
 
     command: |
-      # First we donwload the artifacts from the current PR build
+      # First we download the artifacts from the current PR build
       buildkite-agent artifact download "*.txt" .
 
       # Getting the JSON file of the latest passing main build

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -3,8 +3,8 @@ using Oceananigans.Units
 using Oceananigans.Architectures: on_architecture
 using Oceananigans.TurbulenceClosures.TKEBasedVerticalDiffusivities: CATKEVerticalDiffusivity
 using SeawaterPolynomials.TEOS10
-using Random
 using CUDA
+using Random
 
 function ocean_benchmark(arch, Nx, Ny, Nz, topology, immersed, tracer_advection=WENO(order=7))    
     

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -4,6 +4,7 @@ using Oceananigans.Architectures: on_architecture
 using Oceananigans.TurbulenceClosures.TKEBasedVerticalDiffusivities: CATKEVerticalDiffusivity
 using SeawaterPolynomials.TEOS10
 using Random
+using CUDA
 
 function ocean_benchmark(arch, Nx, Ny, Nz, topology, immersed, tracer_advection=WENO(order=7))    
     

--- a/test/dependencies_for_poisson_solvers.jl
+++ b/test/dependencies_for_poisson_solvers.jl
@@ -54,7 +54,7 @@ function random_divergent_source_term(grid::ImmersedBoundaryGrid)
     set!(Ru, rand(size(Ru)...))
     set!(Rv, rand(size(Rv)...))
     set!(Rw, rand(size(Rw)...))
-    
+
     mask_immersed_field!(Ru)
     mask_immersed_field!(Rv)
     mask_immersed_field!(Rw)
@@ -125,7 +125,7 @@ function divergence_free_poisson_solution(grid, planner_flag=FFTW.MEASURE)
 
     compute_∇²!(∇²ϕ, ϕ, arch, grid)
 
-    return CUDA.@allowscalar interior(∇²ϕ) ≈ R
+    return @allowscalar interior(∇²ϕ) ≈ R
 end
 
 #####
@@ -213,7 +213,7 @@ function stretched_poisson_solver_correct_answer(FT, arch, topo, N1, N2, faces; 
     solve!(ϕc, solver)
 
     # interior(ϕ) = solution(solver) or solution!(interior(ϕ), solver)
-    CUDA.@allowscalar interior(ϕ) .= real.(solver.storage)
+    @allowscalar interior(ϕ) .= real.(solver.storage)
     compute_∇²!(∇²ϕ, ϕ, arch, stretched_grid)
 
     return Array(interior(∇²ϕ)) ≈ Array(R)

--- a/test/dependencies_for_runtests.jl
+++ b/test/dependencies_for_runtests.jl
@@ -10,10 +10,10 @@ using JLD2
 using FFTW
 using OffsetArrays
 using SeawaterPolynomials
-using CUDA
 using MPI
 using Adapt
 using GPUArraysCore
+using CUDA
 
 MPI.Initialized() || MPI.Init()
 

--- a/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
+++ b/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
@@ -143,7 +143,7 @@ function run_ocean_large_eddy_simulation_regression_test(arch, grid_type, closur
 
     solution₁, Gⁿ₁, G⁻₁ = get_fields_from_checkpoint(final_filename)
 
-    test_fields = CUDA.@allowscalar (u = Array(interior(model.velocities.u)),
+    test_fields = @allowscalar (u = Array(interior(model.velocities.u)),
                                      v = Array(interior(model.velocities.v)),
                                      w = Array(interior(model.velocities.w)[:, :, 1:nz]),
                                      T = Array(interior(model.tracers.T)),

--- a/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
+++ b/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
@@ -144,10 +144,10 @@ function run_ocean_large_eddy_simulation_regression_test(arch, grid_type, closur
     solution₁, Gⁿ₁, G⁻₁ = get_fields_from_checkpoint(final_filename)
 
     test_fields = @allowscalar (u = Array(interior(model.velocities.u)),
-                                     v = Array(interior(model.velocities.v)),
-                                     w = Array(interior(model.velocities.w)[:, :, 1:nz]),
-                                     T = Array(interior(model.tracers.T)),
-                                     S = Array(interior(model.tracers.S)))
+                                v = Array(interior(model.velocities.v)),
+                                w = Array(interior(model.velocities.w)[:, :, 1:nz]),
+                                T = Array(interior(model.tracers.T)),
+                                S = Array(interior(model.tracers.S)))
 
     u₁ = partition(Array(solution₁.u)[2:end-1, 2:end-1, 2:end-1], cpu_arch, size(u))
     v₁ = partition(Array(solution₁.v)[2:end-1, 2:end-1, 2:end-1], cpu_arch, size(v))

--- a/test/regression_tests/rayleigh_benard_regression_test.jl
+++ b/test/regression_tests/rayleigh_benard_regression_test.jl
@@ -158,10 +158,10 @@ function run_rayleigh_benard_regression_test(arch, grid_type)
     solution₁, Gⁿ₁, G⁻₁ = get_fields_from_checkpoint(final_filename)
 
     test_fields =  @allowscalar (u = Array(interior(model.velocities.u)),
-                                      v = Array(interior(model.velocities.v)),
-                                      w = Array(interior(model.velocities.w)[:, :, 1:Nz]),
-                                      b = Array(interior(model.tracers.b)),
-                                      c = Array(interior(model.tracers.c)))
+                                 v = Array(interior(model.velocities.v)),
+                                 w = Array(interior(model.velocities.w)[:, :, 1:Nz]),
+                                 b = Array(interior(model.tracers.b)),
+                                 c = Array(interior(model.tracers.c)))
 
     global_grid = reconstruct_global_grid(model.grid)
 

--- a/test/regression_tests/rayleigh_benard_regression_test.jl
+++ b/test/regression_tests/rayleigh_benard_regression_test.jl
@@ -157,7 +157,7 @@ function run_rayleigh_benard_regression_test(arch, grid_type)
 
     solution₁, Gⁿ₁, G⁻₁ = get_fields_from_checkpoint(final_filename)
 
-    test_fields =  CUDA.@allowscalar (u = Array(interior(model.velocities.u)),
+    test_fields =  @allowscalar (u = Array(interior(model.velocities.u)),
                                       v = Array(interior(model.velocities.v)),
                                       w = Array(interior(model.velocities.w)[:, :, 1:Nz]),
                                       b = Array(interior(model.tracers.b)),

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -4,7 +4,7 @@ function simple_binary_operation(op, a, b, num1, num2)
     a_b = op(a, b)
     interior(a) .= num1
     interior(b) .= num2
-    return CUDA.@allowscalar a_b[2, 2, 2] == op(num1, num2)
+    return @allowscalar a_b[2, 2, 2] == op(num1, num2)
 end
 
 function three_field_addition(a, b, c, num1, num2)
@@ -12,7 +12,7 @@ function three_field_addition(a, b, c, num1, num2)
     interior(a) .= num1
     interior(b) .= num2
     interior(c) .= num2
-    return CUDA.@allowscalar a_b_c[2, 2, 2] == num1 + num2 + num2
+    return @allowscalar a_b_c[2, 2, 2] == num1 + num2 + num2
 end
 
 function x_derivative(a)
@@ -27,7 +27,7 @@ function x_derivative(a)
         interior(a)[:, 3, k] .= one_two_three
     end
 
-    return CUDA.@allowscalar dx_a[2, 2, 2] == 1
+    return @allowscalar dx_a[2, 2, 2] == 1
 end
 
 function y_derivative(a)
@@ -42,7 +42,7 @@ function y_derivative(a)
         interior(a)[3, :, k] .= one_three_five
     end
 
-    return CUDA.@allowscalar dy_a[2, 2, 2] == 2
+    return @allowscalar dy_a[2, 2, 2] == 2
 end
 
 function z_derivative(a)
@@ -57,7 +57,7 @@ function z_derivative(a)
         interior(a)[3, k, :] .= one_four_seven
     end
 
-    return CUDA.@allowscalar dz_a[2, 2, 2] == 3
+    return @allowscalar dz_a[2, 2, 2] == 3
 end
 
 function x_derivative_cell(arch)
@@ -73,12 +73,12 @@ function x_derivative_cell(arch)
         interior(a)[:, 3, k] .= one_four_four
     end
 
-    return CUDA.@allowscalar dx_a[2, 2, 2] == 3
+    return @allowscalar dx_a[2, 2, 2] == 3
 end
 
 function times_x_derivative(a, b, location, i, j, k, answer)
     b∇a = @at location b * ∂x(a)
-    return CUDA.@allowscalar b∇a[i, j, k] == answer
+    return @allowscalar b∇a[i, j, k] == answer
 end
 
 for arch in archs
@@ -92,12 +92,12 @@ for arch in archs
         @testset "Unary operations and derivatives [$(typeof(arch))]" begin
             for ψ in (u, v, w, c)
                 for op in (sqrt, sin, cos, exp, tanh)
-                    @test CUDA.@allowscalar typeof(op(ψ)[2, 2, 2]) <: Number
+                    @test @allowscalar typeof(op(ψ)[2, 2, 2]) <: Number
                 end
 
                 for d_symbol in Oceananigans.AbstractOperations.derivative_operators
                     d = eval(d_symbol)
-                    @test CUDA.@allowscalar typeof(d(ψ)[2, 2, 2]) <: Number
+                    @test @allowscalar typeof(d(ψ)[2, 2, 2]) <: Number
                 end
             end
         end
@@ -107,7 +107,7 @@ for arch in archs
             for (ψ, ϕ) in ((u, v), (u, w), (v, w), (u, c), (generic_function, c), (u, generic_function))
                 for op_symbol in Oceananigans.AbstractOperations.binary_operators
                     op = eval(op_symbol)
-                    @test CUDA.@allowscalar typeof(op(ψ, ϕ)[2, 2, 2]) <: Number
+                    @test @allowscalar typeof(op(ψ, ϕ)[2, 2, 2]) <: Number
                 end
             end
 
@@ -149,7 +149,7 @@ for arch in archs
             for (ψ, ϕ, σ) in ((u, v, w), (u, v, c), (u, v, generic_function))
                 for op_symbol in Oceananigans.AbstractOperations.multiary_operators
                     op = eval(op_symbol)
-                    @test CUDA.@allowscalar typeof(op((Center, Center, Center), ψ, ϕ, σ)[2, 2, 2]) <: Number
+                    @test @allowscalar typeof(op((Center, Center, Center), ψ, ϕ, σ)[2, 2, 2]) <: Number
                 end
             end
         end
@@ -301,7 +301,7 @@ for arch in archs
                         f = Field(loc, rectilinear_grid)
                         f .= 1
 
-                        CUDA.@allowscalar begin
+                        @allowscalar begin
                             # Δx, Δy, Δz = 2, 3, 4
                             # Ax, Ay, Az = 12, 8, 6
                             # volume = 24

--- a/test/test_biogeochemistry.jl
+++ b/test/test_biogeochemistry.jl
@@ -118,8 +118,8 @@ function test_biogeochemistry(grid, MinimalBiogeochemistryType, ModelType)
 
     time_step!(model, 1)
 
-    @test CUDA.@allowscalar any(biogeochemistry.photosynthetic_active_radiation .!= 0) # update state did get called
-    @test CUDA.@allowscalar any(model.tracers.P .!= 1) # bgc forcing did something
+    @test @allowscalar any(biogeochemistry.photosynthetic_active_radiation .!= 0) # update state did get called
+    @test @allowscalar any(model.tracers.P .!= 1) # bgc forcing did something
 
     return nothing
 end

--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -15,20 +15,20 @@ include("dependencies_for_runtests.jl")
         Nx, Ny, Nz = size(a)
 
         a .= 1
-        @test CUDA.@allowscalar all(a .== 1)
+        @test @allowscalar all(a .== 1)
 
         b .= 2
 
         c .= a .+ b
-        @test CUDA.@allowscalar all(c .== 3)
+        @test @allowscalar all(c .== 3)
 
         c .= a .+ b .+ 1
-        @test CUDA.@allowscalar all(c .== 4)
+        @test @allowscalar all(c .== 4)
 
         # Halo regions
         fill_halo_regions!(c) # Does not happen by default in broadcasting now
 
-        CUDA.@allowscalar begin
+        @allowscalar begin
             @test c[1, 1, 0] == 4
             @test c[1, 1, Nz+1] == 4
         end
@@ -47,7 +47,7 @@ include("dependencies_for_runtests.jl")
         b2 .= 1
         fill_halo_regions!(b2) # sets b2[1, 1, 1] = b[1, 1, 4] = 0
 
-        CUDA.@allowscalar begin
+        @allowscalar begin
             @test b2[1, 1, 1] == 0
             @test b2[1, 1, 2] == 1
             @test b2[1, 1, 3] == 1
@@ -56,7 +56,7 @@ include("dependencies_for_runtests.jl")
 
         a2 .= b2
 
-        CUDA.@allowscalar begin
+        @allowscalar begin
             @test a2[1, 1, 1] == 0.5
             @test a2[1, 1, 2] == 1.0
             @test a2[1, 1, 3] == 0.5
@@ -64,7 +64,7 @@ include("dependencies_for_runtests.jl")
 
         a2 .= b2 .+ 1
 
-        CUDA.@allowscalar begin
+        @allowscalar begin
             @test a2[1, 1, 1] == 1.5
             @test a2[1, 1, 2] == 2.0
             @test a2[1, 1, 3] == 1.5
@@ -89,15 +89,15 @@ include("dependencies_for_runtests.jl")
             r, p, q = [Field(loc, grid) for i = 1:3]
 
             r .= 2
-            @test CUDA.@allowscalar all(r .== 2)
+            @test @allowscalar all(r .== 2)
 
             p .= 3
 
             q .= r .* p
-            @test CUDA.@allowscalar all(q .== 6)
+            @test @allowscalar all(q .== 6)
 
             q .= r .* p .+ 1
-            @test CUDA.@allowscalar all(q .== 7)
+            @test @allowscalar all(q .== 7)
         end
 
 

--- a/test/test_buoyancy.jl
+++ b/test/test_buoyancy.jl
@@ -20,48 +20,48 @@ end
 function density_perturbation_works(arch, FT, eos)
     grid = RectilinearGrid(arch, FT, size=(3, 3, 3), extent=(1, 1, 1))
     C = TracerFields((:T, :S), grid)
-    density_anomaly = CUDA.@allowscalar ρ′(2, 2, 2, grid, eos, C.T, C.S)
+    density_anomaly = @allowscalar ρ′(2, 2, 2, grid, eos, C.T, C.S)
     return true
 end
 
 function ∂x_b_works(arch, FT, buoyancy)
     grid = RectilinearGrid(arch, FT, size=(3, 3, 3), extent=(1, 1, 1))
     C = TracerFields(required_tracers(buoyancy), grid)
-    dbdx = CUDA.@allowscalar ∂x_b(2, 2, 2, grid, buoyancy, C)
+    dbdx = @allowscalar ∂x_b(2, 2, 2, grid, buoyancy, C)
     return true
 end
 
 function ∂y_b_works(arch, FT, buoyancy)
     grid = RectilinearGrid(arch, FT, size=(3, 3, 3), extent=(1, 1, 1))
     C = TracerFields(required_tracers(buoyancy), grid)
-    dbdy = CUDA.@allowscalar ∂y_b(2, 2, 2, grid, buoyancy, C)
+    dbdy = @allowscalar ∂y_b(2, 2, 2, grid, buoyancy, C)
     return true
 end
 
 function ∂z_b_works(arch, FT, buoyancy)
     grid = RectilinearGrid(arch, FT, size=(3, 3, 3), extent=(1, 1, 1))
     C = TracerFields(required_tracers(buoyancy), grid)
-    dbdz = CUDA.@allowscalar ∂z_b(2, 2, 2, grid, buoyancy, C)
+    dbdz = @allowscalar ∂z_b(2, 2, 2, grid, buoyancy, C)
     return true
 end
 
 function thermal_expansion_works(arch, FT, eos)
     grid = RectilinearGrid(arch, FT, size=(3, 3, 3), extent=(1, 1, 1))
     C = TracerFields((:T, :S), grid)
-    α = CUDA.@allowscalar thermal_expansionᶜᶜᶜ(2, 2, 2, grid, eos, C.T, C.S)
-    α = CUDA.@allowscalar thermal_expansionᶠᶜᶜ(2, 2, 2, grid, eos, C.T, C.S)
-    α = CUDA.@allowscalar thermal_expansionᶜᶠᶜ(2, 2, 2, grid, eos, C.T, C.S)
-    α = CUDA.@allowscalar thermal_expansionᶜᶜᶠ(2, 2, 2, grid, eos, C.T, C.S)
+    α = @allowscalar thermal_expansionᶜᶜᶜ(2, 2, 2, grid, eos, C.T, C.S)
+    α = @allowscalar thermal_expansionᶠᶜᶜ(2, 2, 2, grid, eos, C.T, C.S)
+    α = @allowscalar thermal_expansionᶜᶠᶜ(2, 2, 2, grid, eos, C.T, C.S)
+    α = @allowscalar thermal_expansionᶜᶜᶠ(2, 2, 2, grid, eos, C.T, C.S)
     return true
 end
 
 function haline_contraction_works(arch, FT, eos)
     grid = RectilinearGrid(arch, FT, size=(3, 3, 3), extent=(1, 1, 1))
     C = TracerFields((:T, :S), grid)
-    β = CUDA.@allowscalar haline_contractionᶜᶜᶜ(2, 2, 2, grid, eos, C.T, C.S)
-    β = CUDA.@allowscalar haline_contractionᶠᶜᶜ(2, 2, 2, grid, eos, C.T, C.S)
-    β = CUDA.@allowscalar haline_contractionᶜᶠᶜ(2, 2, 2, grid, eos, C.T, C.S)
-    β = CUDA.@allowscalar haline_contractionᶜᶜᶠ(2, 2, 2, grid, eos, C.T, C.S)
+    β = @allowscalar haline_contractionᶜᶜᶜ(2, 2, 2, grid, eos, C.T, C.S)
+    β = @allowscalar haline_contractionᶠᶜᶜ(2, 2, 2, grid, eos, C.T, C.S)
+    β = @allowscalar haline_contractionᶜᶠᶜ(2, 2, 2, grid, eos, C.T, C.S)
+    β = @allowscalar haline_contractionᶜᶜᶠ(2, 2, 2, grid, eos, C.T, C.S)
     return true
 end
 

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -7,7 +7,7 @@ using Glob
 #####
 
 function test_model_equality(test_model, true_model)
-    CUDA.@allowscalar begin
+    @allowscalar begin
         test_model_fields = prognostic_fields(test_model)
         true_model_fields = prognostic_fields(true_model)
         field_names = keys(test_model_fields)
@@ -183,7 +183,7 @@ function test_constant_fields_checkpointer(arch)
 
     simulation = Simulation(model, Δt=0.1, stop_iteration=1)
     simulation.output_writers[:checkpointer] = Checkpointer(model, prefix="constant_fields_test",
-                                                            schedule=IterationInterval(1), 
+                                                            schedule=IterationInterval(1),
                                                             properties = [:grid, :velocities])
 
     run!(simulation)

--- a/test/test_computed_field.jl
+++ b/test/test_computed_field.jl
@@ -107,7 +107,7 @@ function volume_average_of_times(model)
     T, S = model.tracers
 
     @compute ST = Field(Average(S * T, dims=(1, 2, 3)))
-    result = CUDA.@allowscalar ST[1, 1, 1]
+    result = @allowscalar ST[1, 1, 1]
 
     return result ≈ 0.5
 end

--- a/test/test_conditional_reductions.jl
+++ b/test/test_conditional_reductions.jl
@@ -59,7 +59,7 @@ include("dependencies_for_runtests.jl")
 
         redimm = Field{Nothing, Center, Center}(ibg)
         for (reduc, reduc!) in zip((mean, maximum, minimum, sum, prod), (mean!, maximum!, minimum!, sum!, prod!))
-            @test CUDA.@allowscalar reduc!(redimm, fimm)[1, 1 , 1] == reduc(fcon, condition = (i, j, k, x, y) -> i > 3, dims = 1)[1, 1, 1]
+            @test @allowscalar reduc!(redimm, fimm)[1, 1 , 1] == reduc(fcon, condition = (i, j, k, x, y) -> i > 3, dims = 1)[1, 1, 1]
         end
     end
 end

--- a/test/test_conjugate_gradient_poisson_solver.jl
+++ b/test/test_conjugate_gradient_poisson_solver.jl
@@ -233,7 +233,7 @@ function test_divergence_free_solution(arch, float_type, topos)
         for N in [7, 16]
             grid = make_random_immersed_grid(RectilinearGrid(arch, float_type, topology=topo; size_and_extent_from_topo(N, topo)...))
             ϕ, ∇²ϕ, R = compute_pressure_solution(grid)
-            @test CUDA.@allowscalar interior(∇²ϕ) ≈ interior(R)
+            @test @allowscalar interior(∇²ϕ) ≈ interior(R)
             @test isapprox(mean(ϕ), 0, atol=eps(eltype(grid)))
         end
     end
@@ -246,7 +246,7 @@ function test_divergence_free_solution_on_rectangular_grids(arch, topos)
         for Nx in Ns, Ny in Ns, Nz in Ns
             grid = make_random_immersed_grid(RectilinearGrid(arch, topology=topo, size=(Nx, Ny, Nz), extent=(1, 1, 1)))
             ϕ, ∇²ϕ, R = compute_pressure_solution(grid)
-            @test CUDA.@allowscalar interior(∇²ϕ) ≈ interior(R)
+            @test @allowscalar interior(∇²ϕ) ≈ interior(R)
             @test isapprox(mean(ϕ), 0, atol=eps(eltype(grid)))
         end
     end

--- a/test/test_cubed_sphere_circulation.jl
+++ b/test/test_cubed_sphere_circulation.jl
@@ -54,7 +54,7 @@ for arch in archs
             v_field = YFaceField(grid)
 
             ψ(λ, φ) = R * sind(φ)
-            CUDA.@allowscalar set_velocities_from_streamfunction!(u_field, v_field, ψ, arch, grid)
+            @allowscalar set_velocities_from_streamfunction!(u_field, v_field, ψ, arch, grid)
 
             fill_horizontal_velocity_halos!(u_field, v_field, arch)
 

--- a/test/test_cubed_sphere_halo_exchange.jl
+++ b/test/test_cubed_sphere_halo_exchange.jl
@@ -38,14 +38,14 @@ for arch in archs
             j_digits(n) = digits(abs(Int(n)))[1:2] |> undigits
 
             for (face_number, field_face) in enumerate(faces(field))
-                for i in 1:field_face.grid.Nx, j in 1:field_face.grid.Ny
-                    CUDA.@allowscalar field_face[i, j, 1] = parse(Int, @sprintf("%d%02d%02d", face_number, i, j))
+                for j in 1:field_face.grid.Ny, i in 1:field_face.grid.Nx,
+                    @allowscalar field_face[i, j, 1] = parse(Int, @sprintf("%d%02d%02d", face_number, i, j))
                 end
             end
 
             fill_halo_regions!(field)
 
-            CUDA.allowscalar(true)
+            allowscalar(true)
 
             @testset "Source and destination faces are correct" begin
                 for (face_number, field_face) in enumerate(faces(field))
@@ -402,14 +402,14 @@ for arch in archs
             j_digits(n) = digits(abs(Int(n)))[1:2] |> undigits
 
             for (face_number, u_field_face) in enumerate(faces(u_field))
-                for i in 1:u_field_face.grid.Nx+1, j in 1:u_field_face.grid.Ny
-                    CUDA.@allowscalar u_field_face[i, j, 1] = parse(Int, @sprintf("%d%d%02d%02d", U_DIGIT, face_number, i, j))
+                for j in 1:u_field_face.grid.Ny, i in 1:u_field_face.grid.Nx+1
+                    @allowscalar u_field_face[i, j, 1] = parse(Int, @sprintf("%d%d%02d%02d", U_DIGIT, face_number, i, j))
                 end
             end
 
             for (face_number, v_field_face) in enumerate(faces(v_field))
-                for i in 1:v_field_face.grid.Nx, j in 1:v_field_face.grid.Ny+1
-                    CUDA.@allowscalar v_field_face[i, j, 1] = parse(Int, @sprintf("%d%d%02d%02d", V_DIGIT, face_number, i, j))
+                for j in 1:v_field_face.grid.Ny+1, i in 1:v_field_face.grid.Nx
+                    @allowscalar v_field_face[i, j, 1] = parse(Int, @sprintf("%d%d%02d%02d", V_DIGIT, face_number, i, j))
                 end
             end
 

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -92,7 +92,7 @@ function advective_timescale_cfl_on_stretched_grid(arch, FT)
     Δy = model.grid.Δyᵃᶜᵃ
 
     # At k = 1, w = 0 so the CFL constraint happens at the second face (k = 2).
-    Δz_min = CUDA.@allowscalar Oceananigans.Operators.Δzᵃᵃᶠ(1, 1, 2, grid)
+    Δz_min = @allowscalar Oceananigans.Operators.Δzᵃᵃᶠ(1, 1, 2, grid)
 
     u₀ = FT(1.2)
     v₀ = FT(-2.5)
@@ -116,10 +116,10 @@ function advective_timescale_cfl_on_lat_lon_grid(arch, FT)
     Nx, Ny, Nz = size(grid)
 
     # Will be the smallest at higher latitudes.
-    Δx_min = CUDA.@allowscalar Oceananigans.Operators.Δxᶠᶜᵃ(1, Ny, 1, grid)
+    Δx_min = @allowscalar Oceananigans.Operators.Δxᶠᶜᵃ(1, Ny, 1, grid)
 
     # Will be the same at every grid point.
-    Δy_min = CUDA.@allowscalar Oceananigans.Operators.Δyᶜᶠᵃ(1, 1, 1, grid)
+    Δy_min = @allowscalar Oceananigans.Operators.Δyᶜᶠᵃ(1, 1, 1, grid)
 
     Δz = model.grid.z.Δᵃᵃᶠ
 

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -478,7 +478,7 @@ end
             @test sum(c) == 1*N + 2*N + 3*N + 4*N
 
             sum!(c_reduced, c)
-            @test CUDA.@allowscalar c_reduced[1, 1, 1] == 1*N + 2*N + 3*N + 4*N
+            @test @allowscalar c_reduced[1, 1, 1] == 1*N + 2*N + 3*N + 4*N
 
             cbool = CenterField(grid, Bool)
             cbool_reduced = Field{Nothing, Nothing, Nothing}(grid, Bool)
@@ -489,10 +489,10 @@ end
             @test all(cbool) == false
 
             any!(cbool_reduced, cbool)
-            @test CUDA.@allowscalar cbool_reduced[1, 1, 1] == true
+            @test @allowscalar cbool_reduced[1, 1, 1] == true
             
             all!(cbool_reduced, cbool)
-            @test CUDA.@allowscalar cbool_reduced[1, 1, 1] == false
+            @test @allowscalar cbool_reduced[1, 1, 1] == false
         end
     end
 

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -355,7 +355,7 @@ end
 
 function test_triply_periodic_halo_communication_with_141_ranks(halo, child_arch)
     arch = Distributed(child_arch; partition=Partition(1, 4))
-    grid  = RectilinearGrid(arch; topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3), halos)
+    grid  = RectilinearGrid(arch; topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3), halo)
     model = NonhydrostaticModel(; grid)
 
     for field in (fields(model)..., model.pressures.pNHS)

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -489,9 +489,13 @@ end
             @test all(cbool) == false
 
             any!(cbool_reduced, cbool)
+            @show cbool_reduced[1, 1, 1]
+            @allowscalar cbool_reduced[1, 1, 1]
             @test @allowscalar cbool_reduced[1, 1, 1] == true
 
             all!(cbool_reduced, cbool)
+            @show cbool_reduced[1, 1, 1]
+            @show @allowscalar cbool_reduced[1, 1, 1]
             @test @allowscalar cbool_reduced[1, 1, 1] == false
         end
     end

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -478,8 +478,6 @@ end
             @test sum(c) == 1*N + 2*N + 3*N + 4*N
 
             sum!(c_reduced, c)
-            @show @allowscalar c_reduced[1, 1, 1]
-            @show 1*N + 2*N + 3*N + 4*N
             @test @allowscalar c_reduced[1, 1, 1] == 1*N + 2*N + 3*N + 4*N
 
             cbool = CenterField(grid, Bool)
@@ -491,13 +489,9 @@ end
             @test all(cbool) == false
 
             any!(cbool_reduced, cbool)
-            @show cbool_reduced[1, 1, 1]
-            @allowscalar cbool_reduced[1, 1, 1]
             @test @allowscalar cbool_reduced[1, 1, 1] == true
 
             all!(cbool_reduced, cbool)
-            @show cbool_reduced[1, 1, 1]
-            @show @allowscalar cbool_reduced[1, 1, 1]
             @test @allowscalar cbool_reduced[1, 1, 1] == false
         end
     end

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -282,7 +282,7 @@ end
 function test_triply_periodic_bc_injection_with_411_ranks()
     arch = Distributed(partition=Partition(4))
     grid = RectilinearGrid(arch, topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3))
-    model = NonhydrostaticModel(grid=grid)
+    model = NonhydrostaticModel(; grid)
 
     for field in merge(fields(model))
         fbcs = field.boundary_conditions
@@ -298,7 +298,7 @@ end
 function test_triply_periodic_bc_injection_with_141_ranks()
     arch = Distributed(partition=Partition(1, 4))
     grid = RectilinearGrid(arch, topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3))
-    model = NonhydrostaticModel(grid=grid)
+    model = NonhydrostaticModel(; grid)
 
     for field in merge(fields(model))
         fbcs = field.boundary_conditions
@@ -314,7 +314,7 @@ end
 function test_triply_periodic_bc_injection_with_221_ranks()
     arch = Distributed(partition=Partition(2, 2))
     grid = RectilinearGrid(arch, topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3))
-    model = NonhydrostaticModel(grid=grid)
+    model = NonhydrostaticModel(; grid)
 
     for field in merge(fields(model))
         fbcs = field.boundary_conditions
@@ -333,8 +333,8 @@ end
 
 function test_triply_periodic_halo_communication_with_411_ranks(halo, child_arch)
     arch = Distributed(child_arch; partition=Partition(4))
-    grid = RectilinearGrid(arch, topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3), halo=halo)
-    model = NonhydrostaticModel(grid=grid)
+    grid = RectilinearGrid(arch; topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3), halo)
+    model = NonhydrostaticModel(; grid)
 
     for field in merge(fields(model))
         fill!(field, arch.local_rank)
@@ -355,8 +355,8 @@ end
 
 function test_triply_periodic_halo_communication_with_141_ranks(halo, child_arch)
     arch = Distributed(child_arch; partition=Partition(1, 4))
-    grid  = RectilinearGrid(arch, topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3), halo=halo)
-    model = NonhydrostaticModel(grid=grid)
+    grid  = RectilinearGrid(arch; topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3), halos)
+    model = NonhydrostaticModel(; grid)
 
     for field in (fields(model)..., model.pressures.pNHS)
         fill!(field, arch.local_rank)
@@ -377,8 +377,8 @@ end
 
 function test_triply_periodic_halo_communication_with_221_ranks(halo, child_arch)
     arch = Distributed(child_arch; partition=Partition(2, 2))
-    grid = RectilinearGrid(arch, topology=(Periodic, Periodic, Periodic), size=(8, 8, 4), extent=(1, 2, 3), halo=halo)
-    model = NonhydrostaticModel(grid=grid)
+    grid = RectilinearGrid(arch; topology=(Periodic, Periodic, Periodic), size=(8, 8, 4), extent=(1, 2, 3), halo)
+    model = NonhydrostaticModel(; grid)
 
     for field in merge(fields(model))
         fill!(field, arch.local_rank)
@@ -478,6 +478,8 @@ end
             @test sum(c) == 1*N + 2*N + 3*N + 4*N
 
             sum!(c_reduced, c)
+            @show @allowscalar c_reduced[1, 1, 1]
+            @show 1*N + 2*N + 3*N + 4*N
             @test @allowscalar c_reduced[1, 1, 1] == 1*N + 2*N + 3*N + 4*N
 
             cbool = CenterField(grid, Bool)
@@ -538,4 +540,3 @@ end
         @test model.clock.time ≈ 2
     end
 end
-

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -478,9 +478,6 @@ end
             @test sum(c) == 1*N + 2*N + 3*N + 4*N
 
             sum!(c_reduced, c)
-            @show @allowscalar c_reduced[1, 1, 1]
-            @show 1*N + 2*N + 3*N + 4*N
-            @show c_reduced[1, 1, 1]
             @test @allowscalar c_reduced[1, 1, 1] == 1*N + 2*N + 3*N + 4*N
 
             cbool = CenterField(grid, Bool)

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -478,19 +478,22 @@ end
             @test sum(c) == 1*N + 2*N + 3*N + 4*N
 
             sum!(c_reduced, c)
+            @show @allowscalar c_reduced[1, 1, 1]
+            @show 1*N + 2*N + 3*N + 4*N
+            @show c_reduced[1, 1, 1]
             @test @allowscalar c_reduced[1, 1, 1] == 1*N + 2*N + 3*N + 4*N
 
             cbool = CenterField(grid, Bool)
             cbool_reduced = Field{Nothing, Nothing, Nothing}(grid, Bool)
-            bool_val = arch.local_rank == 0 ? true : false        
-            set!(cbool, bool_val)            
+            bool_val = arch.local_rank == 0 ? true : false
+            set!(cbool, bool_val)
 
             @test any(cbool) == true
             @test all(cbool) == false
 
             any!(cbool_reduced, cbool)
             @test @allowscalar cbool_reduced[1, 1, 1] == true
-            
+
             all!(cbool_reduced, cbool)
             @test @allowscalar cbool_reduced[1, 1, 1] == false
         end

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -296,7 +296,7 @@ function stratified_fluid_remains_at_rest_with_tilted_gravity_buoyancy_tracer(ar
     @test N² * g̃[2] ≈ mean(∂y_b)
     @test N² * g̃[3] ≈ mean(∂z_b)
 
-    CUDA.@allowscalar begin
+    @allowscalar begin
         @test all(N² * g̃[2] .≈ interior(∂y_b))
         @test all(N² * g̃[3] .≈ interior(∂z_b))
     end
@@ -345,7 +345,7 @@ function stratified_fluid_remains_at_rest_with_tilted_gravity_temperature_tracer
     @test ∂T∂z * g̃[2] ≈ mean(∂y_T)
     @test ∂T∂z * g̃[3] ≈ mean(∂z_T)
 
-    CUDA.@allowscalar begin
+    @allowscalar begin
         @test all(∂T∂z * g̃[2] .≈ interior(∂y_T))
         @test all(∂T∂z * g̃[3] .≈ interior(∂z_T))
     end
@@ -600,7 +600,7 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
             end
         end
     end
-    
+
     @testset "Gaussian immersed diffusion" begin
         for time_discretization in (ExplicitTimeDiscretization(), VerticallyImplicitTimeDiscretization())
 

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -80,7 +80,7 @@ function run_field_reduction_tests(FT, arch)
         ε = eps(eltype(ϕ_vals)) * 10 * maximum(maximum.(ϕs_vals))
         @info "    Testing field reductions with tolerance $ε..."
 
-        @test CUDA.@allowscalar all(isapprox.(ϕ, ϕ_vals, atol=ε)) # if this isn't true, reduction tests can't pass
+        @test @allowscalar all(isapprox.(ϕ, ϕ_vals, atol=ε)) # if this isn't true, reduction tests can't pass
 
         # Important to make sure no CUDA scalar operations occur!
         CUDA.allowscalar(false)
@@ -128,7 +128,7 @@ function run_field_interpolation_tests(grid)
 
     # TODO: remove this allowscalar when `nodes` returns broadcastable object on GPU
     xf, yf, zf = nodes(grid, (Face(), Face(), Face()), reshape=true)
-    f_max = CUDA.@allowscalar maximum(func.(xf, yf, zf))
+    f_max = @allowscalar maximum(func.(xf, yf, zf))
     ε_max = eps(f_max)
     tolerance = 10 * ε_max
 
@@ -144,7 +144,7 @@ function run_field_interpolation_tests(grid)
         x, y, z = nodes(f, reshape=true)
         loc = Tuple(L() for L in location(f))
 
-        CUDA.@allowscalar begin
+        @allowscalar begin
             ℑf = interpolate_xyz.(x, y, z, Ref(f.data), Ref(loc), Ref(f.grid))
         end
 
@@ -166,7 +166,7 @@ function run_field_interpolation_tests(grid)
     ys = on_architecture(arch, ys)
     zs = on_architecture(arch, zs)
 
-    CUDA.@allowscalar begin
+    @allowscalar begin
         for f in (u, v, w, c)
             loc = Tuple(L() for L in location(f))
             ℑf = interpolate_xyz.(xs, ys, zs, Ref(f.data), Ref(loc), Ref(f.grid))
@@ -213,7 +213,7 @@ function run_field_interpolation_tests(grid)
     set!(If, (x, y)-> x * y)
     interpolate!(wf, If)
 
-    CUDA.@allowscalar begin
+    @allowscalar begin
         @test all(interior(wf) .≈ interior(If))
     end
 
@@ -406,7 +406,7 @@ end
                 sz = size(field)
                 A = rand(FT, sz...)
                 set!(field, A)
-                @test CUDA.@allowscalar field.data[1, 1, 1] == A[1, 1, 1]
+                @test @allowscalar field.data[1, 1, 1] == A[1, 1, 1]
             end
 
             Nx = 8
@@ -428,10 +428,10 @@ end
             xw, yw, zw = nodes(w)
             xc, yc, zc = nodes(c)
 
-            @test CUDA.@allowscalar u[1, 2, 3] ≈ f(xu[1], yu[2], zu[3])
-            @test CUDA.@allowscalar v[1, 2, 3] ≈ f(xv[1], yv[2], zv[3])
-            @test CUDA.@allowscalar w[1, 2, 3] ≈ f(xw[1], yw[2], zw[3])
-            @test CUDA.@allowscalar c[1, 2, 3] ≈ f(xc[1], yc[2], zc[3])
+            @test @allowscalar u[1, 2, 3] ≈ f(xu[1], yu[2], zu[3])
+            @test @allowscalar v[1, 2, 3] ≈ f(xv[1], yv[2], zv[3])
+            @test @allowscalar w[1, 2, 3] ≈ f(xw[1], yw[2], zw[3])
+            @test @allowscalar c[1, 2, 3] ≈ f(xc[1], yc[2], zc[3])
 
             # Test for Field-to-Field setting on same architecture, and cross architecture.
             # The behavior depends on halo size: if the halos of two fields are the same, we can
@@ -491,8 +491,8 @@ end
                 @test fun(windowed_c) ≈ fun(interior(windowed_c))
             end
 
-            @test mean(c) ≈ CUDA.@allowscalar mean(interior(c))
-            @test mean(windowed_c) ≈ CUDA.@allowscalar mean(interior(windowed_c))
+            @test mean(c) ≈ @allowscalar mean(interior(c))
+            @test mean(windowed_c) ≈ @allowscalar mean(interior(windowed_c))
         end
 end
 
@@ -605,18 +605,18 @@ end
             cv = view(c, :, :, 1+1:k_top-1)
             @test size(cv) == (Nx, Ny, k_top-2)
             @test size(parent(cv)) == (Nx+2Hx, Ny+2Hy, k_top-2)
-            CUDA.@allowscalar @test all(cv[i, j, k] == c[i, j, k] for k in 1+1:k_top-1, j in 1:Ny, i in 1:Nx)
+            @allowscalar @test all(cv[i, j, k] == c[i, j, k] for k in 1+1:k_top-1, j in 1:Ny, i in 1:Nx)
 
             # Now test the views of views
             cvv = view(cv, :, :, 1+2:k_top-2)
             @test size(cvv) == (Nx, Ny, k_top-4)
             @test size(parent(cvv)) == (Nx+2Hx, Ny+2Hy, k_top-4)
-            CUDA.@allowscalar @test all(cvv[i, j, k] == cv[i, j, k] for k in 1+2:k_top-2, j in 1:Ny, i in 1:Nx)
+            @allowscalar @test all(cvv[i, j, k] == cv[i, j, k] for k in 1+2:k_top-2, j in 1:Ny, i in 1:Nx)
 
             cvvv = view(cvv, :, :, 1+3:k_top-3)
             @test size(cvvv) == (1, 1, k_top-6)
             @test size(parent(cvvv)) == (Nx+2Hx, Ny+2Hy, k_top-6)
-            CUDA.@allowscalar @test all(cvvv[i, j, k] == cvv[i, j, k] for k in 1+3:k_top-3, j in 1:Ny, i in 1:Nx)
+            @allowscalar @test all(cvvv[i, j, k] == cvv[i, j, k] for k in 1+3:k_top-3, j in 1:Ny, i in 1:Nx)
 
             @test_throws ArgumentError view(cv, :, :, 1)
             @test_throws ArgumentError view(cv, :, :, k_top)

--- a/test/test_field_scans.jl
+++ b/test/test_field_scans.jl
@@ -151,11 +151,11 @@ interior_array(a, i, j, k) = Array(interior(a, i, j, k))
                 @test Txyz.operand.dims === (1, 2, 3)
                 @test wxyz.operand.dims === (1, 2, 3)
 
-                @test CUDA.@allowscalar Txyz[1, 1, 1] ≈ 3
+                @test @allowscalar Txyz[1, 1, 1] ≈ 3
                 @test interior_array(Txy, 1, 1, :) ≈ [2.5, 3.5]
                 @test interior_array(Tx, 1, :, :) ≈ [[2, 3] [3, 4]]
 
-                @test CUDA.@allowscalar wxyz[1, 1, 1] ≈ 3
+                @test @allowscalar wxyz[1, 1, 1] ≈ 3
                 @test interior_array(wxy, 1, 1, :) ≈ [2, 3, 4]
                 @test interior_array(wx, 1, :, :) ≈ [[1.5, 2.5] [2.5, 3.5] [3.5, 4.5]]
 
@@ -194,19 +194,19 @@ interior_array(a, i, j, k) = Array(interior(a, i, j, k))
                 @test interior_array(wry, 1, :, 1) ≈ [3, 2]
                 @test interior_array(wrz, 1, 1, :) ≈ [6, 5, 3]
 
-                @compute Txyz = CUDA.@allowscalar Field(Average(T, condition=T.>3))
-                @compute Txy = CUDA.@allowscalar Field(Average(T, dims=(1, 2), condition=T.>3))
-                @compute Tx = CUDA.@allowscalar Field(Average(T, dims=1, condition=T.>2))
+                @compute Txyz = @allowscalar Field(Average(T, condition=T.>3))
+                @compute Txy = @allowscalar Field(Average(T, dims=(1, 2), condition=T.>3))
+                @compute Tx = @allowscalar Field(Average(T, dims=1, condition=T.>2))
 
-                @test CUDA.@allowscalar Txyz[1, 1, 1] ≈ 3.75
+                @test @allowscalar Txyz[1, 1, 1] ≈ 3.75
                 @test interior_array(Txy, 1, 1, :) ≈ [3.5, 11.5/3]
                 @test interior_array(Tx, 1, :, :) ≈ [[2.5, 3] [3, 4]]
 
-                @compute wxyz = CUDA.@allowscalar Field(Average(w, condition=w.>3))
-                @compute wxy = CUDA.@allowscalar Field(Average(w, dims=(1, 2), condition=w.>2))
-                @compute wx = CUDA.@allowscalar Field(Average(w, dims=1, condition=w.>1))
+                @compute wxyz = @allowscalar Field(Average(w, condition=w.>3))
+                @compute wxy = @allowscalar Field(Average(w, dims=(1, 2), condition=w.>2))
+                @compute wx = @allowscalar Field(Average(w, dims=1, condition=w.>1))
 
-                @test CUDA.@allowscalar wxyz[1, 1, 1] ≈ 4.25
+                @test @allowscalar wxyz[1, 1, 1] ≈ 4.25
                 @test interior_array(wxy, 1, 1, :) ≈ [3, 10/3, 4]
                 @test interior_array(wx, 1, :, :) ≈ [[2, 2.5] [2.5, 3.5] [3.5, 4.5]]
 
@@ -281,11 +281,11 @@ interior_array(a, i, j, k) = Array(interior(a, i, j, k))
             @compute wx = Field(Average(w, dims=1))
 
             # Mean
-            @test CUDA.@allowscalar Txyz[1, 1, 1] == mean(T)
+            @test @allowscalar Txyz[1, 1, 1] == mean(T)
             @test interior(Txy) == interior(mean(T, dims=(1, 2)))
             @test interior(Tx) == interior(mean(T, dims=1))
 
-            @test CUDA.@allowscalar wxyz[1, 1, 1] == mean(w)
+            @test @allowscalar wxyz[1, 1, 1] == mean(w)
             @test interior(wxy) == interior(mean(w, dims=(1, 2)))
             @test interior(wx) == interior(mean(w, dims=1))
 

--- a/test/test_halo_regions.jl
+++ b/test/test_halo_regions.jl
@@ -12,11 +12,11 @@ function halo_regions_initalized_correctly(arch, FT, Nx, Ny, Nz)
 
     # The halo regions should still just contain zeros.
     return @allowscalar (all(field.data[1-Hx:0,          :,          :] .== 0) &&
-                              all(field.data[Nx+1:Nx+Hx,      :,          :] .== 0) &&
-                              all(field.data[:,          1-Hy:0,          :] .== 0) &&
-                              all(field.data[:,      Ny+1:Ny+Hy,          :] .== 0) &&
-                              all(field.data[:,               :,     1-Hz:0] .== 0) &&
-                              all(field.data[:,               :, Nz+1:Nz+Hz] .== 0))
+                         all(field.data[Nx+1:Nx+Hx,      :,          :] .== 0) &&
+                         all(field.data[:,          1-Hy:0,          :] .== 0) &&
+                         all(field.data[:,      Ny+1:Ny+Hy,          :] .== 0) &&
+                         all(field.data[:,               :,     1-Hz:0] .== 0) &&
+                         all(field.data[:,               :, Nz+1:Nz+Hz] .== 0))
 end
 
 function halo_regions_correctly_filled(arch, FT, Nx, Ny, Nz)
@@ -35,9 +35,9 @@ function halo_regions_correctly_filled(arch, FT, Nx, Ny, Nz)
     data = field.data
 
     return @allowscalar (all(data[1-Hx:0,   1:Ny,       1:Nz] .== data[Nx-Hx+1:Nx, 1:Ny,       1:Nz]) &&
-                              all(data[1:Nx,   1-Hy:0,       1:Nz] .== data[1:Nx,      Ny-Hy+1:Ny,  1:Nz]) &&
-                              all(data[1:Nx,     1:Ny,       0:0 ] .== data[1:Nx,        1:Ny,      1:1 ]) &&
-                              all(data[1:Nx,     1:Ny,  Nz+1:Nz+1] .== data[1:Nx,        1:Ny,     Nz:Nz]))
+                         all(data[1:Nx,   1-Hy:0,       1:Nz] .== data[1:Nx,      Ny-Hy+1:Ny,  1:Nz]) &&
+                         all(data[1:Nx,     1:Ny,       0:0 ] .== data[1:Nx,        1:Ny,      1:1 ]) &&
+                         all(data[1:Nx,     1:Ny,  Nz+1:Nz+1] .== data[1:Nx,        1:Ny,     Nz:Nz]))
 end
 
 @testset "Halo regions" begin

--- a/test/test_halo_regions.jl
+++ b/test/test_halo_regions.jl
@@ -11,7 +11,7 @@ function halo_regions_initalized_correctly(arch, FT, Nx, Ny, Nz)
     Hx, Hy, Hz = grid.Hx, grid.Hy, grid.Hz
 
     # The halo regions should still just contain zeros.
-    return CUDA.@allowscalar (all(field.data[1-Hx:0,          :,          :] .== 0) &&
+    return @allowscalar (all(field.data[1-Hx:0,          :,          :] .== 0) &&
                               all(field.data[Nx+1:Nx+Hx,      :,          :] .== 0) &&
                               all(field.data[:,          1-Hy:0,          :] .== 0) &&
                               all(field.data[:,      Ny+1:Ny+Hy,          :] .== 0) &&
@@ -34,7 +34,7 @@ function halo_regions_correctly_filled(arch, FT, Nx, Ny, Nz)
     Hx, Hy, Hz = grid.Hx, grid.Hy, grid.Hz
     data = field.data
 
-    return CUDA.@allowscalar (all(data[1-Hx:0,   1:Ny,       1:Nz] .== data[Nx-Hx+1:Nx, 1:Ny,       1:Nz]) &&
+    return @allowscalar (all(data[1-Hx:0,   1:Ny,       1:Nz] .== data[Nx-Hx+1:Nx, 1:Ny,       1:Nz]) &&
                               all(data[1:Nx,   1-Hy:0,       1:Nz] .== data[1:Nx,      Ny-Hy+1:Ny,  1:Nz]) &&
                               all(data[1:Nx,     1:Ny,       0:0 ] .== data[1:Nx,        1:Ny,      1:1 ]) &&
                               all(data[1:Nx,     1:Ny,  Nz+1:Nz+1] .== data[1:Nx,        1:Ny,     Nz:Nz]))

--- a/test/test_immersed_advection.jl
+++ b/test/test_immersed_advection.jl
@@ -20,14 +20,14 @@ advection_schemes = [linear_advection_schemes... WENO]
 
 function run_tracer_interpolation_test(c, ibg, scheme)
 
-    for i in 6:19, j in 6:19
+    for j in 6:19, i in 6:19
         if typeof(scheme) <: Centered
-            @test CUDA.@allowscalar  _symmetric_interpolate_xᶠᵃᵃ(i+1, j, 1, ibg, scheme, c) ≈ 1.0
+            @test @allowscalar  _symmetric_interpolate_xᶠᵃᵃ(i+1, j, 1, ibg, scheme, c) ≈ 1.0
         else
-            @test CUDA.@allowscalar _biased_interpolate_xᶠᵃᵃ(i+1, j, 1, ibg, scheme, true,  c) ≈ 1.0
-            @test CUDA.@allowscalar _biased_interpolate_xᶠᵃᵃ(i+1, j, 1, ibg, scheme, false, c) ≈ 1.0
-            @test CUDA.@allowscalar _biased_interpolate_yᵃᶠᵃ(i, j+1, 1, ibg, scheme, true,  c) ≈ 1.0
-            @test CUDA.@allowscalar _biased_interpolate_yᵃᶠᵃ(i, j+1, 1, ibg, scheme, false, c) ≈ 1.0
+            @test @allowscalar _biased_interpolate_xᶠᵃᵃ(i+1, j, 1, ibg, scheme, true,  c) ≈ 1.0
+            @test @allowscalar _biased_interpolate_xᶠᵃᵃ(i+1, j, 1, ibg, scheme, false, c) ≈ 1.0
+            @test @allowscalar _biased_interpolate_yᵃᶠᵃ(i, j+1, 1, ibg, scheme, true,  c) ≈ 1.0
+            @test @allowscalar _biased_interpolate_yᵃᶠᵃ(i, j+1, 1, ibg, scheme, false, c) ≈ 1.0
         end
     end
 end
@@ -72,20 +72,20 @@ function run_momentum_interpolation_test(u, v, ibg, scheme)
 
     for i in 7:19, j in 7:19
         if typeof(scheme) <: Centered
-            @test CUDA.@allowscalar  _symmetric_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, u) ≈ 1.0
-            @test CUDA.@allowscalar  _symmetric_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, v) ≈ 1.0
-            @test CUDA.@allowscalar  _symmetric_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, u) ≈ 1.0
-            @test CUDA.@allowscalar  _symmetric_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, v) ≈ 1.0
+            @test @allowscalar  _symmetric_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, u) ≈ 1.0
+            @test @allowscalar  _symmetric_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, v) ≈ 1.0
+            @test @allowscalar  _symmetric_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, u) ≈ 1.0
+            @test @allowscalar  _symmetric_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, v) ≈ 1.0
         else
-            @test CUDA.@allowscalar _biased_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, true,  u) ≈ 1.0
-            @test CUDA.@allowscalar _biased_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, false, u) ≈ 1.0
-            @test CUDA.@allowscalar _biased_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, true,  u) ≈ 1.0
-            @test CUDA.@allowscalar _biased_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, false, u) ≈ 1.0
+            @test @allowscalar _biased_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, true,  u) ≈ 1.0
+            @test @allowscalar _biased_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, false, u) ≈ 1.0
+            @test @allowscalar _biased_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, true,  u) ≈ 1.0
+            @test @allowscalar _biased_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, false, u) ≈ 1.0
 
-            @test CUDA.@allowscalar _biased_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, true,  v) ≈ 1.0
-            @test CUDA.@allowscalar _biased_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, false, v) ≈ 1.0
-            @test CUDA.@allowscalar _biased_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, true,  v) ≈ 1.0
-            @test CUDA.@allowscalar _biased_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, false, v) ≈ 1.0
+            @test @allowscalar _biased_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, true,  v) ≈ 1.0
+            @test @allowscalar _biased_interpolate_xᶜᵃᵃ(i+1, j, 1, ibg, scheme, false, v) ≈ 1.0
+            @test @allowscalar _biased_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, true,  v) ≈ 1.0
+            @test @allowscalar _biased_interpolate_yᵃᶜᵃ(i, j+1, 1, ibg, scheme, false, v) ≈ 1.0
         end
     end
 

--- a/test/test_immersed_boundary_grid.jl
+++ b/test/test_immersed_boundary_grid.jl
@@ -94,7 +94,7 @@ function test_grid_fitted_bottom_cell_detection(FT, arch)
     ibg = ImmersedBoundaryGrid(underlying_grid, ib)
 
     # Test that cells below the bottom are immersed
-    CUDA.@allowscalar begin
+    @allowscalar begin
         for i in 1:4, j in 1:4
             for k in 1:4  # Lower half of domain
                 z_center = znode(i, j, k, ibg, Center(), Center(), Center())
@@ -117,7 +117,7 @@ function test_partial_cell_bottom_cell_detection(FT, arch)
     ibg = ImmersedBoundaryGrid(underlying_grid, ib)
 
     # Test immersed cell detection
-    CUDA.@allowscalar begin
+    @allowscalar begin
         for i in 1:4, j in 1:4, k in 1:8
             # The partial cell criterion is different - need to check grid spacing
             immersed = _immersed_cell(i, j, k, ibg.underlying_grid, ibg.immersed_boundary)
@@ -239,7 +239,7 @@ function test_grid_fitted_boundary_with_function(FT, arch)
     @test eltype(ibg.immersed_boundary.mask) === Bool
 
     # Test immersed cell detection
-    CUDA.@allowscalar begin
+    @allowscalar begin
         for i in 1:4, j in 1:4, k in 1:4
             x, y, z = xnode(i, j, k, ibg, Center(), Center(), Center()),
                       ynode(i, j, k, ibg, Center(), Center(), Center()),
@@ -269,7 +269,7 @@ function test_grid_fitted_boundary_with_array(FT, arch)
     @test eltype(ibg) === FT
     @test size(ibg) == size(underlying_grid)
 
-    CUDA.@allowscalar begin
+    @allowscalar begin
         # Test that the center cell is immersed
         @test _immersed_cell(2, 2, 2, ibg.underlying_grid, ibg.immersed_boundary) == true
 

--- a/test/test_implicit_free_surface_solver.jl
+++ b/test/test_implicit_free_surface_solver.jl
@@ -30,13 +30,13 @@ function set_simple_divergent_velocity!(model)
     i, j, k = Int(floor(grid.Nx / 2)) + 1, Int(floor(grid.Ny / 2)) + 1, grid.Nz
     inactive_cell(i, j, k, grid) && error("The nudged cell at ($i, $j, $k) is inactive.")
 
-    Δy = CUDA.@allowscalar Δyᶜᶠᶜ(i, j, k, grid)
-    Δz = CUDA.@allowscalar Δzᶜᶠᶜ(i, j, k, grid)
+    Δy = @allowscalar Δyᶜᶠᶜ(i, j, k, grid)
+    Δz = @allowscalar Δzᶜᶠᶜ(i, j, k, grid)
 
     # We prescribe the value of the zonal transport in a cell, i.e., `u * Δy * Δz`. This
     # way `norm(rhs)` of the free-surface solver does not depend on the grid extent/resolution.
     transport = 1e5 # m³ s⁻¹
-    CUDA.@allowscalar u[i, j, k] = transport / (Δy * Δz)
+    @allowscalar u[i, j, k] = transport / (Δy * Δz)
 
     update_state!(model)
 
@@ -89,7 +89,7 @@ function run_implicit_free_surface_solver_tests(arch, grid, free_surface)
     @show norm(left_hand_side)
     @show norm(right_hand_side)
 
-    CUDA.@allowscalar begin
+    @allowscalar begin
         @test maximum(abs, interior(left_hand_side) .- interior(right_hand_side)) < extrema_tolerance
         @test std(interior(left_hand_side) .- interior(right_hand_side)) < std_tolerance
     end

--- a/test/test_jld2_writer.jl
+++ b/test/test_jld2_writer.jl
@@ -384,9 +384,9 @@ for arch in archs
 
 
 
-        u₀ = CUDA.@allowscalar model.velocities.u[3, 3, 3]
-        v₀ = CUDA.@allowscalar model.velocities.v[3, 3, 3]
-        w₀ = CUDA.@allowscalar model.velocities.w[3, 3, 3]
+        u₀ = @allowscalar model.velocities.u[3, 3, 3]
+        v₀ = @allowscalar model.velocities.v[3, 3, 3]
+        w₀ = @allowscalar model.velocities.w[3, 3, 3]
 
         run!(simulation)
 

--- a/test/test_lagrangian_particle_tracking.jl
+++ b/test/test_lagrangian_particle_tracking.jl
@@ -78,8 +78,8 @@ function run_simple_particle_tracking_tests(grid, dynamics, timestepper=:QuasiAd
     ##### Test Boundary restitution
     #####
 
-    initial_z = CUDA.@allowscalar grid.z.cᵃᵃᶜ[grid.Nz-1]
-    top_boundary = CUDA.@allowscalar grid.z.cᵃᵃᶠ[grid.Nz+1]
+    initial_z = @allowscalar grid.z.cᵃᵃᶜ[grid.Nz-1]
+    top_boundary = @allowscalar grid.z.cᵃᵃᶠ[grid.Nz+1]
 
     x, y, z = on_architecture.(Ref(arch), ([0.0], [0.0], [initial_z]))
 

--- a/test/test_matrix_poisson_solver.jl
+++ b/test/test_matrix_poisson_solver.jl
@@ -94,7 +94,7 @@ function run_poisson_equation_test(grid)
 
     parent(ϕ_solution) .-= mean(ϕ_solution)
 
-    CUDA.@allowscalar begin
+    @allowscalar begin
         @test all(interior(∇²ϕ_solution) .≈ interior(∇²ϕ))
         @test all(interior(ϕ_solution)   .≈ interior(ϕ_truth))
     end

--- a/test/test_multi_region_cubed_sphere.jl
+++ b/test/test_multi_region_cubed_sphere.jl
@@ -197,7 +197,7 @@ end
                                         horizontal_direction_halo = Hx, z_halo = Hz)
 
         for panel in 1:6
-            CUDA.@allowscalar begin
+            @allowscalar begin
                 # Test only on cca and ffa; fca and cfa are all zeros on grid_cs32!
                 # Only test interior points since halo regions are not filled for grid_cs32!
 
@@ -233,7 +233,7 @@ panel_sizes = ((8, 8, 1), (9, 9, 2))
                 areaᶜᶜᵃ = areaᶠᶜᵃ = areaᶜᶠᵃ = areaᶠᶠᵃ = 0
 
                 for region in 1:number_of_regions(grid)
-                    CUDA.@allowscalar begin
+                    @allowscalar begin
                         areaᶜᶜᵃ += sum(getregion(grid, region).Azᶜᶜᵃ[1:Nx, 1:Ny])
                         areaᶠᶜᵃ += sum(getregion(grid, region).Azᶠᶜᵃ[1:Nx, 1:Ny])
                         areaᶜᶠᵃ += sum(getregion(grid, region).Azᶜᶠᵃ[1:Nx, 1:Ny])
@@ -302,7 +302,7 @@ end
                 north_indices = 1:Nx, Ny-Hy+1:Ny
 
                 # Confirm that the tracer halos were filled according to connectivity described at ConformalCubedSphereGrid docstring.
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     switch_device!(grid, 1)
                     @test get_halo_data(getregion(c, 1), West())  == reverse(create_c_test_data(grid, 5)[north_indices...], dims=1)'
                     @test get_halo_data(getregion(c, 1), East())  ==         create_c_test_data(grid, 2)[west_indices...]
@@ -396,7 +396,7 @@ end
                 west_indices_subset_skip_last_index   = get_boundary_indices(Nx, Ny, Hx, Hy, West();  operation=:subset, index=:last)
 
                 # Confirm that the zonal velocity halos were filled according to connectivity described at ConformalCubedSphereGrid docstring.
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     switch_device!(grid, 1)
 
                     # Trivial halo checks with no off-set in index
@@ -496,7 +496,7 @@ end
 
                 # Confirm that the meridional velocity halos were filled according to connectivity described at
                 # ConformalCubedSphereGrid docstring.
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     switch_device!(grid, 1)
 
                     # Trivial halo checks with no off-set in index
@@ -648,7 +648,7 @@ end
                 west_indices_subset_skip_last_index   = get_boundary_indices(Nx, Ny, Hx, Hy, West();  operation=:subset, index=:last)
 
                 # Confirm that the tracer halos were filled according to connectivity described at ConformalCubedSphereGrid docstring.
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     # Panel 1
                     switch_device!(grid, 1)
 

--- a/test/test_multi_region_poisson_solver.jl
+++ b/test/test_multi_region_poisson_solver.jl
@@ -113,7 +113,7 @@ function run_poisson_equation_test(grid)
     ∇²ϕ_solution = CenterField(grid)
     compute_∇²!(∇²ϕ_solution, ϕ_solution, arch, grid)
 
-    CUDA.@allowscalar begin
+    @allowscalar begin
         @test all(interior(∇²ϕ_solution) .≈ interior(∇²ϕ))
         @test all(interior(ϕ_solution)   .≈ interior(ϕ_truth))
     end

--- a/test/test_netcdf_writer.jl
+++ b/test/test_netcdf_writer.jl
@@ -2457,16 +2457,16 @@ function test_netcdf_vertically_stretched_grid_output(arch)
     @test ds["y_aca"][1] == grid.yᵃᶜᵃ[1]
     @test ds["y_afa"][1] == grid.yᵃᶠᵃ[1]
 
-    @test CUDA.@allowscalar ds["z_aac"][1] == grid.z.cᵃᵃᶜ[1]
-    @test CUDA.@allowscalar ds["z_aaf"][1] == grid.z.cᵃᵃᶠ[1]
+    @test @allowscalar ds["z_aac"][1] == grid.z.cᵃᵃᶜ[1]
+    @test @allowscalar ds["z_aaf"][1] == grid.z.cᵃᵃᶠ[1]
 
     @test ds["x_caa"][end] == grid.xᶜᵃᵃ[Nx]
     @test ds["x_faa"][end] == grid.xᶠᵃᵃ[Nx]
     @test ds["y_aca"][end] == grid.yᵃᶜᵃ[Ny]
     @test ds["y_afa"][end] == grid.yᵃᶠᵃ[Ny]
 
-    @test CUDA.@allowscalar ds["z_aac"][end] == grid.z.cᵃᵃᶜ[Nz]
-    @test CUDA.@allowscalar ds["z_aaf"][end] == grid.z.cᵃᵃᶠ[Nz+1]  # z is Bounded
+    @test @allowscalar ds["z_aac"][end] == grid.z.cᵃᵃᶜ[Nz]
+    @test @allowscalar ds["z_aaf"][end] == grid.z.cᵃᵃᶠ[Nz+1]  # z is Bounded
 
     close(ds)
     rm(nc_filepath)

--- a/test/test_preconditioned_conjugate_gradient_solver.jl
+++ b/test/test_preconditioned_conjugate_gradient_solver.jl
@@ -48,7 +48,7 @@ function run_poisson_equation_test(grid)
     extrema_tolerance = 1e-12
     std_tolerance = 1e-13
 
-    CUDA.@allowscalar begin
+    @allowscalar begin
         @test minimum(abs, interior(∇²ϕ_solution) .- interior(∇²ϕ)) < extrema_tolerance
         @test maximum(abs, interior(∇²ϕ_solution) .- interior(∇²ϕ)) < extrema_tolerance
         @test          std(interior(∇²ϕ_solution) .- interior(∇²ϕ)) < std_tolerance

--- a/test/test_regrid.jl
+++ b/test/test_regrid.jl
@@ -70,7 +70,7 @@ using Oceananigans.Fields: regrid_in_x!, regrid_in_y!, regrid_in_z!
                 c₁ = 1
                 c₂ = 3
 
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     interior(fine_1d_stretched_c)[1] = c₁
                     interior(fine_1d_stretched_c)[2] = c₂
                 end
@@ -78,13 +78,13 @@ using Oceananigans.Fields: regrid_in_x!, regrid_in_y!, regrid_in_z!
                 # Coarse-graining
                 regrid!(coarse_1d_regular_c, fine_1d_stretched_c)
 
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     @test interior(coarse_1d_regular_c)[1] ≈ ℓ/L * c₁ + (1 - ℓ/L) * c₂
                 end
 
                 regrid!(fine_1d_regular_c, fine_1d_stretched_c)
 
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     @test interior(fine_1d_regular_c)[1] ≈ ℓ/(L/2) * c₁ + (1 - ℓ/(L/2)) * c₂
                     @test interior(fine_1d_regular_c)[2] ≈ c₂
                 end
@@ -92,7 +92,7 @@ using Oceananigans.Fields: regrid_in_x!, regrid_in_y!, regrid_in_z!
                 # Fine-graining
                 regrid!(very_fine_1d_stretched_c, fine_1d_stretched_c)
 
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     @test interior(very_fine_1d_stretched_c)[1] ≈ c₁
                     @test interior(very_fine_1d_stretched_c)[2] ≈ (ℓ - 0.2)/0.4 * c₁ + (0.6 - ℓ)/0.4 * c₂
                     @test interior(very_fine_1d_stretched_c)[3] ≈ c₂
@@ -100,7 +100,7 @@ using Oceananigans.Fields: regrid_in_x!, regrid_in_y!, regrid_in_z!
 
                 regrid!(super_fine_1d_stretched_c, fine_1d_stretched_c)
 
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     @test interior(super_fine_1d_stretched_c)[1] ≈ c₁
                     @test interior(super_fine_1d_stretched_c)[2] ≈ c₁
                     @test interior(super_fine_1d_stretched_c)[3] ≈ (ℓ - 0.3)/0.35 * c₁ + (0.65 - ℓ)/0.35 * c₂
@@ -109,7 +109,7 @@ using Oceananigans.Fields: regrid_in_x!, regrid_in_y!, regrid_in_z!
 
                 regrid!(super_fine_1d_regular_c, fine_1d_stretched_c)
 
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     @test interior(super_fine_1d_regular_c)[1] ≈ c₁
                     @test interior(super_fine_1d_regular_c)[2] ≈ c₁
                     @test interior(super_fine_1d_regular_c)[3] ≈ (3 - ℓ/(L/5)) * c₂ + (-2 + ℓ/(L/5)) * c₁
@@ -138,7 +138,7 @@ using Oceananigans.Fields: regrid_in_x!, regrid_in_y!, regrid_in_z!
 
                 regrid!(super_fine_from_reduction_regular_c, fine_stretched_c_mean_xy)
 
-                CUDA.@allowscalar begin
+                @allowscalar begin
                     @test interior(super_fine_from_reduction_regular_c)[1] ≈ c₁
                     @test interior(super_fine_from_reduction_regular_c)[2] ≈ c₁
                     @test interior(super_fine_from_reduction_regular_c)[3] ≈ (3 - ℓ/(L/5)) * c₂ + (-2 + ℓ/(L/5)) * c₁

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -20,9 +20,9 @@ function euler_time_stepping_doesnt_propagate_NaNs(arch)
                                         buoyancy = BuoyancyTracer(),
                                         tracers = :b)
 
-    CUDA.@allowscalar model.timestepper.G⁻.u[1, 1, 1] = NaN
+    @allowscalar model.timestepper.G⁻.u[1, 1, 1] = NaN
     time_step!(model, 1, euler=true)
-    u111 = CUDA.@allowscalar model.velocities.u[1, 1, 1]
+    u111 = @allowscalar model.velocities.u[1, 1, 1]
 
     return !isnan(u111)
 end
@@ -130,7 +130,7 @@ function incompressible_in_time(grid, Nt, timestepper)
     div_U = CenterField(grid)
 
     # Just add a temperature perturbation so we get some velocity field.
-    CUDA.@allowscalar interior(model.tracers.T)[8:24, 8:24, 8:24] .+= 0.01
+    @allowscalar interior(model.tracers.T)[8:24, 8:24, 8:24] .+= 0.01
 
     update_state!(model)
     for n in 1:Nt
@@ -140,11 +140,11 @@ function incompressible_in_time(grid, Nt, timestepper)
     arch = architecture(grid)
     launch!(arch, grid, :xyz, divergence!, grid, u.data, v.data, w.data, div_U.data)
 
-    min_div = CUDA.@allowscalar minimum(interior(div_U))
-    max_div = CUDA.@allowscalar maximum(interior(div_U))
-    max_abs_div = CUDA.@allowscalar maximum(abs, interior(div_U))
-    sum_div = CUDA.@allowscalar sum(interior(div_U))
-    sum_abs_div = CUDA.@allowscalar sum(abs, interior(div_U))
+    min_div = @allowscalar minimum(interior(div_U))
+    max_div = @allowscalar maximum(interior(div_U))
+    max_abs_div = @allowscalar maximum(abs, interior(div_U))
+    sum_div = @allowscalar sum(interior(div_U))
+    sum_abs_div = @allowscalar sum(abs, interior(div_U))
 
     @info "Velocity divergence after $Nt time steps [$(typeof(arch)), $(typeof(grid)), $timestepper]: " *
           "min=$min_div, max=$max_div, max_abs_div=$max_abs_div, sum=$sum_div, abs_sum=$sum_abs_div"
@@ -184,14 +184,14 @@ function tracer_conserved_in_channel(arch, FT, Nt)
     T₀(x, y, z) = 10 + Ty*y + Tz*z + 0.0001*rand()
     set!(model, T=T₀)
 
-    Tavg0 = CUDA.@allowscalar mean(interior(model.tracers.T))
+    Tavg0 = @allowscalar mean(interior(model.tracers.T))
 
     update_state!(model)
     for n in 1:Nt
         time_step!(model, 600)
     end
 
-    Tavg = CUDA.@allowscalar mean(interior(model.tracers.T))
+    Tavg = @allowscalar mean(interior(model.tracers.T))
     @info "Tracer conservation after $Nt time steps [$(typeof(arch)), $FT]: " *
           "⟨T⟩-T₀=$(Tavg-Tavg0) °C"
 

--- a/test/test_tripolar_grid.jl
+++ b/test/test_tripolar_grid.jl
@@ -58,7 +58,7 @@ end
         λᶜᶜᵃ = λnodes(grid, Center(), Center())
         φᶜᶜᵃ = φnodes(grid, Center(), Center())
 
-        min_Δφ = CUDA.@allowscalar minimum(φᶜᶜᵃ[:, 2] .- φᶜᶜᵃ[:, 1])
+        min_Δφ = @allowscalar minimum(φᶜᶜᵃ[:, 2] .- φᶜᶜᵃ[:, 1])
         @allowscalar begin
             @test minimum(λᶜᶜᵃ) ≥ 0
             @test maximum(λᶜᶜᵃ) ≤ 360

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -241,7 +241,7 @@ function compute_closure_specific_diffusive_cfl(arch, closure)
     dcfl = DiffusiveCFL(0.1)
     @test dcfl(model) isa Number
 
-    CUDA.@allowscalar begin
+    @allowscalar begin
         @test diffusive_flux_x(1, 1, 1, grid, args...) == 0
         @test diffusive_flux_y(1, 1, 1, grid, args...) == 0
         @test diffusive_flux_z(1, 1, 1, grid, args...) == 0
@@ -251,7 +251,7 @@ function compute_closure_specific_diffusive_cfl(arch, closure)
     args = (model.closure, model.diffusivity_fields, model.clock, fields(model), model.buoyancy)
     dcfl = DiffusiveCFL(0.2)
     @test dcfl(tracerless_model) isa Number
-    CUDA.@allowscalar begin
+    @allowscalar begin
         @test viscous_flux_ux(1, 1, 1, grid, args...) == 0
         @test viscous_flux_uy(1, 1, 1, grid, args...) == 0
         @test viscous_flux_uz(1, 1, 1, grid, args...) == 0


### PR DESCRIPTION
needed after moving CUDA to an extension

also continues #4499 by changing several `CUDA.@allowscalar` to `GPUArraysCore.@allowscalar`.