### PR TITLE
Add 9 missing papers to the reference list

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -127,6 +127,8 @@ the features they describe! Also, if you have developed a new feature in Oceanan
 
 If you have work using Oceananigans that you would like to have listed here, please open a pull request to add it or let us know!
 
+1. De Abreu, S. and Timmermans, M. (2026). [Mixed-layer deepening and internal wave generation under sea ice in free drift](https://doi.org/10.1175/JPO-D-25-0165.1), _Journal of Physical Oceanography_, in press. DOI: [10.1175/JPO-D-25-0165.1](https://doi.org/10.1175/JPO-D-25-0165.1)
+
 1. Markmann, Τ., Straat, Μ., Peitz, S., Hammer, B. (2026). [Fourier neural operators as data-driven surrogates for two- and three-dimensional Rayleigh–bénard convection](https://doi.org/10.1016/j.neucom.2026.133201), _Neurocomputing_, 133201. DOI: [10.1016/j.neucom.2026.133201](https://doi.org/10.1016/j.neucom.2026.133201)
 
 1. Yakushev, E., Berezina, A., Yakubov, S., Novikov, M., Ghaffari, P., Dzhurova, B., Hristova, O., Vogt, R., and Ranneklev, S. (2026). [Model-based analysis of seasonal hypoxia: The Varna Lake–Bay case study](https://doi.org/10.1016/j.ecolmodel.2026.111535), _Ecological Modelling_, **515**, 111535. DOI: [10.1016/j.ecolmodel.2026.111535](https://doi.org/10.1016/j.ecolmodel.2026.111535)


### PR DESCRIPTION
## Summary

Cross-referenced ~103 Semantic Scholar citations of the JOSS paper (Ramadhan et al. 2020), Google Scholar citations of the overview preprint (Wagner et al. 2025), and citations of the model development papers against the current reference list, then verified each candidate by reading the paper to confirm Oceananigans usage.

These 9 papers are confirmed to use Oceananigans but were missing from the list:

- [De Abreu & Timmermans (2026)](https://doi.org/10.1175/JPO-D-25-0165.1) — "Mixed-layer deepening and internal wave generation under sea ice in free drift" (*JPO*)
- [Allende, Couston, Thalabard & Favier (2026)](https://doi.org/10.48550/arXiv.2601.18674) — "Melting dynamics and mixing layer growth near the ice-ocean interface" (*arXiv*)
- [Middleton et al. (2025)](https://doi.org/10.1126/sciadv.adu3221) — "Observations of a splitting ocean cyclone resulting in subduction of surface waters" (*Science Advances*)
- [Pružina, Zhou, Middleton & Taylor (2025)](https://doi.org/10.1017/jfm.2025.258) — "Layer formation in double-diffusive convection diagnosed in sorted buoyancy coordinates" (*JFM*)
- [Pružina (2025)](https://doi.org/10.1017/jfm.2025.141) — "A one-dimensional model of staircase formation in diffusive convection" (*JFM*)
- [Lee, Hutchings, Horvat, Tavri & Pearson (2025)](https://doi.org/10.5194/egusphere-2025-4239) — "Impact of Surface Waves on Mixing and Circulation in a Summertime Lead" (*EGUsphere preprint*)
- [Fromme, Harder, Allen-Blanchette & Peitz (2025)](https://doi.org/10.48550/arXiv.2505.13569) — "Surrogate Modeling of 3D Rayleigh-Bénard Convection with Equivariant Autoencoders" (*arXiv*)
- [Zhang, Kang & Marshall (2024)](https://doi.org/10.1126/sciadv.adn6857) — "Ocean weather systems on icy moons, with application to Enceladus" (*Science Advances*)
- [Bire et al. (2023)](https://doi.org/10.1029/2023JE007740) — "Divergent behavior of hydrothermal plumes in fresh versus salty icy ocean worlds" (*JGR Planets*)

🤖 Generated with [Claude Code](https://claude.com/claude-code)