### PR TITLE
Add with_number_type function for distributed grids for correct reconstruction

### DIFF
--- a/src/DistributedComputations/distributed_grids.jl
+++ b/src/DistributedComputations/distributed_grids.jl
@@ -5,11 +5,11 @@ using Oceananigans.Grids: AbstractGrid, topology, size, halo_size, architecture,
 using Oceananigans.Grids: validate_rectilinear_grid_args, validate_lat_lon_grid_args
 using Oceananigans.Grids: generate_coordinate, with_precomputed_metrics
 using Oceananigans.Grids: cpu_face_constructor_x, cpu_face_constructor_y, cpu_face_constructor_z
-using Oceananigans.Grids: metrics_precomputed
+using Oceananigans.Grids: metrics_precomputed, constructor_arguments
 
 using Oceananigans.Fields
 
-import Oceananigans.Grids: RectilinearGrid, LatitudeLongitudeGrid, with_halo
+import Oceananigans.Grids: RectilinearGrid, LatitudeLongitudeGrid, with_halo, with_number_type
 
 const DistributedGrid{FT, TX, TY, TZ} = Union{
     AbstractGrid{FT, TX, TY, TZ, <:Distributed{<:CPU}},


### PR DESCRIPTION
Closes #5044.

For an example like
```julia
using Oceananigans
using Oceananigans.DistributedComputations: reconstruct_global_grid
using Oceananigans.Grids: with_number_type

const N = 16

arch = Distributed(CPU())

grid = RectilinearGrid(arch, Float64,
                    size = (N, N, N), 
                    halo = (4, 4, 4),
                    x = (0, 1),
                    y = (0, 1),
                    z = (0, 1),
                    topology = (Bounded, Bounded, Bounded))

slope(x, y) = 0.5

reduced_precision_grid = with_number_type(Float64, grid)
copied_grid = deepcopy(grid)

@info "reduced_precision_grid = $reduced_precision_grid"
@info "copied_grid = $copied_grid"
```
in `main` right now the results we get are:
```julia
┌ Info: reduced_precision_grid = 4×16×16 RectilinearGrid{Float64, LeftConnected, Bounded, Bounded} on Distributed{CPU} with 4×4×4 halo
│ ├── LeftConnected  x ∈ [0.75, 1.0] regularly spaced with Δx=0.0625
│ ├── Bounded  y ∈ [0.0, 1.0]        regularly spaced with Δy=0.0625
└ └── Bounded  z ∈ [0.0, 1.0]        regularly spaced with Δz=0.0625
┌ Info: reduced_precision_grid = 4×16×16 RectilinearGrid{Float64, RightConnected, Bounded, Bounded} on Distributed{CPU} with 4×4×4 halo
│ ├── RightConnected  x ∈ [0.0, 0.25) regularly spaced with Δx=0.0625
│ ├── Bounded  y ∈ [0.0, 1.0]         regularly spaced with Δy=0.0625
└ └── Bounded  z ∈ [0.0, 1.0]         regularly spaced with Δz=0.0625
┌ Info: copied_grid = 8×16×16 RectilinearGrid{Float64, LeftConnected, Bounded, Bounded} on Distributed{CPU} with 4×4×4 halo
│ ├── LeftConnected  x ∈ [0.5, 1.0] regularly spaced with Δx=0.0625
│ ├── Bounded  y ∈ [0.0, 1.0]       regularly spaced with Δy=0.0625
└ └── Bounded  z ∈ [0.0, 1.0]       regularly spaced with Δz=0.0625
┌ Info: copied_grid = 8×16×16 RectilinearGrid{Float64, RightConnected, Bounded, Bounded} on Distributed{CPU} with 4×4×4 halo
│ ├── RightConnected  x ∈ [0.0, 0.5) regularly spaced with Δx=0.0625
│ ├── Bounded  y ∈ [0.0, 1.0]        regularly spaced with Δy=0.0625
└ └── Bounded  z ∈ [0.0, 1.0]        regularly spaced with Δz=0.0625
```

Note that the `reduced_precision_grid` has been further split into two due to the wrong constructor arguments when https://github.com/CliMA/Oceananigans.jl/blob/b5d12644e8ed5f5b2a4e97886f8e8046b3f963a8/src/Grids/rectilinear_grid.jl#L431-L435 is dispatched.

After this fix the output is
```julia
┌ Info: reduced_precision_grid = 8×16×16 RectilinearGrid{Float64, RightConnected, Bounded, Bounded} on Distributed{CPU} with 4×4×4 halo
│ ├── RightConnected  x ∈ [0.0, 0.5) regularly spaced with Δx=0.0625
│ ├── Bounded  y ∈ [0.0, 1.0]        regularly spaced with Δy=0.0625
└ └── Bounded  z ∈ [0.0, 1.0]        regularly spaced with Δz=0.0625
┌ Info: reduced_precision_grid = 8×16×16 RectilinearGrid{Float64, LeftConnected, Bounded, Bounded} on Distributed{CPU} with 4×4×4 halo
│ ├── LeftConnected  x ∈ [0.5, 1.0] regularly spaced with Δx=0.0625
│ ├── Bounded  y ∈ [0.0, 1.0]       regularly spaced with Δy=0.0625
└ └── Bounded  z ∈ [0.0, 1.0]       regularly spaced with Δz=0.0625
┌ Info: copied_grid = 8×16×16 RectilinearGrid{Float64, LeftConnected, Bounded, Bounded} on Distributed{CPU} with 4×4×4 halo
│ ├── LeftConnected  x ∈ [0.5, 1.0] regularly spaced with Δx=0.0625
│ ├── Bounded  y ∈ [0.0, 1.0]       regularly spaced with Δy=0.0625
└ └── Bounded  z ∈ [0.0, 1.0]       regularly spaced with Δz=0.0625
┌ Info: copied_grid = 8×16×16 RectilinearGrid{Float64, RightConnected, Bounded, Bounded} on Distributed{CPU} with 4×4×4 halo
│ ├── RightConnected  x ∈ [0.0, 0.5) regularly spaced with Δx=0.0625
│ ├── Bounded  y ∈ [0.0, 1.0]        regularly spaced with Δy=0.0625
└ └── Bounded  z ∈ [0.0, 1.0]        regularly spaced with Δz=0.0625
```