### PR TITLE
Correct regularization for `ImmersedBoundaryCondition`

### DIFF
--- a/src/ImmersedBoundaries/immersed_boundary_condition.jl
+++ b/src/ImmersedBoundaries/immersed_boundary_condition.jl
@@ -79,12 +79,12 @@ end
 """
 function regularize_immersed_boundary_condition(bc::IBC, grid, loc, field_name, prognostic_field_names)
 
-    west   = loc[1] === Face ? nothing : regularize_boundary_condition(bc.west,   grid, loc, 1, LeftBoundary,  prognostic_field_names)
-    east   = loc[1] === Face ? nothing : regularize_boundary_condition(bc.east,   grid, loc, 1, RightBoundary, prognostic_field_names)
-    south  = loc[2] === Face ? nothing : regularize_boundary_condition(bc.south,  grid, loc, 2, LeftBoundary,  prognostic_field_names)
-    north  = loc[2] === Face ? nothing : regularize_boundary_condition(bc.north,  grid, loc, 2, RightBoundary, prognostic_field_names)
-    bottom = loc[3] === Face ? nothing : regularize_boundary_condition(bc.bottom, grid, loc, 3, LeftBoundary,  prognostic_field_names)
-    top    = loc[3] === Face ? nothing : regularize_boundary_condition(bc.top,    grid, loc, 3, RightBoundary, prognostic_field_names)
+    west   = loc[1] === Center ? regularize_boundary_condition(bc.west,   grid, loc, 1, LeftBoundary,  prognostic_field_names) : nothing
+    east   = loc[1] === Center ? regularize_boundary_condition(bc.east,   grid, loc, 1, RightBoundary, prognostic_field_names) : nothing
+    south  = loc[2] === Center ? regularize_boundary_condition(bc.south,  grid, loc, 2, LeftBoundary,  prognostic_field_names) : nothing
+    north  = loc[2] === Center ? regularize_boundary_condition(bc.north,  grid, loc, 2, RightBoundary, prognostic_field_names) : nothing
+    bottom = loc[3] === Center ? regularize_boundary_condition(bc.bottom, grid, loc, 3, LeftBoundary,  prognostic_field_names) : nothing
+    top    = loc[3] === Center ? regularize_boundary_condition(bc.top,    grid, loc, 3, RightBoundary, prognostic_field_names) : nothing
 
     return ImmersedBoundaryCondition(; west, east, south, north, bottom, top)
 end


### PR DESCRIPTION
I am implementing immersed drag for a `SeaIceModel` [here](https://github.com/CliMA/ClimaSeaIce.jl/pull/84), but I noticed that the regularization for `ImmersedBoundaryCondition` is not correct because it assigns boundary conditions in `nothing` directions, for example, in https://github.com/CliMA/ClimaSeaIce.jl/pull/84 this happens:
```julia
julia> grid = RectilinearGrid(size = (10, 10, 1), x = (0, 1), y = (0, 1), z = (0, 1));

julia> grid = ImmersedBoundaryGrid(grid, GridFittedBottom(rand(10, 10)));

julia> u_bcs = FieldBoundaryConditions(grid, (Face, Center, Nothing); immersed = FluxBoundaryCondition(1));

julia> model = SeaIceModel(grid; boundary_conditions = (; u = u_bcs));

julia> model.velocities.u.boundary_conditions.immersed
ImmersedBoundaryCondition:
├── west: Nothing
├── east: Nothing
├── south: FluxBoundaryCondition: 1.0
├── north: FluxBoundaryCondition: 1.0
├── bottom: FluxBoundaryCondition: 1.0
└── top: FluxBoundaryCondition: 1.0
```
In this case, `top` and `bottom` boundary conditions should be a `Nothing`, so this PR corrects this regularization