### PR TITLE
Correct the implicit Split-RK3 diffusion implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.97.6"
+version = "0.97.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
@@ -125,7 +125,7 @@ function rk3_substep_tracers!(tracers, model, Δt, γⁿ, ζⁿ)
                        Δt)
 
         launch!(architecture(grid), grid, :xyz,
-                _split_rk3_average_field!,cθ, γⁿ, ζⁿ, Ψ⁻)
+                _split_rk3_average_field!, c, γⁿ, ζⁿ, Ψ⁻)
     end
 
     return nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
@@ -33,11 +33,13 @@ rk3_average_free_surface!(free_surface, args...) = nothing
 
 function rk3_average_free_surface!(free_surface::ImplicitFreeSurface, grid, timestepper, γⁿ, ζⁿ)
     arch = architecture(grid)
+    Nx, Ny, Nz = size(grid)
 
     ηⁿ⁻¹ = timestepper.Ψ⁻.η
     ηⁿ   = free_surface.η
+    params = KernelParameters(1:Nx, 1:Ny, Nz+1:Nz+1)
 
-    launch!(arch, grid, :xy, _rk3_average_free_surface!, ηⁿ, grid, ηⁿ⁻¹, γⁿ, ζⁿ)
+    launch!(arch, grid, params, _split_rk3_average_field!, ηⁿ, γⁿ, ζⁿ, ηⁿ⁻¹)
 
     return nothing
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
@@ -141,7 +141,7 @@ end
 #####
 
 
-# σθ is the evolved quantity, so tracer fields need to be evolved
+# σc is the evolved quantity, so tracer fields need to be evolved
 # accounting for the stretching factors from the new and the previous time step.
 @kernel function _euler_substep_tracer_field!(c, grid, Δt, Gⁿ)
     i, j, k = @index(Global, NTuple)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
@@ -138,9 +138,8 @@ end
 #####
 
 
-# σθ is the evolved quantity.
-# We store temporarily σθ in θ. Once σⁿ⁺¹ is known we can retrieve θⁿ⁺¹
-# Ψ⁻ is the previous tracer already scaled by the vertical coordinate scaling factor: ψ⁻ = σ * θ
+# σθ is the evolved quantity, so tracer fields need to be evolved
+# accounting for the stretching factors from the new and the previous time step.
 @kernel function _euler_substep_tracer_field!(θ, grid, Δt, Gⁿ)
     i, j, k = @index(Global, NTuple)
     σᶜᶜⁿ = σⁿ(i, j, k, grid, Center(), Center(), Center())

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
@@ -89,7 +89,7 @@ function rk3_substep_velocities!(velocities, model, Δt, γⁿ, ζⁿ)
 
         if model.clock.stage > 1 
             launch!(architecture(grid), grid, :xyz,
-                _split_rk3_average_field!, velocity_field, γⁿ, ζⁿ, Ψ⁻)
+                    _split_rk3_average_field!, velocity_field, γⁿ, ζⁿ, Ψ⁻)
         end
     end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk3_step.jl
