### PR TITLE
New stencil for computing Ri for turbulence closures

### DIFF
--- a/src/BuoyancyFormulations/BuoyancyFormulations.jl
+++ b/src/BuoyancyFormulations/BuoyancyFormulations.jl
@@ -6,7 +6,7 @@ export
     top_buoyancy_flux
 
 using Oceananigans: Oceananigans
-using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ, ∂xᶠᶜᶜ, ∂yᶜᶠᶜ, ∂zᶜᶜᶠ
+using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ, ℑxyᶠᶠᵃ, ℑxyzᶠᶠᶠ, ∂xᶠᶜᶜ, ∂yᶜᶠᶜ, ∂zᶜᶜᶠ, ∂zᶠᶠᶠ
 using Oceananigans.BoundaryConditions: getbc
 
 using SeawaterPolynomials: SeawaterPolynomials, ρ′, thermal_expansion, haline_contraction, with_float_type

--- a/src/BuoyancyFormulations/buoyancy_force.jl
+++ b/src/BuoyancyFormulations/buoyancy_force.jl
@@ -144,3 +144,5 @@ end
         g.∂z_b[i, j, k] = ∂z_b(i, j, k, grid, b, C)
     end
 end
+
+@inline ∂z_bᶠᶠᶠ(i, j, k, grid, b::BuoyancyForce{<:Any, <:Any, Nothing}, C) = ∂z_bᶠᶠᶠ(i, j, k, grid, b.formulation, C)

--- a/src/BuoyancyFormulations/buoyancy_tracer.jl
+++ b/src/BuoyancyFormulations/buoyancy_tracer.jl
@@ -17,3 +17,5 @@ required_tracers(::BuoyancyTracer) = (:b,)
 
 @inline    top_buoyancy_flux(i, j, grid, ::BuoyancyTracer, top_tracer_bcs, clock, fields) = getbc(top_tracer_bcs.b, i, j, grid, clock, fields)
 @inline bottom_buoyancy_flux(i, j, grid, ::BuoyancyTracer, bottom_tracer_bcs, clock, fields) = getbc(bottom_tracer_bcs.b, i, j, grid, clock, fields)
+
+@inline ∂z_bᶠᶠᶠ(i, j, k, grid, ::BuoyancyTracer, C) = ∂zᶠᶠᶠ(i, j, k, grid, ℑxyᶠᶠᵃ, C.b)

--- a/src/BuoyancyFormulations/linear_equation_of_state.jl
+++ b/src/BuoyancyFormulations/linear_equation_of_state.jl
@@ -51,11 +51,13 @@ LinearEquationOfState(FT=Oceananigans.defaults.FloatType; thermal_expansion=1.67
 @inline  thermal_expansionᶠᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.thermal_expansion
 @inline  thermal_expansionᶜᶠᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.thermal_expansion
 @inline  thermal_expansionᶜᶜᶠ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.thermal_expansion
+@inline  thermal_expansionᶠᶠᶠ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.thermal_expansion
 
 @inline haline_contractionᶜᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.haline_contraction
 @inline haline_contractionᶠᶜᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.haline_contraction
 @inline haline_contractionᶜᶠᶜ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.haline_contraction
 @inline haline_contractionᶜᶜᶠ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.haline_contraction
+@inline haline_contractionᶠᶠᶠ(i, j, k, grid, eos::LinearEquationOfState, C) = eos.haline_contraction
 
 #####
 ##### Convinient aliases to dispatch on


### PR DESCRIPTION
This PR implements a new stencil for computing the Richardson number at ccf (w-points) in turbulence closures. The new stencil follows Appendix A12.1 of Griffies et al 2025: https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2024MS004861

The new stencil is an alternative to simply averaging Ri horizontally, as noted in the paper:

<img width="762" height="873" alt="image" src="https://github.com/user-attachments/assets/6b4dbaa0-a0b6-4d36-8549-c0f9d7bffeef" />

One concern is that the computation is expensive because we have to take horizontal average of a z-derivative. Therefore we may want to split the computation into pieces. cc @simone-silvestri @xkykai 

Note, this stencil does not require recalibrating anything that was calibrated in a single column context, because this stencil doesn't change a single column model.