### PR TITLE
Use more efficient native broadcasting in `mean!` and `_mean`

### DIFF
--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -793,7 +793,7 @@ function Statistics._mean(f, c::AbstractField, dims; condition = nothing, mask =
     operand = condition_operand(f, c, condition, mask)
     r = sum(operand; dims)
     n = conditional_length(operand, dims)
-    r ./= n
+    parent(r) ./= n
     return r
 end
 
@@ -804,7 +804,7 @@ function Statistics.mean!(f::Function, r::ReducedAbstractField, a::AbstractField
     sum!(f, r, a; condition, mask, init=true)
     dims = reduced_dimension(location(r))
     n = conditional_length(condition_operand(f, a, condition, mask), dims)
-    r ./= n
+    parent(r) ./= n
     return r
 end
 


### PR DESCRIPTION
Broadcasting over `Field` directly is still slow; this PR changes flavors of `Statistics.mean` to use broadcasting over the underlying data rather than `Field` as an optimization. The objective is to make these two more similar:

```julia
using Oceananigans
using BenchmarkTools

grid = RectilinearGrid(size=(8, 8, 8), extent=(1, 1, 1), halo=(1, 1, 1))
u = XFaceField(grid)
U = Field{Nothing, Nothing, Nothing}(grid)
Ui = zeros(1, 1, 1)

@benchmark mean!(U, u)
@benchmark mean!(Ui, interior(u))
```

I think this takes the Oceananigans version from something like 20x slower to 10x slower.