### PR TITLE
Eliminate Reactant set_to_field

### DIFF
--- a/ext/OceananigansReactantExt/Fields.jl
+++ b/ext/OceananigansReactantExt/Fields.jl
@@ -26,22 +26,6 @@ deconcretize(field::Field{LX, LY, LZ}) where {LX, LY, LZ} =
                       field.status,
                       field.communication_buffers)
 
-function set!(u::ShardedDistributedField, V::ShardedDistributedField)
-    @jit _set_to_field!(u, V)
-    return nothing
-end
-
-function _set_to_field!(u, v)
-    arch = Oceananigans.Architectures.architecture(u)
-    Oceananigans.Utils.launch!(arch, u.grid, size(u), _copy!, u.data, v.data)
-    return nothing
-end
-
-"""Compute an `operand` and store in `data`."""
-@kernel function _copy!(u, v)
-    i, j, k = @index(Global, NTuple)
-    @inbounds u[i, j, k] = v[i, j, k]
-end
 
 function set_to_function!(u::ReactantField, f)
     # Supports serial and distributed
@@ -53,9 +37,6 @@ function set_to_function!(u::ReactantField, f)
     copyto!(interior(u), interior(cpu_u))
     return nothing
 end
-
-# keepin it simple
-set_to_field!(u::ReactantField, v::ReactantField) = @jit _set_to_field!(u, v)
 
 function set_to_function!(u::ShardedDistributedField, f)
     grid = u.grid


### PR DESCRIPTION
Reactant method of set_to_field produces inconsistent results with the original, and the original now works without erroring.