@@ -59,11 +59,6 @@ function rk3_average_free_surface!(free_surface::SplitExplicitFreeSurface, grid,
     return nothing
 end
 
-@kernel function _rk3_average_free_surface!(η, grid, η⁻, γⁿ, ζⁿ)
-    i, j = @index(Global, NTuple)
-    @inbounds η[i, j, k] = ζⁿ * η⁻[i, j, k] + γⁿ * η[i, j, k]
-end
-
 #####
 ##### Time stepping in each substep
 #####

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -59,12 +59,8 @@ function SplitRungeKutta3TimeStepper(grid, prognostic_fields, args...;
                                      Ψ⁻::PF = map(similar, prognostic_fields),
                                      G⁻::TE = nothing) where {TI, TG, PF, TE}
 
-    @warn("Split barotropic-baroclinic time stepping with SplitRungeKutta3TimeStepper is not tested and experimental.\n" *
+    @warn("Split barotropic-baroclinic time stepping with SplitRungeKutta3TimeStepper is and experimental.\n" *
           "Use at own risk, and report any issues encountered at [https://github.com/CliMA/Oceananigans.jl/issues](https://github.com/CliMA/Oceananigans.jl/issues).")
-
-    !isnothing(implicit_solver) &&
-        @warn("Implicit-explicit time-stepping with SplitRungeKutta3TimeStepper is not tested. " *
-                "\n implicit_solver: $(typeof(implicit_solver))")
 
     γ² = 1 // 4
     γ³ = 2 // 3

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -140,8 +140,6 @@ end
     @inbounds field[i, j, k] = ζⁿ * field⁻[i, j, k] + γⁿ * field[i, j, k]
 end
 
-@kernel _split_rk3_average_field!(field, ::Nothing, ::Nothing, field⁻) = nothing
-
 function split_rk3_substep!(model, Δt, γⁿ, ζⁿ)
 
     grid = model.grid
@@ -164,7 +162,8 @@ function split_rk3_substep!(model, Δt, γⁿ, ζⁿ)
                        model.clock,
                        Δt)
 
-        launch!(arch, grid, :xyz, _split_rk3_average_field!, field, γⁿ, ζⁿ, model.timestepper.Ψ⁻[i])
+        model.clock.stage > 1 && 
+            launch!(arch, grid, :xyz, _split_rk3_average_field!, field, γⁿ, ζⁿ, model.timestepper.Ψ⁻[i])
     end
 end
 

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -130,17 +130,17 @@ function time_step!(model::AbstractModel{<:SplitRungeKutta3TimeStepper}, Δt; ca
     return nothing
 end
 
-@kernel function _euler_substep_field!(θ, Δt, Gⁿ)
+@kernel function _euler_substep_field!(field, Δt, Gⁿ)
     i, j, k = @index(Global, NTuple)
-    @inbounds θ[i, j, k] = θ[i, j, k] + Δt * Gⁿ[i, j, k]
+    @inbounds field[i, j, k] = field[i, j, k] + Δt * Gⁿ[i, j, k]
 end
 
-@kernel function _split_rk3_average_field!(θ, γⁿ, ζⁿ, θ⁻)
+@kernel function _split_rk3_average_field!(field, γⁿ, ζⁿ, field⁻)
     i, j, k = @index(Global, NTuple)
-    @inbounds θ[i, j, k] = ζⁿ * θ⁻[i, j, k] + γⁿ * θ[i, j, k]
+    @inbounds field[i, j, k] = ζⁿ * field⁻[i, j, k] + γⁿ * field[i, j, k]
 end
 
-@kernel _split_rk3_average_field!(θ, ::Nothing, ::Nothing, θ⁻) = nothing
+@kernel _split_rk3_average_field!(field, ::Nothing, ::Nothing, field⁻) = nothing
 
 function split_rk3_substep!(model, Δt, γⁿ, ζⁿ)
 

--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -130,17 +130,17 @@ function time_step!(model::AbstractModel{<:SplitRungeKutta3TimeStepper}, Δt; ca
     return nothing
 end
 
-@kernel function _euler_substep_field!(u, Δt, Gⁿ)
+@kernel function _euler_substep_field!(θ, Δt, Gⁿ)
     i, j, k = @index(Global, NTuple)
-    @inbounds u[i, j, k] = u[i, j, k] + Δt * Gⁿ[i, j, k]
+    @inbounds θ[i, j, k] = θ[i, j, k] + Δt * Gⁿ[i, j, k]
 end
 
-@kernel function _split_rk3_average_field!(θ, γⁿ, ζⁿ, Ψ⁻)
+@kernel function _split_rk3_average_field!(θ, γⁿ, ζⁿ, θ⁻)
     i, j, k = @index(Global, NTuple)
-    @inbounds θ[i, j, k] = ζⁿ * Ψ⁻[i, j, k] + γⁿ * θ[i, j, k] 
+    @inbounds θ[i, j, k] = ζⁿ * θ⁻[i, j, k] + γⁿ * θ[i, j, k]
 end
 
-@kernel _split_rk3_average_field!(θ, ::Nothing, ::Nothing, Ψ⁻) = nothing
+@kernel _split_rk3_average_field!(θ, ::Nothing, ::Nothing, θ⁻) = nothing
 
 function split_rk3_substep!(model, Δt, γⁿ, ζⁿ)
 

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -595,11 +595,11 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                 coord = coords[case]
 
                 for fieldname in fieldnames[case]
+                    @info "  Testing diffusion of a cosine [$fieldname, $(summary(closure)), $(summary(grid))]..."
                     @test test_diffusion_cosine(fieldname, NonhydrostaticModel, :RungeKutta3, grid, closure, coord)
                     @test test_diffusion_cosine(fieldname, NonhydrostaticModel, :QuasiAdamsBashforth2, grid, closure, coord)
 
                     if fieldname != :w && topology(grid)[3] == Bounded                        
-                        @info "  Testing diffusion of a cosine [$fieldname, $(summary(closure)), $(summary(grid))]..."
                         @test test_diffusion_cosine(fieldname, HydrostaticFreeSurfaceModel, :SplitRungeKutta3, grid, closure, coord; free_surface=nothing)
                         @test test_diffusion_cosine(fieldname, HydrostaticFreeSurfaceModel, :QuasiAdamsBashforth2, grid, closure, coord; free_surface = nothing)
                     end

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -401,98 +401,98 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
 @testset "Dynamics" begin
     @info "Testing dynamics..."
 
-    # @testset "Simple diffusion" begin
-    #     @info "  Testing simple diffusion..."
-    #     for fieldname in (:u, :v, :c), timestepper in timesteppers
-    #         for time_discretization in (ExplicitTimeDiscretization(), VerticallyImplicitTimeDiscretization())
-    #             @test test_diffusion_simple(fieldname, timestepper, time_discretization)
-    #         end
-    #     end
-    # end
+    @testset "Simple diffusion" begin
+        @info "  Testing simple diffusion..."
+        for fieldname in (:u, :v, :c), timestepper in timesteppers
+            for time_discretization in (ExplicitTimeDiscretization(), VerticallyImplicitTimeDiscretization())
+                @test test_diffusion_simple(fieldname, timestepper, time_discretization)
+            end
+        end
+    end
 
-    # @testset "Budgets in isotropic diffusion" begin
-    #     @info "  Testing model budgets with isotropic diffusion..."
-    #     for timestepper in timesteppers
-    #         for topology in ((Periodic, Periodic, Periodic),
-    #                          (Periodic, Periodic, Bounded),
-    #                          (Periodic, Bounded, Bounded),
-    #                          (Bounded, Bounded, Bounded))
+    @testset "Budgets in isotropic diffusion" begin
+        @info "  Testing model budgets with isotropic diffusion..."
+        for timestepper in timesteppers
+            for topology in ((Periodic, Periodic, Periodic),
+                             (Periodic, Periodic, Bounded),
+                             (Periodic, Bounded, Bounded),
+                             (Bounded, Bounded, Bounded))
 
-    #             # Can't use implicit time-stepping in vertically-periodic domains right now
-    #             if topology !== (Periodic, Periodic, Periodic)
-    #                 time_discretizations = (ExplicitTimeDiscretization(), VerticallyImplicitTimeDiscretization())
-    #             else
-    #                 time_discretizations = tuple(ExplicitTimeDiscretization())
-    #             end
+                # Can't use implicit time-stepping in vertically-periodic domains right now
+                if topology !== (Periodic, Periodic, Periodic)
+                    time_discretizations = (ExplicitTimeDiscretization(), VerticallyImplicitTimeDiscretization())
+                else
+                    time_discretizations = tuple(ExplicitTimeDiscretization())
+                end
 
-    #             for time_discretization in time_discretizations
-    #                 for closurename in [ScalarDiffusivity, VerticalScalarDiffusivity, HorizontalScalarDiffusivity]
+                for time_discretization in time_discretizations
+                    for closurename in [ScalarDiffusivity, VerticalScalarDiffusivity, HorizontalScalarDiffusivity]
 
-    #                     # VerticallyImplicitTimeDiscretization is not supported for HorizontalScalarDiffusivity
-    #                     (closurename == HorizontalScalarDiffusivity && time_discretization == VerticallyImplicitTimeDiscretization()) && continue
+                        # VerticallyImplicitTimeDiscretization is not supported for HorizontalScalarDiffusivity
+                        (closurename == HorizontalScalarDiffusivity && time_discretization == VerticallyImplicitTimeDiscretization()) && continue
 
-    #                     closure = closurename(time_discretization, ν=1, κ=1)
+                        closure = closurename(time_discretization, ν=1, κ=1)
 
-    #                     fieldnames = [:c]
-    #                     topology[1] === Periodic && push!(fieldnames, :u)
-    #                     topology[2] === Periodic && push!(fieldnames, :v)
-    #                     topology[3] === Periodic && push!(fieldnames, :w)
+                        fieldnames = [:c]
+                        topology[1] === Periodic && push!(fieldnames, :u)
+                        topology[2] === Periodic && push!(fieldnames, :v)
+                        topology[3] === Periodic && push!(fieldnames, :w)
 
-    #                     grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1), topology=topology)
+                        grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1), topology=topology)
 
-    #                     model = NonhydrostaticModel(; timestepper,
-    #                                                   grid,
-    #                                                   closure,
-    #                                                   tracers = :c,
-    #                                                   coriolis = nothing,
-    #                                                   buoyancy = nothing)
+                        model = NonhydrostaticModel(; timestepper,
+                                                      grid,
+                                                      closure,
+                                                      tracers = :c,
+                                                      coriolis = nothing,
+                                                      buoyancy = nothing)
 
-    #                     td = typeof(time_discretization).name.wrapper
+                        td = typeof(time_discretization).name.wrapper
 
-    #                     for fieldname in fieldnames
-    #                         @info "    [$timestepper, $td, $closurename] " *
-    #                               "Testing $fieldname budget in a $topology domain with scalar diffusion..."
-    #                         @test test_ScalarDiffusivity_budget(fieldname, model)
-    #                     end
-    #                 end
-    #             end
-    #         end
-    #     end
-    # end
+                        for fieldname in fieldnames
+                            @info "    [$timestepper, $td, $closurename] " *
+                                  "Testing $fieldname budget in a $topology domain with scalar diffusion..."
+                            @test test_ScalarDiffusivity_budget(fieldname, model)
+                        end
+                    end
+                end
+            end
+        end
+    end
 
-    # @testset "Budgets in biharmonic diffusion" begin
-    #     @info "  Testing model budgets with biharmonic diffusion..."
-    #     for timestepper in timesteppers
-    #         for topology in ((Periodic, Periodic, Periodic),
-    #                          (Periodic, Periodic, Bounded),
-    #                          (Periodic, Bounded, Bounded),
-    #                          (Bounded, Bounded, Bounded))
+    @testset "Budgets in biharmonic diffusion" begin
+        @info "  Testing model budgets with biharmonic diffusion..."
+        for timestepper in timesteppers
+            for topology in ((Periodic, Periodic, Periodic),
+                             (Periodic, Periodic, Bounded),
+                             (Periodic, Bounded, Bounded),
+                             (Bounded, Bounded, Bounded))
 
-    #             fieldnames = [:c]
+                fieldnames = [:c]
 
-    #             topology[1] === Periodic && push!(fieldnames, :u)
-    #             topology[2] === Periodic && push!(fieldnames, :v)
-    #             topology[3] === Periodic && push!(fieldnames, :w)
+                topology[1] === Periodic && push!(fieldnames, :u)
+                topology[2] === Periodic && push!(fieldnames, :v)
+                topology[3] === Periodic && push!(fieldnames, :w)
 
-    #             grid = RectilinearGrid(size=(2, 2, 2), extent=(1, 1, 1), topology=topology)
+                grid = RectilinearGrid(size=(2, 2, 2), extent=(1, 1, 1), topology=topology)
 
-    #             for formulation in (ThreeDimensionalFormulation(), HorizontalFormulation(), VerticalFormulation())
-    #                 model = NonhydrostaticModel(; timestepper,
-    #                                               grid,
-    #                                               closure = ScalarBiharmonicDiffusivity(formulation, ν=1, κ=1),
-    #                                               coriolis = nothing,
-    #                                               tracers = :c,
-    #                                               buoyancy = nothing)
+                for formulation in (ThreeDimensionalFormulation(), HorizontalFormulation(), VerticalFormulation())
+                    model = NonhydrostaticModel(; timestepper,
+                                                  grid,
+                                                  closure = ScalarBiharmonicDiffusivity(formulation, ν=1, κ=1),
+                                                  coriolis = nothing,
+                                                  tracers = :c,
+                                                  buoyancy = nothing)
 
-    #                 for fieldname in fieldnames
-    #                     @info "    [$timestepper] Testing $fieldname budget in a $topology domain " *
-    #                           "with biharmonic diffusion and $formulation..."
-    #                     @test test_ScalarBiharmonicDiffusivity_budget(fieldname, model)
-    #                 end
-    #             end
-    #         end
-    #     end
-    # end
+                    for fieldname in fieldnames
+                        @info "    [$timestepper] Testing $fieldname budget in a $topology domain " *
+                              "with biharmonic diffusion and $formulation..."
+                        @test test_ScalarBiharmonicDiffusivity_budget(fieldname, model)
+                    end
+                end
+            end
+        end
+    end
 
     @testset "Diffusion of a cosine" begin
         for arch in [CPU()] # Need some work to make these run on GPU
@@ -595,17 +595,12 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                 coord = coords[case]
 
                 for fieldname in fieldnames[case]
-                    @info "  Testing diffusion of a cosine [$fieldname, $(summary(closure)), $(summary(grid))]..."
-
-                    @info " RK3 NonhydrostaticModel"
                     @test test_diffusion_cosine(fieldname, NonhydrostaticModel, :RungeKutta3, grid, closure, coord)
-                    @info " QuasiAdamsBashforth2 NonhydrostaticModel"
                     @test test_diffusion_cosine(fieldname, NonhydrostaticModel, :QuasiAdamsBashforth2, grid, closure, coord)
 
-                    if fieldname != :w && topology(grid)[3] == Bounded
-                        @info " SplitRungeKutta3 HydrostaticFreeSurfaceModel"
-                        @test test_diffusion_cosine(fieldname, HydrostaticFreeSurfaceModel, :SplitRungeKutta3, grid, closure, coord; free_surface = nothing)
-                        @info " QuasiAdamsBashforth2 HydrostaticFreeSurfaceModel"
+                    if fieldname != :w && topology(grid)[3] == Bounded                        
+                        @info "  Testing diffusion of a cosine [$fieldname, $(summary(closure)), $(summary(grid))]..."
+                        @test test_diffusion_cosine(fieldname, HydrostaticFreeSurfaceModel, :SplitRungeKutta3, grid, closure, coord; free_surface=nothing)
                         @test test_diffusion_cosine(fieldname, HydrostaticFreeSurfaceModel, :QuasiAdamsBashforth2, grid, closure, coord; free_surface = nothing)
                     end
                 end
@@ -667,10 +662,10 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                       y_periodic_regularly_spaced_vertically_stretched_grid,
                       y_flat_regularly_spaced_vertically_stretched_grid)
 
