### PR TITLE
Cleanup of CATKE and TKE previous_velocities

### DIFF
--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_vertical_diffusivity.jl
@@ -172,13 +172,12 @@ catke_first(catke1::FlavorOfCATKE, catke2::FlavorOfCATKE) = error("Can't have tw
 ##### Diffusivities and diffusivity fields utilities
 #####
 
-struct CATKEClosureFields{K, L, J, U, KC, LC}
+struct CATKEClosureFields{K, L, J, KC, LC}
     κu :: K
     κc :: K
     κe :: K
     Le :: L
     Jᵇ :: J
-    previous_velocities :: U
     _tupled_tracer_diffusivities :: KC
     _tupled_implicit_linear_coefficients :: LC
 end
@@ -189,7 +188,6 @@ Adapt.adapt_structure(to, catke_closure_fields::CATKEClosureFields) =
                            adapt(to, catke_closure_fields.κe),
                            adapt(to, catke_closure_fields.Le),
                            adapt(to, catke_closure_fields.Jᵇ),
-                           adapt(to, catke_closure_fields.previous_velocities),
                            adapt(to, catke_closure_fields._tupled_tracer_diffusivities),
                            adapt(to, catke_closure_fields._tupled_implicit_linear_coefficients))
 
@@ -213,12 +211,6 @@ function build_closure_fields(grid, clock, tracer_names, bcs, closure::FlavorOfC
     κe = ZFaceField(grid, boundary_conditions=bcs.κe)
     Le = CenterField(grid)
     Jᵇ = Field{Center, Center, Nothing}(grid)
-
-    # Note: we may be able to avoid using the "previous velocities" in favor of a "fully implicit"
-    # discretization of shear production
-    u⁻ = XFaceField(grid)
-    v⁻ = YFaceField(grid)
-    previous_velocities = (; u=u⁻, v=v⁻)
 
     # Secret tuple for getting tracer diffusivities with tuple[tracer_index]
     _tupled_tracer_diffusivities         = NamedTuple(name => name === :e ? κe : κc          for name in tracer_names)
@@ -245,18 +237,9 @@ function step_closure_prognostics!(closure_fields, closure::FlavorOfCATKE, model
     # Step TKE equation with the provided timestep
     time_step_catke_equation!(model, model.timestepper, Δt)
 
-    # Update previous velocities and surface buoyancy flux
-    u, v, w = model.velocities
-    u⁻, v⁻ = closure_fields.previous_velocities
-    parent(u⁻) .= parent(u)
-    parent(v⁻) .= parent(v)
-
-    active_cells_map = get_active_cells_map(grid, Val(:xy))
-
     launch!(arch, grid, :xy,
             compute_average_surface_buoyancy_flux!,
-            closure_fields.Jᵇ, grid, closure, velocities, tracers, buoyancy, top_tracer_bcs, clock, Δt;
-            active_cells_map)
+            closure_fields.Jᵇ, grid, closure, velocities, tracers, buoyancy, top_tracer_bcs, clock, Δt)
 
     return nothing
 end

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_vertical_diffusivity.jl
@@ -390,15 +390,13 @@ end
 #####
 
 function prognostic_state(cf::CATKEClosureFields)
-    return (previous_velocities = prognostic_state(cf.previous_velocities),
-            Jᵇ = prognostic_state(cf.Jᵇ),
+    return (Jᵇ = prognostic_state(cf.Jᵇ),
             κu = prognostic_state(cf.κu),
             κc = prognostic_state(cf.κc),
             κe = prognostic_state(cf.κe))
 end
 
 function restore_prognostic_state!(restored::CATKEClosureFields, from)
-    restore_prognostic_state!(restored.previous_velocities, from.previous_velocities)
     restore_prognostic_state!(restored.Jᵇ, from.Jᵇ)
     restore_prognostic_state!(restored.κu, from.κu)
     restore_prognostic_state!(restored.κc, from.κc)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
@@ -28,7 +28,6 @@ function time_step_catke_equation!(model, ::QuasiAdamsBashforth2TimeStepper, Δt
     previous_velocities = closure_fields.previous_velocities
     tracer_index = findfirst(k -> k == :e, keys(model.tracers))
     implicit_solver = model.timestepper.implicit_solver
-    active_cells_map = get_active_cells_map(grid, Val(:xyz))
 
     Δτ = get_time_step(closure)
 
@@ -56,17 +55,15 @@ function time_step_catke_equation!(model, ::QuasiAdamsBashforth2TimeStepper, Δt
         launch!(arch, grid, :xyz,
                 compute_TKE_diffusivity!,
                 κe, grid, closure,
-                model.velocities, tracers, buoyancy, closure_fields;
-                active_cells_map)
+                model.velocities, tracers, buoyancy, closure_fields)
 
         # ... and step forward.
         launch!(arch, grid, :xyz,
                 _ab2_substep_turbulent_kinetic_energy!,
                 Le, grid, closure,
-                model.velocities, previous_velocities,
+                model.velocities, model.transport_velocities,
                 tracers, buoyancy, closure_fields,
-                Δτ, χ, Gⁿe, G⁻e;
-                active_cells_map)
+                Δτ, χ, Gⁿe, G⁻e)
 
         implicit_step!(e, implicit_solver, closure,
                        closure_fields, Val(tracer_index),
@@ -100,55 +97,28 @@ function time_step_catke_equation!(model, ::SplitRungeKuttaTimeStepper, Δt)
     previous_velocities = closure_fields.previous_velocities
     tracer_index = findfirst(k -> k == :e, keys(model.tracers))
     implicit_solver = model.timestepper.implicit_solver
-    active_cells_map = get_active_cells_map(grid, Val(:xyz))
-
-    Δτ = get_time_step(closure)
-
-    if isnothing(Δτ)
-        Δτ = Δt
-        M = 1
-    else
-        M = ceil(Int, Δt / Δτ) # number of substeps
-        Δτ = Δt / M
-    end
 
     tracers = buoyancy_tracers(model)
     buoyancy = buoyancy_force(model)
 
-    for m = 1:M
-        # Compute the linear implicit component of the RHS (closure_fields, L)...
-        launch!(arch, grid, :xyz,
-                compute_TKE_diffusivity!,
-                κe, grid, closure,
-                model.velocities, tracers, buoyancy, closure_fields;
-                active_cells_map)
+    # Compute the linear implicit component of the RHS (closure_fields, L)...
+    launch!(arch, grid, :xyz,
+            compute_TKE_diffusivity!,
+            κe, grid, closure,
+            model.velocities, tracers, buoyancy, closure_fields)
 
-        if m == 1
-            # First substep: reset from cached state σe⁻
-            launch!(arch, grid, :xyz,
-                    _rk_substep_turbulent_kinetic_energy!,
-                    Le, σe⁻, grid, closure,
-                    model.velocities, previous_velocities,
-                    tracers, buoyancy, closure_fields,
-                    Δτ, Gⁿ;
-                    active_cells_map)
-        else
-            # Subsequent substeps: Euler increment from current state
-            launch!(arch, grid, :xyz,
-                    _rk_euler_substep_turbulent_kinetic_energy!,
-                    Le, grid, closure,
-                    model.velocities, previous_velocities,
-                    tracers, buoyancy, closure_fields,
-                    Δτ, Gⁿ;
-                    active_cells_map)
-        end
+    launch!(arch, grid, :xyz,
+            _rk_substep_turbulent_kinetic_energy!,
+            Le, σe⁻, grid, closure,
+            model.velocities, model.transport_velocities,
+            tracers, buoyancy, closure_fields,
+            Δt, Gⁿ)
 
-        implicit_step!(e, implicit_solver, closure,
-                       closure_fields, Val(tracer_index),
-                       model.clock,
-                       fields(model),
-                       Δτ)
-    end
+    implicit_step!(e, implicit_solver, closure,
+                   closure_fields, Val(tracer_index),
+                   model.clock,
+                   fields(model),
+                   Δτ)
 
     return nothing
 end
@@ -290,31 +260,6 @@ end
     @inbounds begin
         total_Gⁿ = slow_Gⁿe[i, j, k] + fast_Gⁿe * σᶜᶜⁿ
         e[i, j, k] = (σe⁻[i, j, k] + Δt * total_Gⁿ * active) / σᶜᶜⁿ
-    end
-end
-
-@kernel function _rk_euler_substep_turbulent_kinetic_energy!(Le, grid, closure,
-                                                             next_velocities, previous_velocities,
-                                                             tracers, buoyancy, closure_fields,
-                                                             Δτ, slow_Gⁿe)
-
-    i, j, k = @index(Global, NTuple)
-
-    e = tracers.e
-
-    fast_Gⁿe = fast_tke_tendency(i, j, k, grid, Le, closure,
-                                 next_velocities, previous_velocities,
-                                 tracers, buoyancy, closure_fields)
-
-    σᶜᶜⁿ = σⁿ(i, j, k, grid, Center(), Center(), Center())
-    active = !inactive_cell(i, j, k, grid)
-
-    FT = eltype(grid)
-    Δτ = convert(FT, Δτ)
-
-    @inbounds begin
-        total_Gⁿ = slow_Gⁿe[i, j, k] + fast_Gⁿe * σᶜᶜⁿ
-        e[i, j, k] += Δτ * total_Gⁿ * active / σᶜᶜⁿ
     end
 end
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
@@ -25,7 +25,6 @@ function time_step_catke_equation!(model, ::QuasiAdamsBashforth2TimeStepper, Δt
 
     κe = closure_fields.κe
     Le = closure_fields.Le
-    previous_velocities = closure_fields.previous_velocities
     tracer_index = findfirst(k -> k == :e, keys(model.tracers))
     implicit_solver = model.timestepper.implicit_solver
 
@@ -94,7 +93,6 @@ function time_step_catke_equation!(model, ::SplitRungeKuttaTimeStepper, Δt)
 
     κe = closure_fields.κe
     Le = closure_fields.Le
-    previous_velocities = closure_fields.previous_velocities
     tracer_index = findfirst(k -> k == :e, keys(model.tracers))
     implicit_solver = model.timestepper.implicit_solver
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_equations.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_equations.jl
@@ -39,7 +39,6 @@ function time_step_tke_dissipation_equations!(model, Δt)
     e_index = findfirst(k -> k == :e, keys(model.tracers))
     ϵ_index = findfirst(k -> k == :ϵ, keys(model.tracers))
     implicit_solver = model.timestepper.implicit_solver
-    active_cells_map = get_active_cells_map(grid, Val(:xyz))
 
     FT = eltype(model.tracers.e)
     Δt = convert(FT, Δt)
@@ -64,8 +63,7 @@ function time_step_tke_dissipation_equations!(model, Δt)
                 compute_tke_dissipation_closure_fields!,
                 κe, κϵ,
                 grid, closure,
-                model.velocities, model.tracers, buoyancy_force(model);
-                active_cells_map)
+                model.velocities, model.tracers, buoyancy_force(model))
 
         # Compute the linear implicit component of the RHS (closure_fields, L)
         # and step forward
@@ -73,10 +71,9 @@ function time_step_tke_dissipation_equations!(model, Δt)
                 substep_tke_dissipation!,
                 Le, Lϵ,
                 grid, closure,
-                model.velocities, previous_velocities,
+                model.velocities, model.transport_velocities,
                 model.tracers, buoyancy_force(model), closure_fields,
-                Δτ, χ, Gⁿe, G⁻e, Gⁿϵ, G⁻ϵ;
-                active_cells_map)
+                Δτ, χ, Gⁿe, G⁻e, Gⁿϵ, G⁻ϵ)
 
         implicit_step!(e, implicit_solver, closure,
                        model.closure_fields, Val(e_index),
@@ -96,7 +93,7 @@ end
 
 # Compute TKE and dissipation closure_fields
 @kernel function compute_tke_dissipation_closure_fields!(κe, κϵ, grid, closure,
-                                                        velocities, tracers, buoyancy)
+                                                         velocities, tracers, buoyancy)
     i, j, k = @index(Global, NTuple)
     closure_ij = getclosure(i, j, closure)
     κe★ = κeᶜᶜᶠ(i, j, k, grid, closure_ij, velocities, tracers, buoyancy)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_equations.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_equations.jl
