### PR TITLE
Remove dependency on `Random`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -96,6 +96,7 @@ OffsetArrays = "1.4"
 OrderedCollections = "1.1"
 Pkg = "<0.0.1, 1"
 Printf = "1.9"
+Random = "1.9"
 Reactant = "0.2.169"
 ReactantCore = "0.1"
 Rotations = "1.0"
@@ -123,6 +124,7 @@ Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -130,4 +132,4 @@ TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
 
 [targets]
-test = ["AMDGPU", "Aqua", "CUDA", "oneAPI", "DataDeps", "ExplicitImports", "SafeTestsets", "Test", "Enzyme", "Reactant", "Metal", "XESMF", "CUDA_Runtime_jll", "MPIPreferences", "TimesDates", "NCDatasets", "CairoMakie", "ConservativeRegridding"]
+test = ["AMDGPU", "Aqua", "CUDA", "oneAPI", "DataDeps", "ExplicitImports", "SafeTestsets", "Test", "Enzyme", "Reactant", "Metal", "XESMF", "CUDA_Runtime_jll", "MPIPreferences", "TimesDates", "NCDatasets", "CairoMakie", "ConservativeRegridding", "Random"]


### PR DESCRIPTION
It's completely unused after #5102, but Aqua doesn't catch it because of a [known bug](https://juliatesting.github.io/Aqua.jl/v0.8/stale_deps/#Known-bug-1bdc65e545db9b95) with stale dependencies which are in the sysimage, like `Random`.

