### PR TITLE
Add partial dimension summation and 1D binning to `Histogram`

### DIFF
--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -295,15 +295,16 @@ true
 
 ## Histogram operation
 
-`Histogram` constructs an `AbstractOperation` that accumulates a weighted 2D histogram from two fields.
+`Histogram` constructs an `AbstractOperation` that accumulates a weighted histogram from field operand(s).
 Like other operations, it is typically materialized with `Field(Histogram(...))` and can be saved with
 standard output writers.
 For example, `JLD2Writer(model, (; histogram = Field(Histogram(...))), ...)` writes time series of histogram fields.
 
-Current MVP limits are:
-- `method = :sum` only.
-- `dims = :` or `dims = (1, 2, 3)` only.
-- `bins` must have exactly two edge vectors in a `NamedTuple`.
+Supported capabilities:
+- `method` can be `:sum`, `:integral`, or `:average`.
+- `dims` can be any subset of `(1, 2, 3)` (or `:` for all dimensions).
+- 2D histograms use two field operands and two edge vectors in a `NamedTuple`.
+- 1D histograms use one field operand and one edge vector (or one-entry `NamedTuple`).
 
 ```jldoctest operations_histogram
 using Oceananigans
@@ -323,6 +324,16 @@ size(h)
 
 # output
 (4, 6, 1)
+```
+
+`Histogram` also supports partial-dimension reductions and 1D binning:
+
+```jldoctest operations_histogram
+h1d = Field(Histogram(a; bins=edges_a, weights=:count, dims=(1, 2), method=:integral))
+size(h1d)
+
+# output
+(4, 4, 1)
 ```
 
 Another way to do the above is to provide the `condition` keyword argument with an array of booleans.

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -293,6 +293,38 @@ conditional_∫c[1, 1, 1] ≈ π * grid.radius^2 # area of spherical zone with 0
 true
 ```
 
+## Histogram operation
+
+`Histogram` constructs an `AbstractOperation` that accumulates a weighted 2D histogram from two fields.
+Like other operations, it is typically materialized with `Field(Histogram(...))` and can be saved with
+standard output writers.
+For example, `JLD2Writer(model, (; histogram = Field(Histogram(...))), ...)` writes time series of histogram fields.
+
+Current MVP limits are:
+- `method = :sum` only.
+- `dims = :` or `dims = (1, 2, 3)` only.
+- `bins` must have exactly two edge vectors in a `NamedTuple`.
+
+```jldoctest operations_histogram
+using Oceananigans
+
+grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
+a = CenterField(grid)
+b = CenterField(grid)
+
+set!(a, (x, y, z) -> x + z)
+set!(b, (x, y, z) -> y - z)
+
+edges_a = collect(range(0.0, stop=2.0, length=5))
+edges_b = collect(range(-1.0, stop=2.0, length=7))
+
+h = Field(Histogram(a, b; bins=(a=edges_a, b=edges_b), weights=:count))
+size(h)
+
+# output
+(4, 6, 1)
+```
+
 Another way to do the above is to provide the `condition` keyword argument with an array of booleans.
 
 ```jldoctest operations_avg_int

--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -2,7 +2,7 @@ module AbstractOperations
 
 export ∂x, ∂y, ∂z, @at, @unary, @binary, @multiary
 export Δx, Δy, Δz, Ax, Ay, Az, volume
-export Average, Integral, CumulativeIntegral, KernelFunctionOperation
+export Average, Integral, CumulativeIntegral, Histogram, KernelFunctionOperation
 export UnaryOperation, Derivative, BinaryOperation, MultiaryOperation, ConditionalOperation
 
 using Base: @propagate_inbounds
@@ -46,6 +46,7 @@ at(loc, f) = f # fallback
 include("grid_validation.jl")
 include("grid_metrics.jl")
 include("metric_field_reductions.jl")
+include("histogram_operation.jl")
 include("unary_operations.jl")
 include("binary_operations.jl")
 include("multiary_operations.jl")

--- a/src/AbstractOperations/computed_field.jl
+++ b/src/AbstractOperations/computed_field.jl
@@ -12,6 +12,16 @@ import Oceananigans.Fields: Field, compute!
 const OperationOrFunctionField = Union{AbstractOperation, FunctionField}
 const ComputedField = Field{<:Any, <:Any, <:Any, <:OperationOrFunctionField}
 
