### PR TITLE
Remove duplicate `hack_cosd`/`hack_sind` definitions

### DIFF
--- a/src/Coriolis/hydrostatic_spherical_coriolis.jl
+++ b/src/Coriolis/hydrostatic_spherical_coriolis.jl
@@ -1,5 +1,5 @@
-using Oceananigans.Grids: LatitudeLongitudeGrid, OrthogonalSphericalShellGrid, φnode
-using Oceananigans.Operators: Δx_qᶜᶠᶜ, Δy_qᶠᶜᶜ, hack_sind
+using Oceananigans.Grids: LatitudeLongitudeGrid, OrthogonalSphericalShellGrid, φnode, hack_sind
+using Oceananigans.Operators: Δx_qᶜᶠᶜ, Δy_qᶠᶜᶜ
 using Oceananigans.Advection: EnergyConserving, EnstrophyConserving
 using Oceananigans.BoundaryConditions
 using Oceananigans.Fields

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -1,7 +1,4 @@
-using Oceananigans.Grids: Center, Face, AbstractGrid
-
-@inline hack_cosd(φ) = cos(π * φ / 180)
-@inline hack_sind(φ) = sin(π * φ / 180)
+using Oceananigans.Grids: Center, Face, AbstractGrid, hack_cosd, hack_sind
 
 """
 Notes:


### PR DESCRIPTION
There are identical functions in https://github.com/CliMA/Oceananigans.jl/blob/9dddbcab95f13a65ceddb73d49b42a7f5841ac79/src/Grids/latitude_longitude_grid.jl#L450-L451