### PR TITLE
Add discrete form for FunctionField

### DIFF
--- a/src/Fields/function_field.jl
+++ b/src/Fields/function_field.jl
@@ -65,7 +65,7 @@ fieldify_function(L, a::Function, grid) = FunctionField(L, a, grid)
 @inline call_func(::Nothing, ::Nothing,  func, x...) = func(x...)
 # If clock is specified for discrete form, pass directly to `func`
 @inline call_func(clock,     parameters, func, i, j, k, grid::AbstractGrid) = func(i, j, k, grid, clock, parameters)
-@inline call_func(clock,     ::Nothing,  func, i, j, k, grid::AbstractGRid) = func(i, j, k, grid, clock)
+@inline call_func(clock,     ::Nothing,  func, i, j, k, grid::AbstractGrid) = func(i, j, k, grid, clock)
 
 @inline function Base.getindex(f::FunctionField{LX, LY, LZ}, i, j, k) where {LX, LY, LZ}
     f_ijk = call_func(f.clock, f.parameters, f.func, node(i, j, k, f.grid, LX(), LY(), LZ())...)

--- a/src/Fields/function_field.jl
+++ b/src/Fields/function_field.jl
@@ -1,11 +1,11 @@
-struct FunctionField{LX, LY, LZ, C, P, F, G, T} <: AbstractField{LX, LY, LZ, G, T, 3}
+struct FunctionField{LX, LY, LZ, C, P, F, G, T, D} <: AbstractField{LX, LY, LZ, G, T, 3}
           func :: F
           grid :: G
          clock :: C
     parameters :: P
 
     @doc """
-        FunctionField{LX, LY, LZ}(func, grid; clock=nothing, parameters=nothing) where {LX, LY, LZ}
+        FunctionField{LX, LY, LZ}(func, grid; clock=nothing, parameters=nothing, discrete_form=false) where {LX, LY, LZ}
 
     Returns a `FunctionField` on `grid` and at location `LX, LY, LZ`.
 
@@ -15,24 +15,32 @@ struct FunctionField{LX, LY, LZ, C, P, F, G, T} <: AbstractField{LX, LY, LZ, G, 
 
     A `FunctionField` will return the result of `func(x, y, z [, t])` at `LX, LY, LZ` on
     `grid` when indexed at `i, j, k`.
+
+    If `discrete_form=true`, then `func` must be a function with signature `func(i, j, k, grid)`,
+    `func(i, j, k, grid, clock)`, or `func(i, j, k, grid, clock, parameters)` depending on whether
+    `clock` or `parameters` are specified.
     """
     @inline function FunctionField{LX, LY, LZ}(func::F,
                                                grid::G;
                                                clock::C=nothing,
-                                               parameters::P=nothing) where {LX, LY, LZ, F, G, C, P}
+                                               parameters::P=nothing,
+                                               discrete_form::Bool=false) where {LX, LY, LZ, F, G, C, P}
         FT = eltype(grid)
-        return new{LX, LY, LZ, C, P, F, G, FT}(func, grid, clock, parameters)
+        return new{LX, LY, LZ, C, P, F, G, FT, discrete_form}(func, grid, clock, parameters)
     end
 
     @inline function FunctionField{LX, LY, LZ}(f::FunctionField,
                                                grid::G;
-                                               clock::C=nothing) where {LX, LY, LZ, G, C}
+                                               clock::C=nothing,
+                                               discrete_form::Bool=false) where {LX, LY, LZ, G, C}
         P = typeof(f.parameters)
         T = eltype(grid)
         F = typeof(f.func)
-        return new{LX, LY, LZ, C, P, F, G, T}(f.func, grid, clock, f.parameters)
+        return new{LX, LY, LZ, C, P, F, G, T, discrete_form}(f.func, grid, clock, f.parameters)
     end
 end
+
+const DiscreteFunctionField{LX, LY, LZ, C, P, F, G, T} = FunctionField{LX, LY, LZ, C, P, F, G, T, true}
 
 Adapt.parent_type(T::Type{<:FunctionField}) = T
 
@@ -51,9 +59,17 @@ fieldify_function(L, a::Function, grid) = FunctionField(L, a, grid)
 @inline call_func(clock,     ::Nothing,  func, x...) = func(x..., clock.time)
 @inline call_func(::Nothing, parameters, func, x...) = func(x..., parameters)
 @inline call_func(::Nothing, ::Nothing,  func, x...) = func(x...)
+# If clock is specified for discrete form, pass directly to `func`
+@inline call_func(clock,     parameters, func, i, j, k, grid::AbstractGrid) = func(i, j, k, grid, clock, parameters)
+@inline call_func(clock,     ::Nothing,  func, i, j, k, grid::AbstractGRid) = func(i, j, k, grid, clock)
 
 @inline function Base.getindex(f::FunctionField{LX, LY, LZ}, i, j, k) where {LX, LY, LZ}
     f_ijk = call_func(f.clock, f.parameters, f.func, node(i, j, k, f.grid, LX(), LY(), LZ())...)
+    return convert(eltype(f.grid), f_ijk)
+end
+
+@inline function Base.getindex(f::DiscreteFunctionField{LX, LY, LZ}, i, j, k) where {LX, LY, LZ}
+    f_ijk = call_func(f.clock, f.parameters, f.func, i, j, k, f.grid)
     return convert(eltype(f.grid), f_ijk)
 end
 

--- a/src/Fields/function_field.jl
+++ b/src/Fields/function_field.jl
@@ -54,6 +54,10 @@ fieldify_function(L, a::Function, grid) = FunctionField(L, a, grid)
 
 @inline indices(::FunctionField) = (:, :, :)
 
+@inline has_discrete_form(f::FunctionField) = has_discrete_form(typeof(f))
+@inline has_discrete_form(::Type{<:FunctionField}) = false
+@inline has_discrete_form(::Type{<:DiscreteFunctionField}) = true
+
 # Various possibilities for calling FunctionField.func:
 @inline call_func(clock,     parameters, func, x...) = func(x..., clock.time, parameters)
 @inline call_func(clock,     ::Nothing,  func, x...) = func(x..., clock.time)
@@ -79,14 +83,16 @@ Adapt.adapt_structure(to, f::FunctionField{LX, LY, LZ}) where {LX, LY, LZ} =
     FunctionField{LX, LY, LZ}(Adapt.adapt(to, f.func),
                            Adapt.adapt(to, f.grid),
                            clock = Adapt.adapt(to, f.clock),
-                           parameters = Adapt.adapt(to, f.parameters))
+                           parameters = Adapt.adapt(to, f.parameters),
+                           discrete_form = has_discrete_form(f))
 
 
 Architectures.on_architecture(to, f::FunctionField{LX, LY, LZ}) where {LX, LY, LZ} =
     FunctionField{LX, LY, LZ}(on_architecture(to, f.func),
                               on_architecture(to, f.grid),
                               clock = on_architecture(to, f.clock),
-                              parameters = on_architecture(to, f.parameters))
+                              parameters = on_architecture(to, f.parameters),
+                              discrete_form = has_discrete_form(f))
 
 Base.show(io::IO, field::FunctionField) =
     print(io, "FunctionField located at ", show_location(field), "\n",


### PR DESCRIPTION
This is a very simple change that I think would be helpful, at least for my purposes. It basically just adds a `discrete_form` option to `FunctionField` that mimics the interface currently provided for BCs and Forcings.

Let me know if this is already redundant with something else and I just missed it.

Still needs unit tests.