### PR TITLE
Test for distributed checkpointing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}  # only needed for some repos (see below)
 
   distributed_output:
-    name: Distributed Output Combining - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Distributed Output - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/test/dependencies_for_checkpoint_tests.jl
+++ b/test/dependencies_for_checkpoint_tests.jl
@@ -1,4 +1,5 @@
-function test_minimal_restore(arch, FT, pickup_method, model_type)
+function test_minimal_restore(arch, FT, pickup_method, model_type,
+                              free_surface = Oceananigans.Models.HydrostaticFreeSurfaceModels.default_free_surface(grid))
     N = 16
     L = 50
 
@@ -10,12 +11,13 @@ function test_minimal_restore(arch, FT, pickup_method, model_type)
     if model_type == :nonhydrostatic
         model = NonhydrostaticModel(grid)
     elseif model_type == :hydrostatic
-        model = HydrostaticFreeSurfaceModel(grid; buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
+        model = HydrostaticFreeSurfaceModel(grid; free_surface, buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
     end
 
     simulation = Simulation(model; Δt=1.0, stop_time=3.0)
 
-    prefix = "mwe_checkpointer_$(model_type)_$(typeof(arch))_$(FT)"
+    arch_str = arch isa Distributed ? "$(nameof(typeof(arch)))_$(typeof(arch.child_architecture))" : "$(nameof(typeof(arch)))"
+    prefix = "mwe_checkpointer_$(model_type)_$(arch_str)_$(FT)"
 
     checkpointer = Checkpointer(model;
                                 schedule = TimeInterval(1.0),
@@ -45,7 +47,7 @@ function test_minimal_restore(arch, FT, pickup_method, model_type)
     if model_type == :nonhydrostatic
         new_model = NonhydrostaticModel(new_grid)
     elseif model_type == :hydrostatic
-        new_model = HydrostaticFreeSurfaceModel(new_grid; buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
+        new_model = HydrostaticFreeSurfaceModel(new_grid; free_surface, uoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
     end
 
     new_simulation = Simulation(new_model; Δt=1.0, stop_time=3.0)

--- a/test/dependencies_for_checkpoint_tests.jl
+++ b/test/dependencies_for_checkpoint_tests.jl
@@ -1,3 +1,4 @@
+
 function test_minimal_restore(arch, FT, pickup_method, model_type)
     N = 16
     L = 50

--- a/test/dependencies_for_checkpoint_tests.jl
+++ b/test/dependencies_for_checkpoint_tests.jl
@@ -1,0 +1,77 @@
+function test_minimal_restore(arch, FT, pickup_method, model_type)
+    N = 16
+    L = 50
+
+    grid = RectilinearGrid(arch, FT,
+                           size = (N, N, N),
+                           topology = (Periodic, Bounded, Bounded),
+                           extent = (L, L, L))
+
+    if model_type == :nonhydrostatic
+        model = NonhydrostaticModel(grid)
+    elseif model_type == :hydrostatic
+        model = HydrostaticFreeSurfaceModel(grid; buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
+    end
+
+    simulation = Simulation(model; Δt=1.0, stop_time=3.0)
+
+    prefix = "mwe_checkpointer_$(model_type)_$(typeof(arch))_$(FT)"
+
+    checkpointer = Checkpointer(model;
+                                schedule = TimeInterval(1.0),
+                                prefix = prefix,
+                                cleanup = false,
+                                verbose = true)
+
+    simulation.output_writers[:checkpointer] = checkpointer
+
+    @test_nowarn run!(simulation)
+
+    @test isfile("$(prefix)_iteration0.jld2")
+    @test isfile("$(prefix)_iteration1.jld2")
+    @test isfile("$(prefix)_iteration2.jld2")
+    @test isfile("$(prefix)_iteration3.jld2")
+
+    grid = nothing
+    model = nothing
+    simulation = nothing
+    checkpointer = nothing
+
+    new_grid = RectilinearGrid(arch, FT,
+                               size = (N, N, N),
+                               topology = (Periodic, Bounded, Bounded),
+                               extent = (L, L, L))
+
+    if model_type == :nonhydrostatic
+        new_model = NonhydrostaticModel(new_grid)
+    elseif model_type == :hydrostatic
+        new_model = HydrostaticFreeSurfaceModel(new_grid; buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
+    end
+
+    new_simulation = Simulation(new_model; Δt=1.0, stop_time=3.0)
+
+    new_checkpointer = Checkpointer(new_model;
+                                    schedule = TimeInterval(1.0),
+                                    prefix = prefix,
+                                    cleanup = false,
+                                    verbose = true)
+
+    new_simulation.output_writers[:checkpointer] = new_checkpointer
+
+    if pickup_method == :boolean
+        @test_nowarn set!(new_simulation; checkpoint=:latest)
+    elseif pickup_method == :iteration
+        @test_nowarn set!(new_simulation; iteration=3)
+    elseif pickup_method == :filepath
+        @test_nowarn set!(new_simulation; checkpoint="$(prefix)_iteration3.jld2")
+    end
+
+    @test iteration(new_simulation) == 3
+    @test time(new_simulation) == 3.0
+
+    @test new_checkpointer.schedule.actuations == 3
+
+    rm.(glob("$(prefix)_iteration*.jld2"))
+
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,6 +218,7 @@ CUDA.allowscalar() do
         reset_cuda_if_necessary()
         @testset "Distributed output combining tests" begin
             include("test_distributed_output_combining.jl")
+            include("test_distributed_checkpointing.jl")
         end
     end
 

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -1,4 +1,5 @@
 include("dependencies_for_runtests.jl")
+include("dependencies_for_checkpoint_tests.jl")
 
 using Glob
 using NCDatasets
@@ -59,84 +60,6 @@ function test_model_equality(test_model, true_model; atol=0)
             @test all(isapprox.(interior(test_model.auxiliary_fields[name]), interior(true_model.auxiliary_fields[name]); atol))
         end
     end
-
-    return nothing
-end
-
-function test_minimal_restore(arch, FT, pickup_method, model_type)
-    N = 16
-    L = 50
-
-    grid = RectilinearGrid(arch, FT,
-                           size = (N, N, N),
-                           topology = (Periodic, Bounded, Bounded),
-                           extent = (L, L, L))
-
-    if model_type == :nonhydrostatic
-        model = NonhydrostaticModel(grid)
-    elseif model_type == :hydrostatic
-        model = HydrostaticFreeSurfaceModel(grid; buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
-    end
-
-    simulation = Simulation(model; Δt=1.0, stop_time=3.0)
-
-    prefix = "mwe_checkpointer_$(model_type)_$(typeof(arch))_$(FT)"
-
-    checkpointer = Checkpointer(model;
-                                schedule = TimeInterval(1.0),
-                                prefix = prefix,
-                                cleanup = false,
-                                verbose = true)
-
-    simulation.output_writers[:checkpointer] = checkpointer
-
-    @test_nowarn run!(simulation)
-
-    @test isfile("$(prefix)_iteration0.jld2")
-    @test isfile("$(prefix)_iteration1.jld2")
-    @test isfile("$(prefix)_iteration2.jld2")
-    @test isfile("$(prefix)_iteration3.jld2")
-
-    grid = nothing
-    model = nothing
-    simulation = nothing
-    checkpointer = nothing
-
-    new_grid = RectilinearGrid(arch, FT,
-                               size = (N, N, N),
-                               topology = (Periodic, Bounded, Bounded),
-                               extent = (L, L, L))
-
-    if model_type == :nonhydrostatic
-        new_model = NonhydrostaticModel(new_grid)
-    elseif model_type == :hydrostatic
-        new_model = HydrostaticFreeSurfaceModel(new_grid; buoyancy=SeawaterBuoyancy(), tracers=(:T, :S))
-    end
-
-    new_simulation = Simulation(new_model; Δt=1.0, stop_time=3.0)
-
-    new_checkpointer = Checkpointer(new_model;
-                                    schedule = TimeInterval(1.0),
-                                    prefix = prefix,
-                                    cleanup = false,
-                                    verbose = true)
-
-    new_simulation.output_writers[:checkpointer] = new_checkpointer
-
-    if pickup_method == :boolean
-        @test_nowarn set!(new_simulation; checkpoint=:latest)
-    elseif pickup_method == :iteration
-        @test_nowarn set!(new_simulation; iteration=3)
-    elseif pickup_method == :filepath
-        @test_nowarn set!(new_simulation; checkpoint="$(prefix)_iteration3.jld2")
-    end
-
-    @test iteration(new_simulation) == 3
-    @test time(new_simulation) == 3.0
-
-    @test new_checkpointer.schedule.actuations == 3
-
-    rm.(glob("$(prefix)_iteration*.jld2"))
 
     return nothing
 end

--- a/test/test_distributed_checkpointing.jl
+++ b/test/test_distributed_checkpointing.jl
@@ -9,7 +9,8 @@ for model_type in (:nonhydrostatic, :hydrostatic)
     for pickup_method in (:boolean, :iteration, :filepath)
         @testset "Minimal distributed restore [$model_type, $pickup_method] [$(typeof(arch))]" begin
             @info "  Testing minimal distributed restore [$model_type, $pickup_method] [$(typeof(arch))]..."
-            test_minimal_restore(arch, Float64, pickup_method, model_type)
+            free_surface = SplitExplicitFreeSurface(grid, substeps=10)
+            test_minimal_restore(arch, Float64, pickup_method, model_type, free_surface)
         end
     end
 end

--- a/test/test_distributed_checkpointing.jl
+++ b/test/test_distributed_checkpointing.jl
@@ -1,0 +1,16 @@
+include("dependencies_for_runtests.jl")
+include("dependencies_for_checkpoint_tests.jl")
+
+using Oceananigans.DistributedComputations
+
+arch = Distributed(CPU(); partition = Partition(y = DistributedComputations.Equal()), synchronized_communication=true)
+
+for model_type in (:nonhydrostatic, :hydrostatic)
+    for pickup_method in (:boolean, :iteration, :filepath)
+        @testset "Minimal distributed restore [$model_type, $pickup_method] [$(typeof(arch))]" begin
+            @info "  Testing minimal distributed restore [$model_type, $pickup_method] [$(typeof(arch))]..."
+            test_minimal_restore(arch, Float64, pickup_method, model_type)
+        end
+    end
+end
+

--- a/test/test_distributed_checkpointing.jl
+++ b/test/test_distributed_checkpointing.jl
@@ -13,4 +13,3 @@ for model_type in (:nonhydrostatic, :hydrostatic)
         end
     end
 end
-


### PR DESCRIPTION
This PR adds a test for the checkpointer for a distributed CPU architecture. 

Current issues are: 

1) Filename does not specify rank automatically, so memory errors are hit
2) Ideally, the checkpoints should be saved combined, so the pickup is rank-agnostic. 

@navidcy 