### PR TITLE
Try reusing the julia path for distributed tests

### DIFF
--- a/.buildkite/distributed/pipeline.yml
+++ b/.buildkite/distributed/pipeline.yml
@@ -23,7 +23,7 @@ steps:
       - echo "--- Initialize distributed tests"
       - "julia -O0 --project -e 'using Pkg; Pkg.test()'"
     agents:
-      slurm_mem: 8G
+      slurm_mem: 50G
       slurm_ntasks: 1
       slurm_gpus_per_task: 1
 
@@ -37,7 +37,7 @@ steps:
     commands:
       - "srun julia -O0 --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
-      slurm_mem: 8G
+      slurm_mem: 50G
       slurm_ntasks: 4
     retry:
       automatic:
@@ -52,7 +52,7 @@ steps:
     commands:
       - "srun julia -O0 --color=yes --project -e 'using Pkg; Pkg.test()'"
     agents:
-      slurm_mem: 8G
+      slurm_mem: 50G
       slurm_ntasks: 4
       slurm_gpus_per_task: 1
     retry:
@@ -115,7 +115,7 @@ steps:
       - "srun julia -O0 --color=yes --project -e 'using Pkg; Pkg.test()'"
     timeout_in_minutes: 1440
     agents:
-      slurm_mem: 100G # Apparently the GPU tests require more memory
+      slurm_mem: 150G # Apparently the GPU tests require more memory?
       slurm_ntasks: 4
       slurm_gpus_per_task: 1
     retry:


### PR DESCRIPTION
To clear the depot:
If you ever need to clear the depot (e.g. if some packages get corrupted and can't be correctly accessed), you can go to the [Clear Depot pipeline](https://buildkite.com/clima/clear-depot), click "new build", and put your pipeline's name as the value for the environment variable `SLUG`, i.e. `slug=oceananigans-distributed` for this pipeline).