### PR TITLE
Add fields with non-default indices to Field tutorial

### DIFF
--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -567,7 +567,7 @@ surface_c[1:4, 1:5, grid.Nz]
 
 The `indices` keyword is particularly useful in combination with field operations.
 For example, suppose we want to compute and store the vertical vorticity
-``\partial v / \partial x - \partial u / \partial y`` only at the surface:
+``∂v / ∂x - ∂u / ∂y`` only at the surface:
 
 ```jldoctest fields
 u = XFaceField(grid)
@@ -588,7 +588,7 @@ v = YFaceField(grid)
 ```
 
 Computing `ωₛ` with `compute!` evaluates the expression `∂x(v) - ∂y(u)` and
-stores the result only at the surface slice:
+stores the result _only_ at the surface slice:
 
 ```jldoctest fields
 compute!(ωₛ)


### PR DESCRIPTION
## Summary
- Adds a new "Reduced-dimension fields with `indices`" section to the Field tutorial (`docs/src/fields.md`)
- Shows how to construct fields at a single index (e.g. surface slice) using the `indices` keyword
- Demonstrates `set!` on reduced fields and using `indices` with field operations (`Field(∂x(v) - ∂y(u), indices=...)`)
- All examples use `jldoctest` blocks with verified outputs

Closes #5206

## Test plan
- [x] Verify doctests pass: `julia --project -e 'using Pkg; Pkg.test("Oceananigans", test_args=["doctest"])'` or equivalent
- [x] Build docs locally and check the new section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)