### PR TITLE
run distributed buildkite on julia 1.12

### DIFF
--- a/.buildkite/distributed/pipeline.yml
+++ b/.buildkite/distributed/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: central
   slurm_mem: 8G
-  modules: climacommon/2025_07_30
+  modules: climacommon/2026_02_18
 
 env:
   JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default:"


### PR DESCRIPTION
Update the climacommon version used in the distributed buildkite pipeline to 2026_02_18. This updates the julia version from 1.11.5 to 1.12.5, and all other modules remain the same