### PR TITLE
Add a hydrostatic barotropic soliton case validation for hydrostatic open boundaries

### DIFF
--- a/validation/open_boundaries/barotropic_soliton.jl
+++ b/validation/open_boundaries/barotropic_soliton.jl
@@ -116,9 +116,9 @@ function u¹(y, e_val, p::SolitonParameters, u_coeffs = Float64[])
     return term1 .+ e_val.^2 .* hermite_series(y, u_coeffs, 10)
 end
 
-function v¹(y, de_val, e_val, v_coeffs = Float64[])
+function v¹(y, de_val, v_coeffs = Float64[])
     isempty(v_coeffs) && return zero(y)
-    return de_val .* e_val .* hermite_series(y, v_coeffs, 10)
+    return de_val .* hermite_series(y, v_coeffs, 10)
 end
 
 function h¹(y, e_val, p::SolitonParameters, h_coeffs = Float64[])


### PR DESCRIPTION
This PR adds a validation case following Haidvogel and Beckmann (1999), section 6.1, used by Marchesiello, McWilliams, & Shchepetkin (2001) in order to test open boundary conditions. For now it runs only with an implicit free surface solver + `PerturbationAdvection`, but in the future we might expand to several cases as we develop capabilities. (For example https://github.com/CliMA/Oceananigans.jl/pull/5351)

That said, the simulation isn't really working very well I'd say. Here's an animation comparing the simulation with the analytical solution:

https://github.com/user-attachments/assets/19c86591-7355-4082-8e2e-aab3e5d9db88

Note that I'm not using any sponge layers in the example above, which definitely would help, but I also would think that the results would be better even without sponge layers. (Maybe that's naive of me?)

For comparison, in their set-up Marchesiello et alia (2001) used

- A split explicit scheme (I think)
- No sponge layers for $\eta$, but weak/strong nudging for both baroclinic and barotropic velocities during outflow/inflow
- Orlanski-like oblique radiation regime for velocities and tracers, but only a zero-gradient boundary condition for the free surface

**Code fixes applied based on review feedback:**
- Removed unused `e_val` argument from the `v¹` first-order correction function (and its erroneous multiplication in the return expression).

cc @simone-silvestri