### PR TITLE
Add `prescribed_tracers` kwarg to HydrostaticFreeSurfaceModel

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl
@@ -117,10 +117,11 @@ cell_advection_timescale(model::HydrostaticFreeSurfaceModel) = cell_advection_ti
     fields(model::HydrostaticFreeSurfaceModel)
 
 Return a flattened `NamedTuple` of the fields in `model.velocities`, `model.free_surface`,
-`model.tracers`, and any auxiliary fields for a `HydrostaticFreeSurfaceModel` model.
+`model.tracers`, `model.prescribed_tracers`, and any auxiliary fields for a `HydrostaticFreeSurfaceModel` model.
 """
 @inline fields(model::HydrostaticFreeSurfaceModel) =
     merge(hydrostatic_fields(model.velocities, model.free_surface, model.tracers),
+          model.prescribed_tracers,
           model.auxiliary_fields,
           biogeochemical_auxiliary_fields(model.biogeochemistry))
 

--- a/src/Models/HydrostaticFreeSurfaceModels/compute_hydrostatic_free_surface_buffers.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/compute_hydrostatic_free_surface_buffers.jl
@@ -39,9 +39,9 @@ function complete_communication_and_compute_momentum_buffer!(model::HydrostaticF
 
     κ_params = buffer_κ_kernel_parameters(grid, model.closure, arch)
 
-    compute_buoyancy_gradients!(model.buoyancy, grid, model.tracers, parameters = volume_params)
+    compute_buoyancy_gradients!(model.buoyancy, grid, all_tracers(model), parameters = volume_params)
     update_vertical_velocities!(model.velocities, grid, model; parameters = surface_params)
-    update_hydrostatic_pressure!(model.pressure.pHY′, arch, grid, model.buoyancy, model.tracers; parameters = surface_params)
+    update_hydrostatic_pressure!(model.pressure.pHY′, arch, grid, model.buoyancy, all_tracers(model); parameters = surface_params)
     compute_closure_fields!(model.closure_fields, model.closure, model; parameters = κ_params)
 
     fill_halo_regions!(model.closure_fields; only_local_halos=true)

--- a/src/Models/HydrostaticFreeSurfaceModels/compute_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/compute_hydrostatic_free_surface_tendencies.jl
@@ -116,7 +116,7 @@ function compute_hydrostatic_tracer_tendencies!(model, kernel_parameters; active
                      model.biogeochemistry,
                      model.transport_velocities,
                      model.free_surface,
-                     model.tracers,
+                     all_tracers(model),
                      model.closure_fields,
                      model.auxiliary_fields,
                      model.clock,
@@ -155,7 +155,7 @@ function compute_hydrostatic_momentum_tendencies!(model, velocities, kernel_para
 
     end_momentum_kernel_args = (velocities,
                                 model.free_surface,
-                                model.tracers,
+                                all_tracers(model),
                                 model.buoyancy,
                                 model.closure_fields,
                                 model.pressure.pHY′,

--- a/src/Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl
@@ -173,7 +173,7 @@ function compute_explicit_free_surface_tendency!(grid, model)
 
     args = tuple(model.velocities,
                  model.free_surface,
-                 model.tracers,
+                 all_tracers(model),
                  model.auxiliary_fields,
                  model.forcing,
                  model.clock)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -4,9 +4,10 @@ using Oceananigans.Biogeochemistry: validate_biogeochemistry, AbstractBiogeochem
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, regularize_field_boundary_conditions
 using Oceananigans.BuoyancyFormulations: validate_buoyancy, materialize_buoyancy
 using Oceananigans.DistributedComputations: Distributed
-using Oceananigans.Fields: CenterField, tracernames, TracerFields
+using Oceananigans.Fields: CenterField, FunctionField, tracernames, TracerFields
 using Oceananigans.Forcings: model_forcing
-using Oceananigans.Grids: AbstractHorizontallyCurvilinearGrid, architecture, halo_size, MutableVerticalDiscretization
+using Oceananigans.OutputReaders: FieldTimeSeries, TimeSeriesInterpolation
+using Oceananigans.Grids: AbstractHorizontallyCurvilinearGrid, Center, architecture, halo_size, MutableVerticalDiscretization
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 using Oceananigans.Models: AbstractModel, validate_model_halo, validate_tracer_advection, extract_boundary_conditions
 using Oceananigans.TimeSteppers: Clock, TimeStepper, AbstractLagrangianParticles
@@ -35,7 +36,7 @@ function default_vertical_coordinate(grid)
 end
 
 mutable struct HydrostaticFreeSurfaceModel{TS, E, A<:AbstractArchitecture, S,
-                                           G, T, V, B, R, F, P, BGC, U, W, C, Φ, K, AF, Z} <: AbstractModel{TS, A}
+                                           G, T, V, B, R, F, P, BGC, U, W, C, PC, Φ, K, AF, Z} <: AbstractModel{TS, A}
 
     architecture :: A          # Computer `Architecture` on which `Model` is run
     grid :: G                  # Grid of physical points on which `Model` is solved
@@ -50,7 +51,8 @@ mutable struct HydrostaticFreeSurfaceModel{TS, E, A<:AbstractArchitecture, S,
     biogeochemistry :: BGC     # Biogeochemistry for Oceananigans tracers
     velocities :: U            # Container for velocity fields `u`, `v`, and `w`
     transport_velocities :: W  # Container for velocity fields used to transport tracers
-    tracers :: C               # Container for tracer fields
+    tracers :: C               # Container for prognostic tracer fields
+    prescribed_tracers :: PC   # Container for prescribed (non-prognostic) tracer fields
     pressure :: Φ              # Container for hydrostatic pressure
     closure_fields :: K        # Container for turbulent closure_fields
     timestepper :: TS          # Object containing timestepper fields and parameters
@@ -59,6 +61,32 @@ mutable struct HydrostaticFreeSurfaceModel{TS, E, A<:AbstractArchitecture, S,
 end
 
 supported_timesteppers = (:QuasiAdamsBashforth2, :SplitRungeKutta2, :SplitRungeKutta3, :SplitRungeKutta4, :SplitRungeKutta5)
+
+"""Return all tracers (prognostic + prescribed) merged into a single NamedTuple."""
+@inline all_tracers(model::HydrostaticFreeSurfaceModel) = merge(model.tracers, model.prescribed_tracers)
+
+#####
+##### Prescribed tracer materialization
+#####
+
+
+"""Materialize a single prescribed tracer entry into a concrete field type."""
+materialize_prescribed_tracer(f::Function, grid, clock) = FunctionField{Center, Center, Center}(f, grid; clock)
+
+function materialize_prescribed_tracer(fts::FieldTimeSeries, grid, clock)
+    return TimeSeriesInterpolation(fts, grid; clock)
+end
+
+# Passthrough for already-materialized fields (Field, FunctionField, TimeSeriesInterpolation, etc.)
+materialize_prescribed_tracer(f, grid, clock) = f
+
+"""Materialize all prescribed tracers in a NamedTuple."""
+function materialize_prescribed_tracers(prescribed_tracers::NamedTuple, grid, clock)
+    names = keys(prescribed_tracers)
+    isempty(names) && return prescribed_tracers
+    materialized = map(f -> materialize_prescribed_tracer(f, grid, clock), values(prescribed_tracers))
+    return NamedTuple{names}(materialized)
+end
 
 default_free_surface(grid::XYRegularStaticRG; gravitational_acceleration=defaults.gravitational_acceleration) =
     ImplicitFreeSurface(; gravitational_acceleration)
@@ -108,8 +136,11 @@ Keyword arguments
                     regularly spaced in the horizontal the default is an `ImplicitFreeSurface`
                     solver with `solver_method = :FFTBasedPoissonSolver`. In all other cases,
                     the default is a `SplitExplicitFreeSurface`.
-  - `tracers`: A tuple of symbols defining the names of the modeled tracers, or a `NamedTuple` of
+  - `tracers`: A tuple of symbols defining the names of the modeled (prognostic) tracers, or a `NamedTuple` of
                preallocated `CenterField`s.
+  - `prescribed_tracers`: `NamedTuple` of prescribed (non-prognostic) tracer fields. Prescribed tracers are
+                           not time-stepped but are available to turbulence closures for buoyancy computation.
+                           Values can be `FieldTimeSeries`, `Function(x, y, z, t)`, or any field-like object.
   - `forcing`: `NamedTuple` of user-defined forcing functions that contribute to solution tendencies.
   - `closure`: The turbulence closure for `model`. See `Oceananigans.TurbulenceClosures`.
   - `timestepper`: A symbol or a `TimeStepper` object that specifies the time-stepping method.
@@ -135,6 +166,7 @@ function HydrostaticFreeSurfaceModel(grid;
                                      coriolis = nothing,
                                      free_surface = default_free_surface(grid, gravitational_acceleration=defaults.gravitational_acceleration),
                                      tracers = nothing,
+                                     prescribed_tracers::NamedTuple = NamedTuple(),
                                      forcing::NamedTuple = NamedTuple(),
                                      closure = nothing,
                                      timestepper = :QuasiAdamsBashforth2,
@@ -189,18 +221,32 @@ function HydrostaticFreeSurfaceModel(grid;
         tracers = tuple(user_tracer_names..., closure_tracer_names...)
     end
 
+    # Validate prescribed tracers don't overlap with prognostic tracers
+    prescribed_tracer_names = keys(prescribed_tracers)
+    prognostic_tracer_names = tracernames(tracers)
+    overlapping = filter(n -> n ∈ prognostic_tracer_names, prescribed_tracer_names)
+    if !isempty(overlapping)
+        throw(ArgumentError("Prescribed tracer names $overlapping overlap with prognostic tracer names."))
+    end
+
+    # Materialize prescribed tracers (FieldTimeSeries → TimeSeriesInterpolation, Function → FunctionField, etc.)
+    prescribed_tracers = materialize_prescribed_tracers(prescribed_tracers, grid, clock)
+
+    # All tracer names (prognostic + prescribed) for buoyancy/closure validation
+    all_tracer_names = tuple(prognostic_tracer_names..., prescribed_tracer_names...)
+
     # Reduce the advection order in directions that do not have enough grid points
     @apply_regionally momentum_advection = validate_momentum_advection(momentum_advection, grid)
     default_tracer_advection, tracer_advection = validate_tracer_advection(tracer_advection, grid)
     default_generator(name, tracer_advection) = default_tracer_advection
 
-    # Generate tracer advection scheme for each tracer
-    tracer_advection_tuple = with_tracers(tracernames(tracers), tracer_advection, default_generator, with_velocities=false)
+    # Generate tracer advection scheme for each prognostic tracer
+    tracer_advection_tuple = with_tracers(prognostic_tracer_names, tracer_advection, default_generator, with_velocities=false)
     momentum_advection_tuple = (; momentum = momentum_advection)
     advection = merge(momentum_advection_tuple, tracer_advection_tuple)
     advection = NamedTuple(name => adapt_advection_order(scheme, grid) for (name, scheme) in pairs(advection))
 
-    validate_buoyancy(buoyancy, tracernames(tracers))
+    validate_buoyancy(buoyancy, all_tracer_names)
     buoyancy = materialize_buoyancy(buoyancy, grid)
 
     # Collect boundary conditions for all model prognostic fields and, if specified, some model
@@ -229,11 +275,11 @@ function HydrostaticFreeSurfaceModel(grid;
     boundary_conditions = add_closure_specific_boundary_conditions(closure,
                                                                    boundary_conditions,
                                                                    grid,
-                                                                   tracernames(tracers),
+                                                                   all_tracer_names,
                                                                    buoyancy)
 
-    # Ensure `closure` describes all tracers
-    closure = with_tracers(tracernames(tracers), closure)
+    # Ensure `closure` describes all tracers (prognostic + prescribed)
+    closure = with_tracers(all_tracer_names, closure)
 
     # Put CATKE first in the list of closures
     closure = validate_closure(closure)
@@ -242,7 +288,7 @@ function HydrostaticFreeSurfaceModel(grid;
     velocities         = hydrostatic_velocity_fields(velocities, grid, clock, boundary_conditions)
     tracers            = TracerFields(tracers, grid, boundary_conditions)
     pressure           = PressureField(grid)
-    closure_fields = build_closure_fields(closure_fields, grid, clock, tracernames(tracers), boundary_conditions, closure)
+    closure_fields     = build_closure_fields(closure_fields, grid, clock, all_tracer_names, boundary_conditions, closure)
 
     @apply_regionally validate_velocity_boundary_conditions(grid, velocities)
 
@@ -267,7 +313,7 @@ function HydrostaticFreeSurfaceModel(grid;
 
     model = HydrostaticFreeSurfaceModel(arch, grid, clock, advection, buoyancy, coriolis,
                                         free_surface, forcing, closure, particles, biogeochemistry, velocities, transport_velocities,
-                                        tracers, pressure, closure_fields, timestepper, auxiliary_fields, vertical_coordinate)
+                                        tracers, prescribed_tracers, pressure, closure_fields, timestepper, auxiliary_fields, vertical_coordinate)
 
     initialization_update_state!(model)
 
@@ -328,7 +374,7 @@ end
 @inline total_velocities(model::HydrostaticFreeSurfaceModel) = model.velocities
 timestepper(model::HydrostaticFreeSurfaceModel) = model.timestepper
 buoyancy_force(model::HydrostaticFreeSurfaceModel) = model.buoyancy
-buoyancy_tracers(model::HydrostaticFreeSurfaceModel) = model.tracers
+buoyancy_tracers(model::HydrostaticFreeSurfaceModel) = all_tracers(model)
 
 #####
 ##### Checkpointing

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -154,8 +154,8 @@ on_architecture(to, velocities::PrescribedVelocityFields) =
                              on_architecture(to, velocities.parameters))
 
 # If the model only tracks particles... do nothing but that!!!
-const OnlyParticleTrackingModel = HydrostaticFreeSurfaceModel{TS, E, A, S, G, T, V, B, R, F, P, U, W, C} where
-                 {TS, E, A, S, G, T, V, B, R, F, P<:AbstractLagrangianParticles, U<:PrescribedVelocityFields, W<:PrescribedVelocityFields, C<:NamedTuple{(), Tuple{}}}
+const OnlyParticleTrackingModel = HydrostaticFreeSurfaceModel{TS, E, A, S, G, T, V, B, R, F, P, BGC, U, W, C} where
+                 {TS, E, A, S, G, T, V, B, R, F, P<:AbstractLagrangianParticles, BGC, U<:PrescribedVelocityFields, W<:PrescribedVelocityFields, C<:NamedTuple{(), Tuple{}}}
 
 function time_step!(model::OnlyParticleTrackingModel, Δt; callbacks = [], kwargs...)
     tick!(model.clock, Δt)

--- a/src/Models/HydrostaticFreeSurfaceModels/set_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/set_hydrostatic_free_surface_model.jl
@@ -55,6 +55,8 @@ model.velocities.u
             ϕ = getproperty(model.velocities, fldname)
         elseif fldname ∈ propertynames(model.tracers)
             ϕ = getproperty(model.tracers, fldname)
+        elseif fldname ∈ propertynames(model.prescribed_tracers)
+            ϕ = getproperty(model.prescribed_tracers, fldname)
         elseif fldname ∈ propertynames(model.free_surface)
             ϕ = getproperty(model.free_surface, fldname)
         elseif fldname === :η
@@ -62,7 +64,7 @@ model.velocities.u
             # but the public interface uses `η` as the canonical name.
             ϕ = model.free_surface.displacement
         else
-            throw(ArgumentError("name $fldname not found in model.velocities, model.tracers, or model.free_surface"))
+            throw(ArgumentError("name $fldname not found in model.velocities, model.tracers, model.prescribed_tracers, or model.free_surface"))
         end
 
         @apply_regionally set!(ϕ, value)

--- a/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/show_hydrostatic_free_surface_model.jl
@@ -12,11 +12,18 @@ end
 function Base.show(io::IO, model::HydrostaticFreeSurfaceModel)
     TS = nameof(typeof(model.timestepper))
     tracernames = prettykeys(model.tracers)
+    prescribed = prettykeys(model.prescribed_tracers)
 
     print(io, summary(model), "\n",
         "├── grid: ", summary(model.grid), "\n",
         "├── timestepper: ", TS, "\n",
-        "├── tracers: ", tracernames, "\n",
+        "├── tracers: ", tracernames, "\n")
+
+    if !isempty(model.prescribed_tracers)
+        print(io, "├── prescribed_tracers: ", prescribed, "\n")
+    end
+
+    print(io,
         "├── closure: ", closure_summary(model.closure), "\n",
         "├── buoyancy: ", summary(model.buoyancy), "\n")
 

--- a/src/Models/HydrostaticFreeSurfaceModels/update_hydrostatic_free_surface_model_state.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/update_hydrostatic_free_surface_model_state.jl
@@ -61,9 +61,9 @@ function update_state!(model::HydrostaticFreeSurfaceModel, grid, callbacks)
         surface_params = surface_kernel_parameters(grid)
         volume_params = volume_kernel_parameters(grid)
         κ_params = diffusivity_kernel_parameters(grid)
-        compute_buoyancy_gradients!(model.buoyancy, grid, tracers, parameters=volume_params)
+        compute_buoyancy_gradients!(model.buoyancy, grid, all_tracers(model), parameters=volume_params)
         update_vertical_velocities!(model.velocities, grid, model, parameters=surface_params)
-        update_hydrostatic_pressure!(model.pressure.pHY′, arch, grid, model.buoyancy, model.tracers, parameters=surface_params)
+        update_hydrostatic_pressure!(model.pressure.pHY′, arch, grid, model.buoyancy, all_tracers(model), parameters=surface_params)
         compute_closure_fields!(model.closure_fields, model.closure, model, parameters=κ_params)
     end
 

--- a/test/test_hydrostatic_free_surface_models.jl
+++ b/test/test_hydrostatic_free_surface_models.jl
@@ -1,6 +1,6 @@
 include("dependencies_for_runtests.jl")
 
-using Oceananigans.Models.HydrostaticFreeSurfaceModels: VectorInvariant, PrescribedVelocityFields
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: VectorInvariant, PrescribedVelocityFields, all_tracers
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: ExplicitFreeSurface, ImplicitFreeSurface
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: SingleColumnGrid
 using Oceananigans.Advection: EnergyConserving, EnstrophyConserving, FluxFormAdvection, CrossAndSelfUpwinding
@@ -418,6 +418,228 @@ topos_3d = ((Periodic, Periodic, Bounded),
             rm(test_filename)
 
             @info "    PrescribedVelocityFields with FieldTimeSeries output test passed"
+        end
+
+        #####
+        ##### Prescribed tracer tests
+        #####
+
+        @testset "Basic prescribed_tracers construction and non-stepping [$arch]" begin
+            @info "  Testing basic prescribed_tracers construction [$arch]..."
+
+            grid = RectilinearGrid(arch, size=(4, 4),
+                                   x=(0, 1), z=(-1, 0),
+                                   topology=(Bounded, Flat, Bounded))
+
+            times = [0.0, 10.0]
+            b_fts = FieldTimeSeries{Center, Center, Center}(grid, times)
+            set!(b_fts, (x, z) -> x / 1000 + 1e-5 * z, 1)
+            set!(b_fts, (x, z) -> x / 1000 + 1e-5 * z, 2)
+
+            closure = IsopycnalSkewSymmetricDiffusivity(κ_skew=1e3, κ_symmetric=1e3)
+
+            model = HydrostaticFreeSurfaceModel(grid;
+                buoyancy = BuoyancyTracer(),
+                closure = closure,
+                tracers = nothing,
+                prescribed_tracers = (b = b_fts,))
+
+            # Time-step the model
+            time_step!(model, 1)
+
+            # Prescribed tracer b should be accessible via all_tracers, not in model.tracers
+            @test isempty(model.tracers)
+            @test :b ∈ keys(model.prescribed_tracers)
+            @test :b ∈ keys(all_tracers(model))
+
+            # No NaN values should be present
+            @test isfinite(model.prescribed_tracers.b[1, 1, 1])
+        end
+
+        @testset "prescribed_tracers with Function [$arch]" begin
+            @info "  Testing prescribed_tracers with Function [$arch]..."
+
+            grid = RectilinearGrid(arch, size=(4, 4),
+                                   x=(0, 1), z=(-1, 0),
+                                   topology=(Bounded, Flat, Bounded))
+
+            # On Flat y-topology, FunctionField expects func(x, z, t)
+            b_func(x, z, t) = x / 1000 + 1e-5 * z
+
+            closure = IsopycnalSkewSymmetricDiffusivity(κ_skew=1e3, κ_symmetric=1e3)
+
+            model = HydrostaticFreeSurfaceModel(grid;
+                buoyancy = BuoyancyTracer(),
+                closure = closure,
+                tracers = nothing,
+                prescribed_tracers = (b = b_func,))
+
+            # Time-step the model
+            for _ in 1:5
+                time_step!(model, 1)
+            end
+
+            @test :b ∈ keys(model.prescribed_tracers)
+            @test isfinite(model.prescribed_tracers.b[1, 1, 1])
+        end
+
+        @testset "Prescribed and prognostic tracers [$arch]" begin
+            @info "  Testing prescribed + prognostic tracers [$arch]..."
+
+            grid = RectilinearGrid(arch, size=(4, 4),
+                                   x=(0, 1), z=(-1, 0),
+                                   topology=(Bounded, Flat, Bounded))
+
+            times = [0.0, 10.0]
+            b_fts = FieldTimeSeries{Center, Center, Center}(grid, times)
+            set!(b_fts, (x, z) -> x / 1000 + 1e-5 * z, 1)
+            set!(b_fts, (x, z) -> x / 1000 + 1e-5 * z, 2)
+
+            closure = IsopycnalSkewSymmetricDiffusivity(κ_skew=1e3, κ_symmetric=1e3)
+
+            model = HydrostaticFreeSurfaceModel(grid;
+                buoyancy = BuoyancyTracer(),
+                closure = closure,
+                tracers = :c,
+                prescribed_tracers = (b = b_fts,))
+
+            set!(model, c = 1)
+            time_step!(model, 1)
+
+            # Prescribed b is in prescribed_tracers, prognostic c is in tracers
+            @test :b ∈ keys(model.prescribed_tracers)
+            @test :c ∈ keys(model.tracers)
+            @test model.tracers.c isa Field
+            @test !any(isnan, model.tracers.c)
+        end
+
+        @testset "Replicate GM test with prescribed tracer [$arch]" begin
+            @info "  Testing GM replication with prescribed tracer [$arch]..."
+
+            Nx = 8
+            Nz = 8
+
+            grid = RectilinearGrid(arch,
+                                   size = (Nx, Nz),
+                                   x = (0, 1),
+                                   z = (-1, 0),
+                                   topology = (Bounded, Flat, Bounded))
+
+            closure = IsopycnalSkewSymmetricDiffusivity(κ_skew=1e3, κ_symmetric=1e3)
+
+            # --- Run 1: Standard prognostic simulation ---
+            model1 = HydrostaticFreeSurfaceModel(grid;
+                buoyancy = BuoyancyTracer(),
+                closure = closure,
+                tracers = (:b, :c))
+
+            set!(model1, b = (x, z) -> x / 10000, c = 1)
+
+            Nsteps = 5
+            Δt = 1
+
+            # Save b field at each time step
+            saved_times = Float64[0.0]
+            b_snapshots = [deepcopy(interior(model1.tracers.b))]
+
+            for n in 1:Nsteps
+                time_step!(model1, Δt)
+                push!(saved_times, model1.clock.time)
+                push!(b_snapshots, deepcopy(interior(model1.tracers.b)))
+            end
+
+            # Also save the closure field ϵ_R₃₃ from the last step of run 1
+            ϵ_R₃₃_run1 = deepcopy(interior(model1.closure_fields.ϵ_R₃₃))
+
+            # --- Build FieldTimeSeries from saved data ---
+            b_fts = FieldTimeSeries{Center, Center, Center}(grid, saved_times)
+            for (n, snapshot) in enumerate(b_snapshots)
+                interior(b_fts[n]) .= snapshot
+                fill_halo_regions!(b_fts[n])
+            end
+
+            # --- Run 2: Same setup but with prescribed b ---
+            model2 = HydrostaticFreeSurfaceModel(grid;
+                buoyancy = BuoyancyTracer(),
+                closure = closure,
+                tracers = :c,
+                prescribed_tracers = (b = b_fts,))
+
+            set!(model2, c = 1)
+
+            for n in 1:Nsteps
+                time_step!(model2, Δt)
+            end
+
+            # The closure field ϵ_R₃₃ should match between the two runs
+            # (both use the same b field at the final time step)
+            ϵ_R₃₃_run2 = interior(model2.closure_fields.ϵ_R₃₃)
+            @test ϵ_R₃₃_run1 ≈ ϵ_R₃₃_run2
+
+            # The prognostic tracer c in run 2 should not contain NaN
+            @test !any(isnan, model2.tracers.c)
+        end
+
+        @testset "Analytical isopycnal slope with prescribed tracer [$arch]" begin
+            @info "  Testing analytical isopycnal slope [$arch]..."
+
+            Nx = 4
+            Nz = 4
+
+            grid = RectilinearGrid(arch,
+                                   size = (Nx, Nz),
+                                   x = (0, 1e5),
+                                   z = (-1e3, 0),
+                                   topology = (Bounded, Flat, Bounded))
+
+            M² = 1e-7  # horizontal buoyancy gradient
+            N² = 1e-5  # vertical buoyancy gradient (stratification)
+
+            # On Flat y-topology, FunctionField expects func(x, z, t)
+            b_func(x, z, t) = M² * x + N² * z
+
+            closure = IsopycnalSkewSymmetricDiffusivity(κ_skew=1e3, κ_symmetric=1e3)
+
+            model = HydrostaticFreeSurfaceModel(grid;
+                buoyancy = BuoyancyTracer(),
+                closure = closure,
+                tracers = nothing,
+                prescribed_tracers = (b = b_func,))
+
+            # Trigger state update which computes closure fields
+            time_step!(model, 1)
+
+            # Expected isopycnal slope
+            Sx = M² / N²  # = 0.01
+            expected_R₃₃ = Sx^2
+
+            # The tapering factor ϵ = min(1, max_slope² / slope²)
+            # With Sx = 0.01 and max_slope = 0.1 (default FluxTapering):
+            # ϵ = min(1, 0.01 / 0.0001) = min(1, 100) = 1
+            # So ϵ_R₃₃ should be ≈ Sx² = 1e-4
+
+            ϵ_R₃₃ = interior(model.closure_fields.ϵ_R₃₃)
+
+            # Check interior points (avoiding boundaries where stencils may differ)
+            for i in 2:Nx-1, k in 2:Nz
+                @test ϵ_R₃₃[i, 1, k] ≈ expected_R₃₃ atol=1e-10
+            end
+        end
+
+        @testset "prescribed_tracers overlap validation [$arch]" begin
+            @info "  Testing prescribed_tracers overlap validation [$arch]..."
+
+            grid = RectilinearGrid(arch, size=(4, 4),
+                                   x=(0, 1), z=(-1, 0),
+                                   topology=(Bounded, Flat, Bounded))
+
+            b_func(x, z, t) = 1e-5 * z
+
+            # Should throw when prescribed tracer name overlaps with prognostic tracer name
+            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid;
+                buoyancy = nothing,
+                tracers = :b,
+                prescribed_tracers = (b = b_func,))
         end
 
         @testset "HydrostaticFreeSurfaceModel with tracers and forcings [$arch]" begin


### PR DESCRIPTION
Alternative design to PR #5343 (PrescribedTracer wrapper approach): instead of wrapping each tracer value in a `PrescribedTracer` type and dispatching at run time to skip time-stepping, this adds a separate `prescribed_tracers` keyword argument that cleanly separates prescribed from prognostic tracers at construction time.

Pros of the kwarg approach:
- ~1/3 the diff size (83+/23- vs 289+/96- source lines, 9 vs 13 files)
- No run-time filtering or no-op dispatches on tracer types
- Simpler user interface: `prescribed_tracers = (b = b_fts,)`
- No new wrapper type to maintain

Cons:
- **Non-modular structural change:** Adds a field/property to the model struct (and type parameter `PC`) 
- Carries an empty `NamedTuple` when no tracers are prescribed

---

### Usage example

In short, with PR #5343 you would construct a model with prescribed buoyancy tracer as:
```julia
model = HydrostaticFreeSurfaceModel(grid;
    buoyancy = BuoyancyTracer(),
    closure = closure,
    tracers = (b = PrescribedTracer(b), c = c))
``` 
where `b` could be a `Function` or a `FieldTimeSeries` or a `Field` (constant in time), and `c` would be the initial `Field` for your passive tracer `c`.

In this PR, you would instead do 
```julia
model = HydrostaticFreeSurfaceModel(grid;
    buoyancy = BuoyancyTracer(),
    closure = closure,
    tracers = :c,
    prescribed_tracers = (b = b_fts,))
```