### PR TITLE
Fix boundary gradient operators on extended conformal cubed sphere grids

### DIFF
--- a/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
+++ b/src/OrthogonalSphericalShellGrids/conformal_cubed_sphere_panel.jl
@@ -758,7 +758,7 @@ import Oceananigans.Operators: δxTᶠᵃᵃ, δyTᵃᶠᵃ
               ifelse((i < 1) & (j == grid.Ny+1),       c[1, grid.Ny-i+1, k] - c[i, grid.Ny, k],
                                                        c[i, j, k]           - c[i, j-1, k]))))
 
-@inline δxᶠᵃᵃ(i, j, k, grid::ConformalCubedSpherePanelGridOfSomeKind, f::F, args...) where F<:Function =
+@inline δxTᶠᵃᵃ(i, j, k, grid::ConformalCubedSpherePanelGridOfSomeKind, f::F, args...) where F<:Function =
     @inbounds ifelse((i == 1) & (j < 1),               f(1, j, k, grid, args...)           - f(j, 1, k, grid, args...),
               ifelse((i == grid.Nx+1) & (j < 1),       f(grid.Nx-j+1, 1, k, grid, args...) - f(grid.Nx, j, k, grid, args...),
               ifelse((i == grid.Nx+1) & (j > grid.Ny), f(j, grid.Ny, k, grid, args...)     - f(grid.Nx, j, k, grid, args...),


### PR DESCRIPTION
This pull request fixes an issue in the computation of gradient operators along conformal cubed sphere panel boundaries when using the extended grid configuration. In the extended grid, halo cells are exchanged only once at the beginning of each baroclinic time step to improve performance during barotropic substepping. This optimization requires boundary gradients to be computed correctly using the extended halo information. The previous implementation produced incorrect finite differences at panel boundaries in this configuration. This PR corrects the boundary gradient evaluation, ensuring consistent and accurate gradients while preserving the intended performance benefits of reduced halo exchanges.