### PR TITLE
Add manual restart verification to examples

### DIFF
--- a/examples/restart_verification.sh
+++ b/examples/restart_verification.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+for script in *.jl; do
+    casename=${script%.jl}
+    echo $casename $script
+
+    mkdir -p $casename
+    cd $casename
+
+    norestart="${casename}_0.jl"
+    if [ ! -f "$norestart" ]; then
+        cp ../$script $norestart
+        sed -i '' '/^simulation =/s/stop_[^)]*)/stop_iteration=200)/' $norestart
+        sed -i '' '/^run!/q' $norestart
+        sed -i '' '/^run!/s/)$/, checkpoint_at_end=true)/' $norestart
+        sed -i '' "/^run!/i\\"$'\n'"simulation.output_writers[:checkpointer] = Checkpointer(model, schedule=IterationInterval(100), prefix=\"norestart\")\\"$'\n'"" $norestart
+        sed -i '' 's/^simulation.stop_iteration =/#simulation.stop_iteration =/' $restarted # to be safe, don't overwrite stop_iteration
+    fi
+
+    restarted="${casename}_1.jl"
+    if [ ! -f "$restarted" ]; then
+        cp ../$script $restarted
+        sed -i '' '/^simulation =/s/stop_[^)]*)/stop_iteration=200)/' $restarted
+        sed -i '' '/^run!/q' $restarted
+        sed -i '' '/^run!/s/)$/, checkpoint_at_end=true)/' $restarted
+        sed -i '' "/^run!/i\\"$'\n'"simulation.output_writers[:checkpointer] = Checkpointer(model, schedule=IterationInterval(100), prefix=\"restarted\")\\"$'\n'"" $restarted
+        sed -i '' 's/^simulation.stop_iteration =/#simulation.stop_iteration =/' $restarted # to be safe, don't overwrite stop_iteration
+
+        # restart specific
+        sed -i '' 's/^set!/#set!/' $restarted # dont re-initialize
+        sed -i '' '/^run!/s/)$/; pickup="norestart_iteration100.jld2")/' $restarted
+    fi
+
+    if [ ! -f 'norestart_iteration200.jld2' ]; then julia $norestart; fi
+    if [ ! -f 'restarted_iteration200.jld2' ]; then julia $restarted; fi
+
+    cd ..
+
+    julia util/compare_checkpoints.jl $casename/norestart_iteration200.jld2 $casename/restarted_iteration200.jld2 2>&1 | tee compare_restart_$casename.log
+done

