### PR TITLE
`BoundedTopology` -> `FaceExtendedTopology`

### DIFF
--- a/ext/OceananigansReactantExt/Grids/Grids.jl
+++ b/ext/OceananigansReactantExt/Grids/Grids.jl
@@ -10,7 +10,7 @@ using Oceananigans
 using Oceananigans: Distributed
 using Oceananigans.Architectures: ReactantState, CPU
 using Oceananigans.Grids: AbstractGrid, AbstractUnderlyingGrid, StaticVerticalDiscretization, MutableVerticalDiscretization
-using Oceananigans.Grids: Center, Face, RightConnected, LeftConnected, Periodic, Bounded, Flat, BoundedTopology
+using Oceananigans.Grids: Center, Face, RightConnected, LeftConnected, Periodic, Bounded, Flat, FaceExtendedTopology
 using Oceananigans.Fields: Field
 using Oceananigans.ImmersedBoundaries: GridFittedBottom, AbstractImmersedBoundary
 
@@ -57,7 +57,7 @@ end
 reactant_total_length(loc, topo, N, H, ::Colon) = reactant_total_length(loc, topo, N, H)
 reactant_total_length(loc, topo, N, H, ind::AbstractUnitRange) = min(reactant_total_length(loc, topo, N, H), length(ind))
 reactant_total_length(loc, topo, N, H) = Oceananigans.Grids.total_length(loc, topo, N, H)
-reactant_total_length(::Face, ::BoundedTopology, N, H=0) = N + 2H
+reactant_total_length(::Face, ::FaceExtendedTopology, N, H=0) = N + 2H
 
 reactant_offset_indices(loc, topo, N, H=0) = 1 - H : N + H
 reactant_offset_indices(::Nothing, topo, N, H=0) = 1:1

--- a/src/Grids/grid_generation.jl
+++ b/src/Grids/grid_generation.jl
@@ -12,16 +12,16 @@ get_face_node(coord::AbstractVector, i) = @allowscalar coord[i]
 const AT = AbstractTopology
 
 lower_exterior_Δcoordᶠ(::AT,              Fi, Hcoord) = [Fi[end - Hcoord + i] - Fi[end - Hcoord + i - 1] for i = 1:Hcoord]
-lower_exterior_Δcoordᶠ(::BoundedTopology, Fi, Hcoord) = [Fi[2]  - Fi[1] for _ = 1:Hcoord]
+lower_exterior_Δcoordᶠ(::FaceExtendedTopology, Fi, Hcoord) = [Fi[2]  - Fi[1] for _ = 1:Hcoord]
 
 upper_exterior_Δcoordᶠ(::AT,              Fi, Hcoord) = [Fi[i + 1] - Fi[i] for i = 1:Hcoord]
-upper_exterior_Δcoordᶠ(::BoundedTopology, Fi, Hcoord) = [Fi[end]   - Fi[end - 1] for _ = 1:Hcoord]
+upper_exterior_Δcoordᶠ(::FaceExtendedTopology, Fi, Hcoord) = [Fi[end]   - Fi[end - 1] for _ = 1:Hcoord]
 
 upper_interior_F(::AT, coord, Δ)           = coord - Δ
-upper_interior_F(::BoundedTopology, coord) = coord
+upper_interior_F(::FaceExtendedTopology, coord) = coord
 
 total_interior_length(::AT, N)              = N
-total_interior_length(::BoundedTopology, N) = N + 1
+total_interior_length(::FaceExtendedTopology, N) = N + 1
 
 bad_coordinate_message(ξ::Function, name) = "The values of $name(index) must increase as the index increases!"
 bad_coordinate_message(ξ::AbstractArray, name) = "The elements of $name must be increasing!"

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -40,12 +40,12 @@ end
     end
 end
 
