### PR TITLE
Removing Reactant extension method for materialize_immersed_boundary

### DIFF
--- a/ext/OceananigansReactantExt/Grids/serial_grids.jl
+++ b/ext/OceananigansReactantExt/Grids/serial_grids.jl
@@ -9,14 +9,6 @@ deconcretize(z::StaticVerticalDiscretization) =
 
 # TODO: handle MutableVerticalDiscretization in grid constructors
 deconcretize(z::MutableVerticalDiscretization) = z
-
-function materialize_immersed_boundary(grid::ReactantGrid, ib::GridFittedBottom)
-    bottom_field = Field{Center, Center, Nothing}(grid)
-    set!(bottom_field, ib.bottom_height)
-    new_ib = GridFittedBottom(bottom_field)
-    return new_ib
-end
-
 deconcretize(gfb::GridFittedBottom) = GridFittedBottom(deconcretize(gfb.bottom_height),
                                                        gfb.immersed_condition)
 


### PR DESCRIPTION
The method in Reactant extension for `materialize_immersed_boundary` only works for a `GridFittedBottom` immersed boundary argument. It has inconsistencies with the base method for this argument, and doesn't appear to be necessary.