### PR TITLE
Correctly load `_part*.jld2` files in `FieldTimeSeries`

### DIFF
--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -451,7 +451,7 @@ end
 function naturalsort(x::Vector{String})
     f = text -> all(isnumeric, text) ? Char(parse(Int, text)) : text
     sorter = key -> join(f(m.match) for m in eachmatch(r"[0-9]+|[^0-9]+", key))
-    sort(x, by=sorter)
+    return sort(x, by=sorter)
 end
 
 struct UnspecifiedBoundaryConditions end


### PR DESCRIPTION
the order of loading was not preserved since, for example, `part10.jld2` was loaded before `part2.jld2`