-        free_surface_types(::Val{:QuasiAdamsBashforth2}, g) = (ImplicitFreeSurface(; gravitational_acceleration=g), 
-                                                               SplitExplicitFreeSurface(; gravitational_acceleratio=g, cfl=0.5))   
+        free_surface_types(::Val{:QuasiAdamsBashforth2}, g, grid) = (ImplicitFreeSurface(; gravitational_acceleration=g), 
+                                                                     SplitExplicitFreeSurface(grid, ; gravitational_acceleration=g, cfl=0.5))
 
-        free_surface_types(::Val{:SplitRungeKutta3}, g) = (SplitExplicitFreeSurface(; gravitational_acceleratio=g, cfl=0.5), ) 
+        free_surface_types(::Val{:SplitRungeKutta3}, g, grid) = (SplitExplicitFreeSurface(grid; gravitational_acceleration=g, cfl=0.5), ) 
 
         @testset "Internal wave with HydrostaticFreeSurfaceModel" begin
             for grid in test_grids
@@ -681,7 +676,7 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                     # Choose gravitational acceleration so that σ_surface = sqrt(g * Lx) = 10σ
                     gravitational_acceleration = (10σ)^2 / Lx
 
-                    for free_surface in free_surface_types(Val(timestepper), gravitational_acceleration)
+                    for free_surface in free_surface_types(Val(timestepper), gravitational_acceleration, grid)
                         model = HydrostaticFreeSurfaceModel(; free_surface, grid, kwargs...)
 
                         free_surface_type = typeof(free_surface).name.wrapper
