### PR TITLE
Reorganize `test_output_readers.jl`

### DIFF
--- a/src/OutputReaders/OutputReaders.jl
+++ b/src/OutputReaders/OutputReaders.jl
@@ -13,7 +13,7 @@ using Oceananigans.Utils: @apply_regionally
 If `filename` ends in `ext`, return `filename`. Otherwise return `filename * ext`.
 """
 function auto_extension(filename, ext)
-    if endswith(filename, ext) || endswith(filename, ".nc") || endswith(filename, ".jld2")
+    if endswith(filename, ext)
         return filename
     else
         return filename * ext

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -15,7 +15,6 @@ using Oceananigans.Grids
 using Oceananigans.Fields
 
 using Oceananigans.Grids: topology, total_size, interior_parent_indices, AbstractGrid
-using Oceananigans.OutputWriters: reconstruct_grid
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBottom
 
 using Oceananigans.Fields: interior_view_indices,
@@ -506,13 +505,7 @@ function FieldTimeSeries(path::String, name::String;
     if !isfile(path)
         start = path[1:end-5]
         # Look for part1, etc
-        if endswith(path, ".jld2")
-            lookfor = string(start, "_part*.jld2")
-        elseif endswith(path, ".nc")
-            lookfor = string(start, "_part*.nc")
-        else
-            error("Unsupported file extension: $(path)")
-        end
+        lookfor = string(start, "_part*.jld2")
         part_paths = glob(lookfor)
         part_paths = naturalsort(part_paths)
         Nparts = length(part_paths)
@@ -537,15 +530,7 @@ function FieldTimeSeries(path::String, name::String;
         end
     end
 
-    if isnothing(grid)
-        if endswith(path, ".jld2")
-            grid = file["serialized/grid"]
-        elseif endswith(path, ".nc")
-            grid = reconstruct_grid(path)
-        else
-            error("Unsupported file extension: $(path)")
-        end
-    end
+    isnothing(grid) && (grid = file["serialized/grid"])
 
     # If isreconstructed(grid), it probably means that the data was generated prior to
     # Oceananigans version 0.95.0 (12/13/2024). In this case, the best we can do is to try to rebuild


### PR DESCRIPTION
Just making things easier to read. Tests should remain the same for now. (I'll expand them soon when I start working on https://github.com/CliMA/Oceananigans.jl/issues/3935)