### PR TITLE
Revise divergence equation in vertical coordinates

### DIFF
--- a/docs/src/numerical_implementation/generalized_vertical_coordinates.md
+++ b/docs/src/numerical_implementation/generalized_vertical_coordinates.md
@@ -60,7 +60,7 @@ Using the chair rules above, the divergence of the flow in ``r``-coordinates bec
 We can rewrite ``\partial_x \sigma \rvert_r = \partial_r(\partial_x z)`` and similarly for the ``y`` direction. After a bit of reordering the above yields
 ```math
 \begin{equation}
-    \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{v} = \frac{1}{\sigma} \left( \frac{\partial \sigma u}{\partial x} \bigg\rvert_{r} + \frac{\partial \sigma v}{\partial y}\bigg\rvert_{r} \right) + \frac{1}{\sigma} \frac{\partial}{\partial r} \left( -u \frac{\partial z}{\partial x} - v \frac{\partial z}{\partial y} + w \right) \label{div1}
+    \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{v} = \frac{1}{\sigma} \left( \frac{\partial \sigma u}{\partial x} \bigg\rvert_{r} + \frac{\partial \sigma v}{\partial y}\bigg\rvert_{r} \right) - \frac{1}{\sigma} \frac{\partial}{\partial r} \left(u \frac{\partial z}{\partial x} + v \frac{\partial z}{\partial y} - w \right) \label{div1}
 \end{equation}
 ```
 Note that ``w`` above is the vertical velocity referenced to the ``z`` coordinate.


### PR DESCRIPTION
Corrected the sign in the vertical velocity term in the divergence equation (7). Does it seem right?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix divergence equation sign**
> 
> - Adjusts `∇·v` expression in `generalized_vertical_coordinates.md` to use `- (1/σ) ∂/∂r (u ∂z/∂x + v ∂z/∂y - w)` instead of the previous sign, aligning with the definitions of `w` and `ω` and ensuring subsequent derivations are consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e425200941810c7e870b6461543ca08d3d9415a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->