### PR TITLE
Once again, fix warning message formatting in SplitRungeKutta3TimeStepper

### DIFF
--- a/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
+++ b/src/TimeSteppers/split_hydrostatic_runge_kutta_3.jl
@@ -56,7 +56,7 @@ function SplitRungeKutta3TimeStepper(grid, prognostic_fields, args...;
                                      Ψ⁻::PF = map(similar, prognostic_fields),
                                      kwargs...) where {TI, TG, PF}
 
-    @warn("Split barotropic-baroclinic time stepping with SplitRungeKutta3TimeStepper is and experimental.\n" *
+    @warn("Split barotropic-baroclinic time stepping with SplitRungeKutta3TimeStepper is experimental.\n" *
           "Use at own risk, and report any issues encountered at [https://github.com/CliMA/Oceananigans.jl/issues](https://github.com/CliMA/Oceananigans.jl/issues).")
 
     FT = eltype(grid)


### PR DESCRIPTION
We've fixed it at #4728 but it creeped back in!!

This is because without the "update merge before merging" requirement a new PR can undo changes.

For a typo this is insignificant. But sometimes a new PR can undo a bug fix that was dealt with by a previous PR...

cc @glwagner, @simone-silvestri 