### PR TITLE
Eliminate GridMetricOperation and create node metrics

### DIFF
--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -123,8 +123,8 @@ function define_binary_operator(op)
         $op(Lc::Tuple, f::Function, b::AbstractField) = $op(Lc, FunctionField(location(b), f, b.grid), b)
         $op(Lc::Tuple, a::AbstractField, f::Function) = $op(Lc, a, FunctionField(location(a), f, a.grid))
 
-        $op(Lc::Tuple, m::AbstractGridMetric, b::AbstractField) = $op(Lc, GridMetricOperation(location(b), m, b.grid), b)
-        $op(Lc::Tuple, a::AbstractField, m::AbstractGridMetric) = $op(Lc, a, GridMetricOperation(location(a), m, a.grid))
+        $op(Lc::Tuple, m::GridMetric, b::AbstractField) = $op(Lc, grid_metric_operation(location(b), m, b.grid), b)
+        $op(Lc::Tuple, a::AbstractField, m::GridMetric) = $op(Lc, a, grid_metric_operation(location(a), m, a.grid))
 
         # Sugary versions with default locations
         $op(a::AF, b::AF) = $op(location(a), a, b)
@@ -158,7 +158,7 @@ Example
 ```jldoctest
 julia> using Oceananigans, Oceananigans.AbstractOperations
 
-julia> using Oceananigans.AbstractOperations: BinaryOperation, AbstractGridMetric, choose_location
+julia> using Oceananigans.AbstractOperations: BinaryOperation, GridMetric, choose_location
 
 julia> plus_or_times(x, y) = x < 0 ? x + y : x * y
 plus_or_times (generic function with 1 method)

--- a/src/AbstractOperations/grid_metrics.jl
+++ b/src/AbstractOperations/grid_metrics.jl
@@ -1,26 +1,37 @@
 using Adapt
 using Oceananigans.Operators
 using Oceananigans.Grids: AbstractGrid
+using Oceananigans.Grids: xnode, ynode, znode, λnode, φnode, rnode
 using Oceananigans.Fields: AbstractField, default_indices, location
 using Oceananigans.Operators: Δx, Δy, Δz, Δr, Ax, Δλ, Δφ, Ay, Az, volume
+using Oceananigans.Operators: XNode, YNode, ZNode, ΛNode, ΦNode, RNode
+using Oceananigans.Operators: x, y, z, λ, φ, r
 
 import Oceananigans.Grids: xspacings, yspacings, zspacings, rspacings, λspacings, φspacings
 
-const AbstractGridMetric = Union{typeof(Δx),
-                                 typeof(Δy),
-                                 typeof(Δz),
-                                 typeof(Δr),
-                                 typeof(Δλ),
-                                 typeof(Δφ),
-                                 typeof(Ax),
-                                 typeof(Ay),
-                                 typeof(Az),
-                                 typeof(volume)} # Do we want it to be `volume` or just `V` like in the Operators module?
+const GridMetric = Union{XNode, YNode, ZNode, ΛNode, ΦNode, RNode,
+                         typeof(Δx),
+                         typeof(Δy),
+                         typeof(Δz),
+                         typeof(Δr),
+                         typeof(Δλ),
+                         typeof(Δφ),
+                         typeof(Ax),
+                         typeof(Ay),
+                         typeof(Az),
+                         typeof(volume)} # Do we want it to be `volume` or just `V` like in the Operators module?
+
+metric_function(loc, ::XNode) = xnode
+metric_function(loc, ::YNode) = ynode
+metric_function(loc, ::ZNode) = znode
+metric_function(loc, ::ΛNode) = λnode
+metric_function(loc, ::ΦNode) = φnode
+metric_function(loc, ::RNode) = rnode
 
 """
-    metric_function(loc, metric::AbstractGridMetric)
+    metric_function(loc, metric::GridMetric)
 
-Return the function associated with `metric::AbstractGridMetric` at `loc`ation.
+Return the function associated with `metric::GridMetric` at `loc`ation.
 """
 function metric_function(loc, metric)
     code = Tuple(interpolation_code(ℓ) for ℓ in loc)
@@ -32,32 +43,11 @@ function metric_function(loc, metric)
     return getglobal(@__MODULE__, metric_function_symbol)
 end
 
-struct GridMetricOperation{LX, LY, LZ, G, T, M} <: AbstractOperation{LX, LY, LZ, G, T}
-    metric :: M
-    grid :: G
-    function GridMetricOperation{LX, LY, LZ}(metric::M, grid::G) where {LX, LY, LZ, M, G}
-        T = eltype(grid)
-        return new{LX, LY, LZ, G, T, M}(metric, grid)
-    end
-end
-
-Adapt.adapt_structure(to, gm::GridMetricOperation{LX, LY, LZ}) where {LX, LY, LZ} =
-         GridMetricOperation{LX, LY, LZ}(Adapt.adapt(to, gm.metric),
-                                         Adapt.adapt(to, gm.grid))
-
-on_architecture(to, gm::GridMetricOperation{LX, LY, LZ}) where {LX, LY, LZ} =
-    GridMetricOperation{LX, LY, LZ}(on_architecture(to, gm.metric),
-                                    on_architecture(to, gm.grid))
-
-@inline Base.getindex(gm::GridMetricOperation, i, j, k) = gm.metric(i, j, k, gm.grid)
-
-indices(::GridMetricOperation) = default_indices(3)
-
 """
-    GridMetricOperation(loc, metric, grid)
+    grid_metric_operation(loc, metric, grid)
 
-Instance of `GridMetricOperation` that generates `BinaryOperation` of the `metric`
-at `loc`ation of the `grid`.
+Return a `KernelFunctionOperation` of `metric` that participates
+in a `BinaryOperation` at `loc`ation of the `grid`.
 
 Example
 =======
@@ -65,9 +55,9 @@ Example
 ```jldoctest
 julia> using Oceananigans
 
