### PR TITLE
Add indices support to FunctionField

### DIFF
--- a/src/Fields/field_indices.jl
+++ b/src/Fields/field_indices.jl
@@ -73,6 +73,12 @@ function compute_index_intersection(to_idx::AbstractUnitRange, from_idx::Abstrac
     return range_intersection
 end
 
+# Int indices (e.g. from a FunctionField with reduced indices) are treated as
+# single-element ranges so that the existing intersection logic applies cleanly.
+compute_index_intersection(to,      from::Int, args...) = compute_index_intersection(to   , from:from, args...)
+compute_index_intersection(to::Int, from     , args...) = compute_index_intersection(to:to, from     , args...)
+compute_index_intersection(to::Int, from::Int, args...) = compute_index_intersection(to:to, from:from, args...)
+
 validate_shifted_index(shifted_idx) = first(shifted_idx) > last(shifted_idx) &&
     throw(ArgumentError("Cannot compute index intersection!"))
 

--- a/src/Fields/function_field.jl
+++ b/src/Fields/function_field.jl
@@ -6,7 +6,7 @@ struct FunctionField{LX, LY, LZ, C, P, F, G, I, T} <: AbstractField{LX, LY, LZ, 
       indices :: I
 
     @doc """
-        FunctionField{LX, LY, LZ}(func, grid; clock=nothing, parameters=nothing, indices=(:,:,:)) where {LX, LY, LZ}
+        FunctionField{LX, LY, LZ}(func, grid; clock=nothing, parameters=nothing, indices=(:, :, :)) where {LX, LY, LZ}
 
     Returns a `FunctionField` on `grid` and at location `LX, LY, LZ`.
 

--- a/src/Fields/function_field.jl
+++ b/src/Fields/function_field.jl
@@ -21,18 +21,23 @@ struct FunctionField{LX, LY, LZ, C, P, F, G, I, T} <: AbstractField{LX, LY, LZ, 
     `indices = (:, :, Nz+1)` marks the field as living on a single horizontal slice).
     The function signature is always `func(x, y, z [, t])` regardless of `indices`.
 
-    Example (default `indices` — the `indices` line is absent from the output):
+    Examples
+    ========
+
+    Default `indices` — the `indices` line is absent from the output:
 
     ```jldoctest
-    using Oceananigans
-    using Oceananigans.Fields: FunctionField
+    julia> using Oceananigans
 
-    f(x, y, z) = sin(x) * cos(y) + z
-    clock = Clock(time=0.0)
-    grid = RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
-    FunctionField{Center, Center, Center}(f, grid; clock)
+    julia> using Oceananigans.Fields: FunctionField
 
-    # output
+    julia> f(x, y, z) = sin(x) * cos(y) + z;
+
+    julia> clock = Clock(time=0.0);
+
+    julia> grid = RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1));
+
+    julia> FunctionField{Center, Center, Center}(f, grid; clock)
     FunctionField located at (Center, Center, Center)
     ├── func: f (generic function with 1 method)
     ├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
@@ -40,18 +45,20 @@ struct FunctionField{LX, LY, LZ, C, P, F, G, I, T} <: AbstractField{LX, LY, LZ, 
     └── parameters: nothing
     ```
 
-    Example (reduced `indices` — the active footprint is a single horizontal slice):
+    Reduced `indices` — the active footprint is a single horizontal slice:
 
     ```jldoctest
-    using Oceananigans
-    using Oceananigans.Fields: FunctionField
+    julia> using Oceananigans
 
-    η(x, y, z) = sin(x) * cos(y)
-    clock = Clock(time=0.0)
-    grid = RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
-    FunctionField{Center, Center, Face}(η, grid; clock, indices=(:, :, grid.Nz+1))
+    julia> using Oceananigans.Fields: FunctionField
 
-    # output
+    julia> η(x, y, z) = sin(x) * cos(y);
+
+    julia> clock = Clock(time=0.0);
+
+    julia> grid = RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1));
+
+    julia> FunctionField{Center, Center, Face}(η, grid; clock, indices=(:, :, grid.Nz+1))
     FunctionField located at (Center, Center, Face)
     ├── func: η (generic function with 1 method)
     ├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo

--- a/src/Fields/function_field.jl
+++ b/src/Fields/function_field.jl
@@ -79,10 +79,13 @@ Architectures.on_architecture(to, f::FunctionField{LX, LY, LZ}) where {LX, LY, L
                               parameters = on_architecture(to, f.parameters),
                               indices    = f.indices)
 
-Base.show(io::IO, field::FunctionField) =
+function Base.show(io::IO, field::FunctionField)
+    idx = indices_summary(field)
+    idx_str = idx == "(:, :, :)" ? "" : "├── indices: $idx\n"
     print(io, "FunctionField located at ", show_location(field), "\n",
           "├── func: $(prettysummary(field.func))", "\n",
           "├── grid: $(summary(field.grid))\n",
           "├── clock: $(summary(field.clock))\n",
-          "├── indices: $(field.indices)\n",
+          idx_str,
           "└── parameters: $(field.parameters)")
+end

--- a/src/Grids/nodes_and_spacings.jl
+++ b/src/Grids/nodes_and_spacings.jl
@@ -60,6 +60,18 @@ _node_names(grid, ::Nothing, ::Nothing, ::Nothing) = tuple()
 
 @inline node(i, j, k, grid::XYZFlatGrid, ℓx, ℓy, ℓz) = tuple()
 
+# Omission of reduced-index dimensions: when a dimension's index is a fixed integer
+# rather than a range (Colon), pass `nothing` for that location so _node drops it
+# from the coordinate tuple — the same mechanism used for flat grids above.
+@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{Colon,  Colon,  Colon }) = node(i, j, k, grid, ℓx,      ℓy,      ℓz     )
+@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{Colon,  Colon,  <:Int }) = node(i, j, k, grid, ℓx,      ℓy,      nothing)
+@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{Colon,  <:Int,  Colon }) = node(i, j, k, grid, ℓx,      nothing, ℓz     )
+@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{<:Int,  Colon,  Colon }) = node(i, j, k, grid, nothing, ℓy,      ℓz     )
+@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{Colon,  <:Int,  <:Int }) = node(i, j, k, grid, ℓx,      nothing, nothing)
+@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{<:Int,  Colon,  <:Int }) = node(i, j, k, grid, nothing, ℓy,      nothing)
+@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{<:Int,  <:Int,  Colon }) = node(i, j, k, grid, nothing, nothing, ℓz     )
+@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{<:Int,  <:Int,  <:Int }) = node(i, j, k, grid, nothing, nothing, nothing)
+
 #####
 ##### << Nodes >>
 #####

--- a/src/Grids/nodes_and_spacings.jl
+++ b/src/Grids/nodes_and_spacings.jl
@@ -60,18 +60,6 @@ _node_names(grid, ::Nothing, ::Nothing, ::Nothing) = tuple()
 
 @inline node(i, j, k, grid::XYZFlatGrid, ℓx, ℓy, ℓz) = tuple()
 
-# Omission of reduced-index dimensions: when a dimension's index is a fixed integer
-# rather than a range (Colon), pass `nothing` for that location so _node drops it
-# from the coordinate tuple — the same mechanism used for flat grids above.
-@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{Colon,  Colon,  Colon }) = node(i, j, k, grid, ℓx,      ℓy,      ℓz     )
-@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{Colon,  Colon,  <:Int }) = node(i, j, k, grid, ℓx,      ℓy,      nothing)
-@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{Colon,  <:Int,  Colon }) = node(i, j, k, grid, ℓx,      nothing, ℓz     )
-@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{<:Int,  Colon,  Colon }) = node(i, j, k, grid, nothing, ℓy,      ℓz     )
-@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{Colon,  <:Int,  <:Int }) = node(i, j, k, grid, ℓx,      nothing, nothing)
-@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{<:Int,  Colon,  <:Int }) = node(i, j, k, grid, nothing, ℓy,      nothing)
-@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{<:Int,  <:Int,  Colon }) = node(i, j, k, grid, nothing, nothing, ℓz     )
-@inline node(i, j, k, grid, ℓx, ℓy, ℓz, ::Tuple{<:Int,  <:Int,  <:Int }) = node(i, j, k, grid, nothing, nothing, nothing)
-
 #####
 ##### << Nodes >>
 #####

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -935,4 +935,83 @@ end
         @test restore_prognostic_state!(of, :some_state) === of
         @test restore_prognostic_state!(cf, nothing) === cf
     end
+
+    @testset "FunctionField with reduced indices" begin
+        @info "  Testing FunctionField with reduced indices..."
+
+        # Non-symmetric grid so x, y, z coordinates are clearly distinct at every point
+        grid = RectilinearGrid(size=(4, 4, 4),
+                               x=(0, 1), y=(0, 2), z=(-3, 0),
+                               topology=(Periodic, Periodic, Bounded))
+        clock = Clock(time=π)
+
+        # Interior test point and its physical coordinates
+        i, j, k = 2, 3, 2
+        xc = xnode(i, grid, Center())
+        yc = ynode(j, grid, Center())
+        zc = znode(k, grid, Center())
+        t  = clock.time
+
+        # Case 1: (:, :, :) — baseline, func(x, y, z, t)
+        # All Colon: full 3D node is passed, no coordinate is dropped.
+        f = FunctionField{Center, Center, Center}(
+                (x, y, z, t) -> x + 2y + 3z + t, grid; clock)
+        @test f[i, j, k] ≈ xc + 2yc + 3zc + t
+
+        # Case 2: (:, :, Int) — z dropped, func(x, y, t)
+        # Fixed k in indices: z-coordinate not passed; changing k leaves result unchanged.
+        f = FunctionField{Center, Center, Face}(
+                (x, y, t) -> x + 2y + t, grid; clock,
+                indices = (:, :, grid.Nz+1))
+        @test f[i, j, grid.Nz+1] ≈ xc + 2yc + t
+        @test f[i, j, 1]         ≈ f[i, j, grid.Nz+1]   # k is ignored
+
+        # Case 3: (:, Int, :) — y dropped, func(x, z, t)
+        # Fixed j in indices: y-coordinate not passed; changing j leaves result unchanged.
+        f = FunctionField{Center, Center, Center}(
+                (x, z, t) -> x + 3z + t, grid; clock,
+                indices = (:, 2, :))
+        @test f[i, 2, k] ≈ xc + 3zc + t
+        @test f[i, 1, k] ≈ f[i, 2, k]   # j is ignored
+
+        # Case 4: (Int, :, :) — x dropped, func(y, z, t)
+        # Fixed i in indices: x-coordinate not passed; changing i leaves result unchanged.
+        f = FunctionField{Center, Center, Center}(
+                (y, z, t) -> 2y + 3z + t, grid; clock,
+                indices = (2, :, :))
+        @test f[2, j, k] ≈ 2yc + 3zc + t
+        @test f[1, j, k] ≈ f[2, j, k]   # i is ignored
+
+        # Case 5: (:, Int, Int) — y and z dropped, func(x, t)
+        # Fixed j and k in indices: only x passed spatially.
+        f = FunctionField{Center, Center, Face}(
+                (x, t) -> x + t, grid; clock,
+                indices = (:, 2, grid.Nz+1))
+        @test f[i, 2, grid.Nz+1] ≈ xc + t
+        @test f[i, 1, 1]         ≈ f[i, 2, grid.Nz+1]   # j and k ignored
+
+        # Case 6: (Int, :, Int) — x and z dropped, func(y, t)
+        # Fixed i and k in indices: only y passed spatially.
+        f = FunctionField{Center, Center, Face}(
+                (y, t) -> 2y + t, grid; clock,
+                indices = (2, :, grid.Nz+1))
+        @test f[2, j, grid.Nz+1] ≈ 2yc + t
+        @test f[1, j, 1]         ≈ f[2, j, grid.Nz+1]   # i and k ignored
+
+        # Case 7: (Int, Int, :) — x and y dropped, func(z, t)
+        # Fixed i and j in indices: only z passed spatially.
+        f = FunctionField{Center, Center, Center}(
+                (z, t) -> 3z + t, grid; clock,
+                indices = (2, 2, :))
+        @test f[2, 2, k] ≈ 3zc + t
+        @test f[1, 1, k] ≈ f[2, 2, k]   # i and j ignored
+
+        # Case 8: (Int, Int, Int) — all spatial coords dropped, func(t)
+        # All three indices fixed: node returns an empty tuple, func receives only t.
+        f = FunctionField{Center, Center, Face}(
+                t -> t^2, grid; clock,
+                indices = (2, 2, grid.Nz+1))
+        @test f[2, 2, grid.Nz+1] ≈ t^2
+        @test f[1, 1, 1]         ≈ f[2, 2, grid.Nz+1]   # all spatial indices ignored
+    end
 end


### PR DESCRIPTION
This PR adds an indices field to `FunctionField`, consistent with the existing indices support on `Field`. Follows from:
- #5308
- #5297 

With this PR one can do:
```julia
FunctionField{Center, Center, Face}(η, grid; clock, indices = (:, :, grid.Nz+1))
```

The default behaviour (when no `indices` kwarg is passed to `FunctionField`) is fully preserved.

#### What changed:

- `FunctionField` now carries an `indices` tuple (default `(:, :, :)`) that marks its active footprint. `indices(f::FunctionField)` returns it.
- The user function signature is unchanged. It always receives full `(x, y, z[, t])` coordinates regardless of `indices`. The `indices` field only affects the field's footprint for downstream use, like operations.
- `AbstractOperations` intersects `FunctionField` indices with other operands' indices.
- `Field(function_field)` materialises using `indices(function_field)` as the default, so a surface `FunctionField` with `indices = (:, :, Nz+1)` allocates only a 2D slice rather than the full 3D array.
- `Base.show` suppresses the indices line for the default `(:, :, :)` case, matching `Field` behaviour. Two `jldoctest` examples are added to the docstring.
- Tests added.