### PR TITLE
Fix publish-benchmarks pipeline token permissions

### DIFF
--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -348,6 +348,7 @@ jobs:
           tool: "customSmallerIsBetter"
           output-file-path: "github-action-benchmark.json"
           benchmark-data-dir-path: "."
+          gh-repository: "github.com/NumericalEarth/OceananigansBenchmarks"
           github-token: ${{ github.token }}
           comment-always: true
           summary-always: true


### PR DESCRIPTION
## Summary

The `benchmark-action/github-action-benchmark` uses a single `github-token` for all operations. The previous `&&`/`||` expression was resolving to `BENCHMARKS_TOKEN` even for PR events (confirmed by the token expiration header and the successful clone of the external repo in the failing run). This caused a 403 when trying to post PR review comments, since `BENCHMARKS_TOKEN` only has access to `NumericalEarth/OceananigansBenchmarks`.

**Fix**: Split the benchmark action into two conditional steps:
- **`repository_dispatch`**: uses `BENCHMARKS_TOKEN`, pushes to external benchmarks repo, no PR comment
- **`pull_request`**: uses `github.token`, comments on the PR, no push to external repo

## Test plan
- [ ] Verify `pull_request` event posts benchmark comparison as PR comment
- [ ] Verify `repository_dispatch` event pushes to OceananigansBenchmarks without commenting