### PR TITLE
Resolve warnings when `import`ing symbols already `using`ed

### DIFF
--- a/src/ImmersedBoundaries/immersed_grid_metrics.jl
+++ b/src/ImmersedBoundaries/immersed_grid_metrics.jl
@@ -1,7 +1,7 @@
 using Oceananigans.Operators: Δrᵃᵃᶠ, Δrᵃᵃᶜ, Δzᵃᵃᶠ, Δzᵃᵃᶜ
 using Oceananigans.Operators: Δxᶠᵃᵃ, Δxᶜᵃᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Δxᶜᶜᵃ
 using Oceananigans.Operators: Δyᵃᶠᵃ, Δyᵃᶜᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Δyᶠᶠᵃ, Δyᶜᶜᵃ
-using Oceananigans.Operators: Δλᶜᵃᵃ, Δλᶜᶜᵃ, Δλᶜᶠᵃ, Δλᶠᵃᵃ, Δλᶠᶜᵃ, Δλᶠᶠᵃ, Δφᵃᶜᵃ, Δφᵃᶠᵃ, Δφᵃᶠᵃ, Δφᵃᶠᵃ, Δφᶠᶜᵃ, Δφᶠᶠᵃ
+using Oceananigans.Operators: Δλᶜᵃᵃ, Δλᶜᶜᵃ, Δλᶜᶠᵃ, Δλᶠᵃᵃ, Δλᶠᶜᵃ, Δλᶠᶠᵃ, Δφᵃᶜᵃ, Δφᵃᶠᵃ, Δφᵃᶠᵃ, Δφᵃᶠᵃ, Δφᶜᶜᵃ, Δφᶜᶠᵃ, Δφᶠᶜᵃ, Δφᶠᶠᵃ
 using Oceananigans.Operators: Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, Azᶜᶜᵃ
 
 using Oceananigans.Operators: Operators, intrinsic_vector, extrinsic_vector


### PR DESCRIPTION
Probably a side effect of #5015, in Julia v1.11 currently we have the following warnings during precompilation:
```
┌ Oceananigans
│  WARNING: using Operators.Δλᶜᶜᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δλᶜᵃᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δφᶜᶜᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δφᵃᶜᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δλᶜᶠᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δφᶠᶜᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δλᶠᶜᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δλᶠᵃᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δφᶜᶠᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δφᵃᶠᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δλᶠᶠᵃ in module ImmersedBoundaries conflicts with an existing identifier.
│  WARNING: using Operators.Δφᶠᶠᵃ in module ImmersedBoundaries conflicts with an existing identifier.
└
```
But these were not appearing in Julia v1.12, which is what's used here for testing.