-julia> using Oceananigans.AbstractOperations: Ax, GridMetricOperation
+julia> using Oceananigans.AbstractOperations: Ax, grid_metric_operation
 
-julia> Axᶠᶜᶜ = GridMetricOperation((Face, Center, Center), Ax, RectilinearGrid(size=(2, 2, 3), extent=(1, 2, 3)))
+julia> Axᶠᶜᶜ = grid_metric_operation((Face, Center, Center), Ax, RectilinearGrid(size=(2, 2, 3), extent=(1, 2, 3)))
 Axᶠᶜᶜ at (Face, Center, Center)
 ├── grid: 2×2×3 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×2×3 halo
 └── tree:
@@ -77,20 +67,28 @@ Axᶠᶜᶜ at (Face, Center, Center)
 ```jldoctest
 julia> using Oceananigans
 
-julia> using Oceananigans.Operators: Δz
-
 julia> c = CenterField(RectilinearGrid(size=(1, 1, 1), extent=(1, 2, 3)));
 
-julia> c_dz = c * Δz; # returns BinaryOperation between Field and GridMetricOperation
+julia> using Oceananigans.Operators: Δz
 
-julia> c .= 1;
+julia> c_dz = c * Δz; # returns BinaryOperation between Field and GridMetric
+
+julia> set!(c, 1);
 
 julia> c_dz[1, 1, 1]
 3.0
 ```
 """
-GridMetricOperation(loc, metric, grid) =
-    GridMetricOperation{loc[1], loc[2], loc[3]}(metric_function(loc, metric), grid)
+grid_metric_operation(loc, metric, grid) =
+    KernelFunctionOperation{loc[1], loc[2], loc[3]}(metric_function(loc, metric), grid)
+
+const NodeMetric = Union{XNode, YNode, ZNode, ΛNode, ΦNode, RNode}
+
+function grid_metric_operation((LX, LY, LZ), metric::NodeMetric, grid)
+    ℓx, ℓy, ℓz = LX(), LY(), LZ
+    ξnode = metric_function(loc, metric)
+    return KernelFunctionOperation{LX, LY, LZ}(ξnode, grid, ℓx, ℓy, ℓz)
+end
 
 #####
 ##### Spacings

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -75,7 +75,7 @@ function Average(field::AbstractField; dims=:, condition=nothing, mask=0)
     else
         # Compute "size" (length, area, or volume) of averaging region
         dx = reduction_grid_metric(dims)
-        metric = GridMetricOperation(location(field), dx, field.grid)
+        metric = grid_metric_operation(location(field), dx, field.grid)
         volume = sum(metric; condition, mask, dims)
 
         # Construct summand of the Average
@@ -86,7 +86,7 @@ function Average(field::AbstractField; dims=:, condition=nothing, mask=0)
         field_dx = field * dx
         operand = condition_operand(field_dx, condition, mask)
 
-        metric = GridMetricOperation(location(field), dx, field.grid)
+        metric = grid_metric_operation(location(field), dx, field.grid)
         volume = sum(metric; condition, mask, dims)
         averaging = Averaging(volume)
         return Scan(averaging, average!, operand, dims)

--- a/src/Models/HydrostaticFreeSurfaceModels/compute_vertically_integrated_variables.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/compute_vertically_integrated_variables.jl
@@ -1,5 +1,5 @@
 using Oceananigans.Grids: halo_size
-using Oceananigans.AbstractOperations: Ax, Ay, GridMetricOperation
+using Oceananigans.AbstractOperations: Ax, Ay, grid_metric_operation
 # Has to be changed when the regression data is updated
 
 function compute_vertically_integrated_lateral_areas!(∫ᶻ_A)
@@ -10,8 +10,8 @@ function compute_vertically_integrated_lateral_areas!(∫ᶻ_A)
 
     field_grid = ∫ᶻ_A.xᶠᶜᶜ.grid
 
-    Axᶠᶜᶜ = GridMetricOperation((Face, Center, Center), Ax, field_grid)
-    Ayᶜᶠᶜ = GridMetricOperation((Center, Face, Center), Ay, field_grid)
+    Axᶠᶜᶜ = grid_metric_operation((Face, Center, Center), Ax, field_grid)
+    Ayᶜᶠᶜ = grid_metric_operation((Center, Face, Center), Ay, field_grid)
 
     sum!(∫ᶻ_A.xᶠᶜᶜ, Axᶠᶜᶜ)
     sum!(∫ᶻ_A.yᶜᶠᶜ, Ayᶜᶠᶜ)

--- a/src/Models/NonhydrostaticModels/boundary_mass_fluxes.jl
+++ b/src/Models/NonhydrostaticModels/boundary_mass_fluxes.jl
@@ -1,5 +1,5 @@
 using Oceananigans.BoundaryConditions: BoundaryCondition, Open, PerturbationAdvection
-using Oceananigans.AbstractOperations: Integral, Ax, Ay, Az, GridMetricOperation
+using Oceananigans.AbstractOperations: Integral, Ax, Ay, Az, grid_metric_operation
 using Oceananigans.Fields: Field, interior, XFaceField, YFaceField, ZFaceField
 using GPUArraysCore: @allowscalar
 
@@ -9,37 +9,37 @@ const FIOBC = BoundaryCondition{<:Open{<:Nothing}, <:Number} # "Fixed-imposed-ve
 const ZIOBC = BoundaryCondition{<:Open{<:Nothing}, <:Nothing} # "Zero-imposed-velocity" OpenBoundaryCondition (no-inflow)
 
 function get_west_area(grid)
-    dA = GridMetricOperation((Face, Center, Center), Ax, grid)
+    dA = grid_metric_operation((Face, Center, Center), Ax, grid)
     ∫dA = sum(dA, dims=(2, 3))
     return @allowscalar ∫dA[1, 1, 1]
 end
 
 function get_east_area(grid)
-    dA = GridMetricOperation((Face, Center, Center), Ax, grid)
+    dA = grid_metric_operation((Face, Center, Center), Ax, grid)
     ∫dA = sum(dA, dims=(2, 3))
     return @allowscalar ∫dA[grid.Nx+1, 1, 1]
 end
 
 function get_south_area(grid)
-    dA = GridMetricOperation((Center, Face, Center), Ay, grid)
+    dA = grid_metric_operation((Center, Face, Center), Ay, grid)
     ∫dA = sum(dA, dims=(1, 3))
     return @allowscalar ∫dA[1, 1, 1]
 end
 
 function get_north_area(grid)
-    dA = GridMetricOperation((Center, Face, Center), Ay, grid)
+    dA = grid_metric_operation((Center, Face, Center), Ay, grid)
     ∫dA = sum(dA, dims=(1, 3))
     return @allowscalar ∫dA[1, grid.Ny+1, 1]
 end
 
 function get_bottom_area(grid)
-    dA = GridMetricOperation((Center, Center, Face), Az, grid)
+    dA = grid_metric_operation((Center, Center, Face), Az, grid)
     ∫dA = sum(dA, dims=(1, 2))
     return @allowscalar ∫dA[1, 1, 1]
 end
 
 function get_top_area(grid)
-    dA = GridMetricOperation((Center, Center, Face), Az, grid)
+    dA = grid_metric_operation((Center, Center, Face), Az, grid)
     ∫dA = sum(dA, dims=(1, 2))
     return @allowscalar ∫dA[1, 1, grid.Nz+1]
 end

--- a/src/Models/boundary_mean.jl
+++ b/src/Models/boundary_mean.jl
@@ -1,7 +1,7 @@
 using Adapt, GPUArraysCore
 using Oceananigans: instantiated_location
 using Oceananigans.Fields: Center, Face
-using Oceananigans.AbstractOperations: GridMetricOperation, Ax, Ay, Az
+using Oceananigans.AbstractOperations: grid_metric_operation, Ax, Ay, Az
 using Oceananigans.BoundaryConditions: BoundaryCondition, Open, PerturbationAdvection
 
 import Adapt: adapt_structure
@@ -63,9 +63,9 @@ Base.summary(bam::BoundaryAdjacentMean) = "BoundaryAdjacentMean: ($(bam.value[])
 @inline boundary_reduced_field(::Union{Val{:south}, Val{:north}}, grid) = Field{Nothing, Center, Nothing}(grid)
 @inline boundary_reduced_field(::Union{Val{:bottom}, Val{:top}}, grid)  = Field{Nothing, Nothing, Center}(grid)
 
-@inline boundary_normal_area(::Union{Val{:west}, Val{:east}}, grid)   = GridMetricOperation((Face, Center, Center), Ax, grid)
-@inline boundary_normal_area(::Union{Val{:south}, Val{:north}}, grid) = GridMetricOperation((Center, Face, Center), Ay, grid)
-@inline boundary_normal_area(::Union{Val{:bottom}, Val{:top}}, grid)  = GridMetricOperation((Center, Center, Face), Az, grid)
+@inline boundary_normal_area(::Union{Val{:west}, Val{:east}}, grid)   = grid_metric_operation((Face, Center, Center), Ax, grid)
+@inline boundary_normal_area(::Union{Val{:south}, Val{:north}}, grid) = grid_metric_operation((Center, Face, Center), Ay, grid)
+@inline boundary_normal_area(::Union{Val{:bottom}, Val{:top}}, grid)  = grid_metric_operation((Center, Center, Face), Az, grid)
 
 @inline boundary_adjacent_indices(::Val{:east}, grid, loc) = size(grid, 1), 1, 1
 @inline boundary_adjacent_indices(val_side::Val{:west}, grid, loc) = first_interior_index(val_side, loc), 1, 1

--- a/src/MultiRegion/multi_region_split_explicit_free_surface.jl
+++ b/src/MultiRegion/multi_region_split_explicit_free_surface.jl
@@ -1,5 +1,4 @@
 using Oceananigans.Utils
-using Oceananigans.AbstractOperations: GridMetricOperation, Δz
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: free_surface_displacement_field
 using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces
 using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces: calculate_substeps, 

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -116,4 +116,19 @@ include("vector_rotation_operators.jl")
 @inline yarea(args...)    = Ay(args...)
 @inline zarea(args...)    = Az(args...)
 
+# To be used as GridMetrics
+struct XNode end
+struct YNode end
+struct ZNode end
+struct ΛNode end
+struct ΦNode end
+struct RNode end
+
+const x = XNode()
+const y = YNode()
+const z = ZNode()
+const λ = ΛNode()
+const φ = ΦNode()
+const r = RNode()
+
 end # module


### PR DESCRIPTION
This PR gets rid of `GridMetricOperation`, as it seems redundant with `KernelFunctionOperation`. In addition it creates new capabilities to form arithmetic expressions with "coordinates", ie so we can write

```julia
using Oceananigans
grid = RectilinearGrid(size=(4, 4, 4), extent=(4, 4, 4))
c = CenterField(grid)
using Oceananigans.Operators: z
c_z = Field(c * z)
```