### PR TITLE
Extend API to allow passing a buffer scheme to advection schemes

### DIFF
--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -64,6 +64,8 @@ const advection_buffers = [1, 2, 3, 4, 5, 6]
 @inline required_halo_size_y(::AbstractAdvectionScheme{B}) where B = B
 @inline required_halo_size_z(::AbstractAdvectionScheme{B}) where B = B
 
+struct DescreasingOrderAdvectionScheme end
+
 include("centered_advective_fluxes.jl")
 include("upwind_biased_advective_fluxes.jl")
 

--- a/src/Advection/centered_reconstruction.jl
+++ b/src/Advection/centered_reconstruction.jl
@@ -10,12 +10,12 @@ end
 
 function Centered(FT::DataType=Oceananigans.defaults.FloatType; 
                   order = 2,
-                  buffer_scheme = nothing)
+                  buffer_scheme = DescreasingOrderAdvectionScheme())
 
     mod(order, 2) != 0 && throw(ArgumentError("Centered reconstruction scheme is defined only for even orders"))
 
     N  = Int(order ÷ 2)
-    if isnothing(buffer_scheme)
+    if buffer_scheme isa DescreasingOrderAdvectionScheme
         if N > 1
             buffer_scheme = Centered(FT; order=order-2)
         else

--- a/src/Advection/upwind_biased_reconstruction.jl
+++ b/src/Advection/upwind_biased_reconstruction.jl
@@ -12,7 +12,7 @@ end
 
 function UpwindBiased(FT::DataType = Float64; 
                       order = 3,
-                      buffer_scheme = nothing)
+                      buffer_scheme = DescreasingOrderAdvectionScheme())
 
     mod(order, 2) == 0 && throw(ArgumentError("UpwindBiased reconstruction scheme is defined only for odd orders"))
 
@@ -25,7 +25,7 @@ function UpwindBiased(FT::DataType = Float64;
         # Some tests are needed to verify why this is the case (and if it is expected)
         # coefficients = compute_reconstruction_coefficients(grid, FT, :Upwind; order)
         advecting_velocity_scheme = Centered(FT; order = order - 1)
-        if isnothing(buffer_scheme)
+        if buffer_scheme isa DescreasingOrderAdvectionScheme
             buffer_scheme  = UpwindBiased(FT; order = order - 2)
         end
     else

--- a/src/Advection/weno_reconstruction.jl
+++ b/src/Advection/weno_reconstruction.jl
@@ -76,7 +76,7 @@ WENO{5, Float64, Float32}(order=9)
 """
 function WENO(FT::DataType=Oceananigans.defaults.FloatType, FT2::DataType=Float32;
               order = 5,
-              buffer_scheme = nothing,
+              buffer_scheme = DescreasingOrderAdvectionScheme(),
               bounds = nothing)
 
     mod(order, 2) == 0 && throw(ArgumentError("WENO reconstruction scheme is defined only for odd orders"))
@@ -87,7 +87,7 @@ function WENO(FT::DataType=Oceananigans.defaults.FloatType, FT2::DataType=Float3
     else
         advecting_velocity_scheme = Centered(FT; order=order-1)
         
-        if isnothing(buffer_scheme)
+        if buffer_scheme isa DescreasingOrderAdvectionScheme
             buffer_scheme = WENO(FT, FT2; order=order-2, bounds)
         end
 


### PR DESCRIPTION
This was not possible at the moment, but it might be useful to test interactions between different schemes at the boundary (and the code change is minimal)