### PR TITLE
fix error in docs for target function signature

### DIFF
--- a/docs/src/models/forcing_functions.md
+++ b/docs/src/models/forcing_functions.md
@@ -239,7 +239,7 @@ ContinuousForcing{Nothing} at (Center, Center, Face)
 ```
 
 The constructor for `Relaxation` accepts the keyword arguments `mask`, and `target`,
-which specify a `mask(x, y, z)` function that multiplies the forcing, and a `target(x, y, z)`
+which specify a `mask(x, y, z)` function that multiplies the forcing, and a `target(x, y, z, t)`
 distribution for the quantity in question. By default, `mask` uncovered the whole domain
 and `target` restores the field in question to 0
 


### PR DESCRIPTION
fix function signature for target in the `Relaxation` docs