@@ -35,7 +35,6 @@ function time_step_tke_dissipation_equations!(model, Δt)
     κϵ = closure_fields.κϵ
     Le = closure_fields.Le
     Lϵ = closure_fields.Lϵ
-    previous_velocities = closure_fields.previous_velocities
     e_index = findfirst(k -> k == :e, keys(model.tracers))
     ϵ_index = findfirst(k -> k == :ϵ, keys(model.tracers))
     implicit_solver = model.timestepper.implicit_solver

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_vertical_diffusivity.jl
@@ -172,14 +172,13 @@ end
 ##### Diffusivities and diffusivity fields utilities
 #####
 
-struct TKEDissipationClosureFields{K, L, U, KC, LC}
+struct TKEDissipationClosureFields{K, L, KC, LC}
     κu :: K
     κc :: K
     κe :: K
     κϵ :: K
     Le :: L
     Lϵ :: L
-    previous_velocities :: U
     _tupled_tracer_diffusivities :: KC
     _tupled_implicit_linear_coefficients :: LC
 end
@@ -191,7 +190,6 @@ Adapt.adapt_structure(to, tke_dissipation_closure_fields::TKEDissipationClosureF
                                     adapt(to, tke_dissipation_closure_fields.κϵ),
                                     adapt(to, tke_dissipation_closure_fields.Le),
                                     adapt(to, tke_dissipation_closure_fields.Lϵ),
-                                    adapt(to, tke_dissipation_closure_fields.previous_velocities),
                                     adapt(to, tke_dissipation_closure_fields._tupled_tracer_diffusivities),
                                     adapt(to, tke_dissipation_closure_fields._tupled_implicit_linear_coefficients))
 
