### PR TITLE
(0.98.1) Make `convert_for_netcdf()` accesible to users

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.98.0"
+version = "0.98.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/OceananigansNCDatasetsExt.jl
+++ b/ext/OceananigansNCDatasetsExt.jl
@@ -41,7 +41,7 @@ using Oceananigans.OutputWriters:
     show_array_type
 
 import Oceananigans: write_output!
-import Oceananigans.OutputWriters: NetCDFWriter, write_grid_reconstruction_data!, materialize_from_netcdf, reconstruct_grid
+import Oceananigans.OutputWriters: NetCDFWriter, write_grid_reconstruction_data!, convert_for_netcdf, materialize_from_netcdf, reconstruct_grid
 
 const c = Center()
 const f = Face()

--- a/ext/OceananigansNCDatasetsExt.jl
+++ b/ext/OceananigansNCDatasetsExt.jl
@@ -695,11 +695,11 @@ function write_grid_reconstruction_data!(ds, grid; array_type=Array{eltype(grid)
 
     # This is needed for now to prevent NetCDF from throwing an error, but precludes
     # us from reconstructing immersed grids from NetCDF. This is a temporary fix.
-    :mask ∈ keys(args) && delete!(args, :mask)
-    :bottom_height ∈ keys(args) && delete!(args, :bottom_height)
+    "mask" ∈ keys(args) && delete!(args, "mask")
+    "bottom_height" ∈ keys(args) && delete!(args, "bottom_height")
 
     args, kwargs = map(convert_for_netcdf, (args, kwargs))
-    args[:grid_type] = typeof(grid).name.wrapper |> string # Save type of grid for reconstruction
+    args["grid_type"] = typeof(grid).name.wrapper |> string # Save type of grid for reconstruction
 
     defGroup(ds, "grid_reconstruction_args"; attrib = args)
     defGroup(ds, "grid_reconstruction_kwargs"; attrib = kwargs)

--- a/ext/OceananigansNCDatasetsExt.jl
+++ b/ext/OceananigansNCDatasetsExt.jl
@@ -695,8 +695,8 @@ function write_grid_reconstruction_data!(ds, grid; array_type=Array{eltype(grid)
 
     # This is needed for now to prevent NetCDF from throwing an error, but precludes
     # us from reconstructing immersed grids from NetCDF. This is a temporary fix.
-    "mask" ∈ keys(args) && delete!(args, "mask")
-    "bottom_height" ∈ keys(args) && delete!(args, "bottom_height")
+    :mask ∈ keys(args) && delete!(args, :mask)
+    :bottom_height ∈ keys(args) && delete!(args, :bottom_height)
 
     args, kwargs = map(convert_for_netcdf, (args, kwargs))
     args["grid_type"] = typeof(grid).name.wrapper |> string # Save type of grid for reconstruction

--- a/ext/OceananigansNCDatasetsExt.jl
+++ b/ext/OceananigansNCDatasetsExt.jl
@@ -669,8 +669,8 @@ function grid_attributes(ibg::ImmersedBoundaryGrid)
     return attrs, dims
 end
 
-# Using OrderedDict to preserve order of keys. Important for positional arguments.
-convert_for_netcdf(dict::AbstractDict) = OrderedDict{Symbol, Any}(key => convert_for_netcdf(value) for (key, value) in dict)
+# Using OrderedDict to preserve order of keys (important when saving positional arguments), and string(key) because that's what NetCDF supports as global_attributes.
+convert_for_netcdf(dict::AbstractDict) = OrderedDict(string(key) => convert_for_netcdf(value) for (key, value) in dict)
 convert_for_netcdf(x::Number) = x
 convert_for_netcdf(x::Bool) = string(x)
 convert_for_netcdf(x::NTuple{N, Number}) where N = collect(x)

--- a/src/OutputWriters/netcdf_writer.jl
+++ b/src/OutputWriters/netcdf_writer.jl
@@ -31,5 +31,6 @@ function NetCDFWriter(model, outputs; kw...)
 end
 
 function write_grid_reconstruction_data! end
+function convert_for_netcdf end
 function materialize_from_netcdf end
 function reconstruct_grid end


### PR DESCRIPTION
The function `convert_for_netcdf()` (which converts objects for use in NetCDFs as attributes) was used only in the `OceananigansNCDatasets.jl` extension to write grid-reconstruction arguments to NetCDF, but I think it would be nice to make it possible for users to use this interface. It can be useful to write all sorts of objects to NetCDF, and this function makes it easy to do it. It requires minimal code changes and no extra maintenance on our part.