### PR TITLE
Enforce (temporarily) CUDA.jl < v5.8.3 for Buildkite CI docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -62,7 +62,7 @@ OceananigansReactantExt = ["Reactant", "KernelAbstractions", "ConstructionBase"]
 [compat]
 AMDGPU = "1.3.6, 2"
 Adapt = "4.1.1"
-CUDA = "5.8.3"
+CUDA = "5.7"
 ConstructionBase = "1"
 Crayons = "4"
 CubedSphere = "0.2, 0.3"

--- a/Project.toml
+++ b/Project.toml
@@ -62,7 +62,7 @@ OceananigansReactantExt = ["Reactant", "KernelAbstractions", "ConstructionBase"]
 [compat]
 AMDGPU = "1.3.6, 2"
 Adapt = "4.1.1"
-CUDA = "5.7"
+CUDA = "5.8.3"
 ConstructionBase = "1"
 Crayons = "4"
 CubedSphere = "0.2, 0.3"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -16,7 +16,7 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [compat]
-CUDA = "5.4"
+CUDA = "< 5.8.3"
 CairoMakie = "0.11, 0.12, 0.13, 0.14"
 Documenter = "1"
 DocumenterCitations = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -16,7 +16,7 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [compat]
-CUDA = "< 5.8.3"
+CUDA = "5.4"
 CairoMakie = "0.11, 0.12, 0.13, 0.14"
 Documenter = "1"
 DocumenterCitations = "1"


### PR DESCRIPTION
I see the docs are currently failing in Buildkite. I feel like there are a few issues with CUDA.jl right now (e.g. https://github.com/JuliaGPU/CUDA.jl/issues/2879) so this PR tries to fix things by using CUDA.jl v5.8.2. Hopefully this won't be needed once v5.8.4 is tagged and released.

Not sure why the main tests are okay and just the docs fail...