### PR TITLE
Temporarily add `ADTypes` to test environment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,8 +26,6 @@ steps:
       rsync -a . "$OCEANANIGANS_DIR/"
       cd "$OCEANANIGANS_DIR"
 
-      ls -lhrt
-
       julia +$JULIA_VERSION -O0 --color=yes --project -e 'using Pkg; Pkg.test()'
       # After we have instantiated the general environment, move manifest to the
       # version-specific filename, not to clash with the manifest for Enzyme.


### PR DESCRIPTION
This isn't really needed per se, but on CI since today we're getting an extremely puzzling error message during the "init" test group:
```
     Testing Oceananigans
ERROR: `Enzyme=7da242da-08ed-463a-9acd-ee780be4f1d9` depends on `ADTypes=47edcb42-4c32-4615-8424-f2b9edc5f35b`, but no such entry exists in the manifest.
Stacktrace:
  [1] pkgerror(::String, ::Vararg{String})
    @ Pkg.Types ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Types.jl:68
  [2] validate_manifest(julia_version::VersionNumber, project_hash::Base.SHA1, manifest_format::VersionNumber, stage1::Dict{String, Vector{Pkg.Types.Stage1}}, other::Dict{String, Any})
    @ Pkg.Types ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/manifest.jl:159
  [3] Pkg.Types.Manifest(raw::Dict{String, Any}, f_or_io::String)
    @ Pkg.Types ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/manifest.jl:230
  [4] read_manifest(f_or_io::String)
    @ Pkg.Types ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/manifest.jl:253
  [5] Pkg.Types.EnvCache(env::Nothing)
    @ Pkg.Types ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Types.jl:421
  [6] EnvCache
    @ ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Types.jl:388 [inlined]
  [7] #show_update#244
    @ ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:2896 [inlined]
  [8] up(ctx::Pkg.Types.Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel; skip_writing_project::Bool, preserve::Nothing)
    @ Pkg.Operations ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:1908
  [9] up
    @ ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:1880 [inlined]
 [10] up(ctx::Pkg.Types.Context, pkgs::Vector{PackageSpec}; level::UpgradeLevel, mode::PackageMode, preserve::Nothing, update_registry::Bool, skip_writing_project::Bool, kwargs::@Kwargs{io::Base.DevNull})
    @ Pkg.API ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/API.jl:418
 [11] up
    @ ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/API.jl:390 [inlined]
 [12] up
    @ ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/API.jl:169 [inlined]
 [13] #resolve#167
    @ ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/API.jl:424 [inlined]
 [14] resolve
    @ ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/API.jl:423 [inlined]
 [15] (::Pkg.Operations.var"#189#190"{String, Pkg.Types.EnvCache, Bool, Bool, Bool, Pkg.Operations.var"#204#205"{Bool, Cmd, Cmd, Nothing, Pkg.Types.Context, Vector{Tuple{String, Base.Process}}, String, PackageSpec}, Pkg.Types.Context, PackageSpec})()
    @ Pkg.Operations ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:2188
 [16] with_temp_env(fn::Pkg.Operations.var"#189#190"{String, Pkg.Types.EnvCache, Bool, Bool, Bool, Pkg.Operations.var"#204#205"{Bool, Cmd, Cmd, Nothing, Pkg.Types.Context, Vector{Tuple{String, Base.Process}}, String, PackageSpec}, Pkg.Types.Context, PackageSpec}, temp_env::String)
    @ Pkg.Operations ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:2062
 [17] (::Pkg.Operations.var"#185#186"{Dict{String, Any}, Bool, Bool, Bool, Pkg.Operations.var"#204#205"{Bool, Cmd, Cmd, Nothing, Pkg.Types.Context, Vector{Tuple{String, Base.Process}}, String, PackageSpec}, Pkg.Types.Context, PackageSpec, String, String})(tmp::String)
    @ Pkg.Operations ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:2172
 [18] mktempdir(fn::Pkg.Operations.var"#185#186"{Dict{String, Any}, Bool, Bool, Bool, Pkg.Operations.var"#204#205"{Bool, Cmd, Cmd, Nothing, Pkg.Types.Context, Vector{Tuple{String, Base.Process}}, String, PackageSpec}, Pkg.Types.Context, PackageSpec, String, String}, parent::String; prefix::String)
    @ Base.Filesystem ./file.jl:936
 [19] mktempdir(fn::Function, parent::String)
    @ Base.Filesystem ./file.jl:932
 [20] #sandbox#181
    @ ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:2119 [inlined]
 [21] test(ctx::Pkg.Types.Context, pkgs::Vector{PackageSpec}; coverage::Bool, julia_args::Cmd, test_args::Cmd, test_fn::Nothing, force_latest_compatible_version::Bool, allow_earlier_backwards_compatible_versions::Bool, allow_reresolve::Bool)
    @ Pkg.Operations ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:2371
 [22] test
    @ ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:2281 [inlined]
 [23] test(ctx::Pkg.Types.Context, pkgs::Vector{PackageSpec}; coverage::Bool, test_fn::Nothing, julia_args::Cmd, test_args::Cmd, force_latest_compatible_version::Bool, allow_earlier_backwards_compatible_versions::Bool, allow_reresolve::Bool, kwargs::@Kwargs{io::IOContext{IO}})
    @ Pkg.API ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/API.jl:512
 [24] test(pkgs::Vector{PackageSpec}; io::IOContext{IO}, kwargs::@Kwargs{})
    @ Pkg.API ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/API.jl:164
 [25] test(pkgs::Vector{PackageSpec})
    @ Pkg.API ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/API.jl:153
 [26] test(; name::Nothing, uuid::Nothing, version::Nothing, url::Nothing, rev::Nothing, path::Nothing, mode::PackageMode, subdir::Nothing, kwargs::@Kwargs{})
    @ Pkg.API ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/API.jl:179
 [27] test()
    @ Pkg.API ~/.julia/juliaup/julia-1.12.2+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/API.jl:170
 [28] top-level scope
    @ none:1
 [29] eval(m::Module, e::Any)
    @ Core ./boot.jl:489
 [30] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:283
 [31] _start()
    @ Base ./client.jl:550
```
The error doesn't make any sense to me, also because I can't reproduce it locally.  `ADTypes` is a weak dependency of `Enzyme`, not a direct one, and has been so for a while, it's nothing new, so the error is really weird.  Last successful job I could find is https://buildkite.com/clima/oceananigans/builds/27023#019ab470-2971-43dd-b80c-58fbc68b979f/34-47, which also ran on v1.12.2 like we currently do, and also in that case `ADTypes` wasn't part of the test env but Pkg didn't complain about it.

My only suggestion is to add `ADTypes` as a fake test dependency just to make Pkg somewhat happy, this is most definitely not a great solution, but I'm running out of ideas.