@@ -691,66 +686,67 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                 end
             end
         end
+    end
 
-    #     @testset "Internal wave with NonhydrostaticModel" begin
-    #         for grid in test_grids
-    #             grid_name = typeof(grid).name.wrapper
-    #             topo = topology(grid)
+        @testset "Internal wave with NonhydrostaticModel" begin
+            for grid in test_grids
+                grid_name = typeof(grid).name.wrapper
+                topo = topology(grid)
 
-    #             model = NonhydrostaticModel(; grid, kwargs...)
+                model = NonhydrostaticModel(; grid, kwargs...)
 
-    #             @info "  Testing internal wave [NonhydrostaticModel, $grid_name, $topo]..."
-    #             internal_wave_dynamics_test(model, solution, Δt)
-    #         end
-    #     end
-    # end
+                @info "  Testing internal wave [NonhydrostaticModel, $grid_name, $topo]..."
+                internal_wave_dynamics_test(model, solution, Δt)
+            end
+        end
+    end
 
-    # @testset "Taylor-Green vortex" begin
-    #     for timestepper in (:QuasiAdamsBashforth2,) #timesteppers
-    #         for time_discretization in (ExplicitTimeDiscretization(), VerticallyImplicitTimeDiscretization())
-    #             td = typeof(time_discretization).name.wrapper
-    #             @info "  Testing Taylor-Green vortex [$timestepper, $td]..."
-    #             @test taylor_green_vortex_test(CPU(), timestepper, time_discretization)
-    #         end
-    #     end
-    # end
+    @testset "Taylor-Green vortex" begin
+        for timestepper in (:QuasiAdamsBashforth2,) #timesteppers
+            for time_discretization in (ExplicitTimeDiscretization(), VerticallyImplicitTimeDiscretization())
+                td = typeof(time_discretization).name.wrapper
+                @info "  Testing Taylor-Green vortex [$timestepper, $td]..."
+                @test taylor_green_vortex_test(CPU(), timestepper, time_discretization)
+            end
+        end
+    end
 
