### PR TITLE
Skip fill_corners! when no corner neighbors exist

### DIFF
--- a/src/DistributedComputations/halo_communication.jl
+++ b/src/DistributedComputations/halo_communication.jl
@@ -139,6 +139,10 @@ function fill_corners!(c, connectivity, indices, loc, arch, grid, buffers, args.
     # No corner filling needed!
     only_local_halos && return nothing
 
+    # Skip corners entirely if no corner neighbors exist (avoids unnecessary sync_device!)
+    isnothing(connectivity.southwest) && isnothing(connectivity.southeast) &&
+    isnothing(connectivity.northwest) && isnothing(connectivity.northeast) && return nothing
+
     # This has to be synchronized!
     fill_send_buffers!(c, buffers, grid, Val(:corners))
     sync_device!(arch)


### PR DESCRIPTION
Claude came up with this:

Avoid calling `sync_device!` (CUDA.synchronize) in `fill_corners!` when all corner connectivity is `nothing`. This occurs for slab decompositions and single-rank distributed configurations where no diagonal neighbors exist.

Each `sync_device!` call flushes the GPU's async execution pipeline. With ~300 halo fills per 10 timesteps in a typical Breeze.jl anelastic benchmark, the unnecessary syncs cause a 2.95x overhead on a single distributed GPU.

