### PR TITLE
Regularize field boundary conditions with a location rather than a name

### DIFF
--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -229,7 +229,14 @@ function regularize_field_boundary_conditions(bcs::FieldBoundaryConditions,
                                               prognostic_names=nothing)
 
     loc = assumed_field_location(field_name)
+    return regularize_field_boundary_conditions(bcs, grid, loc, prognostic_names)
+end
 
+function regularize_field_boundary_conditions(bcs::FieldBoundaryConditions,
+                                              grid::AbstractGrid,
+                                              loc::Tuple,
+                                              prognostic_names=nothing)
+    
     west   = regularize_west_boundary_condition(bcs.west,     grid, loc, 1, LeftBoundary,  prognostic_names)
     east   = regularize_east_boundary_condition(bcs.east,     grid, loc, 1, RightBoundary, prognostic_names)
     south  = regularize_south_boundary_condition(bcs.south,   grid, loc, 2, LeftBoundary,  prognostic_names)

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -229,13 +229,14 @@ function regularize_field_boundary_conditions(bcs::FieldBoundaryConditions,
                                               prognostic_names=nothing)
 
     loc = assumed_field_location(field_name)
-    return regularize_field_boundary_conditions(bcs, grid, loc, prognostic_names)
+    return regularize_field_boundary_conditions(bcs, grid, loc, prognostic_names, field_name)
 end
 
 function regularize_field_boundary_conditions(bcs::FieldBoundaryConditions,
                                               grid::AbstractGrid,
                                               loc::Tuple,
-                                              prognostic_names=nothing)
+                                              prognostic_names=nothing,
+                                              field_name=nothing)
     
     west   = regularize_west_boundary_condition(bcs.west,     grid, loc, 1, LeftBoundary,  prognostic_names)
     east   = regularize_east_boundary_condition(bcs.east,     grid, loc, 1, RightBoundary, prognostic_names)


### PR DESCRIPTION
Even if `regularize_field_boundary_conditions` is not necessarily thought to be user-facing, it is a bit easier to understand and to use if we pass a location rather than a `field_name`, so that other models can use it without needing to extend the `assumed_field_location` function in oceananigans to add the `field_name` they need.

comes from issue #4702 