--- a/examples/util/compare_checkpoints.jl
+++ b/examples/util/compare_checkpoints.jl
@@ -1,0 +1,138 @@
+using JLD2
+#using Base: isapprox
+using Oceananigans.TimeSteppers: Clock
+using Oceananigans.BoundaryConditions: BoundaryCondition
+
+function compare_clock_struct(a, b)
+    return a.time ≈ b.time &&
+           a.last_Δt ≈ b.last_Δt &&
+           a.last_stage_Δt ≈ b.last_stage_Δt &&
+           a.iteration == b.iteration &&
+           a.stage == b.stage
+end
+
+function compare_all(a, b; name="", verbose=false)
+    if a isa JLD2.Group
+        @assert b isa JLD2.Group
+        @assert issetequal(keys(a), keys(b))
+
+        keys1 = keys(a)
+        keys2 = keys(b)
+        @assert keys1 == keys2
+
+        # recurse
+        for key in keys1
+            fullkey = !isempty(name) ? string(name, ".", key) : key
+            if isnothing(a[key])
+                @assert isnothing(b[key])
+                verbose && println("Note: No $fullkey")
+            else
+                #println("Comparing $fullkey...")
+                compare_all(a[key], b[key]; name=fullkey, verbose=verbose)
+            end
+        end
+
+    elseif a isa Clock
+        @assert b isa Clock
+
+        if a != b
+            if compare_clock_struct(a, b)
+                println("$name are approximately equal")
+            else
+                println("$name DIFFER!?")
+            end
+            @show a
+            @show b
+        elseif verbose
+            println("$name are identical")
+        end
+
+    #else
+    elseif !endswith(name, "boundary_conditions") # dont try to compare BCs
+        if a != b
+            println("Compare arrays $name")
+            @assert a isa Array
+            @assert b isa Array
+            abs_diff = abs.(a .- b)
+            rel_diff = [max(abs(aval), abs(bval)) == 0 ? 0.0 : abs(aval-bval)/max(abs(aval),abs(bval)) for (aval,bval) in zip(a, b)]
+
+            #if all(isapprox.(a, b; atol=1e-8, rtol=1e-5)) # np.allclose default
+            if all(a .≈ b)
+                println("$name are approximately equal ", maximum(abs_diff), " ", maximum(rel_diff))
+            else
+                println("$name DIFFER!? max abs/rel diff : ", maximum(abs_diff), " ", maximum(rel_diff))
+            end
+
+            max_idx = argmax(abs_diff)
+            i, j, k = Tuple(max_idx)
+            println("  location of max abs diff: ", (i,j,k))
+
+            max_idx = argmax(rel_diff)
+            i, j, k = Tuple(max_idx)
+            println("  location of max rel diff: ", (i,j,k))
+
+        elseif verbose
+            println("$name are identical")
+        end
+    end
+
+    return nothing
+end
+
+"""(If only Comonicon worked)
+
+Recursively compare data structures inside a checkpointed model instance
+
+# Args
+
+- `filepath1`: First .jld2 checkpoint file
+- `filepath2`: Second .jld2 checkpoint file
+
+# Flags
+
+- `-v, --verbose`: Print extra information
+"""
+function main()
+    # Defaults
+    verbose = false
+    positional_args = String[]
+
+    # Parse the built-in ARGS array
+    for arg in ARGS
+        if arg in ("-v", "--verbose")
+            verbose = true
+        elseif startswith(arg, "-")
+            println(stderr, "Error: Unknown flag '$arg'")
+            exit(1)
+        else
+            push!(positional_args, arg)
+        end
+    end
+
+    # Validate we got exactly the files we need
+    if length(positional_args) != 2
+        println(stderr, "Usage: julia compare_checkpoints.jl <filepath1> <filepath2> [-v|--verbose]")
+        exit(1)
+    end
+    filepath1 = positional_args[1]
+    filepath2 = positional_args[2]
+
+    # Check filepaths
+    filepath1 = abspath(expanduser(filepath1))
+    !isfile(filepath1) && throw(ArgumentError("File not found: $filepath1"))
+    filepath2 = abspath(expanduser(filepath2))
+    !isfile(filepath2) && throw(ArgumentError("File not found: $filepath2"))
+
+    # Load and compare
+    chk1 = jldopen(filepath1, "r")
+    chk2 = jldopen(filepath2, "r")
+
+    compare_all(chk1["simulation"]["model"],
+                chk2["simulation"]["model"];
+                verbose)
+
+    close(chk1)
+    close(chk2)
+end
+
+main()


### PR DESCRIPTION
Documenting results here to inform https://github.com/NumericalEarth/Breeze.jl/pull/529

The `restart_verification.sh` semi-automates the testing in an old-school way, running 0->200 iterations from scratch and comparing with 100->200 iterations restarted. Results are from my macbook with Julia v1.12.5 and the following environment:
```
  [033835bb] JLD2 v0.6.3
  [85f8d34a] NCDatasets v0.14.12
⌅ [9e8cae18] Oceananigans v0.105.1
  [d496a93d] SeawaterPolynomials v0.3.10
```

| Example Problem | Restart is Bitwise Identical | Notes |
| --- | --- | --- |
| baroclinic_adjustment.jl | ✅ | |
| convecting_plankton.jl | ✅ | |
| horizontal_convection.jl | ✅ | |
| hydrostatic_lock_exchange.jl | ✅ | |
| internal_tide.jl | ✅ | |
| internal_wave.jl | ✅ | |
| kelvin_helmholtz_instability.jl | ? | need to check simulation steps |
| langmuir_turbulence.jl | ? | need to check simulation steps |
| ocean_wind_mixing_and_convection.jl | ☑️ | abs diff ~O(1e-13) |
| one_dimensional_diffusion.jl | ✅ | |
| shallow_water_Bickley_jet.jl | ✅ | |
| spherical_baroclinic_instability.jl (lat-lon) | ✅ | ran on CPU |
| spherical_baroclinic_instability.jl (tripolar) | ❌ | ran on CPU |
| spherical_baroclinic_instability.jl (rotated lat-lon) | ✅ | ran on CPU |
| tilted_bottom_boundary_layer.jl | ? | need to check simulation steps |
| two_dimensional_turbulence.jl | ✅ | |