### PR TITLE
Always run `Base.julia_cmd()` in distributed tests

### DIFF
--- a/test/test_mpi_tripolar.jl
+++ b/test/test_mpi_tripolar.jl
@@ -81,11 +81,11 @@ tripolar_reconstructed_field = """
 
 @testset "Test distributed TripolarGrid..." begin
     write("distributed_tripolar_grid.jl", tripolar_reconstructed_grid)
-    run(`$(mpiexec()) -n 4 julia --project -O0 distributed_tripolar_grid.jl`)
+    run(`$(mpiexec()) -n 4 $(Base.julia_cmd()) --project -O0 distributed_tripolar_grid.jl`)
     rm("distributed_tripolar_grid.jl")
 
     write("distributed_tripolar_field.jl", tripolar_reconstructed_field)
-    run(`$(mpiexec()) -n 4 julia --project -O0 distributed_tripolar_field.jl`)
+    run(`$(mpiexec()) -n 4 $(Base.julia_cmd()) --project -O0 distributed_tripolar_field.jl`)
     rm("distributed_tripolar_field.jl")
 end
 
@@ -144,7 +144,7 @@ tripolar_boundary_conditions = """
     fill_halo_regions!((v, c))
 
     write("distributed_boundary_tests.jl", tripolar_boundary_conditions)
-    run(`$(mpiexec()) -n 4 julia --project -O0 distributed_boundary_tests.jl`)
+    run(`$(mpiexec()) -n 4 $(Base.julia_cmd()) --project -O0 distributed_boundary_tests.jl`)
     rm("distributed_boundary_tests.jl")
 
     # Retrieve Parallel quantities from rank 1 (the north-west rank)


### PR DESCRIPTION
Using `$(Base.julia_cmd())` instead of `julia` in MPI tests is what's [recommended in MPI.jl documentation](https://juliaparallel.org/MPI.jl/stable/usage/#Writing-MPI-tests) and not doing so is problematic for multiple reasons:

* you end up calling a julia process with compiler flags different than the launching process, which in some cases can [cause precompilation failures](https://github.com/JuliaLang/julia/issues/48039)
* furthermore, because of the point above, you now have a bunch of concurrent processes which are all trying to precompile the environment at the same time, stepping on each other's toes, [causing absolute chaos](https://github.com/CliMA/Oceananigans.jl/actions/runs/21729692149/job/62692071513?pr=5246#step:6:1005)

I'd even go further and use `--compiled-modules=strict` which would make a process terminate with an error if a module isn't precompiled (that's what I ***strongly*** recommend doing on clusters, you really don't want wasting hours of compute time because of this).

