### PR TITLE
import `xesmf_coordinates` from XESMF.jl

### DIFF
--- a/ext/OceananigansXESMFExt.jl
+++ b/ext/OceananigansXESMFExt.jl
@@ -8,7 +8,7 @@ using Oceananigans.Grids: AbstractGrid, λnodes, φnodes, Center, Face, total_le
 
 import Oceananigans.Fields: regrid!
 import Oceananigans.Architectures: on_architecture
-import XESMF: Regridder
+import XESMF: Regridder, xesmf_coordinates
 
 node_array(ξ::AbstractMatrix, Nx, Ny) = view(ξ, 1:Nx, 1:Ny)
 


### PR DESCRIPTION
this function should not be local to our extension, but imported by XESMF.jl so that we can use it in other packages