### PR TITLE
Add missing import when extending `FieldBoundaryConditions` in `MultiRegion`

### DIFF
--- a/src/MultiRegion/multi_region_field.jl
+++ b/src/MultiRegion/multi_region_field.jl
@@ -6,7 +6,7 @@ using Oceananigans.OutputWriters: output_indices
 
 using Base: @propagate_inbounds
 
-import Oceananigans.BoundaryConditions: regularize_field_boundary_conditions, FieldBoundaryConditions
+import Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
 import Oceananigans.Diagnostics: hasnan
 import Oceananigans.DistributedComputations: reconstruct_global_field, CommunicationBuffers
 import Oceananigans.Fields: set!, compute!, compute_at!, interior, communication_buffers,
@@ -192,9 +192,6 @@ function inject_regional_bcs(grid, connectivity, loc, indices;
 
     return FieldBoundaryConditions(indices, west, east, south, north, bottom, top, immersed)
 end
-
-FieldBoundaryConditions(mrg::MultiRegionGrids, loc, indices; kwargs...) =
-    construct_regionally(inject_regional_bcs, mrg, mrg.connectivity, Reference(loc), indices; kwargs...)
 
 function Base.show(io::IO, field::MultiRegionField)
     bcs = getregion(field, 1).boundary_conditions


### PR DESCRIPTION
Perhaps this is related to those weird MultiRegion-related methods appearing with Distributed? See https://github.com/CliMA/ClimaOcean.jl/issues/647#issue-3485830061

Since the method wasn't imported, the attempt below to extent it might resulted in overwriting it?

What was missing was:
```julia
import Oceananigans.BoundaryConditions: FieldBoundaryConditions
```

Julia v1.12 warned me for that; that's how I found it.

```Julia
  1 dependency had output during precompilation:
┌ Oceananigans
│  WARNING: Constructor for type "FieldBoundaryConditions" was extended in `MultiRegion` without explicit qualification or import.
│    NOTE: Assumed "FieldBoundaryConditions" refers to `BoundaryConditions.FieldBoundaryConditions`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function FieldBoundaryConditions end`.
│    Hint: To silence the warning, qualify `FieldBoundaryConditions` as `BoundaryConditions.FieldBoundaryConditions` in the method signature or explicitly `import BoundaryConditions: FieldBoundaryConditions`.
└
```

cc @taimoorsohail 