@@ -220,12 +218,6 @@ function build_closure_fields(grid, clock, tracer_names, bcs, closure::FlavorOfT
     Le = CenterField(grid)
     Lϵ = CenterField(grid)
 
-    # Note: we may be able to avoid using the "previous velocities" in favor of a "fully implicit"
-    # discretization of shear production
-    u⁻ = XFaceField(grid)
-    v⁻ = YFaceField(grid)
-    previous_velocities = (; u=u⁻, v=v⁻)
-
     # Secret tuple for getting tracer diffusivities with tuple[tracer_index]
     _tupled_tracer_diffusivities = Dict{Symbol, Any}(name => κc for name in tracer_names)
     _tupled_tracer_diffusivities[:e] = κe
@@ -240,26 +232,14 @@ function build_closure_fields(grid, clock, tracer_names, bcs, closure::FlavorOfT
                                                        for name in tracer_names)
 
     return TKEDissipationClosureFields(κu, κc, κe, κϵ, Le, Lϵ,
-                                           previous_velocities,
-                                           _ntupled_tracer_diffusivities,
-                                           _ntupled_implicit_linear_coefficients)
+                                       _ntupled_tracer_diffusivities,
+                                       _ntupled_implicit_linear_coefficients)
 end
 
 @inline viscosity_location(::FlavorOfTD) = (c, c, f)
 @inline diffusivity_location(::FlavorOfTD) = (c, c, f)
 
