### PR TITLE
Update CI configurations for MakieExt and ConservativeRegridding to use Julia 1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - '1.12'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Updates some CI that was still on Julia v1.10