### PR TITLE
Only enforce open boundary mass conservation for open boundaries

### DIFF
--- a/src/Models/NonhydrostaticModels/boundary_mass_fluxes.jl
+++ b/src/Models/NonhydrostaticModels/boundary_mass_fluxes.jl
@@ -153,7 +153,11 @@ function initialize_boundary_mass_fluxes(velocities::NamedTuple)
                                                 right_matching_scheme_boundaries,
                                                 total_area_matching_scheme_boundaries))
 
-    return boundary_fluxes
+    if length(left_matching_scheme_boundaries) == 0 && length(right_matching_scheme_boundaries) == 0
+        return nothing
+    else
+        return boundary_fluxes
+    end
 end
 
 update_open_boundary_mass_fluxes!(model) = map(compute!, model.boundary_mass_fluxes)
@@ -209,17 +213,19 @@ correct_right_boundary_mass_flux!(v, bc::IOBC, ::Val{:north}, A⁻¹_∮udA) = n
 correct_right_boundary_mass_flux!(w, bc::IOBC, ::Val{:top},   A⁻¹_∮udA) = nothing
 correct_right_boundary_mass_flux!(u, bc, side, A⁻¹_∮udA) = nothing
 
+enforce_open_boundary_mass_conservation!(model, ::Nothing) = nothing
+
 """
-enforce_open_boundary_mass_conservation!(model::NonhydrostaticModel)
+    enforce_open_boundary_mass_conservation!(model, boundary_mass_fluxes)
 
 Correct boundary mass fluxes for perturbation advection boundary conditions to ensure
 zero net mass flux through each boundary.
 """
-function enforce_open_boundary_mass_conservation!(model)
+function enforce_open_boundary_mass_conservation!(model, boundary_mass_fluxes)
     u, v, w = model.velocities
 
     ∮udA = open_boundary_mass_inflow(model)
-    A = model.boundary_mass_fluxes.total_area_matching_scheme_boundaries
+    A = boundary_mass_fluxes.total_area_matching_scheme_boundaries
 
     A⁻¹_∮udA = ∮udA / A
 

--- a/src/Models/NonhydrostaticModels/pressure_correction.jl
+++ b/src/Models/NonhydrostaticModels/pressure_correction.jl
@@ -11,7 +11,7 @@ function compute_pressure_correction!(model::NonhydrostaticModel, Δt)
     foreach(mask_immersed_field!, model.velocities)
     fill_halo_regions!(model.velocities, model.clock, fields(model))
 
-    enforce_open_boundary_mass_conservation!(model)
+    enforce_open_boundary_mass_conservation!(model, model.boundary_mass_fluxes)
 
     solve_for_pressure!(model.pressures.pNHS, model.pressure_solver, Δt, model.velocities)
     fill_halo_regions!(model.pressures.pNHS)
@@ -44,7 +44,7 @@ function make_pressure_correction!(model::NonhydrostaticModel, Δt)
             model.velocities,
             model.grid,
             model.pressures.pNHS)
-    
+
     ϵ = eps(eltype(model.pressures.pNHS))
     Δt⁺ = max(ϵ, Δt)
     model.pressures.pNHS ./= Δt⁺


### PR DESCRIPTION
Following from #4627, I noticed that `enforce_open_boundary_mass_conservation!` was _always_ called and doing stuff even when there was no open boundaries.

This PR deals with that.

with @glwagner 