### PR TITLE
Update CPU architecture reference in OutputReaders.jl

### DIFF
--- a/ext/OceananigansReactantExt/OutputReaders.jl
+++ b/ext/OceananigansReactantExt/OutputReaders.jl
@@ -24,7 +24,7 @@ import Oceananigans.OutputReaders: find_time_index, cpu_interpolating_time_indic
 end
 
 function cpu_interpolating_time_indices(::ReactantState, times, time_indexing, t) 
-    cpu_times = on_architecture(CPU(), times)
+    cpu_times = on_architecture(Oceananigans.Architectures.CPU(), times)
     return TimeInterpolator(time_indexing, times, t)
 end
 


### PR DESCRIPTION
This is another bug found in ClimaOcean. Not sure why the test does not capture it.