+function Field(operand::Union{HistogramOperation, Histogram1DOperation}; kwargs...)
+    if haskey(kwargs, :method)
+        throw(ArgumentError("`method` is a keyword argument for `Histogram`, not `Field`. " *
+                            "Move it inside `Histogram(...; method=...)`, for example:\n" *
+                            "`Field(Histogram((T=T_ocean,); bins=(T=T_bins,), weights=:count, dims=(1, 2), method=:integral))`"))
+    end
+
+    return invoke(Field, Tuple{OperationOrFunctionField}, operand; kwargs...)
+end
+
 """
     Field(operand::OperationOrFunctionField;
           data = nothing,

--- a/src/AbstractOperations/histogram_operation.jl
+++ b/src/AbstractOperations/histogram_operation.jl
@@ -1,0 +1,357 @@
+using Oceananigans.Fields: AbstractField, instantiated_location, compute_at!, indices
+using Oceananigans.Grids: RectilinearGrid, Center, Bounded, Flat, topology, interior_indices
+using Oceananigans.Architectures: architecture, on_architecture, CPU
+using Oceananigans.Utils: KernelParameters, launch!, tupleit
+using Oceananigans.Grids: inactive_cell
+
+using KernelAbstractions: @kernel, @index, @atomic
+
+abstract type AbstractHistogramWeights end
+
+struct HistogramCountWeights <: AbstractHistogramWeights end
+
+struct HistogramVolumeWeights{V} <: AbstractHistogramWeights
+    volume :: V
+end
+
+struct HistogramFieldWeights{W} <: AbstractHistogramWeights
+    field :: W
+end
+
+struct HistogramOperation{G, T, A, B, BN, E1, E2, W, H, C, K} <: AbstractOperation{Center, Center, Center, G, T}
+    grid :: G
+    a :: A
+    b :: B
+    bins :: BN
+    edges1 :: E1
+    edges2 :: E2
+    weights :: W
+    local_histogram :: H
+    global_cache :: C
+    launch_parameters :: K
+    dims :: NTuple{3, Int}
+    method :: Symbol
+end
+
+"""
+    Histogram(a::AbstractField, b::AbstractField; bins=NamedTuple(), weights=:count, dims=(1, 2, 3), method=:sum)
+
+Construct a 2D histogram operation from field operands `a` and `b`.
+
+The result is an `AbstractOperation` that can be used with `Field(...)` and output writers,
+for example `Field(Histogram(...))`.
+
+MVP constraints:
+- `bins` must be a `NamedTuple` with exactly two strictly-increasing edge vectors.
+- `weights` must be one of `:count`, `:cell_volume` (or `:volume`), or an `AbstractField`
+  on the same grid and location as `a` and `b`.
+- `dims` must be `:` or `(1, 2, 3)`.
+- `method` must be `:sum`.
+
+Example
+=======
+
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
+
+julia> T = CenterField(grid); S = CenterField(grid);
+
+julia> set!(T, (x, y, z) -> x + z); set!(S, (x, y, z) -> y - z);
+
+julia> T_edges = collect(range(0.0, stop=2.0, length=5));
+
+julia> S_edges = collect(range(-1.0, stop=2.0, length=7));
+
+julia> h = Field(Histogram(T, S; bins=(T=T_edges, S=S_edges), weights=:count));
+
+julia> size(h)
+(4, 6, 1)
+```
+"""
+function Histogram(a::AbstractField, b::AbstractField;
+                   bins = NamedTuple(),
+                   weights = :count,
+                   dims = (1, 2, 3),
+                   method = :sum)
+
+    validate_histogram_operands(a, b)
+
+    dims = validate_histogram_dims(dims)
+    method = validate_histogram_method(method)
+    bins = validate_histogram_bins(bins)
+    weights = validate_histogram_weights(weights, a, b)
+
+    FT = histogram_eltype(a, b, bins, weights)
+    bins = convert_histogram_bins_eltype(bins, FT)
+    edges1_cpu, edges2_cpu = values(bins)
+
+    nbin1 = length(edges1_cpu) - 1
+    nbin2 = length(edges2_cpu) - 1
+
+    # Keep histogram data on host for deterministic indexing/output while computing
+    # local contributions on the operand architecture.
+    histogram_grid = RectilinearGrid(CPU(), FT;
+                                     size = (nbin1, nbin2, 1),
+                                     topology = (Bounded, Bounded, Flat),
+                                     halo = (0, 0, 0),
+                                     x = edges1_cpu,
+                                     y = edges2_cpu,
+                                     z = zero(FT))
+
+    arch = architecture(a.grid)
+    edges1 = on_architecture(arch, edges1_cpu)
+    edges2 = on_architecture(arch, edges2_cpu)
+
+    local_histogram = zeros(arch, FT, nbin1, nbin2)
+    global_cache = zeros(FT, nbin1, nbin2, 1)
+    launch_parameters = KernelParameters(histogram_launch_indices(a, b, weights)...)
+
+    return HistogramOperation(histogram_grid, a, b, bins, edges1, edges2, weights,
+                              local_histogram, global_cache, launch_parameters,
+                              dims, method)
+end
+
+Base.summary(::HistogramCountWeights) = ":count"
+Base.summary(::HistogramVolumeWeights) = ":cell_volume"
+Base.summary(w::HistogramFieldWeights) = "field ($(summary(w.field)))"
+
+function Base.summary(op::HistogramOperation)
+    nbin1, nbin2 = size(op.global_cache)[1:2]
+    return "Histogram ($nbin1 × $nbin2 bins)"
+end
+
+function Base.show(io::IO, op::HistogramOperation)
+    print(io, summary(op), '\n',
+              "├── method: ", op.method, '\n',
+              "├── dims: ", op.dims, '\n',
+              "├── bins: ", keys(op.bins), '\n',
+              "├── weights: ", summary(op.weights), '\n',
+              "├── operand 1: ", summary(op.a), '\n',
+              "└── operand 2: ", summary(op.b))
+end
+
+@inline Base.getindex(op::HistogramOperation, i, j, k) = @inbounds op.global_cache[i, j, k]
+
+function compute_at!(op::HistogramOperation, time)
+    compute_at!(op.a, time)
+    compute_at!(op.b, time)
+    compute_histogram_weights_at!(op.weights, time)
+
+    fill!(op.local_histogram, zero(eltype(op.local_histogram)))
+
+    grid = op.a.grid
+    arch = architecture(grid)
+
+    launch!(arch, grid, op.launch_parameters, _accumulate_histogram!,
+            op.local_histogram, op.a, op.b, op.edges1, op.edges2, grid, op.weights)
+
+    local_histogram_cpu = on_architecture(CPU(), op.local_histogram)
+    copyto!(view(op.global_cache, :, :, 1), local_histogram_cpu)
+    histogram_all_reduce!(+, op.global_cache, arch)
+
+    return nothing
+end
+
+@inline function histogram_all_reduce!(op, val, arch::Any)
+    if isdefined(Oceananigans, :DistributedComputations)
+        Oceananigans.DistributedComputations.all_reduce!(op, val, arch)
+    end
+    return val
+end
+
+@inline compute_histogram_weights_at!(::HistogramCountWeights, time) = nothing
+@inline compute_histogram_weights_at!(weights::HistogramVolumeWeights, time) = compute_at!(weights.volume, time)
+@inline compute_histogram_weights_at!(weights::HistogramFieldWeights, time) = compute_at!(weights.field, time)
+
+@inline histogram_weight(i, j, k, grid, ::HistogramCountWeights) = 1
+@inline histogram_weight(i, j, k, grid, weights::HistogramVolumeWeights) = @inbounds weights.volume[i, j, k]
+@inline histogram_weight(i, j, k, grid, weights::HistogramFieldWeights) = @inbounds weights.field[i, j, k]
+
+@inline function find_histogram_bin(value, edges)
+    N = length(edges)
+
+    @inbounds begin
+        value < edges[1] && return 0
+        value > edges[N] && return 0
+        value == edges[N] && return N - 1
+    end
+
+    lo = 1
+    hi = N
+
+    while lo <= hi
+        mid = (lo + hi) >>> 1
+        @inbounds edge = edges[mid]
+
+        if edge <= value
+            lo = mid + 1
+        else
+            hi = mid - 1
+        end
+    end
+
+    return ifelse(1 <= hi < N, hi, 0)
+end
+
+@kernel function _accumulate_histogram!(histogram, a, b, edges1, edges2, grid, weights)
+    i, j, k = @index(Global, NTuple)
+
+    if !inactive_cell(i, j, k, grid)
+        @inbounds aᵢ = a[i, j, k]
+        @inbounds bᵢ = b[i, j, k]
+
+        ibin1 = find_histogram_bin(aᵢ, edges1)
+        ibin2 = find_histogram_bin(bᵢ, edges2)
+
+        in_range = (ibin1 > 0) & (ibin2 > 0)
+        if in_range
+            weight = convert(eltype(histogram), histogram_weight(i, j, k, grid, weights))
+            @atomic histogram[ibin1, ibin2] += weight
+        end
+    end
+end
+
+@inline histogram_weight_operand(::HistogramCountWeights) = nothing
+@inline histogram_weight_operand(weights::HistogramVolumeWeights) = weights.volume
+@inline histogram_weight_operand(weights::HistogramFieldWeights) = weights.field
+
+function histogram_launch_indices(a, b, weights)
+    loc = instantiated_location(a)
+    grid = a.grid
+
+    idx1 = restricted_field_indices(a, 1, loc, grid)
+    idx2 = restricted_field_indices(a, 2, loc, grid)
+    idx3 = restricted_field_indices(a, 3, loc, grid)
+
+    idx1 = intersect_histogram_ranges(idx1, restricted_field_indices(b, 1, loc, grid))
+    idx2 = intersect_histogram_ranges(idx2, restricted_field_indices(b, 2, loc, grid))
+    idx3 = intersect_histogram_ranges(idx3, restricted_field_indices(b, 3, loc, grid))
+
+    weight_operand = histogram_weight_operand(weights)
+    if !isnothing(weight_operand)
+        idx1 = intersect_histogram_ranges(idx1, restricted_field_indices(weight_operand, 1, loc, grid))
+        idx2 = intersect_histogram_ranges(idx2, restricted_field_indices(weight_operand, 2, loc, grid))
+        idx3 = intersect_histogram_ranges(idx3, restricted_field_indices(weight_operand, 3, loc, grid))
+    end
+
+    return (idx1, idx2, idx3)
+end
+
+function restricted_field_indices(field, dim, loc, grid)
+    topo = topology(grid, dim)()
+    interior = interior_indices(loc[dim], topo, size(grid, dim))
+    return intersect_histogram_ranges(interior, indices(field)[dim])
+end
+
+intersect_histogram_ranges(interior::AbstractUnitRange, ::Colon) = interior
+
+function intersect_histogram_ranges(i1::AbstractUnitRange, i2::AbstractUnitRange)
+    i = max(first(i1), first(i2)):min(last(i1), last(i2))
+    first(i) > last(i) && throw(ArgumentError("Histogram operands do not have intersecting indices."))
+    return i
+end
+
+function validate_histogram_operands(a, b)
+    a.grid == b.grid ||
+        throw(ArgumentError("Histogram operands must be on the same grid."))
+
+    instantiated_location(a) == instantiated_location(b) ||
+        throw(ArgumentError("Histogram operands must have the same location. Histogram does not perform automatic co-location/interpolation."))
+
+    return nothing
+end
+
+validate_histogram_dims(::Colon) = (1, 2, 3)
+
+function validate_histogram_dims(dims)
+    dims_tuple = tupleit(dims)
+    dims_tuple == (1, 2, 3) ||
+        throw(ArgumentError("Histogram currently only supports dims = : or dims = (1, 2, 3)."))
+    return dims_tuple
+end
+
+function validate_histogram_method(method::Symbol)
+    method === :sum ||
+        throw(ArgumentError("Histogram currently only supports method = :sum."))
+    return method
+end
+
+validate_histogram_method(method) =
+    throw(ArgumentError("Histogram currently only supports method = :sum."))
+
+function validate_histogram_bins(bins::NamedTuple)
+    length(bins) == 2 ||
+        throw(ArgumentError("Histogram requires bins to be a NamedTuple with exactly two entries."))
+
+    edge_values = map(collect, values(bins))
+    edge_names = keys(bins)
+
+    for (name, edges) in zip(edge_names, edge_values)
+        length(edges) >= 2 ||
+            throw(ArgumentError("Histogram bin edges for `$name` must contain at least two values."))
+
+        for n in 2:length(edges)
+            edges[n] > edges[n-1] ||
+                throw(ArgumentError("Histogram bin edges for `$name` must be strictly increasing."))
+        end
+    end
+
+    return NamedTuple{edge_names}(edge_values)
+end
+
+validate_histogram_bins(bins) =
+    throw(ArgumentError("Histogram requires bins to be a NamedTuple with exactly two entries."))
+
+function validate_histogram_weights(weights::Symbol, a, b)
+    if weights === :count
+        return HistogramCountWeights()
+    elseif weights === :cell_volume || weights === :volume
+        volume_field = grid_metric_operation(instantiated_location(a), volume, a.grid)
+        return HistogramVolumeWeights(volume_field)
+    else
+        throw(ArgumentError("Unsupported Histogram weights = $weights. Use :count, :cell_volume, :volume, or an AbstractField."))
+    end
+end
+
+function validate_histogram_weights(weights::AbstractField, a, b)
+    weights.grid == a.grid ||
+        throw(ArgumentError("Histogram weight field must be on the same grid as the operands."))
+
+    instantiated_location(weights) == instantiated_location(a) ||
+        throw(ArgumentError("Histogram weight field must have the same location as the operands."))
+
+    return HistogramFieldWeights(weights)
+end
+
+validate_histogram_weights(weights, a, b) =
+    throw(ArgumentError("Unsupported Histogram weights = $weights. Use :count, :cell_volume, :volume, or an AbstractField."))
+
+@inline function histogram_eltype(a, b, bins, ::HistogramCountWeights)
+    edges1, edges2 = values(bins)
+    return promote_type(float(eltype(a)), float(eltype(b)), float(eltype(edges1)), float(eltype(edges2)))
+end
+
+@inline function histogram_eltype(a, b, bins, ::HistogramVolumeWeights)
+    edges1, edges2 = values(bins)
+    return promote_type(float(eltype(a)),
+                        float(eltype(b)),
+                        float(eltype(edges1)),
+                        float(eltype(edges2)),
+                        float(eltype(a.grid)))
+end
+
+@inline function histogram_eltype(a, b, bins, weights::HistogramFieldWeights)
+    edges1, edges2 = values(bins)
+    return promote_type(float(eltype(a)),
+                        float(eltype(b)),
+                        float(eltype(edges1)),
+                        float(eltype(edges2)),
+                        float(eltype(weights.field)))
+end
+
+function convert_histogram_bins_eltype(bins::NamedTuple, ::Type{FT}) where FT
+    edges = map(edges -> convert(Vector{FT}, edges), values(bins))
+    return NamedTuple{keys(bins)}(edges)
+end

--- a/src/AbstractOperations/histogram_operation.jl
+++ b/src/AbstractOperations/histogram_operation.jl
@@ -1,10 +1,12 @@
-using Oceananigans.Fields: AbstractField, instantiated_location, compute_at!, indices
+using Oceananigans.Fields: AbstractField, instantiated_location, compute_at!, indices, filter_nothing_dims
 using Oceananigans.Grids: RectilinearGrid, Center, Bounded, Flat, topology, interior_indices
 using Oceananigans.Architectures: architecture, on_architecture, CPU
 using Oceananigans.Utils: KernelParameters, launch!, tupleit
 using Oceananigans.Grids: inactive_node
 
 using KernelAbstractions: @kernel, @index, @atomic
+
+const HISTOGRAM_MEMORY_WARNING_BYTES = 512 * 1024^2 # 0.5 GiB across local + global buffers
 
 abstract type AbstractHistogramWeights end
 
@@ -18,6 +20,15 @@ struct HistogramFieldWeights{W} <: AbstractHistogramWeights
     field :: W
 end
 
+struct HistogramIntegralCountWeights{M} <: AbstractHistogramWeights
+    metric :: M
+end
+
+struct HistogramIntegralFieldWeights{W, M} <: AbstractHistogramWeights
+    field :: W
+    metric :: M
+end
+
 struct HistogramOperation{G, T, A, B, BN, E1, E2, W, H, C, K} <: AbstractOperation{Center, Center, Center, G, T}
     grid :: G
     a :: A
@@ -29,62 +40,82 @@ struct HistogramOperation{G, T, A, B, BN, E1, E2, W, H, C, K} <: AbstractOperati
     local_histogram :: H
     global_cache :: C
     launch_parameters :: K
-    dims :: NTuple{3, Int}
+    dims :: NTuple{N, Int} where N
     method :: Symbol
+    reduced_dimensions :: NTuple{3, Bool}
+    retained_offsets :: NTuple{3, Int}
+    retained_lengths :: NTuple{3, Int}
 end
 
 function HistogramOperation(grid::G, a::A, b::B, bins::BN, edges1::E1, edges2::E2,
                             weights::W, local_histogram::H, global_cache::C,
-                            launch_parameters::K, dims::NTuple{3, Int}, method::Symbol) where {G, A, B, BN, E1, E2, W, H, C, K}
+                            launch_parameters::K, dims::NTuple{N, Int}, method::Symbol,
+                            reduced_dimensions::NTuple{3, Bool},
+                            retained_offsets::NTuple{3, Int},
+                            retained_lengths::NTuple{3, Int}) where {G, A, B, BN, E1, E2, W, H, C, K, N}
     T = eltype(global_cache)
     return HistogramOperation{G, T, A, B, BN, E1, E2, W, H, C, K}(grid, a, b, bins, edges1, edges2,
                                                                    weights, local_histogram, global_cache,
-                                                                   launch_parameters, dims, method)
+                                                                   launch_parameters, dims, method,
+                                                                   reduced_dimensions, retained_offsets,
+                                                                   retained_lengths)
+end
+
+struct Histogram1DOperation{G, T, A, BN, E1, W, H, C, K} <: AbstractOperation{Center, Center, Center, G, T}
+    grid :: G
+    a :: A
+    bins :: BN
+    edges1 :: E1
+    weights :: W
+    local_histogram :: H
+    global_cache :: C
+    launch_parameters :: K
+    dims :: NTuple{N, Int} where N
+    method :: Symbol
+    reduced_dimensions :: NTuple{3, Bool}
+    retained_offsets :: NTuple{3, Int}
+    retained_lengths :: NTuple{3, Int}
+end
+
+function Histogram1DOperation(grid::G, a::A, bins::BN, edges1::E1,
+                              weights::W, local_histogram::H, global_cache::C,
+                              launch_parameters::K, dims::NTuple{N, Int}, method::Symbol,
+                              reduced_dimensions::NTuple{3, Bool},
+                              retained_offsets::NTuple{3, Int},
+                              retained_lengths::NTuple{3, Int}) where {G, A, BN, E1, W, H, C, K, N}
+    T = eltype(global_cache)
+    return Histogram1DOperation{G, T, A, BN, E1, W, H, C, K}(grid, a, bins, edges1,
+                                                              weights, local_histogram, global_cache,
+                                                              launch_parameters, dims, method,
+                                                              reduced_dimensions, retained_offsets,
+                                                              retained_lengths)
 end
 
 """
     Histogram(a::AbstractField, b::AbstractField; bins=NamedTuple(), weights=:count, dims=(1, 2, 3), method=:sum)
     Histogram(fields::NamedTuple; bins=NamedTuple(), weights=:count, dims=(1, 2, 3), method=:sum)
+    Histogram(a::AbstractField; bins, weights=:count, dims=(1, 2, 3), method=:sum)
 
-Construct a 2D histogram operation from field operands `a` and `b`.
+Construct a weighted histogram operation from field operand(s).
 
 The result is an `AbstractOperation` that can be used with `Field(...)` and output writers,
 for example `Field(Histogram(...))`.
 
-MVP constraints:
-- `bins` must be a `NamedTuple` with exactly two strictly-increasing edge vectors.
-- `weights` must be one of `:count`, `:cell_volume` (or `:volume`), or an `AbstractField`
-  on the same grid and location as `a` and `b`.
-- `dims` must be `:` or `(1, 2, 3)`.
-- `method` must be `:sum`.
+Constraints:
+- `bins` must be strictly-increasing edge vectors:
+  - 2D histogram: exactly two edge vectors.
+  - 1D histogram: exactly one edge vector.
+- `weights` must be:
+  - with `method=:sum`: `:count`, a metric-weight symbol (`:volume` / legacy aliases), or an `AbstractField`;
+  - with `method=:integral`: `:count` or an `AbstractField`.
+- `:count` with `method=:sum` accumulates one count per sample.
+- `:count` with `method=:integral` accumulates the geometric integration metric for `dims`
+  (`Δx`, `Δy`, `Δz`, `Az`, `Ay`, `Ax`, or `volume`), matching `Integral` semantics.
+- `dims` is the subset of spatial dimensions to reduce over. `dims=:` is shorthand for `(1, 2, 3)`.
+- `method` must be `:sum` or `:integral`.
 - Distributed architectures are not supported yet.
 
-Bin mapping behavior:
-- `Histogram(a, b; bins=(..., ...))` maps bins by value order.
-- `Histogram((name1=a, name2=b); bins=(...))` maps bins by key and then reorders
-  to operand order. This allows bin tuple order to differ from operand order.
-
-Example
-=======
-
-```jldoctest
-julia> using Oceananigans
-
-julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
-
-julia> T = CenterField(grid); S = CenterField(grid);
-
-julia> set!(T, (x, y, z) -> x + z); set!(S, (x, y, z) -> y - z);
-
-julia> T_edges = collect(range(0.0, stop=2.0, length=5));
-
-julia> S_edges = collect(range(-1.0, stop=2.0, length=7));
-
-julia> h = Field(Histogram(T, S; bins=(T=T_edges, S=S_edges), weights=:count));
-
-julia> size(h)
-(4, 6, 1)
-```
+For partial reductions, retained dimensions are flattened into histogram output indices.
 """
 function Histogram(a::AbstractField, b::AbstractField;
                    bins = NamedTuple(),
@@ -95,9 +126,12 @@ function Histogram(a::AbstractField, b::AbstractField;
     validate_histogram_operands(a, b)
 
     dims = validate_histogram_dims(dims)
+    dims = filter_nothing_dims(dims, instantiated_location(a))
+    isempty(dims) &&
+        throw(ArgumentError("Histogram dims cannot be empty after filtering dimensions absent from operand location $(instantiated_location(a))."))
     method = validate_histogram_method(method)
-    bins = validate_histogram_bins(bins)
-    weights = validate_histogram_weights(weights, a, b)
+    bins = validate_histogram_bins_2d(bins)
+    weights = validate_histogram_weights(weights, method, dims, a, b)
 
     arch = architecture(a.grid)
     validate_histogram_architecture(arch)
@@ -109,25 +143,81 @@ function Histogram(a::AbstractField, b::AbstractField;
     nbin1 = length(edges1_cpu) - 1
     nbin2 = length(edges2_cpu) - 1
 
-    # Keep histogram data on host for deterministic indexing/output while computing
-    # local contributions on the operand architecture.
+    launch_indices = histogram_launch_indices(a, b, weights)
+    launch_parameters = KernelParameters(launch_indices...)
+
+    reduced_dimensions, retained_offsets, retained_lengths, retained_count =
+        histogram_reduction_metadata(launch_indices, dims)
+
+    maybe_warn_histogram_memory((nbin1, nbin2, retained_count), FT; dims)
+
     histogram_grid = RectilinearGrid(CPU(), FT;
-                                     size = (nbin1, nbin2),
-                                     topology = (Bounded, Bounded, Flat),
-                                     halo = (1, 1),
+                                     size = (nbin1, nbin2, retained_count),
+                                     topology = (Bounded, Bounded, Bounded),
+                                     halo = (1, 1, 1),
                                      x = edges1_cpu,
-                                     y = edges2_cpu)
+                                     y = edges2_cpu,
+                                     z = (zero(FT), FT(retained_count)))
 
     edges1 = on_architecture(arch, edges1_cpu)
     edges2 = on_architecture(arch, edges2_cpu)
 
-    local_histogram = zeros(arch, FT, nbin1, nbin2)
-    global_cache = zeros(FT, nbin1, nbin2, 1)
-    launch_parameters = KernelParameters(histogram_launch_indices(a, b, weights)...)
+    local_histogram = zeros(arch, FT, nbin1, nbin2, retained_count)
+    global_cache = zeros(FT, nbin1, nbin2, retained_count)
 
     return HistogramOperation(histogram_grid, a, b, bins, edges1, edges2, weights,
                               local_histogram, global_cache, launch_parameters,
-                              dims, method)
+                              dims, method, reduced_dimensions,
+                              retained_offsets, retained_lengths)
+end
+
+function Histogram(a::AbstractField;
+                   bins = NamedTuple(),
+                   weights = :count,
+                   dims = (1, 2, 3),
+                   method = :sum)
+
+    dims = validate_histogram_dims(dims)
+    dims = filter_nothing_dims(dims, instantiated_location(a))
+    isempty(dims) &&
+        throw(ArgumentError("Histogram dims cannot be empty after filtering dimensions absent from operand location $(instantiated_location(a))."))
+    method = validate_histogram_method(method)
+    bins = validate_histogram_bins_1d(bins)
+    weights = validate_histogram_weights(weights, method, dims, a)
+
+    arch = architecture(a.grid)
+    validate_histogram_architecture(arch)
+
+    FT = histogram_eltype(a, bins, weights)
+    bins = convert_histogram_bins_eltype(bins, FT)
+    edges1_cpu = first(values(bins))
+
+    nbin1 = length(edges1_cpu) - 1
+
+    launch_indices = histogram_launch_indices(a, weights)
+    launch_parameters = KernelParameters(launch_indices...)
+
+    reduced_dimensions, retained_offsets, retained_lengths, retained_count =
+        histogram_reduction_metadata(launch_indices, dims)
+
+    maybe_warn_histogram_memory((nbin1, retained_count, 1), FT; dims)
+
+    histogram_grid = RectilinearGrid(CPU(), FT;
+                                     size = (nbin1, retained_count),
+                                     topology = (Bounded, Bounded, Flat),
+                                     halo = (1, 1),
+                                     x = edges1_cpu,
+                                     y = (zero(FT), FT(retained_count)))
+
+    edges1 = on_architecture(arch, edges1_cpu)
+
+    local_histogram = zeros(arch, FT, nbin1, retained_count, 1)
+    global_cache = zeros(FT, nbin1, retained_count, 1)
+
+    return Histogram1DOperation(histogram_grid, a, bins, edges1, weights,
+                                local_histogram, global_cache, launch_parameters,
+                                dims, method, reduced_dimensions,
+                                retained_offsets, retained_lengths)
 end
 
 function Histogram(fields::NamedTuple;
@@ -136,29 +226,46 @@ function Histogram(fields::NamedTuple;
                    dims = (1, 2, 3),
                    method = :sum)
 
-    length(fields) == 2 ||
-        throw(ArgumentError("Histogram(fields=...) requires exactly two named field operands."))
+    if length(fields) == 2
+        operand_names = keys(fields)
+        a, b = values(fields)
 
-    operand_names = keys(fields)
-    a, b = values(fields)
+        a isa AbstractField ||
+            throw(ArgumentError("Histogram(fields=...) requires field operands, but `$(operand_names[1])` is $(typeof(a))."))
 
-    a isa AbstractField ||
-        throw(ArgumentError("Histogram(fields=...) requires field operands, but `$(operand_names[1])` is $(typeof(a))."))
+        b isa AbstractField ||
+            throw(ArgumentError("Histogram(fields=...) requires field operands, but `$(operand_names[2])` is $(typeof(b))."))
 
-    b isa AbstractField ||
-        throw(ArgumentError("Histogram(fields=...) requires field operands, but `$(operand_names[2])` is $(typeof(b))."))
+        bins = reorder_histogram_bins_for_named_operands(bins, operand_names)
+        return Histogram(a, b; bins, weights, dims, method)
+    elseif length(fields) == 1
+        operand_name = first(keys(fields))
+        a = first(values(fields))
 
-    bins = reorder_histogram_bins_for_named_operands(bins, operand_names)
-    return Histogram(a, b; bins, weights, dims, method)
+        a isa AbstractField ||
+            throw(ArgumentError("Histogram(fields=...) requires field operands, but `$(operand_name)` is $(typeof(a))."))
+
+        bins = bins isa NamedTuple ? reorder_histogram_bins_for_named_operand(bins, operand_name) : bins
+        return Histogram(a; bins, weights, dims, method)
+    else
+        throw(ArgumentError("Histogram(fields=...) requires exactly one or two named field operands."))
+    end
 end
 
 Base.summary(::HistogramCountWeights) = ":count"
 Base.summary(::HistogramVolumeWeights) = ":cell_volume"
 Base.summary(w::HistogramFieldWeights) = "field ($(summary(w.field)))"
+Base.summary(w::HistogramIntegralCountWeights) = "integral(:count)"
+Base.summary(w::HistogramIntegralFieldWeights) = "integral(field ($(summary(w.field))))"
 
 function Base.summary(op::HistogramOperation)
-    nbin1, nbin2 = size(op.global_cache)[1:2]
-    return "Histogram ($nbin1 × $nbin2 bins)"
+    nbin1, nbin2, nret = size(op.global_cache)
+    return "Histogram2D ($nbin1 × $nbin2 bins, retained=$nret)"
+end
+
+function Base.summary(op::Histogram1DOperation)
+    nbin1, nret, _ = size(op.global_cache)
+    return "Histogram1D ($nbin1 bins, retained=$nret)"
 end
 
 function Base.show(io::IO, op::HistogramOperation)
@@ -171,7 +278,17 @@ function Base.show(io::IO, op::HistogramOperation)
               "└── operand 2: ", summary(op.b))
 end
 
+function Base.show(io::IO, op::Histogram1DOperation)
+    print(io, summary(op), '\n',
+              "├── method: ", op.method, '\n',
+              "├── dims: ", op.dims, '\n',
+              "├── bins: ", keys(op.bins), '\n',
+              "├── weights: ", summary(op.weights), '\n',
+              "└── operand: ", summary(op.a))
+end
+
 @inline Base.getindex(op::HistogramOperation, i, j, k) = @inbounds op.global_cache[i, j, k]
+@inline Base.getindex(op::Histogram1DOperation, i, j, k) = @inbounds op.global_cache[i, j, k]
 
 function compute_at!(op::HistogramOperation, time)
     compute_at!(op.a, time)
@@ -183,21 +300,52 @@ function compute_at!(op::HistogramOperation, time)
     grid = op.a.grid
     arch = architecture(grid)
 
-    launch!(arch, grid, op.launch_parameters, _accumulate_histogram!,
-            op.local_histogram, op.a, op.b, op.edges1, op.edges2, grid, op.weights, instantiated_location(op.a))
+    launch!(arch, grid, op.launch_parameters, _accumulate_histogram_2d!,
+            op.local_histogram, op.a, op.b, op.edges1, op.edges2,
+            grid, op.weights, instantiated_location(op.a),
+            op.reduced_dimensions, op.retained_offsets, op.retained_lengths)
 
     local_histogram_cpu = on_architecture(CPU(), op.local_histogram)
-    copyto!(view(op.global_cache, :, :, 1), local_histogram_cpu)
+    copyto!(op.global_cache, local_histogram_cpu)
+
+    return nothing
+end
+
+function compute_at!(op::Histogram1DOperation, time)
+    compute_at!(op.a, time)
+    compute_histogram_weights_at!(op.weights, time)
+
+    fill!(op.local_histogram, zero(eltype(op.local_histogram)))
+
+    grid = op.a.grid
+    arch = architecture(grid)
+
+    launch!(arch, grid, op.launch_parameters, _accumulate_histogram_1d!,
+            op.local_histogram, op.a, op.edges1,
+            grid, op.weights, instantiated_location(op.a),
+            op.reduced_dimensions, op.retained_offsets, op.retained_lengths)
+
+    local_histogram_cpu = on_architecture(CPU(), op.local_histogram)
+    copyto!(op.global_cache, local_histogram_cpu)
+
     return nothing
 end
 
 @inline compute_histogram_weights_at!(::HistogramCountWeights, time) = nothing
 @inline compute_histogram_weights_at!(weights::HistogramVolumeWeights, time) = compute_at!(weights.volume, time)
 @inline compute_histogram_weights_at!(weights::HistogramFieldWeights, time) = compute_at!(weights.field, time)
+@inline compute_histogram_weights_at!(weights::HistogramIntegralCountWeights, time) = compute_at!(weights.metric, time)
+@inline function compute_histogram_weights_at!(weights::HistogramIntegralFieldWeights, time)
+    compute_at!(weights.field, time)
+    compute_at!(weights.metric, time)
+    return nothing
+end
 
 @inline histogram_weight(i, j, k, grid, ::HistogramCountWeights) = 1
 @inline histogram_weight(i, j, k, grid, weights::HistogramVolumeWeights) = @inbounds weights.volume[i, j, k]
 @inline histogram_weight(i, j, k, grid, weights::HistogramFieldWeights) = @inbounds weights.field[i, j, k]
+@inline histogram_weight(i, j, k, grid, weights::HistogramIntegralCountWeights) = @inbounds weights.metric[i, j, k]
+@inline histogram_weight(i, j, k, grid, weights::HistogramIntegralFieldWeights) = @inbounds weights.field[i, j, k] * weights.metric[i, j, k]
 
 @inline function find_histogram_bin(value, edges)
     N = length(edges)
@@ -225,7 +373,22 @@ end
     return ifelse(1 <= hi < N, hi, 0)
 end
 
-@kernel function _accumulate_histogram!(histogram, a, b, edges1, edges2, grid, weights, loc)
+@inline function retained_linear_index(i, j, k,
+                                       reduced_dimensions::NTuple{3, Bool},
+                                       retained_offsets::NTuple{3, Int},
+                                       retained_lengths::NTuple{3, Int})
+    iR = reduced_dimensions[1] ? 1 : i - retained_offsets[1] + 1
+    jR = reduced_dimensions[2] ? 1 : j - retained_offsets[2] + 1
+    kR = reduced_dimensions[3] ? 1 : k - retained_offsets[3] + 1
+
+    return iR + retained_lengths[1] * ((jR - 1) + retained_lengths[2] * (kR - 1))
+end
+
+@kernel function _accumulate_histogram_2d!(histogram, a, b, edges1, edges2,
+                                           grid, weights, loc,
+                                           reduced_dimensions,
+                                           retained_offsets,
+                                           retained_lengths)
     i, j, k = @index(Global, NTuple)
 
     if !inactive_node(i, j, k, grid, loc...)
@@ -237,15 +400,38 @@ end
 
         in_range = (ibin1 > 0) & (ibin2 > 0)
         if in_range
+            retained_index = retained_linear_index(i, j, k, reduced_dimensions, retained_offsets, retained_lengths)
             weight = convert(eltype(histogram), histogram_weight(i, j, k, grid, weights))
-            @atomic histogram[ibin1, ibin2] += weight
+            @atomic histogram[ibin1, ibin2, retained_index] += weight
         end
     end
 end
 
-@inline histogram_weight_operand(::HistogramCountWeights) = nothing
-@inline histogram_weight_operand(weights::HistogramVolumeWeights) = weights.volume
-@inline histogram_weight_operand(weights::HistogramFieldWeights) = weights.field
+@kernel function _accumulate_histogram_1d!(histogram, a, edges1,
+                                           grid, weights, loc,
+                                           reduced_dimensions,
+                                           retained_offsets,
+                                           retained_lengths)
+    i, j, k = @index(Global, NTuple)
+
+    if !inactive_node(i, j, k, grid, loc...)
+        @inbounds aᵢ = a[i, j, k]
+
+        ibin1 = find_histogram_bin(aᵢ, edges1)
+
+        if ibin1 > 0
+            retained_index = retained_linear_index(i, j, k, reduced_dimensions, retained_offsets, retained_lengths)
+            weight = convert(eltype(histogram), histogram_weight(i, j, k, grid, weights))
+            @atomic histogram[ibin1, retained_index, 1] += weight
+        end
+    end
+end
+
+@inline histogram_weight_operands(::HistogramCountWeights) = ()
+@inline histogram_weight_operands(weights::HistogramVolumeWeights) = (weights.volume,)
+@inline histogram_weight_operands(weights::HistogramFieldWeights) = (weights.field,)
+@inline histogram_weight_operands(weights::HistogramIntegralCountWeights) = (weights.metric,)
+@inline histogram_weight_operands(weights::HistogramIntegralFieldWeights) = (weights.field, weights.metric)
 
 function histogram_launch_indices(a, b, weights)
     loc = instantiated_location(a)
@@ -259,14 +445,50 @@ function histogram_launch_indices(a, b, weights)
     idx2 = intersect_histogram_ranges(idx2, restricted_field_indices(b, 2, loc, grid))
     idx3 = intersect_histogram_ranges(idx3, restricted_field_indices(b, 3, loc, grid))
 
-    weight_operand = histogram_weight_operand(weights)
-    if !isnothing(weight_operand)
+    for weight_operand in histogram_weight_operands(weights)
         idx1 = intersect_histogram_ranges(idx1, restricted_field_indices(weight_operand, 1, loc, grid))
         idx2 = intersect_histogram_ranges(idx2, restricted_field_indices(weight_operand, 2, loc, grid))
         idx3 = intersect_histogram_ranges(idx3, restricted_field_indices(weight_operand, 3, loc, grid))
     end
 
     return (idx1, idx2, idx3)
+end
+
+function histogram_launch_indices(a, weights)
+    loc = instantiated_location(a)
+    grid = a.grid
+
+    idx1 = restricted_field_indices(a, 1, loc, grid)
+    idx2 = restricted_field_indices(a, 2, loc, grid)
+    idx3 = restricted_field_indices(a, 3, loc, grid)
+
+    for weight_operand in histogram_weight_operands(weights)
+        idx1 = intersect_histogram_ranges(idx1, restricted_field_indices(weight_operand, 1, loc, grid))
+        idx2 = intersect_histogram_ranges(idx2, restricted_field_indices(weight_operand, 2, loc, grid))
+        idx3 = intersect_histogram_ranges(idx3, restricted_field_indices(weight_operand, 3, loc, grid))
+    end
+
+    return (idx1, idx2, idx3)
+end
+
+function histogram_reduction_metadata(launch_indices::NTuple{3, <:AbstractUnitRange}, dims)
+    reduced_dimensions = (1 in dims, 2 in dims, 3 in dims)
+    retained_offsets = ntuple(d -> first(launch_indices[d]), 3)
+    retained_lengths = ntuple(d -> reduced_dimensions[d] ? 1 : length(launch_indices[d]), 3)
+    retained_count = prod(retained_lengths)
+
+    return reduced_dimensions, retained_offsets, retained_lengths, retained_count
+end
+
+function maybe_warn_histogram_memory(shape, ::Type{FT}; dims) where FT
+    bytes = 2 * sizeof(FT) * prod(shape)
+
+    if bytes > HISTOGRAM_MEMORY_WARNING_BYTES
+        gib = round(bytes / 1024^3; digits=3)
+        @warn "Histogram allocation is large (local + global buffers)." dims shape eltype=FT estimated_gib=gib
+    end
+
+    return nothing
 end
 
 function restricted_field_indices(field, dim, loc, grid)
@@ -296,20 +518,25 @@ end
 validate_histogram_dims(::Colon) = (1, 2, 3)
 
 function validate_histogram_dims(dims)
-    dims_tuple = tupleit(dims)
-    dims_tuple == (1, 2, 3) ||
-        throw(ArgumentError("Histogram currently only supports dims = : or dims = (1, 2, 3)."))
+    dims_tuple = Tuple(sort(unique(tupleit(dims))))
+
+    isempty(dims_tuple) &&
+        throw(ArgumentError("Histogram dims cannot be empty. Use dims=: to reduce over all dimensions."))
+
+    all(d -> d in (1, 2, 3), dims_tuple) ||
+        throw(ArgumentError("Histogram dims must be a subset of (1, 2, 3), but got dims=$dims."))
+
     return dims_tuple
 end
 
 function validate_histogram_method(method::Symbol)
-    method === :sum ||
-        throw(ArgumentError("Histogram currently only supports method = :sum."))
+    method ∈ (:sum, :integral) ||
+        throw(ArgumentError("Histogram currently only supports method = :sum or method = :integral."))
     return method
 end
 
 validate_histogram_method(method) =
-    throw(ArgumentError("Histogram currently only supports method = :sum."))
+    throw(ArgumentError("Histogram currently only supports method = :sum or method = :integral."))
 
 function validate_histogram_architecture(arch)
     if isdefined(Oceananigans, :DistributedComputations) &&
@@ -321,8 +548,8 @@ function validate_histogram_architecture(arch)
 end
 
 function validate_histogram_bins(bins::NamedTuple)
-    length(bins) == 2 ||
-        throw(ArgumentError("Histogram requires bins to be a NamedTuple with exactly two entries."))
+    length(bins) >= 1 ||
+        throw(ArgumentError("Histogram requires bins to be a NamedTuple with at least one entry."))
 
     edge_values = map(collect, values(bins))
     edge_names = keys(bins)
@@ -341,10 +568,28 @@ function validate_histogram_bins(bins::NamedTuple)
 end
 
 validate_histogram_bins(bins) =
-    throw(ArgumentError("Histogram requires bins to be a NamedTuple with exactly two entries."))
+    throw(ArgumentError("Histogram requires bins to be a NamedTuple, or a single edge vector for 1D histograms."))
+
+function validate_histogram_bins_2d(bins)
+    bins = validate_histogram_bins(bins)
+    length(bins) == 2 ||
+        throw(ArgumentError("2D Histogram requires bins to be a NamedTuple with exactly two entries."))
+
+    return bins
+end
+
+function validate_histogram_bins_1d(bins::NamedTuple)
+    bins = validate_histogram_bins(bins)
+    length(bins) == 1 ||
+        throw(ArgumentError("1D Histogram requires bins to be a NamedTuple with exactly one entry."))
+
+    return bins
+end
+
+validate_histogram_bins_1d(edges) = validate_histogram_bins_1d((a = edges,))
 
 function reorder_histogram_bins_for_named_operands(bins::NamedTuple, operand_names::Tuple{Symbol, Symbol})
-    bins = validate_histogram_bins(bins)
+    bins = validate_histogram_bins_2d(bins)
     first_name, second_name = operand_names
 
     first_name ∈ keys(bins) ||
@@ -357,29 +602,63 @@ function reorder_histogram_bins_for_named_operands(bins::NamedTuple, operand_nam
                                       getproperty(bins, second_name)))
 end
 
-function validate_histogram_weights(weights::Symbol, a, b)
-    if weights === :count
-        return HistogramCountWeights()
-    elseif weights === :cell_volume || weights === :volume
-        volume_field = grid_metric_operation(instantiated_location(a), volume, a.grid)
-        return HistogramVolumeWeights(volume_field)
-    else
-        throw(ArgumentError("Unsupported Histogram weights = $weights. Use :count, :cell_volume, :volume, or an AbstractField."))
+function reorder_histogram_bins_for_named_operand(bins::NamedTuple, operand_name::Symbol)
+    bins = validate_histogram_bins_1d(bins)
+
+    operand_name ∈ keys(bins) ||
+        throw(ArgumentError("Histogram bins are missing key `$operand_name` required by named operand mapping."))
+
+    return NamedTuple{(operand_name,)}((getproperty(bins, operand_name),))
+end
+
+@inline histogram_integral_metric(a, dims) =
+    grid_metric_operation(instantiated_location(a), reduction_grid_metric(dims), a.grid)
+
+function validate_histogram_weights(weights::Symbol, method::Symbol, dims, a::AbstractField)
+    if method === :sum
+        if weights === :count
+            return HistogramCountWeights()
+        elseif weights === :cell_volume || weights === :volume
+            volume_field = grid_metric_operation(instantiated_location(a), volume, a.grid)
+            return HistogramVolumeWeights(volume_field)
+        else
+            throw(ArgumentError("Unsupported Histogram weights = $weights for method=:sum. Use :count, :cell_volume, :volume, or an AbstractField."))
+        end
+    else # method === :integral
+        metric = histogram_integral_metric(a, dims)
+
+        if weights === :count
+            return HistogramIntegralCountWeights(metric)
+        elseif weights === :cell_volume || weights === :volume
+            throw(ArgumentError("Histogram weights=:cell_volume is not supported with method=:integral because it would double-apply metrics. Use weights=:count or an AbstractField."))
+        else
+            throw(ArgumentError("Unsupported Histogram weights = $weights for method=:integral. Use :count or an AbstractField."))
+        end
     end
 end
 
-function validate_histogram_weights(weights::AbstractField, a, b)
+function validate_histogram_weights(weights::AbstractField, method::Symbol, dims, a::AbstractField)
     weights.grid == a.grid ||
-        throw(ArgumentError("Histogram weight field must be on the same grid as the operands."))
+        throw(ArgumentError("Histogram weight field must be on the same grid as the operand."))
 
     instantiated_location(weights) == instantiated_location(a) ||
-        throw(ArgumentError("Histogram weight field must have the same location as the operands."))
+        throw(ArgumentError("Histogram weight field must have the same location as the operand."))
 
-    return HistogramFieldWeights(weights)
+    if method === :sum
+        return HistogramFieldWeights(weights)
+    else
+        metric = histogram_integral_metric(a, dims)
+        return HistogramIntegralFieldWeights(weights, metric)
+    end
 end
 
-validate_histogram_weights(weights, a, b) =
-    throw(ArgumentError("Unsupported Histogram weights = $weights. Use :count, :cell_volume, :volume, or an AbstractField."))
+validate_histogram_weights(weights, method::Symbol, dims, a::AbstractField) =
+    throw(ArgumentError("Unsupported Histogram weights = $weights for method=$method."))
+
+function validate_histogram_weights(weights, method::Symbol, dims, a::AbstractField, b::AbstractField)
+    validate_histogram_operands(a, b)
+    return validate_histogram_weights(weights, method, dims, a)
+end
 
 @inline function histogram_eltype(a, b, bins, ::HistogramCountWeights)
     edges1, edges2 = values(bins)
@@ -402,6 +681,50 @@ end
                         float(eltype(edges1)),
                         float(eltype(edges2)),
                         float(eltype(weights.field)))
+end
+
+@inline function histogram_eltype(a, b, bins, weights::HistogramIntegralCountWeights)
+    edges1, edges2 = values(bins)
+    return promote_type(float(eltype(a)),
+                        float(eltype(b)),
+                        float(eltype(edges1)),
+                        float(eltype(edges2)),
+                        float(eltype(weights.metric)))
+end
+
+@inline function histogram_eltype(a, b, bins, weights::HistogramIntegralFieldWeights)
+    edges1, edges2 = values(bins)
+    return promote_type(float(eltype(a)),
+                        float(eltype(b)),
+                        float(eltype(edges1)),
+                        float(eltype(edges2)),
+                        float(eltype(weights.field)),
+                        float(eltype(weights.metric)))
+end
+
+@inline function histogram_eltype(a, bins, ::HistogramCountWeights)
+    edges1 = first(values(bins))
+    return promote_type(float(eltype(a)), float(eltype(edges1)))
+end
+
+@inline function histogram_eltype(a, bins, ::HistogramVolumeWeights)
+    edges1 = first(values(bins))
+    return promote_type(float(eltype(a)), float(eltype(edges1)), float(eltype(a.grid)))
+end
+
+@inline function histogram_eltype(a, bins, weights::HistogramFieldWeights)
+    edges1 = first(values(bins))
+    return promote_type(float(eltype(a)), float(eltype(edges1)), float(eltype(weights.field)))
+end
+
+@inline function histogram_eltype(a, bins, weights::HistogramIntegralCountWeights)
+    edges1 = first(values(bins))
+    return promote_type(float(eltype(a)), float(eltype(edges1)), float(eltype(weights.metric)))
+end
+
+@inline function histogram_eltype(a, bins, weights::HistogramIntegralFieldWeights)
+    edges1 = first(values(bins))
+    return promote_type(float(eltype(a)), float(eltype(edges1)), float(eltype(weights.field)), float(eltype(weights.metric)))
 end
 
 function convert_histogram_bins_eltype(bins::NamedTuple, ::Type{FT}) where FT

--- a/src/AbstractOperations/histogram_operation.jl
+++ b/src/AbstractOperations/histogram_operation.jl
@@ -1,5 +1,6 @@
 using Oceananigans.Fields: AbstractField, instantiated_location, compute_at!, indices, filter_nothing_dims
-using Oceananigans.Grids: RectilinearGrid, Center, Bounded, Flat, topology, interior_indices
+using Oceananigans.Grids: RectilinearGrid, Face, Center, Bounded, Flat, topology, interior_indices
+using Oceananigans.Grids: ξnodes, ηnodes, rnodes
 using Oceananigans.Architectures: architecture, on_architecture, CPU
 using Oceananigans.Utils: KernelParameters, launch!, tupleit
 using Oceananigans.Grids: inactive_node
@@ -33,6 +34,13 @@ struct HistogramAverageFieldWeights{W, M} <: AbstractHistogramWeights
     field :: W
     metric :: M
 end
+
+Adapt.adapt_structure(to, ::HistogramCountWeights) = HistogramCountWeights()
+Adapt.adapt_structure(to, weights::HistogramFieldWeights) = HistogramFieldWeights(adapt(to, weights.field))
+Adapt.adapt_structure(to, weights::HistogramIntegralCountWeights) = HistogramIntegralCountWeights(adapt(to, weights.metric))
+Adapt.adapt_structure(to, weights::HistogramIntegralFieldWeights) = HistogramIntegralFieldWeights(adapt(to, weights.field), adapt(to, weights.metric))
+Adapt.adapt_structure(to, weights::HistogramAverageCountWeights) = HistogramAverageCountWeights(adapt(to, weights.metric))
+Adapt.adapt_structure(to, weights::HistogramAverageFieldWeights) = HistogramAverageFieldWeights(adapt(to, weights.field), adapt(to, weights.metric))
 
 struct HistogramOperation{G, T, A, B, BN, E1, E2, W, H, LN, C, GN, K} <: AbstractOperation{Center, Center, Center, G, T}
     grid :: G
@@ -104,6 +112,33 @@ function Histogram1DOperation(grid::G, a::A, bins::BN, edges1::E1,
                                                               retained_lengths)
 end
 
+@inline retained_dimension_face_nodes(grid, retained_dimension, face_indices) =
+    retained_dimension === 1 ? ξnodes(grid, Face(); indices=face_indices) :
+    retained_dimension === 2 ? ηnodes(grid, Face(); indices=face_indices) :
+                               rnodes(grid, Face(); indices=face_indices)
+
+function histogram_retained_coordinate(a, launch_indices, reduced_dimensions, retained_count, ::Type{FT}) where FT
+    retained_dimensions = Tuple(d for d in 1:3 if !reduced_dimensions[d])
+
+    if length(retained_dimensions) != 1
+        return (zero(FT), FT(retained_count))
+    end
+
+    retained_dimension = only(retained_dimensions)
+    retained_location = instantiated_location(a)[retained_dimension]
+
+    if !(retained_location isa Center) || topology(a.grid, retained_dimension) !== Bounded
+        return (zero(FT), FT(retained_count))
+    end
+
+    retained_indices = launch_indices[retained_dimension]
+    face_indices = first(retained_indices):(last(retained_indices) + 1)
+    retained_faces = retained_dimension_face_nodes(a.grid, retained_dimension, face_indices)
+    retained_faces_cpu = collect(on_architecture(CPU(), retained_faces))
+
+    return convert(Vector{FT}, retained_faces_cpu)
+end
+
 """
     Histogram(a::AbstractField, b::AbstractField; bins=NamedTuple(), weights=:count, dims=(1, 2, 3), method=:sum)
     Histogram(fields::NamedTuple; bins=NamedTuple(), weights=:count, dims=(1, 2, 3), method=:sum)
@@ -167,6 +202,7 @@ function Histogram(a::AbstractField, b::AbstractField;
 
     reduced_dimensions, retained_offsets, retained_lengths, retained_count =
         histogram_reduction_metadata(launch_indices, dims)
+    retained_coordinate = histogram_retained_coordinate(a, launch_indices, reduced_dimensions, retained_count, FT)
 
     buffers = method === :average ? 4 : 2
     maybe_warn_histogram_memory((nbin1, nbin2, retained_count), FT; dims, buffers)
@@ -177,7 +213,7 @@ function Histogram(a::AbstractField, b::AbstractField;
                                      halo = (1, 1, 1),
                                      x = edges1_cpu,
                                      y = edges2_cpu,
-                                     z = (zero(FT), FT(retained_count)))
+                                     z = retained_coordinate)
 
     edges1 = on_architecture(arch, edges1_cpu)
     edges2 = on_architecture(arch, edges2_cpu)
@@ -222,6 +258,7 @@ function Histogram(a::AbstractField;
 
     reduced_dimensions, retained_offsets, retained_lengths, retained_count =
         histogram_reduction_metadata(launch_indices, dims)
+    retained_coordinate = histogram_retained_coordinate(a, launch_indices, reduced_dimensions, retained_count, FT)
 
     buffers = method === :average ? 4 : 2
     maybe_warn_histogram_memory((nbin1, retained_count, 1), FT; dims, buffers)
@@ -231,7 +268,7 @@ function Histogram(a::AbstractField;
                                      topology = (Bounded, Bounded, Flat),
                                      halo = (1, 1),
                                      x = edges1_cpu,
-                                     y = (zero(FT), FT(retained_count)))
+                                     y = retained_coordinate)
 
     edges1 = on_architecture(arch, edges1_cpu)
 

--- a/src/AbstractOperations/histogram_operation.jl
+++ b/src/AbstractOperations/histogram_operation.jl
@@ -12,10 +12,6 @@ abstract type AbstractHistogramWeights end
 
 struct HistogramCountWeights <: AbstractHistogramWeights end
 
-struct HistogramVolumeWeights{V} <: AbstractHistogramWeights
-    volume :: V
-end
-
 struct HistogramFieldWeights{W} <: AbstractHistogramWeights
     field :: W
 end
@@ -29,7 +25,16 @@ struct HistogramIntegralFieldWeights{W, M} <: AbstractHistogramWeights
     metric :: M
 end
 
-struct HistogramOperation{G, T, A, B, BN, E1, E2, W, H, C, K} <: AbstractOperation{Center, Center, Center, G, T}
+struct HistogramAverageCountWeights{M} <: AbstractHistogramWeights
+    metric :: M
+end
+
+struct HistogramAverageFieldWeights{W, M} <: AbstractHistogramWeights
+    field :: W
+    metric :: M
+end
+
+struct HistogramOperation{G, T, A, B, BN, E1, E2, W, H, LN, C, GN, K} <: AbstractOperation{Center, Center, Center, G, T}
     grid :: G
     a :: A
     b :: B
@@ -38,7 +43,9 @@ struct HistogramOperation{G, T, A, B, BN, E1, E2, W, H, C, K} <: AbstractOperati
     edges2 :: E2
     weights :: W
     local_histogram :: H
+    local_normalization :: LN
     global_cache :: C
+    global_normalization :: GN
     launch_parameters :: K
     dims :: NTuple{N, Int} where N
     method :: Symbol
@@ -48,27 +55,31 @@ struct HistogramOperation{G, T, A, B, BN, E1, E2, W, H, C, K} <: AbstractOperati
 end
 
 function HistogramOperation(grid::G, a::A, b::B, bins::BN, edges1::E1, edges2::E2,
-                            weights::W, local_histogram::H, global_cache::C,
+                            weights::W, local_histogram::H, local_normalization::LN,
+                            global_cache::C, global_normalization::GN,
                             launch_parameters::K, dims::NTuple{N, Int}, method::Symbol,
                             reduced_dimensions::NTuple{3, Bool},
                             retained_offsets::NTuple{3, Int},
-                            retained_lengths::NTuple{3, Int}) where {G, A, B, BN, E1, E2, W, H, C, K, N}
+                            retained_lengths::NTuple{3, Int}) where {G, A, B, BN, E1, E2, W, H, LN, C, GN, K, N}
     T = eltype(global_cache)
-    return HistogramOperation{G, T, A, B, BN, E1, E2, W, H, C, K}(grid, a, b, bins, edges1, edges2,
-                                                                   weights, local_histogram, global_cache,
+    return HistogramOperation{G, T, A, B, BN, E1, E2, W, H, LN, C, GN, K}(grid, a, b, bins, edges1, edges2,
+                                                                   weights, local_histogram, local_normalization,
+                                                                   global_cache, global_normalization,
                                                                    launch_parameters, dims, method,
                                                                    reduced_dimensions, retained_offsets,
                                                                    retained_lengths)
 end
 
-struct Histogram1DOperation{G, T, A, BN, E1, W, H, C, K} <: AbstractOperation{Center, Center, Center, G, T}
+struct Histogram1DOperation{G, T, A, BN, E1, W, H, LN, C, GN, K} <: AbstractOperation{Center, Center, Center, G, T}
     grid :: G
     a :: A
     bins :: BN
     edges1 :: E1
     weights :: W
     local_histogram :: H
+    local_normalization :: LN
     global_cache :: C
+    global_normalization :: GN
     launch_parameters :: K
     dims :: NTuple{N, Int} where N
     method :: Symbol
@@ -78,14 +89,16 @@ struct Histogram1DOperation{G, T, A, BN, E1, W, H, C, K} <: AbstractOperation{Ce
 end
 
 function Histogram1DOperation(grid::G, a::A, bins::BN, edges1::E1,
-                              weights::W, local_histogram::H, global_cache::C,
+                              weights::W, local_histogram::H, local_normalization::LN,
+                              global_cache::C, global_normalization::GN,
                               launch_parameters::K, dims::NTuple{N, Int}, method::Symbol,
                               reduced_dimensions::NTuple{3, Bool},
                               retained_offsets::NTuple{3, Int},
-                              retained_lengths::NTuple{3, Int}) where {G, A, BN, E1, W, H, C, K, N}
+                              retained_lengths::NTuple{3, Int}) where {G, A, BN, E1, W, H, LN, C, GN, K, N}
     T = eltype(global_cache)
-    return Histogram1DOperation{G, T, A, BN, E1, W, H, C, K}(grid, a, bins, edges1,
-                                                              weights, local_histogram, global_cache,
+    return Histogram1DOperation{G, T, A, BN, E1, W, H, LN, C, GN, K}(grid, a, bins, edges1,
+                                                              weights, local_histogram, local_normalization,
+                                                              global_cache, global_normalization,
                                                               launch_parameters, dims, method,
                                                               reduced_dimensions, retained_offsets,
                                                               retained_lengths)
@@ -106,13 +119,19 @@ Constraints:
   - 2D histogram: exactly two edge vectors.
   - 1D histogram: exactly one edge vector.
 - `weights` must be:
-  - with `method=:sum`: `:count`, a metric-weight symbol (`:volume` / legacy aliases), or an `AbstractField`;
+  - with `method=:sum`: `:count` or an `AbstractField`;
   - with `method=:integral`: `:count` or an `AbstractField`.
+  - with `method=:average`: `:count` or an `AbstractField`.
 - `:count` with `method=:sum` accumulates one count per sample.
 - `:count` with `method=:integral` accumulates the geometric integration metric for `dims`
   (`Δx`, `Δy`, `Δz`, `Az`, `Ay`, `Ax`, or `volume`), matching `Integral` semantics.
+- `:average` computes a metric-weighted mean:
+  `Histogram(...; weights=w, method=:integral) / Histogram(...; weights=:count, method=:integral)`
+  with zero returned for bins whose denominator is zero.
+- Typical use: `weights=tracer_field, method=:average` to compute a binned mean tracer.
+- `weights=:count, method=:average` yields one for populated bins and zero for empty bins.
 - `dims` is the subset of spatial dimensions to reduce over. `dims=:` is shorthand for `(1, 2, 3)`.
-- `method` must be `:sum` or `:integral`.
+- `method` must be `:sum`, `:integral`, or `:average`.
 - Distributed architectures are not supported yet.
 
 For partial reductions, retained dimensions are flattened into histogram output indices.
@@ -149,7 +168,8 @@ function Histogram(a::AbstractField, b::AbstractField;
     reduced_dimensions, retained_offsets, retained_lengths, retained_count =
         histogram_reduction_metadata(launch_indices, dims)
 
-    maybe_warn_histogram_memory((nbin1, nbin2, retained_count), FT; dims)
+    buffers = method === :average ? 4 : 2
+    maybe_warn_histogram_memory((nbin1, nbin2, retained_count), FT; dims, buffers)
 
     histogram_grid = RectilinearGrid(CPU(), FT;
                                      size = (nbin1, nbin2, retained_count),
@@ -164,9 +184,12 @@ function Histogram(a::AbstractField, b::AbstractField;
 
     local_histogram = zeros(arch, FT, nbin1, nbin2, retained_count)
     global_cache = zeros(FT, nbin1, nbin2, retained_count)
+    local_normalization = method === :average ? zeros(arch, FT, nbin1, nbin2, retained_count) : nothing
+    global_normalization = method === :average ? zeros(FT, nbin1, nbin2, retained_count) : nothing
 
     return HistogramOperation(histogram_grid, a, b, bins, edges1, edges2, weights,
-                              local_histogram, global_cache, launch_parameters,
+                              local_histogram, local_normalization,
+                              global_cache, global_normalization, launch_parameters,
                               dims, method, reduced_dimensions,
                               retained_offsets, retained_lengths)
 end
@@ -200,7 +223,8 @@ function Histogram(a::AbstractField;
     reduced_dimensions, retained_offsets, retained_lengths, retained_count =
         histogram_reduction_metadata(launch_indices, dims)
 
-    maybe_warn_histogram_memory((nbin1, retained_count, 1), FT; dims)
+    buffers = method === :average ? 4 : 2
+    maybe_warn_histogram_memory((nbin1, retained_count, 1), FT; dims, buffers)
 
     histogram_grid = RectilinearGrid(CPU(), FT;
                                      size = (nbin1, retained_count),
@@ -213,9 +237,12 @@ function Histogram(a::AbstractField;
 
     local_histogram = zeros(arch, FT, nbin1, retained_count, 1)
     global_cache = zeros(FT, nbin1, retained_count, 1)
+    local_normalization = method === :average ? zeros(arch, FT, nbin1, retained_count, 1) : nothing
+    global_normalization = method === :average ? zeros(FT, nbin1, retained_count, 1) : nothing
 
     return Histogram1DOperation(histogram_grid, a, bins, edges1, weights,
-                                local_histogram, global_cache, launch_parameters,
+                                local_histogram, local_normalization,
+                                global_cache, global_normalization, launch_parameters,
                                 dims, method, reduced_dimensions,
                                 retained_offsets, retained_lengths)
 end
@@ -253,10 +280,11 @@ function Histogram(fields::NamedTuple;
 end
 
 Base.summary(::HistogramCountWeights) = ":count"
-Base.summary(::HistogramVolumeWeights) = ":cell_volume"
 Base.summary(w::HistogramFieldWeights) = "field ($(summary(w.field)))"
 Base.summary(w::HistogramIntegralCountWeights) = "integral(:count)"
 Base.summary(w::HistogramIntegralFieldWeights) = "integral(field ($(summary(w.field))))"
+Base.summary(w::HistogramAverageCountWeights) = "average(:count)"
+Base.summary(w::HistogramAverageFieldWeights) = "average(field ($(summary(w.field))))"
 
 function Base.summary(op::HistogramOperation)
     nbin1, nbin2, nret = size(op.global_cache)
@@ -300,13 +328,26 @@ function compute_at!(op::HistogramOperation, time)
     grid = op.a.grid
     arch = architecture(grid)
 
-    launch!(arch, grid, op.launch_parameters, _accumulate_histogram_2d!,
-            op.local_histogram, op.a, op.b, op.edges1, op.edges2,
-            grid, op.weights, instantiated_location(op.a),
-            op.reduced_dimensions, op.retained_offsets, op.retained_lengths)
+    if op.method === :average
+        fill!(op.local_normalization, zero(eltype(op.local_normalization)))
 
-    local_histogram_cpu = on_architecture(CPU(), op.local_histogram)
-    copyto!(op.global_cache, local_histogram_cpu)
+        launch!(arch, grid, op.launch_parameters, _accumulate_histogram_2d_average!,
+                op.local_histogram, op.local_normalization, op.a, op.b, op.edges1, op.edges2,
+                grid, op.weights, instantiated_location(op.a),
+                op.reduced_dimensions, op.retained_offsets, op.retained_lengths)
+
+        copyto!(op.global_cache, on_architecture(CPU(), op.local_histogram))
+        copyto!(op.global_normalization, on_architecture(CPU(), op.local_normalization))
+        finalize_average_histogram!(op.global_cache, op.global_normalization)
+    else
+        launch!(arch, grid, op.launch_parameters, _accumulate_histogram_2d!,
+                op.local_histogram, op.a, op.b, op.edges1, op.edges2,
+                grid, op.weights, instantiated_location(op.a),
+                op.reduced_dimensions, op.retained_offsets, op.retained_lengths)
+
+        local_histogram_cpu = on_architecture(CPU(), op.local_histogram)
+        copyto!(op.global_cache, local_histogram_cpu)
+    end
 
     return nothing
 end
@@ -320,19 +361,36 @@ function compute_at!(op::Histogram1DOperation, time)
     grid = op.a.grid
     arch = architecture(grid)
 
-    launch!(arch, grid, op.launch_parameters, _accumulate_histogram_1d!,
-            op.local_histogram, op.a, op.edges1,
-            grid, op.weights, instantiated_location(op.a),
-            op.reduced_dimensions, op.retained_offsets, op.retained_lengths)
+    if op.method === :average
+        fill!(op.local_normalization, zero(eltype(op.local_normalization)))
 
-    local_histogram_cpu = on_architecture(CPU(), op.local_histogram)
-    copyto!(op.global_cache, local_histogram_cpu)
+        launch!(arch, grid, op.launch_parameters, _accumulate_histogram_1d_average!,
+                op.local_histogram, op.local_normalization, op.a, op.edges1,
+                grid, op.weights, instantiated_location(op.a),
+                op.reduced_dimensions, op.retained_offsets, op.retained_lengths)
+
+        copyto!(op.global_cache, on_architecture(CPU(), op.local_histogram))
+        copyto!(op.global_normalization, on_architecture(CPU(), op.local_normalization))
+        finalize_average_histogram!(op.global_cache, op.global_normalization)
+    else
+        launch!(arch, grid, op.launch_parameters, _accumulate_histogram_1d!,
+                op.local_histogram, op.a, op.edges1,
+                grid, op.weights, instantiated_location(op.a),
+                op.reduced_dimensions, op.retained_offsets, op.retained_lengths)
+
+        local_histogram_cpu = on_architecture(CPU(), op.local_histogram)
+        copyto!(op.global_cache, local_histogram_cpu)
+    end
 
     return nothing
 end
 
+@inline function finalize_average_histogram!(numerator, denominator)
+    @. numerator = ifelse(denominator > 0, numerator / denominator, zero(eltype(numerator)))
+    return nothing
+end
+
 @inline compute_histogram_weights_at!(::HistogramCountWeights, time) = nothing
-@inline compute_histogram_weights_at!(weights::HistogramVolumeWeights, time) = compute_at!(weights.volume, time)
 @inline compute_histogram_weights_at!(weights::HistogramFieldWeights, time) = compute_at!(weights.field, time)
 @inline compute_histogram_weights_at!(weights::HistogramIntegralCountWeights, time) = compute_at!(weights.metric, time)
 @inline function compute_histogram_weights_at!(weights::HistogramIntegralFieldWeights, time)
@@ -340,12 +398,22 @@ end
     compute_at!(weights.metric, time)
     return nothing
 end
+@inline compute_histogram_weights_at!(weights::HistogramAverageCountWeights, time) = compute_at!(weights.metric, time)
+@inline function compute_histogram_weights_at!(weights::HistogramAverageFieldWeights, time)
+    compute_at!(weights.field, time)
+    compute_at!(weights.metric, time)
+    return nothing
+end
 
 @inline histogram_weight(i, j, k, grid, ::HistogramCountWeights) = 1
-@inline histogram_weight(i, j, k, grid, weights::HistogramVolumeWeights) = @inbounds weights.volume[i, j, k]
 @inline histogram_weight(i, j, k, grid, weights::HistogramFieldWeights) = @inbounds weights.field[i, j, k]
 @inline histogram_weight(i, j, k, grid, weights::HistogramIntegralCountWeights) = @inbounds weights.metric[i, j, k]
 @inline histogram_weight(i, j, k, grid, weights::HistogramIntegralFieldWeights) = @inbounds weights.field[i, j, k] * weights.metric[i, j, k]
+@inline histogram_weight(i, j, k, grid, weights::HistogramAverageCountWeights) = @inbounds weights.metric[i, j, k]
+@inline histogram_weight(i, j, k, grid, weights::HistogramAverageFieldWeights) = @inbounds weights.field[i, j, k] * weights.metric[i, j, k]
+
+@inline histogram_normalization_weight(i, j, k, grid, weights::HistogramAverageCountWeights) = @inbounds weights.metric[i, j, k]
+@inline histogram_normalization_weight(i, j, k, grid, weights::HistogramAverageFieldWeights) = @inbounds weights.metric[i, j, k]
 
 @inline function find_histogram_bin(value, edges)
     N = length(edges)
@@ -407,6 +475,31 @@ end
     end
 end
 
+@kernel function _accumulate_histogram_2d_average!(histogram, normalization, a, b, edges1, edges2,
+                                                   grid, weights, loc,
+                                                   reduced_dimensions,
+                                                   retained_offsets,
+                                                   retained_lengths)
+    i, j, k = @index(Global, NTuple)
+
+    if !inactive_node(i, j, k, grid, loc...)
+        @inbounds aᵢ = a[i, j, k]
+        @inbounds bᵢ = b[i, j, k]
+
+        ibin1 = find_histogram_bin(aᵢ, edges1)
+        ibin2 = find_histogram_bin(bᵢ, edges2)
+
+        in_range = (ibin1 > 0) & (ibin2 > 0)
+        if in_range
+            retained_index = retained_linear_index(i, j, k, reduced_dimensions, retained_offsets, retained_lengths)
+            numerator_weight = convert(eltype(histogram), histogram_weight(i, j, k, grid, weights))
+            denominator_weight = convert(eltype(normalization), histogram_normalization_weight(i, j, k, grid, weights))
+            @atomic histogram[ibin1, ibin2, retained_index] += numerator_weight
+            @atomic normalization[ibin1, ibin2, retained_index] += denominator_weight
+        end
+    end
+end
+
 @kernel function _accumulate_histogram_1d!(histogram, a, edges1,
                                            grid, weights, loc,
                                            reduced_dimensions,
@@ -427,11 +520,34 @@ end
     end
 end
 
+@kernel function _accumulate_histogram_1d_average!(histogram, normalization, a, edges1,
+                                                   grid, weights, loc,
+                                                   reduced_dimensions,
+                                                   retained_offsets,
+                                                   retained_lengths)
+    i, j, k = @index(Global, NTuple)
+
+    if !inactive_node(i, j, k, grid, loc...)
+        @inbounds aᵢ = a[i, j, k]
+
+        ibin1 = find_histogram_bin(aᵢ, edges1)
+
+        if ibin1 > 0
+            retained_index = retained_linear_index(i, j, k, reduced_dimensions, retained_offsets, retained_lengths)
+            numerator_weight = convert(eltype(histogram), histogram_weight(i, j, k, grid, weights))
+            denominator_weight = convert(eltype(normalization), histogram_normalization_weight(i, j, k, grid, weights))
+            @atomic histogram[ibin1, retained_index, 1] += numerator_weight
+            @atomic normalization[ibin1, retained_index, 1] += denominator_weight
+        end
+    end
+end
+
 @inline histogram_weight_operands(::HistogramCountWeights) = ()
-@inline histogram_weight_operands(weights::HistogramVolumeWeights) = (weights.volume,)
 @inline histogram_weight_operands(weights::HistogramFieldWeights) = (weights.field,)
 @inline histogram_weight_operands(weights::HistogramIntegralCountWeights) = (weights.metric,)
 @inline histogram_weight_operands(weights::HistogramIntegralFieldWeights) = (weights.field, weights.metric)
+@inline histogram_weight_operands(weights::HistogramAverageCountWeights) = (weights.metric,)
+@inline histogram_weight_operands(weights::HistogramAverageFieldWeights) = (weights.field, weights.metric)
 
 function histogram_launch_indices(a, b, weights)
     loc = instantiated_location(a)
@@ -480,8 +596,8 @@ function histogram_reduction_metadata(launch_indices::NTuple{3, <:AbstractUnitRa
     return reduced_dimensions, retained_offsets, retained_lengths, retained_count
 end
 
-function maybe_warn_histogram_memory(shape, ::Type{FT}; dims) where FT
-    bytes = 2 * sizeof(FT) * prod(shape)
+function maybe_warn_histogram_memory(shape, ::Type{FT}; dims, buffers=2) where FT
+    bytes = buffers * sizeof(FT) * prod(shape)
 
     if bytes > HISTOGRAM_MEMORY_WARNING_BYTES
         gib = round(bytes / 1024^3; digits=3)
@@ -530,13 +646,13 @@ function validate_histogram_dims(dims)
 end
 
 function validate_histogram_method(method::Symbol)
-    method ∈ (:sum, :integral) ||
-        throw(ArgumentError("Histogram currently only supports method = :sum or method = :integral."))
+    method ∈ (:sum, :integral, :average) ||
+        throw(ArgumentError("Histogram currently only supports method = :sum, :integral, or :average."))
     return method
 end
 
 validate_histogram_method(method) =
-    throw(ArgumentError("Histogram currently only supports method = :sum or method = :integral."))
+    throw(ArgumentError("Histogram currently only supports method = :sum, :integral, or :average."))
 
 function validate_histogram_architecture(arch)
     if isdefined(Oceananigans, :DistributedComputations) &&
@@ -618,21 +734,24 @@ function validate_histogram_weights(weights::Symbol, method::Symbol, dims, a::Ab
     if method === :sum
         if weights === :count
             return HistogramCountWeights()
-        elseif weights === :cell_volume || weights === :volume
-            volume_field = grid_metric_operation(instantiated_location(a), volume, a.grid)
-            return HistogramVolumeWeights(volume_field)
         else
-            throw(ArgumentError("Unsupported Histogram weights = $weights for method=:sum. Use :count, :cell_volume, :volume, or an AbstractField."))
+            throw(ArgumentError("Unsupported Histogram weights = $weights for method=:sum. Use :count or an AbstractField."))
         end
-    else # method === :integral
+    elseif method === :integral
         metric = histogram_integral_metric(a, dims)
 
         if weights === :count
             return HistogramIntegralCountWeights(metric)
-        elseif weights === :cell_volume || weights === :volume
-            throw(ArgumentError("Histogram weights=:cell_volume is not supported with method=:integral because it would double-apply metrics. Use weights=:count or an AbstractField."))
         else
             throw(ArgumentError("Unsupported Histogram weights = $weights for method=:integral. Use :count or an AbstractField."))
+        end
+    else # method === :average
+        metric = histogram_integral_metric(a, dims)
+
+        if weights === :count
+            return HistogramAverageCountWeights(metric)
+        else
+            throw(ArgumentError("Unsupported Histogram weights = $weights for method=:average. Use :count or an AbstractField."))
         end
     end
 end
@@ -646,9 +765,12 @@ function validate_histogram_weights(weights::AbstractField, method::Symbol, dims
 
     if method === :sum
         return HistogramFieldWeights(weights)
-    else
+    elseif method === :integral
         metric = histogram_integral_metric(a, dims)
         return HistogramIntegralFieldWeights(weights, metric)
+    else
+        metric = histogram_integral_metric(a, dims)
+        return HistogramAverageFieldWeights(weights, metric)
     end
 end
 
@@ -663,15 +785,6 @@ end
 @inline function histogram_eltype(a, b, bins, ::HistogramCountWeights)
     edges1, edges2 = values(bins)
     return promote_type(float(eltype(a)), float(eltype(b)), float(eltype(edges1)), float(eltype(edges2)))
-end
-
-@inline function histogram_eltype(a, b, bins, ::HistogramVolumeWeights)
-    edges1, edges2 = values(bins)
-    return promote_type(float(eltype(a)),
-                        float(eltype(b)),
-                        float(eltype(edges1)),
-                        float(eltype(edges2)),
-                        float(eltype(a.grid)))
 end
 
 @inline function histogram_eltype(a, b, bins, weights::HistogramFieldWeights)
@@ -702,14 +815,28 @@ end
                         float(eltype(weights.metric)))
 end
 
+@inline function histogram_eltype(a, b, bins, weights::HistogramAverageCountWeights)
+    edges1, edges2 = values(bins)
+    return promote_type(float(eltype(a)),
+                        float(eltype(b)),
+                        float(eltype(edges1)),
+                        float(eltype(edges2)),
+                        float(eltype(weights.metric)))
+end
+
+@inline function histogram_eltype(a, b, bins, weights::HistogramAverageFieldWeights)
+    edges1, edges2 = values(bins)
+    return promote_type(float(eltype(a)),
+                        float(eltype(b)),
+                        float(eltype(edges1)),
+                        float(eltype(edges2)),
+                        float(eltype(weights.field)),
+                        float(eltype(weights.metric)))
+end
+
 @inline function histogram_eltype(a, bins, ::HistogramCountWeights)
     edges1 = first(values(bins))
     return promote_type(float(eltype(a)), float(eltype(edges1)))
-end
-
-@inline function histogram_eltype(a, bins, ::HistogramVolumeWeights)
-    edges1 = first(values(bins))
-    return promote_type(float(eltype(a)), float(eltype(edges1)), float(eltype(a.grid)))
 end
 
 @inline function histogram_eltype(a, bins, weights::HistogramFieldWeights)
@@ -723,6 +850,16 @@ end
 end
 
 @inline function histogram_eltype(a, bins, weights::HistogramIntegralFieldWeights)
+    edges1 = first(values(bins))
+    return promote_type(float(eltype(a)), float(eltype(edges1)), float(eltype(weights.field)), float(eltype(weights.metric)))
+end
+
+@inline function histogram_eltype(a, bins, weights::HistogramAverageCountWeights)
+    edges1 = first(values(bins))
+    return promote_type(float(eltype(a)), float(eltype(edges1)), float(eltype(weights.metric)))
+end
+
+@inline function histogram_eltype(a, bins, weights::HistogramAverageFieldWeights)
     edges1 = first(values(bins))
     return promote_type(float(eltype(a)), float(eltype(edges1)), float(eltype(weights.field)), float(eltype(weights.metric)))
 end

--- a/src/AbstractOperations/histogram_operation.jl
+++ b/src/AbstractOperations/histogram_operation.jl
@@ -33,6 +33,15 @@ struct HistogramOperation{G, T, A, B, BN, E1, E2, W, H, C, K} <: AbstractOperati
     method :: Symbol
 end
 
+function HistogramOperation(grid::G, a::A, b::B, bins::BN, edges1::E1, edges2::E2,
+                            weights::W, local_histogram::H, global_cache::C,
+                            launch_parameters::K, dims::NTuple{3, Int}, method::Symbol) where {G, A, B, BN, E1, E2, W, H, C, K}
+    T = eltype(global_cache)
+    return HistogramOperation{G, T, A, B, BN, E1, E2, W, H, C, K}(grid, a, b, bins, edges1, edges2,
+                                                                   weights, local_histogram, global_cache,
+                                                                   launch_parameters, dims, method)
+end
+
 """
     Histogram(a::AbstractField, b::AbstractField; bins=NamedTuple(), weights=:count, dims=(1, 2, 3), method=:sum)
 
@@ -93,12 +102,11 @@ function Histogram(a::AbstractField, b::AbstractField;
     # Keep histogram data on host for deterministic indexing/output while computing
     # local contributions on the operand architecture.
     histogram_grid = RectilinearGrid(CPU(), FT;
-                                     size = (nbin1, nbin2, 1),
+                                     size = (nbin1, nbin2),
                                      topology = (Bounded, Bounded, Flat),
-                                     halo = (0, 0, 0),
+                                     halo = (1, 1),
                                      x = edges1_cpu,
-                                     y = edges2_cpu,
-                                     z = zero(FT))
+                                     y = edges2_cpu)
 
     arch = architecture(a.grid)
     edges1 = on_architecture(arch, edges1_cpu)

--- a/src/AbstractOperations/histogram_operation.jl
+++ b/src/AbstractOperations/histogram_operation.jl
@@ -44,6 +44,7 @@ end
 
 """
     Histogram(a::AbstractField, b::AbstractField; bins=NamedTuple(), weights=:count, dims=(1, 2, 3), method=:sum)
+    Histogram(fields::NamedTuple; bins=NamedTuple(), weights=:count, dims=(1, 2, 3), method=:sum)
 
 Construct a 2D histogram operation from field operands `a` and `b`.
 
@@ -56,6 +57,11 @@ MVP constraints:
   on the same grid and location as `a` and `b`.
 - `dims` must be `:` or `(1, 2, 3)`.
 - `method` must be `:sum`.
+
+Bin mapping behavior:
+- `Histogram(a, b; bins=(..., ...))` maps bins by value order.
+- `Histogram((name1=a, name2=b); bins=(...))` maps bins by key and then reorders
+  to operand order. This allows bin tuple order to differ from operand order.
 
 Example
 =======
@@ -77,6 +83,25 @@ julia> h = Field(Histogram(T, S; bins=(T=T_edges, S=S_edges), weights=:count));
 
 julia> size(h)
 (4, 6, 1)
+```
+
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
+
+julia> T = CenterField(grid); S = CenterField(grid);
+
+julia> set!(T, (x, y, z) -> x + z); set!(S, (x, y, z) -> y - z);
+
+julia> T_edges = collect(range(0.0, stop=2.0, length=5));
+
+julia> S_edges = collect(range(-1.0, stop=2.0, length=7));
+
+julia> h_named = Field(Histogram((S=S, T=T); bins=(T=T_edges, S=S_edges), weights=:count));
+
+julia> size(h_named)
+(6, 4, 1)
 ```
 """
 function Histogram(a::AbstractField, b::AbstractField;
@@ -119,6 +144,28 @@ function Histogram(a::AbstractField, b::AbstractField;
     return HistogramOperation(histogram_grid, a, b, bins, edges1, edges2, weights,
                               local_histogram, global_cache, launch_parameters,
                               dims, method)
+end
+
+function Histogram(fields::NamedTuple;
+                   bins = NamedTuple(),
+                   weights = :count,
+                   dims = (1, 2, 3),
+                   method = :sum)
+
+    length(fields) == 2 ||
+        throw(ArgumentError("Histogram(fields=...) requires exactly two named field operands."))
+
+    operand_names = keys(fields)
+    a, b = values(fields)
+
+    a isa AbstractField ||
+        throw(ArgumentError("Histogram(fields=...) requires field operands, but `$(operand_names[1])` is $(typeof(a))."))
+
+    b isa AbstractField ||
+        throw(ArgumentError("Histogram(fields=...) requires field operands, but `$(operand_names[2])` is $(typeof(b))."))
+
+    bins = reorder_histogram_bins_for_named_operands(bins, operand_names)
+    return Histogram(a, b; bins, weights, dims, method)
 end
 
 Base.summary(::HistogramCountWeights) = ":count"
@@ -311,6 +358,20 @@ end
 
 validate_histogram_bins(bins) =
     throw(ArgumentError("Histogram requires bins to be a NamedTuple with exactly two entries."))
+
+function reorder_histogram_bins_for_named_operands(bins::NamedTuple, operand_names::Tuple{Symbol, Symbol})
+    bins = validate_histogram_bins(bins)
+    first_name, second_name = operand_names
+
+    first_name ∈ keys(bins) ||
+        throw(ArgumentError("Histogram bins are missing key `$first_name` required by named operand mapping."))
+
+    second_name ∈ keys(bins) ||
+        throw(ArgumentError("Histogram bins are missing key `$second_name` required by named operand mapping."))
+
+    return NamedTuple{operand_names}((getproperty(bins, first_name),
+                                      getproperty(bins, second_name)))
+end
 
 function validate_histogram_weights(weights::Symbol, a, b)
     if weights === :count

--- a/src/AbstractOperations/histogram_operation.jl
+++ b/src/AbstractOperations/histogram_operation.jl
@@ -1,5 +1,6 @@
 using Oceananigans.Fields: AbstractField, instantiated_location, compute_at!, indices, filter_nothing_dims
 using Oceananigans.Grids: RectilinearGrid, Face, Center, Bounded, Flat, topology, interior_indices
+using Oceananigans.Grids: OrthogonalSphericalShellGrid
 using Oceananigans.Grids: ξnodes, ηnodes, rnodes
 using Oceananigans.Architectures: architecture, on_architecture, CPU
 using Oceananigans.Utils: KernelParameters, launch!, tupleit
@@ -139,6 +140,21 @@ function histogram_retained_coordinate(a, launch_indices, reduced_dimensions, re
     return convert(Vector{FT}, retained_faces_cpu)
 end
 
+@inline histogram_retained_dimensions(dims) = Tuple(d for d in 1:3 if !(d in dims))
+
+function validate_histogram_retained_dims_grid_compatibility(grid, dims)
+    if hasproperty(grid, :underlying_grid)
+        return validate_histogram_retained_dims_grid_compatibility(getproperty(grid, :underlying_grid), dims)
+    end
+
+    retained_dims = histogram_retained_dimensions(dims)
+    if !isempty(retained_dims) && grid isa OrthogonalSphericalShellGrid
+        throw(ArgumentError("Histogram with retained dimensions $(retained_dims) is not supported on $(typeof(grid)). " *
+                            "For OrthogonalSphericalShellGrid/Tripolar grids, reduce over all dimensions with dims=(1, 2, 3)."))
+    end
+    return nothing
+end
+
 """
     Histogram(a::AbstractField, b::AbstractField; bins=NamedTuple(), weights=:count, dims=(1, 2, 3), method=:sum)
     Histogram(fields::NamedTuple; bins=NamedTuple(), weights=:count, dims=(1, 2, 3), method=:sum)
@@ -183,6 +199,7 @@ function Histogram(a::AbstractField, b::AbstractField;
     dims = filter_nothing_dims(dims, instantiated_location(a))
     isempty(dims) &&
         throw(ArgumentError("Histogram dims cannot be empty after filtering dimensions absent from operand location $(instantiated_location(a))."))
+    validate_histogram_retained_dims_grid_compatibility(a.grid, dims)
     method = validate_histogram_method(method)
     bins = validate_histogram_bins_2d(bins)
     weights = validate_histogram_weights(weights, method, dims, a, b)
@@ -240,6 +257,7 @@ function Histogram(a::AbstractField;
     dims = filter_nothing_dims(dims, instantiated_location(a))
     isempty(dims) &&
         throw(ArgumentError("Histogram dims cannot be empty after filtering dimensions absent from operand location $(instantiated_location(a))."))
+    validate_histogram_retained_dims_grid_compatibility(a.grid, dims)
     method = validate_histogram_method(method)
     bins = validate_histogram_bins_1d(bins)
     weights = validate_histogram_weights(weights, method, dims, a)

--- a/src/AbstractOperations/histogram_operation.jl
+++ b/src/AbstractOperations/histogram_operation.jl
@@ -2,7 +2,7 @@ using Oceananigans.Fields: AbstractField, instantiated_location, compute_at!, in
 using Oceananigans.Grids: RectilinearGrid, Center, Bounded, Flat, topology, interior_indices
 using Oceananigans.Architectures: architecture, on_architecture, CPU
 using Oceananigans.Utils: KernelParameters, launch!, tupleit
-using Oceananigans.Grids: inactive_cell
+using Oceananigans.Grids: inactive_node
 
 using KernelAbstractions: @kernel, @index, @atomic
 
@@ -57,6 +57,7 @@ MVP constraints:
   on the same grid and location as `a` and `b`.
 - `dims` must be `:` or `(1, 2, 3)`.
 - `method` must be `:sum`.
+- Distributed architectures are not supported yet.
 
 Bin mapping behavior:
 - `Histogram(a, b; bins=(..., ...))` maps bins by value order.
@@ -84,25 +85,6 @@ julia> h = Field(Histogram(T, S; bins=(T=T_edges, S=S_edges), weights=:count));
 julia> size(h)
 (4, 6, 1)
 ```
