### PR TITLE
Move benchmarks from GPU 1 to GPU 0

### DIFF
--- a/.buildkite/pipeline-benchmarks.yml
+++ b/.buildkite/pipeline-benchmarks.yml
@@ -7,7 +7,7 @@ env:
   JULIA_NUM_PRECOMPILE_TASKS: 24
   JULIA_NUM_THREADS: 8
   NSYS: "/storage6/nsight/bin/nsys"
-  CUDA_VISIBLE_DEVICES: "0" # Tartarus device for GPU Benchmarking
+  CUDA_VISIBLE_DEVICES: "0" # Tartarus device for GPU Benchmarking TODO: Find a better solution, i.e. an idle device
   TMPDIR: "$TARTARUS_HOME/tmp"
 
 steps:


### PR DESCRIPTION
Looks like GPU 1 is very busy on tartarus, while GPU 0 is mostly idle.
The benchmarks are failing because they go out of memory:
https://buildkite.com/clima/oceananigans-benchmarks-1
so maybe changing the GPU will make them restart at least just to check how #5140 performs before #4882 comes online