-const BoundedTopology = Union{Bounded, LeftConnected, RightFaceFolded,
+const FaceExtendedTopology = Union{Bounded, LeftConnected, RightFaceFolded,
                               LeftConnectedRightFaceFolded,
                               LeftConnectedRightFaceConnected}
 const AT = AbstractTopology
 
-Base.length(::Face,    ::BoundedTopology, N) = N + 1
+Base.length(::Face,    ::FaceExtendedTopology, N) = N + 1
 Base.length(::Nothing, ::AT,              N) = 1
 Base.length(::Face,    ::AT,              N) = N
 Base.length(::Center,  ::AT,              N) = N
@@ -67,7 +67,7 @@ is restricted by `length(ind)`.
 """
 total_length(::Face,    ::AT,              N, H=0) = N + 2H
 total_length(::Center,  ::AT,              N, H=0) = N + 2H
-total_length(::Face,    ::BoundedTopology, N, H=0) = N + 1 + 2H
+total_length(::Face,    ::FaceExtendedTopology, N, H=0) = N + 1 + 2H
 total_length(::Nothing, ::AT,              N, H=0) = 1
 total_length(::Nothing, ::Flat,            N, H=0) = N
 total_length(::Face,    ::Flat,            N, H=0) = N
@@ -120,7 +120,7 @@ Return the total extent, including halo regions, of constant-spaced
 constant grid spacing `Δ`, and interior extent `L`.
 """
 @inline total_extent(topo, H, Δ, L) = L + (2H - 1) * Δ
-@inline total_extent(::BoundedTopology, H, Δ, L) = L + 2H * Δ
+@inline total_extent(::FaceExtendedTopology, H, Δ, L) = L + 2H * Δ
 
 # Grid domains
 @inline domain(topo, N, ξ) = @allowscalar ξ[1], ξ[N+1]
@@ -141,18 +141,18 @@ regular_dimensions(grid) = ()
 @inline left_halo_indices(::Nothing, ::AT, N, H) = 1:0 # empty
 
 @inline right_halo_indices(loc, ::AT, N, H) = N+1:N+H
-@inline right_halo_indices(::Face, ::BoundedTopology, N, H) = N+2:N+1+H
+@inline right_halo_indices(::Face, ::FaceExtendedTopology, N, H) = N+2:N+1+H
 @inline right_halo_indices(::Nothing, ::AT, N, H) = 1:0 # empty
 
 @inline underlying_left_halo_indices(loc, ::AT, N, H) = 1:H
 @inline underlying_left_halo_indices(::Nothing, ::AT, N, H) = 1:0 # empty
 
 @inline underlying_right_halo_indices(loc,       ::AT, N, H) = N+1+H:N+2H
-@inline underlying_right_halo_indices(::Face,    ::BoundedTopology, N, H) = N+2+H:N+1+2H
+@inline underlying_right_halo_indices(::Face,    ::FaceExtendedTopology, N, H) = N+2+H:N+1+2H
 @inline underlying_right_halo_indices(::Nothing, ::AT, N, H) = 1:0 # empty
 
 @inline interior_indices(loc,       ::AT,              N) = 1:N
-@inline interior_indices(::Face,    ::BoundedTopology, N) = 1:N+1
+@inline interior_indices(::Face,    ::FaceExtendedTopology, N) = 1:N+1
 @inline interior_indices(::Nothing, ::AT,              N) = 1:1
 
 @inline interior_indices(::Nothing, ::Flat, N) = 1:N
@@ -167,7 +167,7 @@ regular_dimensions(grid) = ()
 @inline interior_parent_offset(::Nothing, ::AT, H) = 0
 
 @inline interior_parent_indices(::Nothing, ::AT,              N, H) = 1:1
-@inline interior_parent_indices(::Face,    ::BoundedTopology, N, H) = 1+H:N+1+H
+@inline interior_parent_indices(::Face,    ::FaceExtendedTopology, N, H) = 1+H:N+1+H
 @inline interior_parent_indices(loc,       ::AT,              N, H) = 1+H:N+H
 
 
@@ -177,7 +177,7 @@ regular_dimensions(grid) = ()
 
 # All indices including halos.
 @inline all_indices(::Nothing, ::AT,              N, H) = 1:1
-@inline all_indices(::Face,    ::BoundedTopology, N, H) = 1-H:N+1+H
+@inline all_indices(::Face,    ::FaceExtendedTopology, N, H) = 1-H:N+1+H
 @inline all_indices(loc,       ::AT,              N, H) = 1-H:N+H
 
 @inline all_indices(::Nothing, ::Flat, N, H) = 1:N
@@ -189,7 +189,7 @@ regular_dimensions(grid) = ()
 @inline all_z_indices(grid, loc) = all_indices(loc[3](), topology(grid, 3)(), size(grid, 3), halo_size(grid, 3))
 
 @inline all_parent_indices(loc,       ::AT,              N, H) = 1:N+2H
-@inline all_parent_indices(::Face,    ::BoundedTopology, N, H) = 1:N+1+2H
+@inline all_parent_indices(::Face,    ::FaceExtendedTopology, N, H) = 1:N+1+2H
 @inline all_parent_indices(::Nothing, ::AT,              N, H) = 1:1
 
 @inline all_parent_indices(::Nothing, ::Flat, N, H) = 1:N

--- a/src/Grids/new_data.jl
+++ b/src/Grids/new_data.jl
@@ -4,16 +4,17 @@
 
 """
 Return a range of indices for a field located at either cell `Center`s or `Face`s along a
-grid dimension which is `Periodic`, or cell `Center`s for a grid dimension which is `Bounded`.
+grid dimension which is `Periodic`, or cell `Center`s for a grid dimension
+that has an extended topology.
 The dimension has length `N` and `H` halo points.
 """
 offset_indices(loc, topo, N, H=0) = 1 - H : N + H
 
 """
 Return a range of indices for a field located at cell `Face`s along a grid dimension which
-is `Bounded` and has length `N` and with halo points `H`.
+has an extended topology and has length `N` and with halo points `H`.
 """
-offset_indices(::Face, ::BoundedTopology, N, H=0) = 1 - H : N + H + 1
+offset_indices(::Face, ::FaceExtendedTopology, N, H=0) = 1 - H : N + H + 1
 
 """
 Return a range of indices for a field along a 'reduced' dimension.

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -109,8 +109,8 @@ OrthogonalSphericalShellGrid(architecture, Nx, Ny, Nz, Hx, Hy, Hz, Lz,
 Fill the `x`-halo regions of the `metric` that lives on locations `ℓx`, `ℓy`, with halo size `Hx`, `Hy`, and topology
 `tx`, `ty`.
 """
-function fill_metric_halo_regions_x!(metric, ℓx, ℓy, tx::BoundedTopology, ty, Nx, Ny, Hx, Hy)
-    # = N+1 for ::BoundedTopology or N otherwise
+function fill_metric_halo_regions_x!(metric, ℓx, ℓy, tx::FaceExtendedTopology, ty, Nx, Ny, Hx, Hy)
+    # = N+1 for ::FaceExtendedTopology or N otherwise
     Nx⁺ = length(ℓx, tx, Nx)
     Ny⁺ = length(ℓy, ty, Ny)
 
@@ -131,7 +131,7 @@ function fill_metric_halo_regions_x!(metric, ℓx, ℓy, tx::BoundedTopology, ty
 end
 
 function fill_metric_halo_regions_x!(metric, ℓx, ℓy, tx::AbstractTopology, ty, Nx, Ny, Hx, Hy)
-    # = N+1 for ::BoundedTopology or N otherwise
+    # = N+1 for ::FaceExtendedTopology or N otherwise
     Nx⁺ = length(ℓx, tx, Nx)
     Ny⁺ = length(ℓy, ty, Ny)
 
@@ -157,8 +157,8 @@ end
 Fill the `y`-halo regions of the `metric` that lives on locations `ℓx`, `ℓy`, with halo size `Hx`, `Hy`, and topology
 `tx`, `ty`.
 """
-function fill_metric_halo_regions_y!(metric, ℓx, ℓy, tx, ty::BoundedTopology, Nx, Ny, Hx, Hy)
-    # = N+1 for ::BoundedTopology or N otherwise
+function fill_metric_halo_regions_y!(metric, ℓx, ℓy, tx, ty::FaceExtendedTopology, Nx, Ny, Hx, Hy)
+    # = N+1 for ::FaceExtendedTopology or N otherwise
     Nx⁺ = length(ℓx, tx, Nx)
     Ny⁺ = length(ℓy, ty, Ny)
 
@@ -179,7 +179,7 @@ function fill_metric_halo_regions_y!(metric, ℓx, ℓy, tx, ty::BoundedTopology
 end
 
 function fill_metric_halo_regions_y!(metric, ℓx, ℓy, tx, ty::AbstractTopology, Nx, Ny, Hx, Hy)
-    # = N+1 for ::BoundedTopology or N otherwise
+    # = N+1 for ::FaceExtendedTopology or N otherwise
     Nx⁺ = length(ℓx, tx, Nx)
     Ny⁺ = length(ℓy, ty, Ny)
 
@@ -207,7 +207,7 @@ choose to fill with the average of the neighboring metric in the halo regions. T
 `x`- and `y`-halo regions have already been filled.
 """
 function fill_metric_halo_corner_regions!(metric, ℓx, ℓy, tx, ty, Nx, Ny, Hx, Hy)
-    # = N+1 for ::BoundedTopology or N otherwise
+    # = N+1 for ::FaceExtendedTopology or N otherwise
     Nx⁺ = length(ℓx, tx, Nx)
     Ny⁺ = length(ℓy, ty, Ny)
 


### PR DESCRIPTION
This is another maybe-bikeshedding PR from a Slack discussion for renaming `BoundedTopology` to `FaceExtendedTopology`.

`BoundedTopology` is a type union used for extending the fields at face-locations by 1. But currently it is a bit of misnomer as it contains the `RightFaceFolded` topology and its distributed consorts, which are _not_ bounded. Since it is used solely for extending sizes of face locations, I proposed `FaceExtendedTopology`.

This is just a variable renaming so it should not break anything.