### PR TITLE
add mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,23 @@
+Ali Ramadhan <ali.hh.ramadhan@gmail.com>
+Gregory Wagner <wagner.greg@gmail.com>
+Gregory Wagner <wagner.greg@gmail.com> <gregory.leclaire.wagner@gmail.com>
+Gregory Wagner <wagner.greg@gmail.com> Gregory Wagner <gregorywagner@Gregorys-MacBook-Pro.local>
+Navid Constantinou <navidcy@gmail.com> <navidcy@users.noreply.github.com>
+Simone Silvestri <silvestri.simone0@gmail.com>
+Simone Silvestri <silvestri.simone0@gmail.com> <33547697+simone-silvestri@users.noreply.github.com>
+Simone Silvestri <silvestri.simone0@gmail.com> <simonesilvestri@dhcp-10-29-66-48.dyn.mit.edu>
+Simone Silvestri <silvestri.simone0@gmail.com> <ssilvest@MIT.EDU>
+Simone Silvestri <silvestri.simone0@gmail.com> <simonesilvestri@Simones-MacBook-Pro.local>
+Tomas Chor <tomaschor@gmail.com>
+Andre Souza <andrenogueirasouza@gmail.com> 
+Elise Palethorpe <ellypaley@gmail.com> <elise.palethorpe@anu.edu.au>
+Elise Palethorpe <ellypaley@gmail.com> <73727706+elise-palethorpe@users.noreply.github.com>
+Francis J. Poulin <fpoulin@uwaterloo.ca>
+Francis J. Poulin <fpoulin@uwaterloo.ca> <fpoulin@pop-os.localdomain>
+Chris Hill <cnh@mit.edu>
+Victoria Whitley <whitleyv@att.net> <67593861+whitleyv@users.noreply.github.com>
+hennyg888 <henryg2002@hotmail.com> <45054739+hennyg888@users.noreply.github.com>
+Jago Strong-Wright <jagostrongwright@gmail.com> <jagoosw@protonmail.com>
+Gabriele Bozzola <gbozzola@caltech.edu> <sbozzolator@gmail.com>
+Markus Eckhardt <markus.eckhardt@mail.de>
+Valentin Churavy <v.churavy@gmail.com> <vchuravy@users.noreply.github.com>


### PR DESCRIPTION
For tools like `git shortlog -nse` or `git-ship-of-theseus` it is very nice to have git collapse all commits by the same author.

