### PR TITLE
[docs] Use PNG figures in more places

### DIFF
--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -191,7 +191,7 @@ Let's visualize the situation:
 using Oceananigans
 using CairoMakie
 set_theme!(Theme(fontsize=20))
-CairoMakie.activate!(type="svg")
+CairoMakie.activate!(type="png")
 
 grid = RectilinearGrid(topology = (Periodic, Periodic, Bounded),
                        size = (4, 4, 4),

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -4,7 +4,7 @@
 DocTestSetup = quote
     using Oceananigans
     using CairoMakie
-    CairoMakie.activate!(type = "svg")
+    CairoMakie.activate!(type = "png")
     set_theme!(Theme(fontsize=20))
 end
 ```
@@ -191,7 +191,7 @@ using Oceananigans
 using Oceananigans.Units
 
 using CairoMakie
-CairoMakie.activate!(type = "svg")
+CairoMakie.activate!(type = "png")
 set_theme!(Theme(fontsize=20))
 
 grid = RectilinearGrid(topology = (Bounded, Bounded, Bounded),
@@ -369,7 +369,7 @@ grid = RectilinearGrid(size = (Nx, Ny, Nz),
 using Oceananigans
 using CairoMakie
 set_theme!(Theme(Lines = (linewidth = 3,)))
-CairoMakie.activate!(type="svg")
+CairoMakie.activate!(type="png")
 set_theme!(Theme(fontsize=20))
 
 Nx, Ny, Nz = 64, 64, 32


### PR DESCRIPTION
Follow up to #5031, ref https://github.com/CliMA/Oceananigans.jl/pull/5031#issuecomment-3634569461.  Figures in https://clima.github.io/OceananigansDocumentation/dev/grids/ and https://clima.github.io/OceananigansDocumentation/dev/fields/ are still in SVG format (but they are 840 kB total, not a huge deal)