### PR TITLE
Add reference to Zhang et al. (2025) on Enceladus

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -119,6 +119,8 @@ If you have work using Oceananigans that you would like to have listed here, ple
 
 1. Johnston, D. R., Shakespeare, C. J., and Constantinou, N. C. (2026) [Evaluating and improving wave and non-wave stress parametrisations for oceanic flows](https://doi.org/10.1175/JPO-D-25-0064.1), _Journal of Physical Oceanography_, in press. DOI: [10.1175/JPO-D-25-0064.1](https://doi.org/10.1175/JPO-D-25-0064.1)
 
+1. Zhang, Y., Bire, S., Wang, S., Nath, A., Ramadhan, A., Kang, W., and Marshall, J. (2025). [Long transit time from the seafloor to the ice shell on Enceladus](https://doi.org/10.1093/mnras/staf1008), _Monthly Notices of the Royal Astronomical Society_, **541(2)**, 859–871. DOI: [10.1093/mnras/staf1008](https://doi.org/10.1093/mnras/staf1008)
+
 1. Chor, T., Wenegrat, J., and Wagner, G. L. (2025) [Turbulent mixing and dissipation around rough seamounts](https://doi.org/10.22541/essoar.176659936.64523492/v1), _ESS Open Archive_. DOI: [10.22541/essoar.176659936.64523492/v1](https://doi.org/10.22541/essoar.176659936.64523492/v1)
 
 1. Lee, X. K., Ramadhan, A., Souza, A., Wagner, G. L., Silvestri, S., Marshall, J. and Ferrari, R. (2025) [NORi: An ML-augmented ocean boundary layer parameterization](https://doi.org/10.48550/arXiv.2512.04452), _arXiv preprint_, arXiv:2512.04452. DOI: [10.48550/arXiv.2512.04452](https://doi.org/10.48550/arXiv.2512.04452)


### PR DESCRIPTION
Added a new reference to Zhang et al. (2025) discussing transit time from the seafloor to the ice shell on Enceladus.

