### PR TITLE
Add dependency guardrail to Common Pitfalls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,10 @@ src/
 12. **Hardcoded Float64**: never use `0.0`, `1.0` in kernels or constructors; use `zero(grid)` etc.
 13. **Scope creep in PRs**: keep changes focused on a single concern. Unrelated cleanup goes
     in a separate PR
+14. **Modifying Project.toml dependencies**: never add, remove, or change `[deps]` or `[weakdeps]`
+    in the root `Project.toml` unless the task absolutely requires it. Dependency changes have
+    wide-reaching consequences — they affect CI, load time, and downstream compatibility.
+    Only touch `[compat]` bounds when explicitly asked.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

- Adds a new entry to Common Pitfalls warning agents not to modify `[deps]` or `[weakdeps]` in the root `Project.toml` unless absolutely required
- Dependency changes affect CI, load time, and downstream compatibility — agents should not make them casually

## Test plan

- [ ] No functional code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)