### PR TITLE
Add `Oceananigans` to the `docs` environment with `[sources]` section

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
     command: |
       cd "$OCEANANIGANS_DIR"
       julia +$JULIA_VERSION --color=yes --project=docs/ -e \
-        'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        'using Pkg; Pkg.instantiate()'
       julia +$JULIA_VERSION --color=yes --project=docs/ docs/make.jl
 
   - label: "{{ matrix.architecture }} - {{ matrix.group }} tests"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,6 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
+Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
@@ -17,6 +18,9 @@ SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 XESMF = "2e0b0046-e7a1-486f-88de-807ee8ffabe5"
+
+[sources]
+Oceananigans = {path = ".."}
 
 [compat]
 CairoMakie = "0.15"


### PR DESCRIPTION
In Julia v1.11+, the [`[sources]` section](https://pkgdocs.julialang.org/v1/toml-files/#The-%5Bsources%5D-section) of `Project.toml` is a much saner way to refer to local packages than manually fiddling with `Pkg.develop` every single time.