### PR TITLE
Don't materialize gradients by default

### DIFF
--- a/src/BuoyancyFormulations/buoyancy_force.jl
+++ b/src/BuoyancyFormulations/buoyancy_force.jl
@@ -48,7 +48,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 └── coriolis: Nothing
 ```
 """
-function BuoyancyForce(grid, formulation::AbstractBuoyancyFormulation; gravity_unit_vector=NegativeZDirection(), materialize_gradients=true)
+function BuoyancyForce(grid, formulation::AbstractBuoyancyFormulation; gravity_unit_vector=NegativeZDirection(), materialize_gradients=false)
     gravity_unit_vector = validate_unit_vector(gravity_unit_vector)
 
     if materialize_gradients


### PR DESCRIPTION
I don't think we want to allocate memory for these by default, since they are not used in the majority of cases (especially the horizontal gradients).