### PR TITLE
Disambiguate binary operations on Numbers

### DIFF
--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -115,7 +115,7 @@ function define_binary_operator(op)
         end
 
         # Numbers are not fields...
-        $op(Lc::Tuple, a::Number, b::Number) = $op(a, b)
+        $op(Lc::Tuple{<:$Location, <:$Location, <:$Location}, a::Number, b::Number) = $op(a, b)
 
         # Sugar for mixing in functions of (x, y, z)
         $op(Lc::Tuple{<:$Location, <:$Location, <:$Location}, f::Function, b::AbstractField) = $op(Lc, FunctionField(location(b), f, b.grid), b)


### PR DESCRIPTION
Found this bug when building a BinaryOperation --- would be nice to test this. I believe it requires using `@at` in a BinaryOperation that involves multiplying numbers.