-
-```jldoctest
-julia> using Oceananigans
-
-julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
-
-julia> T = CenterField(grid); S = CenterField(grid);
-
-julia> set!(T, (x, y, z) -> x + z); set!(S, (x, y, z) -> y - z);
-
-julia> T_edges = collect(range(0.0, stop=2.0, length=5));
-
-julia> S_edges = collect(range(-1.0, stop=2.0, length=7));
-
-julia> h_named = Field(Histogram((S=S, T=T); bins=(T=T_edges, S=S_edges), weights=:count));
-
-julia> size(h_named)
-(6, 4, 1)
-```
 """
 function Histogram(a::AbstractField, b::AbstractField;
                    bins = NamedTuple(),
@@ -116,6 +98,9 @@ function Histogram(a::AbstractField, b::AbstractField;
     method = validate_histogram_method(method)
     bins = validate_histogram_bins(bins)
     weights = validate_histogram_weights(weights, a, b)
+
+    arch = architecture(a.grid)
+    validate_histogram_architecture(arch)
 
     FT = histogram_eltype(a, b, bins, weights)
     bins = convert_histogram_bins_eltype(bins, FT)
@@ -133,7 +118,6 @@ function Histogram(a::AbstractField, b::AbstractField;
                                      x = edges1_cpu,
                                      y = edges2_cpu)
 
-    arch = architecture(a.grid)
     edges1 = on_architecture(arch, edges1_cpu)
     edges2 = on_architecture(arch, edges2_cpu)
 
@@ -200,20 +184,11 @@ function compute_at!(op::HistogramOperation, time)
     arch = architecture(grid)
 
     launch!(arch, grid, op.launch_parameters, _accumulate_histogram!,
-            op.local_histogram, op.a, op.b, op.edges1, op.edges2, grid, op.weights)
+            op.local_histogram, op.a, op.b, op.edges1, op.edges2, grid, op.weights, instantiated_location(op.a))
 
     local_histogram_cpu = on_architecture(CPU(), op.local_histogram)
     copyto!(view(op.global_cache, :, :, 1), local_histogram_cpu)
-    histogram_all_reduce!(+, op.global_cache, arch)
-
     return nothing
-end
-
-@inline function histogram_all_reduce!(op, val, arch::Any)
-    if isdefined(Oceananigans, :DistributedComputations)
-        Oceananigans.DistributedComputations.all_reduce!(op, val, arch)
-    end
-    return val
 end
 
 @inline compute_histogram_weights_at!(::HistogramCountWeights, time) = nothing
@@ -250,10 +225,10 @@ end
     return ifelse(1 <= hi < N, hi, 0)
 end
 
-@kernel function _accumulate_histogram!(histogram, a, b, edges1, edges2, grid, weights)
+@kernel function _accumulate_histogram!(histogram, a, b, edges1, edges2, grid, weights, loc)
     i, j, k = @index(Global, NTuple)
 
-    if !inactive_cell(i, j, k, grid)
+    if !inactive_node(i, j, k, grid, loc...)
         @inbounds aᵢ = a[i, j, k]
         @inbounds bᵢ = b[i, j, k]
 
@@ -335,6 +310,15 @@ end
 
 validate_histogram_method(method) =
     throw(ArgumentError("Histogram currently only supports method = :sum."))
+
+function validate_histogram_architecture(arch)
+    if isdefined(Oceananigans, :DistributedComputations) &&
+       arch isa Oceananigans.DistributedComputations.Distributed
+        throw(ArgumentError("Histogram does not support distributed architectures yet."))
+    end
+
+    return nothing
+end
 
 function validate_histogram_bins(bins::NamedTuple)
     length(bins) == 2 ||

--- a/src/AbstractOperations/histogram_operation.jl
+++ b/src/AbstractOperations/histogram_operation.jl
@@ -821,7 +821,7 @@ end
 
 @inline function histogram_eltype(a, b, bins, ::HistogramCountWeights)
     edges1, edges2 = values(bins)
-    return promote_type(float(eltype(a)), float(eltype(b)), float(eltype(edges1)), float(eltype(edges2)))
+    return promote_type(Float64, float(eltype(a)), float(eltype(b)), float(eltype(edges1)), float(eltype(edges2)))
 end
 
 @inline function histogram_eltype(a, b, bins, weights::HistogramFieldWeights)
@@ -873,7 +873,7 @@ end
 
 @inline function histogram_eltype(a, bins, ::HistogramCountWeights)
     edges1 = first(values(bins))
-    return promote_type(float(eltype(a)), float(eltype(edges1)))
+    return promote_type(Float64, float(eltype(a)), float(eltype(edges1)))
 end
 
 @inline function histogram_eltype(a, bins, weights::HistogramFieldWeights)

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -44,7 +44,7 @@ export
 
     # Fields and field manipulation
     Field, CenterField, XFaceField, YFaceField, ZFaceField,
-    Average, Integral, CumulativeIntegral, Reduction, Accumulation, BackgroundField,
+    Average, Integral, CumulativeIntegral, Histogram, Reduction, Accumulation, BackgroundField,
     interior, set!, compute!, regrid!,
 
     # Forcing functions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,7 @@ CUDA.allowscalar() do
         @testset "Simulation tests" begin
             include("test_simulations.jl")
             include("test_diagnostics.jl")
+            include("test_histogram_operation.jl")
             include("test_implicit_diffusion_diagnostic.jl")
             include("test_output_writers.jl")
             include("test_output_readers.jl")

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -146,9 +146,6 @@ function advective_timescale_cfl_on_flat_2d_grid(arch, FT)
     return cfl(model) == 0
 end
 
-get_iteration(model) = model.clock.iteration
-get_time(model) = model.clock.time
-
 @testset "Diagnostics" begin
     @info "Testing diagnostics..."
 
@@ -165,5 +162,6 @@ get_time(model) = model.clock.time
                 @test advective_timescale_cfl_on_flat_2d_grid(arch, FT)
             end
         end
+
     end
 end

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -24,6 +24,8 @@ MPI.Init()
 using Oceananigans.BoundaryConditions: fill_halo_regions!, DCBC
 using Oceananigans.DistributedComputations: Distributed, index2rank, cpu_architecture, child_architecture
 using Oceananigans.Fields: AbstractField
+using Oceananigans.AbstractOperations: Histogram, KernelFunctionOperation
+using Oceananigans.Operators: Vᶜᶜᶜ
 using Oceananigans.Grids:
     architecture,
     halo_size,
@@ -444,6 +446,26 @@ function test_triply_periodic_halo_communication_with_221_ranks(halo, child_arch
     return nothing
 end
 
+function test_distributed_histogram_volume_conservation(partition, child_arch)
+    arch = Distributed(child_arch; partition)
+    grid = RectilinearGrid(arch, topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3))
+    a = CenterField(grid)
+    b = CenterField(grid)
+
+    set!(a, (x, y, z) -> 0.5x + 0.25y + 0.1z)
+    set!(b, (x, y, z) -> 34 + 0.2x - 0.3y - 0.05z)
+
+    a_edges = collect(range(-2.0, stop=2.0, length=17))
+    b_edges = collect(range(32.0, stop=36.0, length=17))
+
+    histogram = Field(Histogram(a, b; bins=(a=a_edges, b=b_edges), weights=:cell_volume))
+    total_histogram_volume = sum(histogram)
+    total_grid_volume = sum(KernelFunctionOperation{Center, Center, Center}(Vᶜᶜᶜ, grid))
+
+    @test total_histogram_volume ≈ total_grid_volume
+    return nothing
+end
+
 #####
 ##### Run tests!
 #####
@@ -561,6 +583,15 @@ end
 
             all!(cbool_reduced, cbool)
             @test @allowscalar cbool_reduced[1, 1, 1] == false
+        end
+    end
+
+    @testset "Distributed histogram operation" begin
+        child_arch = get(ENV, "TEST_ARCHITECTURE", "CPU") == "GPU" ? GPU() : CPU()
+
+        for partition in [Partition(1, 4), Partition(2, 2), Partition(4, 1)]
+            @info "Testing the closure of a histogram code with partition $partition..."
+            test_distributed_histogram_volume_conservation(partition, child_arch)
         end
     end
 

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -24,8 +24,6 @@ MPI.Init()
 using Oceananigans.BoundaryConditions: fill_halo_regions!, DCBC
 using Oceananigans.DistributedComputations: Distributed, index2rank, cpu_architecture, child_architecture
 using Oceananigans.Fields: AbstractField
-using Oceananigans.AbstractOperations: Histogram, KernelFunctionOperation
-using Oceananigans.Operators: Vᶜᶜᶜ
 using Oceananigans.Grids:
     architecture,
     halo_size,
@@ -446,26 +444,6 @@ function test_triply_periodic_halo_communication_with_221_ranks(halo, child_arch
     return nothing
 end
 
-function test_distributed_histogram_volume_conservation(partition, child_arch)
-    arch = Distributed(child_arch; partition)
-    grid = RectilinearGrid(arch, topology=(Periodic, Periodic, Periodic), size=(8, 8, 8), extent=(1, 2, 3))
-    a = CenterField(grid)
-    b = CenterField(grid)
-
-    set!(a, (x, y, z) -> 0.5x + 0.25y + 0.1z)
-    set!(b, (x, y, z) -> 34 + 0.2x - 0.3y - 0.05z)
-
-    a_edges = collect(range(-2.0, stop=2.0, length=17))
-    b_edges = collect(range(32.0, stop=36.0, length=17))
-
-    histogram = Field(Histogram(a, b; bins=(a=a_edges, b=b_edges), weights=:cell_volume))
-    total_histogram_volume = sum(histogram)
-    total_grid_volume = sum(KernelFunctionOperation{Center, Center, Center}(Vᶜᶜᶜ, grid))
-
-    @test total_histogram_volume ≈ total_grid_volume
-    return nothing
-end
-
 #####
 ##### Run tests!
 #####
@@ -583,15 +561,6 @@ end
 
             all!(cbool_reduced, cbool)
             @test @allowscalar cbool_reduced[1, 1, 1] == false
-        end
-    end
-
-    @testset "Distributed histogram operation" begin
-        child_arch = get(ENV, "TEST_ARCHITECTURE", "CPU") == "GPU" ? GPU() : CPU()
-
-        for partition in [Partition(1, 4), Partition(2, 2), Partition(4, 1)]
-            @info "Testing the closure of a histogram code with partition $partition..."
-            test_distributed_histogram_volume_conservation(partition, child_arch)
         end
     end
 

--- a/test/test_histogram_operation.jl
+++ b/test/test_histogram_operation.jl
@@ -46,8 +46,6 @@ function reference_histogram(a, b, grid, edges1, edges2; weights=:count, dims=(1
         if in_range
             weight = if weights === :count
                 1
-            elseif weights === :cell_volume
-                Vᶜᶜᶜ(i, j, k, grid)
             else
                 weights[i, j, k]
             end
@@ -76,8 +74,6 @@ function reference_histogram_1d(a, grid, edges1; weights=:count, dims=(1, 2, 3))
         if i1 > 0
             weight = if weights === :count
                 1
-            elseif weights === :cell_volume
-                Vᶜᶜᶜ(i, j, k, grid)
             else
                 weights[i, j, k]
             end
@@ -109,18 +105,26 @@ function histogram_constructor_validation()
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, dims=())
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, dims=(1, 4))
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=:mass)
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=:cell_volume)
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=:volume)
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=w_face)
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=w_other)
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=:cell_volume, method=:integral)
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=:cell_volume, method=:average)
 
     @test_throws ArgumentError Histogram(a; bins=valid_bins, weights=:count)
     @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0, 0.5], weights=:count)
+    @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0], weights=:cell_volume)
+    @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0], weights=:volume)
     @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0], weights=w_face)
     @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0], weights=w_other)
     @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0], weights=:cell_volume, method=:integral)
+    @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0], weights=:cell_volume, method=:average)
 
     @test Histogram(a, b; bins=valid_bins, weights=:count, method=:integral) isa AbstractOperation
     @test Histogram(a; bins=[0.0, 1.0], weights=:count, method=:integral) isa AbstractOperation
+    @test Histogram(a, b; bins=valid_bins, weights=a, method=:average) isa AbstractOperation
+    @test Histogram(a; bins=[0.0, 1.0], weights=a, method=:average) isa AbstractOperation
 end
 
 function histogram_is_correct(arch, FT)
@@ -140,19 +144,15 @@ function histogram_is_correct(arch, FT)
     w_cpu = Array(interior(model.tracers.w))
 
     count_field = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=:count))
-    volume_field = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=:cell_volume))
     weighted_field = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=model.tracers.w))
 
     count_hist = Array(interior(count_field))
-    volume_hist = Array(interior(volume_field))
     weighted_hist = Array(interior(weighted_field))
 
     expected_count = reference_histogram(a_cpu, b_cpu, grid, edges1, edges2; weights=:count)
-    expected_volume = reference_histogram(a_cpu, b_cpu, grid, edges1, edges2; weights=:cell_volume)
     expected_weighted = reference_histogram(a_cpu, b_cpu, grid, edges1, edges2; weights=w_cpu)
 
     @test count_hist == expected_count
-    @test volume_hist ≈ expected_volume
     @test weighted_hist ≈ expected_weighted
 end
 
@@ -264,6 +264,51 @@ function histogram_integral_method_matches_sum_with_metric_1d(arch, FT)
     @test Array(interior(count_integral)) ≈ Array(interior(count_sum))
 end
 
+function histogram_average_method_matches_integral_ratio_2d(arch, FT)
+    grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
+    model = NonhydrostaticModel(grid; tracers=(:a, :b, :c))
+
+    set!(model, a=(x, y, z) -> FT(0.8x + 0.2z),
+                b=(x, y, z) -> FT(31 + 0.3y - 0.1z),
+                c=(x, y, z) -> FT(2 + 0.1x + 0.2y + 0.3z))
+
+    edges1 = FT[0, 1, 2, 3, 4, 5, 6]
+    edges2 = FT[30, 30.5, 31, 31.5, 32, 32.5, 33]
+    bins = (a = edges1, b = edges2)
+    dims = (1, 2)
+
+    average_field = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=model.tracers.c, dims, method=:average))
+    numerator = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=model.tracers.c, dims, method=:integral))
+    denominator = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=:count, dims, method=:integral))
+
+    expected = Array(interior(numerator))
+    denom = Array(interior(denominator))
+    @. expected = ifelse(denom > 0, expected / denom, zero(eltype(expected)))
+
+    @test Array(interior(average_field)) ≈ expected
+end
+
+function histogram_average_method_matches_integral_ratio_1d(arch, FT)
+    grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
+    model = NonhydrostaticModel(grid; tracers=(:a, :c))
+
+    set!(model, a=(x, y, z) -> FT(0.8x + 0.2z),
+                c=(x, y, z) -> FT(2 + 0.1x + 0.2y + 0.3z))
+
+    bins = FT[0, 1, 2, 3, 4, 5, 6]
+    dims = (1, 2)
+
+    average_field = Field(Histogram(model.tracers.a; bins, weights=model.tracers.c, dims, method=:average))
+    numerator = Field(Histogram(model.tracers.a; bins, weights=model.tracers.c, dims, method=:integral))
+    denominator = Field(Histogram(model.tracers.a; bins, weights=:count, dims, method=:integral))
+
+    expected = Array(interior(numerator))
+    denom = Array(interior(denominator))
+    @. expected = ifelse(denom > 0, expected / denom, zero(eltype(expected)))
+
+    @test Array(interior(average_field)) ≈ expected
+end
+
 function histogram_edge_semantics()
     grid = RectilinearGrid(CPU(), size=(2, 2, 1), extent=(1, 1, 1))
     a = CenterField(grid)
@@ -326,7 +371,7 @@ function histogram_face_location_includes_bounded_boundary_faces(arch, FT)
     @test sum(histogram_cpu) == length(a_cpu)
 end
 
-function histogram_cell_volume_conservation(arch, FT)
+function histogram_integral_count_conservation(arch, FT)
     grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
     a = CenterField(grid)
     b = CenterField(grid)
@@ -337,7 +382,7 @@ function histogram_cell_volume_conservation(arch, FT)
     a_edges = FT[-1, 0, 1, 2, 3, 4, 5]
     b_edges = FT[32, 33, 34, 35, 36]
 
-    histogram = Field(Histogram(a, b; bins=(a=a_edges, b=b_edges), weights=:cell_volume))
+    histogram = Field(Histogram(a, b; bins=(a=a_edges, b=b_edges), weights=:count, method=:integral))
     total_histogram_volume = sum(histogram)
     total_grid_volume = sum(KernelFunctionOperation{Center, Center, Center}(Vᶜᶜᶜ, grid))
 
@@ -410,9 +455,11 @@ end
                 histogram_1d_is_correct(arch, FT)
                 histogram_integral_method_matches_sum_with_metric_2d(arch, FT)
                 histogram_integral_method_matches_sum_with_metric_1d(arch, FT)
+                histogram_average_method_matches_integral_ratio_2d(arch, FT)
+                histogram_average_method_matches_integral_ratio_1d(arch, FT)
                 histogram_named_operands_map_bins_by_key(arch, FT)
                 histogram_face_location_includes_bounded_boundary_faces(arch, FT)
-                histogram_cell_volume_conservation(arch, FT)
+                histogram_integral_count_conservation(arch, FT)
             end
         end
     end

--- a/test/test_histogram_operation.jl
+++ b/test/test_histogram_operation.jl
@@ -1,0 +1,173 @@
+include("dependencies_for_runtests.jl")
+
+using Oceananigans.AbstractOperations: Histogram
+using Oceananigans.Operators: Vᶜᶜᶜ
+
+function reference_bin(value, edges)
+    if value < first(edges) || value > last(edges)
+        return 0
+    elseif value == last(edges)
+        return length(edges) - 1
+    end
+
+    idx = searchsortedlast(edges, value)
+    return (1 <= idx < length(edges)) ? idx : 0
+end
+
+function reference_histogram(a, b, grid, edges1, edges2; weights=:count)
+    FT = promote_type(eltype(a), eltype(b), eltype(edges1), eltype(edges2))
+    histogram = zeros(FT, length(edges1) - 1, length(edges2) - 1)
+
+    Nx, Ny, Nz = size(a)
+    for k in 1:Nz, j in 1:Ny, i in 1:Nx
+        i1 = reference_bin(a[i, j, k], edges1)
+        i2 = reference_bin(b[i, j, k], edges2)
+
+        in_range = (i1 > 0) & (i2 > 0)
+        if in_range
+            weight = if weights === :count
+                1
+            elseif weights === :cell_volume
+                Vᶜᶜᶜ(i, j, k, grid)
+            else
+                weights[i, j, k]
+            end
+
+            histogram[i1, i2] += weight
+        end
+    end
+
+    return histogram
+end
+
+function histogram_constructor_validation()
+    grid = RectilinearGrid(CPU(), size=(4, 4, 4), extent=(1, 1, 1))
+    a = CenterField(grid)
+    b = CenterField(grid)
+    b_face = XFaceField(grid)
+    w_face = XFaceField(grid)
+    grid2 = RectilinearGrid(CPU(), size=(4, 4, 4), extent=(1, 1, 1))
+    w_other = CenterField(grid2)
+
+    valid_bins = (x = [0.0, 1.0], y = [0.0, 1.0])
+
+    @test_throws ArgumentError Histogram(a, b; bins=(x=[0.0, 1.0],), weights=:count)
+    @test_throws ArgumentError Histogram(a, b; bins=(x=[0.0, 1.0, 0.5], y=[0.0, 1.0]), weights=:count)
+    @test_throws ArgumentError Histogram(a, b_face; bins=valid_bins, weights=:count)
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, method=:mean)
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, dims=(1, 2))
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=:mass)
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=w_face)
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=w_other)
+end
+
+function histogram_is_correct(arch, FT)
+    grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
+    model = NonhydrostaticModel(grid; tracers=(:a, :b, :w))
+
+    set!(model, a=(x, y, z) -> FT(0.8x + 0.2z),
+                b=(x, y, z) -> FT(31 + 0.3y - 0.1z),
+                w=(x, y, z) -> FT(2 + 0.1x + 0.2y + 0.3z))
+
+    edges1 = FT[0, 1, 2, 3, 4, 5, 6]
+    edges2 = FT[30, 30.5, 31, 31.5, 32, 32.5, 33]
+    bins = (a = edges1, b = edges2)
+
+    a_cpu = Array(interior(model.tracers.a))
+    b_cpu = Array(interior(model.tracers.b))
+    w_cpu = Array(interior(model.tracers.w))
+
+    count_field = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=:count))
+    volume_field = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=:cell_volume))
+    weighted_field = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=model.tracers.w))
+
+    count_hist = Array(interior(count_field))[:, :, 1]
+    volume_hist = Array(interior(volume_field))[:, :, 1]
+    weighted_hist = Array(interior(weighted_field))[:, :, 1]
+
+    expected_count = reference_histogram(a_cpu, b_cpu, grid, edges1, edges2; weights=:count)
+    expected_volume = reference_histogram(a_cpu, b_cpu, grid, edges1, edges2; weights=:cell_volume)
+    expected_weighted = reference_histogram(a_cpu, b_cpu, grid, edges1, edges2; weights=w_cpu)
+
+    @test count_hist == expected_count
+    @test volume_hist ≈ expected_volume
+    @test weighted_hist ≈ expected_weighted
+end
+
+function histogram_edge_semantics()
+    grid = RectilinearGrid(CPU(), size=(2, 2, 1), extent=(1, 1, 1))
+    a = CenterField(grid)
+    b = CenterField(grid)
+
+    set!(a, reshape([0.0, 1.0, 2.0, 2.5], 2, 2, 1))
+    set!(b, reshape([0.0, 1.2, 2.0, -1.0], 2, 2, 1))
+
+    bins = (a = [0.0, 1.0, 2.0], b = [0.0, 1.0, 2.0])
+    h = Field(Histogram(a, b; bins, weights=:count))
+    histogram = Array(interior(h))[:, :, 1]
+
+    @test histogram == [1.0 0.0; 0.0 2.0]
+end
+
+function histogram_writer_smoke_test()
+    mktempdir() do dir
+        grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
+        model = NonhydrostaticModel(grid; tracers=(:a, :b))
+        set!(model, a=(x, y, z) -> x + z,
+                    b=(x, y, z) -> y - z)
+
+        bins = (a = collect(range(0.0, stop=2.0, length=5)),
+                b = collect(range(-1.0, stop=2.0, length=7)))
+
+        histogram = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=:count))
+        simulation = Simulation(model; Δt=1, stop_iteration=1)
+        simulation.output_writers[:histogram] = JLD2Writer(model, (; histogram);
+                                                           schedule = IterationInterval(1),
+                                                           dir = dir,
+                                                           filename = "histogram_operation_test.jld2",
+                                                           with_halos = false,
+                                                           overwrite_existing = true)
+
+        run!(simulation)
+
+        filepath = joinpath(dir, "histogram_operation_test.jld2")
+        jldopen(filepath, "r") do file
+            snapshot_keys = collect(keys(file["timeseries/histogram"]))
+            @test !isempty(snapshot_keys)
+
+            latest = string(maximum(parse.(Int, snapshot_keys)))
+            snapshot = file["timeseries/histogram/$latest"]
+
+            @test size(snapshot, 1) == length(bins.a) - 1
+            @test size(snapshot, 2) == length(bins.b) - 1
+            @test sum(snapshot) > 0
+        end
+    end
+
+    return nothing
+end
+
+@testset "Histogram operation" begin
+    @info "Testing Histogram operation..."
+
+    @testset "Constructor validation" begin
+        histogram_constructor_validation()
+    end
+
+    @testset "Bin edge semantics" begin
+        histogram_edge_semantics()
+    end
+
+    for arch in archs
+        @testset "Correctness [$(typeof(arch))]" begin
+            @info "  Testing Histogram correctness [$(typeof(arch))]..."
+            for FT in float_types
+                histogram_is_correct(arch, FT)
+            end
+        end
+    end
+
+    @testset "Writer integration" begin
+        histogram_writer_smoke_test()
+    end
+end

--- a/test/test_histogram_operation.jl
+++ b/test/test_histogram_operation.jl
@@ -125,6 +125,18 @@ function histogram_constructor_validation()
     @test Histogram(a; bins=[0.0, 1.0], weights=:count, method=:integral) isa AbstractOperation
     @test Histogram(a, b; bins=valid_bins, weights=a, method=:average) isa AbstractOperation
     @test Histogram(a; bins=[0.0, 1.0], weights=a, method=:average) isa AbstractOperation
+
+    # Partial reductions (retained dimensions) are unsupported on orthogonal shell grids.
+    shell_grid = TripolarGrid(CPU(); size=(16, 8, 1), southernmost_latitude=-45, z=(-1, 0))
+    a_shell = CenterField(shell_grid)
+    b_shell = CenterField(shell_grid)
+
+    @test_throws ArgumentError Histogram(a_shell, b_shell; bins=valid_bins, weights=:count, dims=(1, 2))
+    @test_throws ArgumentError Histogram(a_shell; bins=[0.0, 1.0], weights=:count, dims=(1, 2))
+
+    # Full reduction remains supported.
+    @test Histogram(a_shell, b_shell; bins=valid_bins, weights=:count, dims=(1, 2, 3)) isa AbstractOperation
+    @test Histogram(a_shell; bins=[0.0, 1.0], weights=:count, dims=(1, 2, 3)) isa AbstractOperation
 end
 
 function histogram_is_correct(arch, FT)

--- a/test/test_histogram_operation.jl
+++ b/test/test_histogram_operation.jl
@@ -389,6 +389,25 @@ function histogram_integral_count_conservation(arch, FT)
     @test total_histogram_volume ≈ total_grid_volume
 end
 
+function histogram_count_accumulator_uses_float64(arch)
+    FT = Float32
+    grid = RectilinearGrid(arch, FT, size=(4, 4, 4), extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid; tracers=(:a, :b))
+
+    set!(model, a=(x, y, z) -> FT(0.8x + 0.2z),
+                b=(x, y, z) -> FT(31 + 0.3y - 0.1z))
+
+    bins_2d = (a = FT[0, 1, 2, 3, 4, 5],
+               b = FT[30, 30.5, 31, 31.5, 32, 32.5, 33])
+    bins_1d = FT[0, 1, 2, 3, 4, 5]
+
+    histogram_2d = Field(Histogram(model.tracers.a, model.tracers.b; bins=bins_2d, weights=:count))
+    histogram_1d = Field(Histogram(model.tracers.a; bins=bins_1d, weights=:count))
+
+    @test eltype(histogram_2d) == Float64
+    @test eltype(histogram_1d) == Float64
+end
+
 function histogram_retained_axis_coordinates_are_preserved(arch, FT)
     z_faces = FT[-6, -2, -0.5, 0]
     grid = RectilinearGrid(arch, FT, size=(6, 5, 3), x=(0, 6), y=(0, 5), z=z_faces)
@@ -486,6 +505,12 @@ end
                 histogram_integral_count_conservation(arch, FT)
                 histogram_retained_axis_coordinates_are_preserved(arch, FT)
             end
+        end
+    end
+
+    @testset "Count precision" begin
+        for arch in archs
+            histogram_count_accumulator_uses_float64(arch)
         end
     end
 

--- a/test/test_histogram_operation.jl
+++ b/test/test_histogram_operation.jl
@@ -2,6 +2,7 @@ include("dependencies_for_runtests.jl")
 
 using Oceananigans.AbstractOperations: Histogram
 using Oceananigans.Operators: Vᶜᶜᶜ
+using Oceananigans: location
 
 function reference_bin(value, edges)
     if value < first(edges) || value > last(edges)
@@ -14,11 +15,29 @@ function reference_bin(value, edges)
     return (1 <= idx < length(edges)) ? idx : 0
 end
 
-function reference_histogram(a, b, grid, edges1, edges2; weights=:count)
+@inline function reference_retained_index(i, j, k, dims, Nx, Ny, Nz)
+    reduced = (1 in dims, 2 in dims, 3 in dims)
+
+    iR = reduced[1] ? 1 : i
+    jR = reduced[2] ? 1 : j
+    kR = reduced[3] ? 1 : k
+
+    len1 = reduced[1] ? 1 : Nx
+    len2 = reduced[2] ? 1 : Ny
+
+    return iR + len1 * ((jR - 1) + len2 * (kR - 1))
+end
+
+function reference_histogram(a, b, grid, edges1, edges2; weights=:count, dims=(1, 2, 3))
     FT = promote_type(eltype(a), eltype(b), eltype(edges1), eltype(edges2))
-    histogram = zeros(FT, length(edges1) - 1, length(edges2) - 1)
 
     Nx, Ny, Nz = size(a)
+    nret = (1 in dims ? 1 : Nx) *
+           (2 in dims ? 1 : Ny) *
+           (3 in dims ? 1 : Nz)
+
+    histogram = zeros(FT, length(edges1) - 1, length(edges2) - 1, nret)
+
     for k in 1:Nz, j in 1:Ny, i in 1:Nx
         i1 = reference_bin(a[i, j, k], edges1)
         i2 = reference_bin(b[i, j, k], edges2)
@@ -33,7 +52,38 @@ function reference_histogram(a, b, grid, edges1, edges2; weights=:count)
                 weights[i, j, k]
             end
 
-            histogram[i1, i2] += weight
+            r = reference_retained_index(i, j, k, dims, Nx, Ny, Nz)
+            histogram[i1, i2, r] += weight
+        end
+    end
+
+    return histogram
+end
+
+function reference_histogram_1d(a, grid, edges1; weights=:count, dims=(1, 2, 3))
+    FT = promote_type(eltype(a), eltype(edges1))
+
+    Nx, Ny, Nz = size(a)
+    nret = (1 in dims ? 1 : Nx) *
+           (2 in dims ? 1 : Ny) *
+           (3 in dims ? 1 : Nz)
+
+    histogram = zeros(FT, length(edges1) - 1, nret, 1)
+
+    for k in 1:Nz, j in 1:Ny, i in 1:Nx
+        i1 = reference_bin(a[i, j, k], edges1)
+
+        if i1 > 0
+            weight = if weights === :count
+                1
+            elseif weights === :cell_volume
+                Vᶜᶜᶜ(i, j, k, grid)
+            else
+                weights[i, j, k]
+            end
+
+            r = reference_retained_index(i, j, k, dims, Nx, Ny, Nz)
+            histogram[i1, r, 1] += weight
         end
     end
 
@@ -56,10 +106,21 @@ function histogram_constructor_validation()
     @test_throws ArgumentError Histogram(a, b_face; bins=valid_bins, weights=:count)
     @test_throws ArgumentError Histogram((S=a, T=b); bins=valid_bins, weights=:count)
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, method=:mean)
-    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, dims=(1, 2))
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, dims=())
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, dims=(1, 4))
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=:mass)
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=w_face)
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=w_other)
+    @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=:cell_volume, method=:integral)
+
+    @test_throws ArgumentError Histogram(a; bins=valid_bins, weights=:count)
+    @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0, 0.5], weights=:count)
+    @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0], weights=w_face)
+    @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0], weights=w_other)
+    @test_throws ArgumentError Histogram(a; bins=[0.0, 1.0], weights=:cell_volume, method=:integral)
+
+    @test Histogram(a, b; bins=valid_bins, weights=:count, method=:integral) isa AbstractOperation
+    @test Histogram(a; bins=[0.0, 1.0], weights=:count, method=:integral) isa AbstractOperation
 end
 
 function histogram_is_correct(arch, FT)
@@ -82,9 +143,9 @@ function histogram_is_correct(arch, FT)
     volume_field = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=:cell_volume))
     weighted_field = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=model.tracers.w))
 
-    count_hist = Array(interior(count_field))[:, :, 1]
-    volume_hist = Array(interior(volume_field))[:, :, 1]
-    weighted_hist = Array(interior(weighted_field))[:, :, 1]
+    count_hist = Array(interior(count_field))
+    volume_hist = Array(interior(volume_field))
+    weighted_hist = Array(interior(weighted_field))
 
     expected_count = reference_histogram(a_cpu, b_cpu, grid, edges1, edges2; weights=:count)
     expected_volume = reference_histogram(a_cpu, b_cpu, grid, edges1, edges2; weights=:cell_volume)
@@ -93,6 +154,114 @@ function histogram_is_correct(arch, FT)
     @test count_hist == expected_count
     @test volume_hist ≈ expected_volume
     @test weighted_hist ≈ expected_weighted
+end
+
+function histogram_partial_reduction_is_correct(arch, FT)
+    grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
+    model = NonhydrostaticModel(grid; tracers=(:a, :b, :w))
+
+    set!(model, a=(x, y, z) -> FT(0.8x + 0.2z),
+                b=(x, y, z) -> FT(31 + 0.3y - 0.1z),
+                w=(x, y, z) -> FT(2 + 0.1x + 0.2y + 0.3z))
+
+    edges1 = FT[0, 1, 2, 3, 4, 5, 6]
+    edges2 = FT[30, 30.5, 31, 31.5, 32, 32.5, 33]
+    bins = (a = edges1, b = edges2)
+
+    a_cpu = Array(interior(model.tracers.a))
+    b_cpu = Array(interior(model.tracers.b))
+    w_cpu = Array(interior(model.tracers.w))
+
+    h_z = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=:count, dims=(3,)))
+    h_xy = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=model.tracers.w, dims=(1, 2)))
+
+    h_z_cpu = Array(interior(h_z))
+    h_xy_cpu = Array(interior(h_xy))
+
+    expected_z = reference_histogram(a_cpu, b_cpu, grid, edges1, edges2; weights=:count, dims=(3,))
+    expected_xy = reference_histogram(a_cpu, b_cpu, grid, edges1, edges2; weights=w_cpu, dims=(1, 2))
+
+    @test h_z_cpu == expected_z
+    @test h_xy_cpu ≈ expected_xy
+end
+
+function histogram_1d_is_correct(arch, FT)
+    grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
+    model = NonhydrostaticModel(grid; tracers=(:a, :w))
+
+    set!(model, a=(x, y, z) -> FT(0.8x + 0.2z),
+                w=(x, y, z) -> FT(2 + 0.1x + 0.2y + 0.3z))
+
+    edges1 = FT[0, 1, 2, 3, 4, 5, 6]
+
+    a_cpu = Array(interior(model.tracers.a))
+    w_cpu = Array(interior(model.tracers.w))
+
+    h_all = Field(Histogram(model.tracers.a; bins=edges1, weights=:count))
+    h_xy = Field(Histogram(model.tracers.a; bins=edges1, weights=model.tracers.w, dims=(1, 2)))
+
+    h_all_cpu = Array(interior(h_all))
+    h_xy_cpu = Array(interior(h_xy))
+
+    expected_all = reference_histogram_1d(a_cpu, grid, edges1; weights=:count)
+    expected_xy = reference_histogram_1d(a_cpu, grid, edges1; weights=w_cpu, dims=(1, 2))
+
+    @test h_all_cpu == expected_all
+    @test h_xy_cpu ≈ expected_xy
+
+    h_named = Field(Histogram((rho=model.tracers.a,); bins=(rho=edges1,), weights=:count, dims=(1, 2)))
+    @test Array(interior(h_named)) == reference_histogram_1d(a_cpu, grid, edges1; weights=:count, dims=(1, 2))
+end
+
+function histogram_integral_method_matches_sum_with_metric_2d(arch, FT)
+    grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
+    model = NonhydrostaticModel(grid; tracers=(:a, :b, :w))
+
+    set!(model, a=(x, y, z) -> FT(0.8x + 0.2z),
+                b=(x, y, z) -> FT(31 + 0.3y - 0.1z),
+                w=(x, y, z) -> FT(2 + 0.1x + 0.2y + 0.3z))
+
+    edges1 = FT[0, 1, 2, 3, 4, 5, 6]
+    edges2 = FT[30, 30.5, 31, 31.5, 32, 32.5, 33]
+    bins = (a = edges1, b = edges2)
+    dims = (1, 2)
+
+    metric = Oceananigans.AbstractOperations.grid_metric_operation(location(model.tracers.a),
+                                                                   Oceananigans.AbstractOperations.reduction_grid_metric(dims),
+                                                                   grid)
+
+    weighted_integral = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=model.tracers.w, dims, method=:integral))
+    weighted_sum = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=model.tracers.w * metric, dims, method=:sum))
+
+    count_integral = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=:count, dims, method=:integral))
+    count_sum = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=metric, dims, method=:sum))
+
+    @test Array(interior(weighted_integral)) ≈ Array(interior(weighted_sum))
+    @test Array(interior(count_integral)) ≈ Array(interior(count_sum))
+end
+
+function histogram_integral_method_matches_sum_with_metric_1d(arch, FT)
+    grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
+    model = NonhydrostaticModel(grid; tracers=(:a, :w))
+
+    set!(model, a=(x, y, z) -> FT(0.8x + 0.2z),
+                w=(x, y, z) -> FT(2 + 0.1x + 0.2y + 0.3z))
+
+    bins = FT[0, 1, 2, 3, 4, 5, 6]
+    dims = (1, 2)
+
+    metric = Oceananigans.AbstractOperations.grid_metric_operation(location(model.tracers.a),
+                                                                   Oceananigans.AbstractOperations.reduction_grid_metric(dims),
+                                                                   grid)
+
+    weighted_integral = Field(Histogram(model.tracers.a; bins, weights=model.tracers.w, dims, method=:integral))
+    weighted_sum = Field(Histogram(model.tracers.a; bins, weights=model.tracers.w * metric, dims, method=:sum))
+
+    count_integral = Field(Histogram(model.tracers.a; bins, weights=:count, dims, method=:integral))
+    count_sum = Field(Histogram(model.tracers.a; bins, weights=metric, dims, method=:sum))
+
+    @test Array(interior(weighted_integral)) ≈ Array(interior(weighted_sum))
+    @test Array(interior(count_integral)) ≈ Array(interior(count_sum))
 end
 
 function histogram_edge_semantics()
@@ -132,7 +301,7 @@ function histogram_named_operands_map_bins_by_key(arch, FT)
     a_cpu = Array(interior(model.tracers.a))
     b_cpu = Array(interior(model.tracers.b))
     expected = reference_histogram(b_cpu, a_cpu, grid, b_edges, a_edges; weights=:count)
-    @test h1_cpu[:, :, 1] == expected
+    @test h1_cpu == expected
 end
 
 function histogram_face_location_includes_bounded_boundary_faces(arch, FT)
@@ -147,7 +316,7 @@ function histogram_face_location_includes_bounded_boundary_faces(arch, FT)
     b_edges = FT[34, 35]
 
     histogram = Field(Histogram(a, b; bins=(a=a_edges, b=b_edges), weights=:count))
-    histogram_cpu = Array(interior(histogram))[:, :, 1]
+    histogram_cpu = Array(interior(histogram))
 
     a_cpu = Array(interior(a))
     b_cpu = Array(interior(b))
@@ -182,12 +351,15 @@ function histogram_writer_smoke_test()
         set!(model, a=(x, y, z) -> x + z,
                     b=(x, y, z) -> y - z)
 
-        bins = (a = collect(range(0.0, stop=2.0, length=5)),
-                b = collect(range(-1.0, stop=2.0, length=7)))
+        bins2d = (a = collect(range(0.0, stop=2.0, length=5)),
+                  b = collect(range(-1.0, stop=2.0, length=7)))
+        bins1d = collect(range(0.0, stop=2.0, length=5))
 
-        histogram = Field(Histogram(model.tracers.a, model.tracers.b; bins, weights=:count))
+        histogram = Field(Histogram(model.tracers.a, model.tracers.b; bins=bins2d, weights=:count))
+        histogram_1d = Field(Histogram(model.tracers.a; bins=bins1d, weights=:count, dims=(1, 2)))
+
         simulation = Simulation(model; Δt=1, stop_iteration=1)
-        simulation.output_writers[:histogram] = JLD2Writer(model, (; histogram);
+        simulation.output_writers[:histogram] = JLD2Writer(model, (; histogram, histogram_1d);
                                                            schedule = IterationInterval(1),
                                                            dir = dir,
                                                            filename = "histogram_operation_test.jld2",
@@ -202,11 +374,16 @@ function histogram_writer_smoke_test()
             @test !isempty(snapshot_keys)
 
             latest = string(maximum(parse.(Int, snapshot_keys)))
-            snapshot = file["timeseries/histogram/$latest"]
+            snapshot_2d = file["timeseries/histogram/$latest"]
+            snapshot_1d = file["timeseries/histogram_1d/$latest"]
 
-            @test size(snapshot, 1) == length(bins.a) - 1
-            @test size(snapshot, 2) == length(bins.b) - 1
-            @test sum(snapshot) > 0
+            @test size(snapshot_2d, 1) == length(bins2d.a) - 1
+            @test size(snapshot_2d, 2) == length(bins2d.b) - 1
+            @test sum(snapshot_2d) > 0
+
+            @test size(snapshot_1d, 1) == length(bins1d) - 1
+            @test size(snapshot_1d, 2) == size(grid, 3)
+            @test sum(snapshot_1d) > 0
         end
     end
 
@@ -229,6 +406,10 @@ end
             @info "  Testing Histogram correctness [$(typeof(arch))]..."
             for FT in float_types
                 histogram_is_correct(arch, FT)
+                histogram_partial_reduction_is_correct(arch, FT)
+                histogram_1d_is_correct(arch, FT)
+                histogram_integral_method_matches_sum_with_metric_2d(arch, FT)
+                histogram_integral_method_matches_sum_with_metric_1d(arch, FT)
                 histogram_named_operands_map_bins_by_key(arch, FT)
                 histogram_face_location_includes_bounded_boundary_faces(arch, FT)
                 histogram_cell_volume_conservation(arch, FT)

--- a/test/test_histogram_operation.jl
+++ b/test/test_histogram_operation.jl
@@ -54,6 +54,7 @@ function histogram_constructor_validation()
     @test_throws ArgumentError Histogram(a, b; bins=(x=[0.0, 1.0],), weights=:count)
     @test_throws ArgumentError Histogram(a, b; bins=(x=[0.0, 1.0, 0.5], y=[0.0, 1.0]), weights=:count)
     @test_throws ArgumentError Histogram(a, b_face; bins=valid_bins, weights=:count)
+    @test_throws ArgumentError Histogram((S=a, T=b); bins=valid_bins, weights=:count)
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, method=:mean)
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, dims=(1, 2))
     @test_throws ArgumentError Histogram(a, b; bins=valid_bins, weights=:mass)
@@ -107,6 +108,31 @@ function histogram_edge_semantics()
     histogram = Array(interior(h))[:, :, 1]
 
     @test histogram == [1.0 0.0; 0.0 2.0]
+end
+
+function histogram_named_operands_map_bins_by_key(arch, FT)
+    grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
+    model = NonhydrostaticModel(grid; tracers=(:a, :b))
+
+    set!(model, a=(x, y, z) -> FT(0.8x + 0.2z),
+                b=(x, y, z) -> FT(31 + 0.3y - 0.1z))
+
+    a_edges = FT[0, 1, 2, 3, 4, 5, 6]
+    b_edges = FT[30, 30.5, 31, 31.5, 32, 32.5, 33]
+
+    # Named operands map bins by key, not by tuple order.
+    h1 = Field(Histogram((S=model.tracers.b, T=model.tracers.a); bins=(T=a_edges, S=b_edges), weights=:count))
+    h2 = Field(Histogram((S=model.tracers.b, T=model.tracers.a); bins=(S=b_edges, T=a_edges), weights=:count))
+
+    h1_cpu = Array(interior(h1))
+    h2_cpu = Array(interior(h2))
+
+    @test h1_cpu == h2_cpu
+
+    a_cpu = Array(interior(model.tracers.a))
+    b_cpu = Array(interior(model.tracers.b))
+    expected = reference_histogram(b_cpu, a_cpu, grid, b_edges, a_edges; weights=:count)
+    @test h1_cpu[:, :, 1] == expected
 end
 
 function histogram_writer_smoke_test()
@@ -163,6 +189,7 @@ end
             @info "  Testing Histogram correctness [$(typeof(arch))]..."
             for FT in float_types
                 histogram_is_correct(arch, FT)
+                histogram_named_operands_map_bins_by_key(arch, FT)
             end
         end
     end

--- a/test/test_histogram_operation.jl
+++ b/test/test_histogram_operation.jl
@@ -135,6 +135,24 @@ function histogram_named_operands_map_bins_by_key(arch, FT)
     @test h1_cpu[:, :, 1] == expected
 end
 
+function histogram_cell_volume_conservation(arch, FT)
+    grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
+    a = CenterField(grid)
+    b = CenterField(grid)
+
+    set!(a, (x, y, z) -> FT(0.5x + 0.25y + 0.1z))
+    set!(b, (x, y, z) -> FT(34 + 0.2x - 0.3y - 0.05z))
+
+    a_edges = FT[-1, 0, 1, 2, 3, 4, 5]
+    b_edges = FT[32, 33, 34, 35, 36]
+
+    histogram = Field(Histogram(a, b; bins=(a=a_edges, b=b_edges), weights=:cell_volume))
+    total_histogram_volume = sum(histogram)
+    total_grid_volume = sum(KernelFunctionOperation{Center, Center, Center}(Vᶜᶜᶜ, grid))
+
+    @test total_histogram_volume ≈ total_grid_volume
+end
+
 function histogram_writer_smoke_test()
     mktempdir() do dir
         grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
@@ -190,6 +208,7 @@ end
             for FT in float_types
                 histogram_is_correct(arch, FT)
                 histogram_named_operands_map_bins_by_key(arch, FT)
+                histogram_cell_volume_conservation(arch, FT)
             end
         end
     end

--- a/test/test_histogram_operation.jl
+++ b/test/test_histogram_operation.jl
@@ -135,6 +135,28 @@ function histogram_named_operands_map_bins_by_key(arch, FT)
     @test h1_cpu[:, :, 1] == expected
 end
 
+function histogram_face_location_includes_bounded_boundary_faces(arch, FT)
+    grid = RectilinearGrid(arch, FT, topology=(Bounded, Periodic, Bounded), size=(6, 5, 4), extent=(6, 5, 4))
+    a = XFaceField(grid)
+    b = XFaceField(grid)
+
+    set!(a, FT(0.5))
+    set!(b, FT(34.5))
+
+    a_edges = FT[0, 1]
+    b_edges = FT[34, 35]
+
+    histogram = Field(Histogram(a, b; bins=(a=a_edges, b=b_edges), weights=:count))
+    histogram_cpu = Array(interior(histogram))[:, :, 1]
+
+    a_cpu = Array(interior(a))
+    b_cpu = Array(interior(b))
+    expected = reference_histogram(a_cpu, b_cpu, grid, a_edges, b_edges; weights=:count)
+
+    @test histogram_cpu == expected
+    @test sum(histogram_cpu) == length(a_cpu)
+end
+
 function histogram_cell_volume_conservation(arch, FT)
     grid = RectilinearGrid(arch, FT, size=(6, 5, 4), extent=(6, 5, 4))
     a = CenterField(grid)
@@ -208,6 +230,7 @@ end
             for FT in float_types
                 histogram_is_correct(arch, FT)
                 histogram_named_operands_map_bins_by_key(arch, FT)
+                histogram_face_location_includes_bounded_boundary_faces(arch, FT)
                 histogram_cell_volume_conservation(arch, FT)
             end
         end

--- a/test/test_histogram_operation.jl
+++ b/test/test_histogram_operation.jl
@@ -389,6 +389,30 @@ function histogram_integral_count_conservation(arch, FT)
     @test total_histogram_volume ≈ total_grid_volume
 end
 
+function histogram_retained_axis_coordinates_are_preserved(arch, FT)
+    z_faces = FT[-6, -2, -0.5, 0]
+    grid = RectilinearGrid(arch, FT, size=(6, 5, 3), x=(0, 6), y=(0, 5), z=z_faces)
+    model = NonhydrostaticModel(grid; tracers=(:a, :b))
+
+    set!(model, a=(x, y, z) -> FT(0.8x + 0.2z),
+                b=(x, y, z) -> FT(31 + 0.3y - 0.1z))
+
+    bins_1d = FT[0, 1, 2, 3, 4, 5, 6]
+    bins_2d = (a = FT[0, 1, 2, 3, 4, 5, 6],
+               b = FT[30, 30.5, 31, 31.5, 32, 32.5, 33])
+
+    histogram_1d = Field(Histogram(model.tracers.a; bins=bins_1d, weights=:count, dims=(1, 2)))
+    histogram_2d = Field(Histogram(model.tracers.a, model.tracers.b; bins=bins_2d, weights=:count, dims=(1, 2)))
+
+    expected_z = collect(znodes(model.tracers.a))
+    observed_z_1d = collect(ynodes(histogram_1d))
+    observed_z_2d = collect(znodes(histogram_2d))
+
+    @test !all(diff(expected_z) .≈ first(diff(expected_z)))
+    @test observed_z_1d ≈ expected_z
+    @test observed_z_2d ≈ expected_z
+end
+
 function histogram_writer_smoke_test()
     mktempdir() do dir
         grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
@@ -460,6 +484,7 @@ end
                 histogram_named_operands_map_bins_by_key(arch, FT)
                 histogram_face_location_includes_bounded_boundary_faces(arch, FT)
                 histogram_integral_count_conservation(arch, FT)
+                histogram_retained_axis_coordinates_are_preserved(arch, FT)
             end
         end
     end


### PR DESCRIPTION
This PR adds 1D binning functionality and partial dimension summation to the `Histogram` function. Key additions are:

- `Histogram` no longer _requires_ `dims=(1,2,3)`. Any omitted dims will be added to the output histogram, e.g. `dims=(1,2)` will leave the depth dimension so `hist[size(a), size(b), size(depth)]`. 
- 1D binning has been added to enable depth- or latitude- (etc.) based calculations. 
- Added the `:average` method which performs a weighted average of the Field in the dimensions specified

```
Histogram(T, bins= T_bins, method = :integral, weights = S, dims = (1,2))
```

Will give a histogram with dimensions depth. 


edit: depends on #5357 