-    # @testset "Background fields" begin
-    #     for timestepper in (:QuasiAdamsBashforth2,) #timesteppers
-    #         @info "  Testing dynamics with background fields [$timestepper]..."
-    #         @test_skip passive_tracer_advection_test(timestepper, background_velocity_field=true)
+    @testset "Background fields" begin
+        for timestepper in (:QuasiAdamsBashforth2,) #timesteppers
+            @info "  Testing dynamics with background fields [$timestepper]..."
+            @test_skip passive_tracer_advection_test(timestepper, background_velocity_field=true)
 
-    #         Nx = Nz = 128
-    #         Lx = Lz = 2π
+            Nx = Nz = 128
+            Lx = Lz = 2π
 
-    #         # Regular grid with no flat dimension
-    #         y_periodic_regular_grid = RectilinearGrid(topology=(Periodic, Periodic, Bounded),
-    #                                                   size=(Nx, 1, Nz), x=(0, Lx), y=(0, Lx), z=(-Lz, 0))
+            # Regular grid with no flat dimension
+            y_periodic_regular_grid = RectilinearGrid(topology=(Periodic, Periodic, Bounded),
+                                                      size=(Nx, 1, Nz), x=(0, Lx), y=(0, Lx), z=(-Lz, 0))
 
-    #         solution, kwargs, background_fields, Δt, σ = internal_wave_solution(L=Lx, background_stratification=true)
+            solution, kwargs, background_fields, Δt, σ = internal_wave_solution(L=Lx, background_stratification=true)
 