-function step_closure_prognostics!(closure_fields, closure::FlavorOfTD, model, Δt)
-    # Step TKE/dissipation equations with the provided timestep
-    time_step_tke_dissipation_equations!(model, Δt)
-
-    # Update previous velocities
-    u, v, w = model.velocities
-    u⁻, v⁻ = closure_fields.previous_velocities
-    parent(u⁻) .= parent(u)
-    parent(v⁻) .= parent(v)
-
-    return nothing
-end
+step_closure_prognostics!(closure_fields, closure::FlavorOfTD, model, Δt) = time_step_tke_dissipation_equations!(model, Δt)
 
 function compute_closure_fields!(closure_fields, closure::FlavorOfTD, model; parameters = :xyz)
     arch = model.architecture

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_vertical_diffusivity.jl
@@ -392,15 +392,13 @@ end
 #####
 
 function prognostic_state(cf::TKEDissipationClosureFields)
-    return (previous_velocities = prognostic_state(cf.previous_velocities),
-            κu = prognostic_state(cf.κu),
+    return (κu = prognostic_state(cf.κu),
             κc = prognostic_state(cf.κc),
             κe = prognostic_state(cf.κe),
             κϵ = prognostic_state(cf.κϵ))
 end
 
 function restore_prognostic_state!(restored::TKEDissipationClosureFields, from)
-    restore_prognostic_state!(restored.previous_velocities, from.previous_velocities)
     restore_prognostic_state!(restored.κu, from.κu)
     restore_prognostic_state!(restored.κc, from.κc)
     restore_prognostic_state!(restored.κe, from.κe)

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -1061,8 +1061,6 @@ function test_checkpointing_tke_dissipation_closure(arch, timestepper)
     @test_nowarn run!(new_simulation)
 
     # Verify previous_velocities state matches reference at iteration 10
-    ref_pv = ref_model.closure_fields.previous_velocities
-    new_pv = new_model.closure_fields.previous_velocities
     @test all(Array(interior(new_pv.u)) .≈ Array(interior(ref_pv.u)))
     @test all(Array(interior(new_pv.v)) .≈ Array(interior(ref_pv.v)))
 

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -1060,10 +1060,6 @@ function test_checkpointing_tke_dissipation_closure(arch, timestepper)
     @test_nowarn set!(new_simulation; checkpoint=:latest)
     @test_nowarn run!(new_simulation)
 
-    # Verify previous_velocities state matches reference at iteration 10
-    @test all(Array(interior(new_pv.u)) .≈ Array(interior(ref_pv.u)))
-    @test all(Array(interior(new_pv.v)) .≈ Array(interior(ref_pv.v)))
-
     # Compare final states at iteration 10
     # We need a small atol because while all prognostic fields are exactly equal, the e and ϵ
     # fields can have tiny differences due to floating-point ordering with RK3 I think.


### PR DESCRIPTION
we do not need the `previous_velocities` for CATKE and TKEBased vertical diffusivities anymore because the velocities used to advect the tracers are in themselves "previous velocities". 

Therefore, this PR removes the extra memory allocation by passing the `transport_velocities` to CATKE and TKE-based closure. 

I also removed the `active_cell_map` since it is introduced automatically when launching the kernels with `:xyz` and `:xy`

This PR also removes the substepping of TKE for RK time discretization since the derivation was done for AB2 so the interaction with RK  is not validated.