### PR TITLE
Fix regions inference for tuples with leading nothing in multi-region transformations

### DIFF
--- a/src/Utils/multi_region_transformation.jl
+++ b/src/Utils/multi_region_transformation.jl
@@ -72,6 +72,18 @@ end
 @inline regions(t::Union{Tuple, NamedTuple}) = regions(first(t))
 @inline regions(mo::MultiRegionObject) = 1:length(mo.regional_objects)
 
+@inline function regions(t::Tuple{Nothing, Vararg{Any}})
+    for x in t
+        x === nothing && continue
+        try
+            return regions(x)
+        catch err
+            err isa MethodError || rethrow()
+        end
+    end
+    throw(ArgumentError("Cannot infer regions from Tuple: no element supports `regions` (or all are `nothing`)."))
+end
+
 Base.getindex(mo::MultiRegionObject, i, args...) = Base.getindex(mo.regional_objects, i, args...)
 Base.length(mo::MultiRegionObject)               = Base.length(mo.regional_objects)
 


### PR DESCRIPTION
This PR fixes a `MethodError` that occurs during multi-region transformations when `regions` is called on tuples whose first element is `nothing`. A more specific method is added to safely skip `nothing` entries and infer `regions` from the first element that supports `regions`, while preserving existing behavior for all other tuples.