-    #         model = NonhydrostaticModel(; grid=y_periodic_regular_grid, background_fields, kwargs...)
-    #         internal_wave_dynamics_test(model, solution, Δt)
-    #     end
-    # end
+            model = NonhydrostaticModel(; grid=y_periodic_regular_grid, background_fields, kwargs...)
+            internal_wave_dynamics_test(model, solution, Δt)
+        end
+    end
 
-    # @testset "Tilted gravity" begin
-    #     for arch in archs
-    #         @info "  Testing tilted gravity [$(typeof(arch))]..."
-    #         for θ in (0, 1, -30, 60, 90, -180)
-    #             stratified_fluid_remains_at_rest_with_tilted_gravity_buoyancy_tracer(arch, Float64, θ=θ)
-    #             stratified_fluid_remains_at_rest_with_tilted_gravity_temperature_tracer(arch, Float64, θ=θ)
-    #         end
-    #     end
-    # end
+    @testset "Tilted gravity" begin
+        for arch in archs
+            @info "  Testing tilted gravity [$(typeof(arch))]..."
+            for θ in (0, 1, -30, 60, 90, -180)
+                stratified_fluid_remains_at_rest_with_tilted_gravity_buoyancy_tracer(arch, Float64, θ=θ)
+                stratified_fluid_remains_at_rest_with_tilted_gravity_temperature_tracer(arch, Float64, θ=θ)
+            end
+        end
+    end
 
