### PR TITLE
Fix `HydroStaticFreeSurfaceModel` init for open boundary conditions with `SplitExplicitFreeSurface`

### DIFF
--- a/examples/internal_tide_open_boundaries.jl
+++ b/examples/internal_tide_open_boundaries.jl
@@ -132,6 +132,8 @@ end
     return -p.rate * mask * (@inbounds fields.u[i, j, k] - ut)
 end
 
+@inline b_bg(z, p) = p.N² * z
+
 @inline function b_sponge_forcing(i, j, k, grid, clock, fields, p)
     x = xnode(i, grid, Center())
     z = znode(k, grid, Center())

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -52,7 +52,6 @@ end
 
 validate_boundary_condition_location(bc, ::Center, side) = nothing          # anything goes for centers
 validate_boundary_condition_location(::Nothing, ::Nothing, side) = nothing  # its nothing or nothing
-validate_boundary_condition_location(bc, ::Nothing, side) = nothing         # anything goes on Nothing-dimension fields
 
 const ValidFaceBCS = Union{OBC, Nothing, Missing, MCBC}
 validate_boundary_condition_location(::ValidFaceBCS, ::Face, side) = nothing  # only open, connected or nothing on faces

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -52,6 +52,7 @@ end
 
 validate_boundary_condition_location(bc, ::Center, side) = nothing          # anything goes for centers
 validate_boundary_condition_location(::Nothing, ::Nothing, side) = nothing  # its nothing or nothing
+validate_boundary_condition_location(bc, ::Nothing, side) = nothing         # anything goes on Nothing-dimension fields
 
 const ValidFaceBCS = Union{OBC, Nothing, Missing, MCBC}
 validate_boundary_condition_location(::ValidFaceBCS, ::Face, side) = nothing  # only open, connected or nothing on faces

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
@@ -249,7 +249,7 @@ function materialize_free_surface(free_surface::SplitExplicitFreeSurface{extend_
     end
 
     timestepper = materialize_timestepper(free_surface.timestepper, maybe_extended_grid, free_surface, velocities,
-                                          u_bcs, v_bcs)
+                                          bcs.u, bcs.v)
 
     return SplitExplicitFreeSurface{extend_halos}(η,
                                                   barotropic_velocities,

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
@@ -249,7 +249,7 @@ function materialize_free_surface(free_surface::SplitExplicitFreeSurface{extend_
     end
 
     timestepper = materialize_timestepper(free_surface.timestepper, maybe_extended_grid, free_surface, velocities,
-                                          bcs.u, bcs.v)
+                                          bcs.U, bcs.V)
 
     return SplitExplicitFreeSurface{extend_halos}(η,
                                                   barotropic_velocities,

--- a/src/Operators/interpolation_utils.jl
+++ b/src/Operators/interpolation_utils.jl
@@ -88,6 +88,8 @@ function assumed_field_location(name)
     name === :ρv && return (Center(), Face(), Center())
     name === :w  && return (Center(), Center(), Face())
     name === :ρw && return (Center(), Center(), Face())
+    name === :U  && return (Face(), Center(), nothing)
+    name === :V  && return (Center(), Face(), nothing)
     return (Center(), Center(), Center())
 end
 

--- a/src/Operators/interpolation_utils.jl
+++ b/src/Operators/interpolation_utils.jl
@@ -90,6 +90,7 @@ function assumed_field_location(name)
     name === :ρw && return (Center(), Center(), Face())
     name === :U  && return (Face(), Center(), nothing)
     name === :V  && return (Center(), Face(), nothing)
+    name === :η  && return (Center(), Center(), Face())
     return (Center(), Center(), Center())
 end
 


### PR DESCRIPTION
Currently, the `internal_tide_open_boundaries` example fails with:

```
ArgumentError: Cannot specify bottom boundary condition FluxBoundaryCondition: Nothing on a field at nothing!
```

I think this is for two reasons:
- `U` and `V` are not listed in the `assumed_field_location` mapping for boundary condition locations, so they fall through to the `Center(), Center(), Center()` default which is incorrect for a 2D field
- ~Missing dispatch for validating boundary conditions on a `nothing` z-location, so this also falls through to a catch-all error~ Note: this was extra, I've removed it after review.

This pull request adds a mapping for `U` and `V`. I've also added missing references in a couple of places. The example runs with these changes, but I have not checked it for correctness.

I'm very new to Oceananigans, so please double check and feel free to make any changes to this branch.