### PR TITLE
[docs] Use PNG format for CairoMakie images

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,7 @@ Distributed.addprocs(2)
 
     using CairoMakie # to avoid capturing precompilation output by Literate
     set_theme!(Theme(fontsize=20))
-    CairoMakie.activate!(type = "svg")
+    CairoMakie.activate!(type = "png")
 
     using NCDatasets
     using XESMF


### PR DESCRIPTION
This should produce smaller images than the SVG format, especially for high resolution pictures.

Similar to https://github.com/NumericalEarth/Breeze.jl/pull/238.  Ref #5027.