-    # # This test alone runs for 2 hours on the GPU!!!!!
-    # @testset "Background rotation about arbitrary axis" begin
-    #     for arch in archs
-    #         if arch == CPU() # This test is removed on the GPU (see Issue #2647)
-    #             @info "  Testing background rotation about arbitrary axis [$(typeof(arch))]..."
-    #             inertial_oscillations_work_with_rotation_in_different_axis(arch, Float64)
-    #         end
-    #     end
-    # end
+    # This test alone runs for 2 hours on the GPU!!!!!
+    @testset "Background rotation about arbitrary axis" begin
+        for arch in archs
+            if arch == CPU() # This test is removed on the GPU (see Issue #2647)
+                @info "  Testing background rotation about arbitrary axis [$(typeof(arch))]..."
+                inertial_oscillations_work_with_rotation_in_different_axis(arch, Float64)
+            end
+        end
+    end
 end

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -686,7 +686,6 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
                 end
             end
         end
-    end
 
         @testset "Internal wave with NonhydrostaticModel" begin
             for grid in test_grids


### PR DESCRIPTION
Following discoveries in #4705 it seems like there is some difference in the AB2 and the RK3 timestepper for the hydrostatic free surface model regarding implicit timestepping. This PR is here to try to fix the (possibly) bug in the RK3 timestepper with implicit diffusion

This is a chance to add also dynamics tests for the hydrostatic RK3 timestepper which were lacking.

EDIT: Indeed, the implicit-explicit timestepping was not correctly implemented with RK3. The implicit timestep needs to be applied to the "Forward Euler" evolved variables before averaging, not to the averaged variables that include previous time-step information.

As part of this PR, I also remove the warning on the implicit - explicit stepping with split RK3 since it is tested