### PR TITLE
Bump the compat entry for AMDGPU.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -60,7 +60,7 @@ OceananigansOneAPIExt = "oneAPI"
 OceananigansReactantExt = ["Reactant", "KernelAbstractions", "ConstructionBase"]
 
 [compat]
-AMDGPU = "1.2.7"
+AMDGPU = "1.3.6"
 Adapt = "4.1.1"
 CUDA = "5.7"
 ConstructionBase = "1"


### PR DESCRIPTION
The release 1.3.4 added a few fixes for GPU kernel on new AMD GPUs. It fixed a few issues that I got on the new MI250.

