### PR TITLE
Adding automated CPU benchmarks

### DIFF
--- a/.buildkite/pipeline-benchmarks.yml
+++ b/.buildkite/pipeline-benchmarks.yml
@@ -62,12 +62,17 @@ steps:
         rm \${OUTPUT_PREFIX}.sqlite
       done
 
+      # Unit tests (on CPU) using BenchmarkTools
+      export BENCHMARK_GROUP="unit"
+      $TARTARUS_HOME/julia-$JULIA_VERSION/bin/julia --color=yes --project --check-bounds=no test/benchmark_tests.jl
+
     artifact_paths:
       - "periodic_output.txt"
       - "bounded_output.txt"
       - "periodic_cheap_advection_output.txt"
       - "bounded_cheap_advection_output.txt"
       - "immersed_output.txt"
+      - "unit.txt"
     soft_fail:
       - exit_status: 3
 
@@ -114,3 +119,4 @@ steps:
       - "diff_periodic_cheap_advection_output.txt"
       - "diff_bounded_cheap_advection_output.txt"
       - "diff_immersed_output.txt"
+      - "diff_unit.txt"


### PR DESCRIPTION
This PR is here in preparation for #4706. It adds some unit benchmarks that will run on the CPU. 
They have to be taken with a grain of salt since Tartarus might be occupied while running the benchmarks so the performance might show high variance. However it is good to have at least a pipeline for tests