### PR TITLE
Add missing method for `ReactantState` architecture

### DIFF
--- a/ext/OceananigansReactantExt/OutputReaders.jl
+++ b/ext/OceananigansReactantExt/OutputReaders.jl
@@ -1,7 +1,9 @@
 module OutputReaders
 
-import Oceananigans.OutputReaders: find_time_index, cpu_interpolating_time_indices
+using Oceananigans.Architectures: ReactantState
 using Reactant: TracedStepRangeLen
+
+import Oceananigans.OutputReaders: find_time_index, cpu_interpolating_time_indices
 
 @inline function find_time_index(times::TracedStepRangeLen, t)
     n₂ = searchsortedfirst(times, t)


### PR DESCRIPTION
`cpu_interpolating_time_indices` is missing for a `ReactantState` architecture.
This PR introduces it.
exposed in this error: https://github.com/CliMA/ClimaOcean.jl/actions/runs/19296994671/job/55181367934

I am not sure that what I wrote here is valid though, this assumes that `times` for a `ReactantState` architecture are accessible and stored on the CPU