### PR TITLE
Remove redundant `FT` definition in fields tests

### DIFF
--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -693,4 +693,3 @@ end
         end
     end
 end
-


### PR DESCRIPTION
Ooops 😅 