### PR TITLE
Typo in `BuoyancyFormulations`

### DIFF
--- a/src/BuoyancyFormulations/g_dot_b.jl
+++ b/src/BuoyancyFormulations/g_dot_b.jl
@@ -5,7 +5,7 @@
 
 const NZBF = BuoyancyForce{<:Any, NegativeZDirection}
 
-@inline x_dot_g_bᶠᶜᶜ(i, j, k, grid, ::NZBF) = 0
-@inline y_dot_g_bᶜᶠᶜ(i, j, k, grid, ::NZBF) = 0
-@inline z_dot_g_bᶜᶜᶠ(i, j, k, grid, bf::NZBF) = ℑzᵃᵃᶠ(i, j, k, grid, buoyancy_perturbationᶜᶜᶜ, bf.formulation, C)
+@inline x_dot_g_bᶠᶜᶜ(i, j, k, grid, bf::NZBF, C) = 0
+@inline y_dot_g_bᶜᶠᶜ(i, j, k, grid, bf::NZBF, C) = 0
+@inline z_dot_g_bᶜᶜᶠ(i, j, k, grid, bf::NZBF, C) = ℑzᵃᵃᶠ(i, j, k, grid, buoyancy_perturbationᶜᶜᶜ, bf.formulation, C)
 


### PR DESCRIPTION
With @giordano, we are trying to debug the problem encountered in julia 1.11 and 1.12, but we are encountering a very strange issue.  We found a typo that this PR fixes, but now I am incredibly puzzled how the codebase has been working till now.

Edit: the function above was used here.