### PR TITLE
Avoid topology-aware operators when filling halos in the SplitExplicitFreeSurface

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/SplitExplicitFreeSurfaces.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/SplitExplicitFreeSurfaces.jl
@@ -5,7 +5,9 @@ export FixedSubstepNumber, FixedTimeStepSize
 
 using Oceananigans.Architectures: convert_to_device, architecture
 using Oceananigans.Utils: KernelParameters, configure_kernel, launch!, @apply_regionally
-using Oceananigans.Operators: Az⁻¹ᶜᶜᶠ, Δx_qᶜᶠᶠ, Δy_qᶠᶜᶠ, Δzᶜᶠᶜ, Δzᶠᶜᶜ, δxTᶜᵃᵃ, δyTᵃᶜᵃ, ∂xᵣTᶠᶜᶠ, ∂yᵣTᶜᶠᶠ
+using Oceananigans.Operators: Az⁻¹ᶜᶜᶠ, Δx_qᶜᶠᶠ, Δy_qᶠᶜᶠ, Δzᶜᶠᶜ, Δzᶠᶜᶜ
+using Oceananigans.ImmersedBoundaries: column_depthTᶠᶜᵃ, column_depthTᶜᶠᵃ, column_depthᶠᶜᵃ, column_depthᶜᶠᵃ
+using Oceananigans.Operators: ∂xᵣTᶠᶜᶠ, ∂xᵣᶠᶜᶠ, ∂yᵣTᶜᶠᶠ, ∂yᵣᶜᶠᶠ, δxTᶜᵃᵃ, δxᶜᵃᵃ, δyTᵃᶜᵃ, δyᵃᶜᵃ
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, fill_halo_regions!
 using Oceananigans.Fields: Field
 using Oceananigans.Grids: Center, Face, get_active_column_map, topology

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/step_split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/step_split_explicit_free_surface.jl
@@ -1,6 +1,4 @@
 using KernelAbstractions.Extras.LoopInfo: @unroll
-using Oceananigans.ImmersedBoundaries: column_depthTᶠᶜᵃ, column_depthTᶜᶠᵃ, column_depthᶠᶜᵃ, column_depthᶜᶠᵃ
-using Oceananigans.Operators: ∂xᵣTᶠᶜᶠ, ∂xᵣᶠᶜᶠ, ∂yᵣTᶜᶠᶠ, ∂yᵣᶜᶠᶠ, δxTᶜᵃᵃ, δxᶜᵃᵃ, δyTᵃᶜᵃ, δyᵃᶜᵃ 
 
 # Selection between topology aware and non-aware operators
 # depending on whether we fill halos or not in between substeps


### PR DESCRIPTION
we already have a "fill_halo" mode for the split explicit free surface. We can use that as a prototype to implement open boundary conditions since the literature review in #5229 showed that we need to fill the halos each substep.

However, at the moment, the split explicit evolution use topology-aware operators that automatically encode boundary conditions in the barotropic mode.

This PR chooses the operators to used based on if the halos are filled (then we can use normal operators) or not (we use topology-aware operators).

A little step to start supporting #5229 

After this I will open a PR that slightly refactors the "fill halo mode" of the split explicit free surface to avoid distributed halos (`only_local_halos=true`) and convert the necessary fill halo inputs to devices only once such that it will still be efficient (hopefully) even if we introduce open boundaries.