### PR TITLE
(0.107.0) Save grid per field in `JLD2Writer` to be consumed by `FieldTimeSeries`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.106.5"
+version = "0.107.0"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/docs/src/developer_docs/model_interface.md
+++ b/docs/src/developer_docs/model_interface.md
@@ -382,8 +382,7 @@ simulation = Simulation(ks_model; Δt=0.002, stop_time=60)
 simulation.output_writers[:solution] = JLD2Writer(ks_model, (; u=ks_model.solution),
                                                   filename = "ks_solution.jld2",
                                                   schedule = TimeInterval(1),
-                                                  overwrite_existing = true,
-                                                  including = [:grid])
+                                                  overwrite_existing = true)
 
 run!(simulation)
 nothing # hide

--- a/docs/src/simulations/output_writers.md
+++ b/docs/src/simulations/output_writers.md
@@ -127,13 +127,12 @@ simulation.output_writers[:things] =
                  global_attributes=global_attributes, output_attributes=output_attributes)
 ```
 
-`NetCDFWriter` can also be configured for `outputs` that are interpolated or regridded
-to a different grid than `model.grid`. To use this functionality, include the keyword argument
-`grid = output_grid`.
+`NetCDFWriter` supports outputs that live on different grids within a single writer.
+The grid is automatically extracted from each output field, and dimensions are
+suffixed (e.g., `_grid1`, `_grid2`) when multiple grids are present.
 
 ```@example
 using Oceananigans
-using Oceananigans.Fields: interpolate!
 using NCDatasets
 
 grid = RectilinearGrid(size=(1, 1, 8), extent=(1, 1, 1));
@@ -142,12 +141,11 @@ model = NonhydrostaticModel(grid)
 coarse_grid = RectilinearGrid(size=(grid.Nx, grid.Ny, grid.Nz÷2), extent=(grid.Lx, grid.Ly, grid.Lz))
 coarse_u = Field{Face, Center, Center}(coarse_grid)
 
-interpolate_u(model) = interpolate!(coarse_u, model.velocities.u)
-outputs = (; u = interpolate_u)
+# u lives on coarse_grid, w lives on model.grid — both in the same file
+outputs = (; u = coarse_u, w = model.velocities.w)
 
 output_writer = NetCDFWriter(model, outputs;
-                             grid = coarse_grid,
-                             filename = "coarse_u.nc",
+                             filename = "multi_grid.nc",
                              schedule = IterationInterval(1))
 ```
 

--- a/ext/OceananigansNCDatasetsExt/OceananigansNCDatasetsExt.jl
+++ b/ext/OceananigansNCDatasetsExt/OceananigansNCDatasetsExt.jl
@@ -27,7 +27,7 @@ using Oceananigans.Fields: set!, Reduction, reduced_dimensions, reduced_location
 using Oceananigans.Grids:
     Center, Face, Flat, Periodic, Bounded,
     AbstractGrid, RectilinearGrid, LatitudeLongitudeGrid, StaticVerticalDiscretization,
-    topology, halo_size, xspacings, yspacings, zspacings, λspacings, φspacings,
+    grid, topology, halo_size, xspacings, yspacings, zspacings, λspacings, φspacings,
     parent_index_range, nodes, ξnodes, ηnodes, rnodes, validate_index, peripheral_node,
     constructor_arguments, architecture
 using Oceananigans.ImmersedBoundaries:
@@ -73,6 +73,7 @@ import Oceananigans.OutputWriters:
     materialize_from_netcdf,
     reconstruct_grid,
     trilocation_dim_name,
+    add_grid_suffix,
     dimension_name_generator_free_surface
 
 const c = Center()

--- a/ext/OceananigansNCDatasetsExt/dimensions.jl
+++ b/ext/OceananigansNCDatasetsExt/dimensions.jl
@@ -280,7 +280,7 @@ function default_dimension_attributes(grid::RectilinearGrid, dim_name_generator;
                                            Δxᶜᵃᵃ_name => Δxᶜᵃᵃ_attrs,
                                            Δyᵃᶠᵃ_name => Δyᵃᶠᵃ_attrs,
                                            Δyᵃᶜᵃ_name => Δyᵃᶜᵃ_attrs)
-    
+
     horizontal_dimension_attributes = suffix_grid_keys(horizontal_dimension_attributes, grid_index)
     vertical_dimension_attributes   = default_vertical_dimension_attributes(grid.z, dim_name_generator; grid_index)
 
@@ -365,7 +365,7 @@ function default_dimension_attributes(grid::LatitudeLongitudeGrid, dim_name_gene
                                            Δyᶜᶠᵃ_name => Δyᶜᶠᵃ_attrs,
                                            Δyᶜᶜᵃ_name => Δyᶜᶜᵃ_attrs)
 
-    horizontal_dimension_attributes = suffix_grid_keys(horizontal_dimension_attributes, grid_index)                                       
+    horizontal_dimension_attributes = suffix_grid_keys(horizontal_dimension_attributes, grid_index)
     vertical_dimension_attributes   = default_vertical_dimension_attributes(grid.z, dim_name_generator; grid_index)
 
     return merge(base_dimension_attributes,

--- a/ext/OceananigansNCDatasetsExt/dimensions.jl
+++ b/ext/OceananigansNCDatasetsExt/dimensions.jl
@@ -31,11 +31,11 @@ Arguments:
 - `dim_names`: Tuple of dimension names to create/validate
 - `dimension_name_generator`: Function to generate dimension names
 """
-function create_field_dimensions!(ds, fd::AbstractField, dimension_name_generator; time_dependent=false, with_halos=false, array_type=Array{eltype(fd)}, dimension_type=Float64)
+function create_field_dimensions!(ds, fd::AbstractField, dimension_name_generator; time_dependent=false, with_halos=false, array_type=Array{eltype(fd)}, dimension_type=Float64, grid_index=nothing)
     # Assess and create the dimensions for the field
 
-    dimension_attributes = default_dimension_attributes(fd.grid, dimension_name_generator)
-    spatial_dim_names = field_dimensions(fd, dimension_name_generator)
+    dimension_attributes = default_dimension_attributes(grid(fd), dimension_name_generator; grid_index)
+    spatial_dim_names = field_dimensions(fd, dimension_name_generator; grid_index)
     spatial_dim_data = nodes(fd; with_halos)
 
     # Create dictionary of spatial dimensions and their data. Using OrderedDict to ensure the order of the dimensions is preserved.
@@ -97,6 +97,8 @@ function maybe_add_particle_dims!(dims, outputs)
     return dims
 end
 
+suffix_grid_keys(dims, grid_index) = Dict(add_grid_suffix(key, grid_index) => value for (key, value) in dims)
+
 function gather_vertical_dimensions(coordinate::StaticVerticalDiscretization, TZ, Nz, Hz, z_indices, with_halos, dim_name_generator)
     zᵃᵃᶠ_name = dim_name_generator("z", coordinate, nothing, nothing, f, Val(:z))
     zᵃᵃᶜ_name = dim_name_generator("z", coordinate, nothing, nothing, c, Val(:z))
@@ -108,7 +110,7 @@ function gather_vertical_dimensions(coordinate::StaticVerticalDiscretization, TZ
                 zᵃᵃᶜ_name => zᵃᵃᶜ_data)
 end
 
-function gather_dimensions(outputs, grid::RectilinearGrid, indices, with_halos, dim_name_generator)
+function gather_dimensions(outputs, grid::RectilinearGrid, indices, with_halos, dim_name_generator; grid_index=nothing)
     TX, TY, TZ = topology(grid)
     Nx, Ny, Nz = size(grid)
     Hx, Hy, Hz = halo_size(grid)
@@ -144,10 +146,10 @@ function gather_dimensions(outputs, grid::RectilinearGrid, indices, with_halos, 
 
     maybe_add_particle_dims!(dims, outputs)
 
-    return dims
+    return suffix_grid_keys(dims, grid_index)
 end
 
-function gather_dimensions(outputs, grid::LatitudeLongitudeGrid, indices, with_halos, dim_name_generator)
+function gather_dimensions(outputs, grid::LatitudeLongitudeGrid, indices, with_halos, dim_name_generator; grid_index=nothing)
     TΛ, TΦ, TZ = topology(grid)
     Nλ, Nφ, Nz = size(grid)
     Hλ, Hφ, Hz = halo_size(grid)
@@ -183,17 +185,17 @@ function gather_dimensions(outputs, grid::LatitudeLongitudeGrid, indices, with_h
 
     maybe_add_particle_dims!(dims, outputs)
 
-    return dims
+    return suffix_grid_keys(dims, grid_index)
 end
 
-gather_dimensions(outputs, grid::ImmersedBoundaryGrid, args...) =
-    gather_dimensions(outputs, grid.underlying_grid, args...)
+gather_dimensions(outputs, grid::ImmersedBoundaryGrid, args...; kw...) =
+    gather_dimensions(outputs, grid.underlying_grid, args...; kw...)
 
 #####
 ##### Mapping outputs/fields to dimensions
 #####
 
-function field_dimensions(fd::AbstractField, grid::RectilinearGrid, dim_name_generator)
+function field_dimensions(fd::AbstractField, grid::RectilinearGrid, dim_name_generator; grid_index=nothing)
     LX, LY, LZ = location(fd)
     TX, TY, TZ = topology(grid)
 
@@ -201,10 +203,10 @@ function field_dimensions(fd::AbstractField, grid::RectilinearGrid, dim_name_gen
     y_dim_name = LY == Nothing ? "" : dim_name_generator("y", grid, nothing, LY(), nothing, Val(:y))
     z_dim_name = LZ == Nothing ? "" : dim_name_generator("z", grid, nothing, nothing, LZ(), Val(:z))
 
-    return tuple(x_dim_name, y_dim_name, z_dim_name)
+    return Tuple(add_grid_suffix(dim_name, grid_index) for dim_name in (x_dim_name, y_dim_name, z_dim_name))
 end
 
-function field_dimensions(fd::AbstractField, grid::LatitudeLongitudeGrid, dim_name_generator)
+function field_dimensions(fd::AbstractField, grid::LatitudeLongitudeGrid, dim_name_generator; grid_index=nothing)
     LΛ, LΦ, LZ = location(fd)
     TΛ, TΦ, TZ = topology(grid)
 
@@ -212,14 +214,14 @@ function field_dimensions(fd::AbstractField, grid::LatitudeLongitudeGrid, dim_na
     φ_dim_name = LΦ == Nothing ? "" : dim_name_generator("φ", grid, nothing, LΦ(), nothing, Val(:y))
     z_dim_name = LZ == Nothing ? "" : dim_name_generator("z", grid, nothing, nothing, LZ(), Val(:z))
 
-    return tuple(λ_dim_name, φ_dim_name, z_dim_name)
+    return Tuple(add_grid_suffix(dim_name, grid_index) for dim_name in (λ_dim_name, φ_dim_name, z_dim_name))
 end
 
-field_dimensions(fd::AbstractField, grid::ImmersedBoundaryGrid, dim_name_generator) =
-    field_dimensions(fd, grid.underlying_grid, dim_name_generator)
+field_dimensions(fd::AbstractField, grid::ImmersedBoundaryGrid, dim_name_generator; kw...) =
+    field_dimensions(fd, grid.underlying_grid, dim_name_generator; kw...)
 
-field_dimensions(fd::AbstractField, dim_name_generator) =
-    field_dimensions(fd, fd.grid, dim_name_generator)
+field_dimensions(fd::AbstractField, dim_name_generator; kw...) =
+    field_dimensions(fd, grid(fd), dim_name_generator; kw...)
 
 #####
 ##### Dimension attributes
@@ -228,7 +230,7 @@ field_dimensions(fd::AbstractField, dim_name_generator) =
 const base_dimension_attributes = Dict("time"        => Dict("long_name" => "Time", "units" => "s"),
                                        "particle_id" => Dict("long_name" => "Particle ID"))
 
-function default_vertical_dimension_attributes(coordinate::StaticVerticalDiscretization, dim_name_generator)
+function default_vertical_dimension_attributes(coordinate::StaticVerticalDiscretization, dim_name_generator; grid_index=nothing)
     zᵃᵃᶠ_name = dim_name_generator("z", coordinate, nothing, nothing, f, Val(:z))
     zᵃᵃᶜ_name = dim_name_generator("z", coordinate, nothing, nothing, c, Val(:z))
 
@@ -241,13 +243,15 @@ function default_vertical_dimension_attributes(coordinate::StaticVerticalDiscret
     Δzᵃᵃᶠ_attrs = Dict("long_name" => "Spacings between cell centers (located at cell faces) in the z-direction.", "units" => "m")
     Δzᵃᵃᶜ_attrs = Dict("long_name" => "Spacings between cell faces (located at cell centers) in the z-direction.", "units" => "m")
 
-    return Dict(zᵃᵃᶠ_name => zᵃᵃᶠ_attrs,
-                zᵃᵃᶜ_name => zᵃᵃᶜ_attrs,
-                Δzᵃᵃᶠ_name => Δzᵃᵃᶠ_attrs,
-                Δzᵃᵃᶜ_name => Δzᵃᵃᶜ_attrs)
+    vertical_dimension_attributes = Dict(zᵃᵃᶠ_name  => zᵃᵃᶠ_attrs,
+                                         zᵃᵃᶜ_name  => zᵃᵃᶜ_attrs,
+                                         Δzᵃᵃᶠ_name => Δzᵃᵃᶠ_attrs,
+                                         Δzᵃᵃᶜ_name => Δzᵃᵃᶜ_attrs)
+
+    return suffix_grid_keys(vertical_dimension_attributes, grid_index)
 end
 
-function default_dimension_attributes(grid::RectilinearGrid, dim_name_generator)
+function default_dimension_attributes(grid::RectilinearGrid, dim_name_generator; grid_index=nothing)
     xᶠᵃᵃ_name = dim_name_generator("x", grid, f, nothing, nothing, Val(:x))
     xᶜᵃᵃ_name = dim_name_generator("x", grid, c, nothing, nothing, Val(:x))
     yᵃᶠᵃ_name = dim_name_generator("y", grid, nothing, f, nothing, Val(:y))
@@ -276,15 +280,16 @@ function default_dimension_attributes(grid::RectilinearGrid, dim_name_generator)
                                            Δxᶜᵃᵃ_name => Δxᶜᵃᵃ_attrs,
                                            Δyᵃᶠᵃ_name => Δyᵃᶠᵃ_attrs,
                                            Δyᵃᶜᵃ_name => Δyᵃᶜᵃ_attrs)
-
-    vertical_dimension_attributes = default_vertical_dimension_attributes(grid.z, dim_name_generator)
+    
+    horizontal_dimension_attributes = suffix_grid_keys(horizontal_dimension_attributes, grid_index)
+    vertical_dimension_attributes   = default_vertical_dimension_attributes(grid.z, dim_name_generator; grid_index)
 
     return merge(base_dimension_attributes,
                  horizontal_dimension_attributes,
                  vertical_dimension_attributes)
 end
 
-function default_dimension_attributes(grid::LatitudeLongitudeGrid, dim_name_generator)
+function default_dimension_attributes(grid::LatitudeLongitudeGrid, dim_name_generator; grid_index=nothing)
     λᶠᵃᵃ_name = dim_name_generator("λ", grid, f, nothing, nothing, Val(:x))
     λᶜᵃᵃ_name = dim_name_generator("λ", grid, c, nothing, nothing, Val(:x))
 
@@ -360,12 +365,13 @@ function default_dimension_attributes(grid::LatitudeLongitudeGrid, dim_name_gene
                                            Δyᶜᶠᵃ_name => Δyᶜᶠᵃ_attrs,
                                            Δyᶜᶜᵃ_name => Δyᶜᶜᵃ_attrs)
 
-    vertical_dimension_attributes = default_vertical_dimension_attributes(grid.z, dim_name_generator)
+    horizontal_dimension_attributes = suffix_grid_keys(horizontal_dimension_attributes, grid_index)                                       
+    vertical_dimension_attributes   = default_vertical_dimension_attributes(grid.z, dim_name_generator; grid_index)
 
     return merge(base_dimension_attributes,
                  horizontal_dimension_attributes,
                  vertical_dimension_attributes)
 end
 
-default_dimension_attributes(grid::ImmersedBoundaryGrid, dim_name_generator) =
-    default_dimension_attributes(grid.underlying_grid, dim_name_generator)
+default_dimension_attributes(grid::ImmersedBoundaryGrid, dim_name_generator; kw...) =
+    default_dimension_attributes(grid.underlying_grid, dim_name_generator; kw...)

--- a/ext/OceananigansNCDatasetsExt/grid_reconstruction.jl
+++ b/ext/OceananigansNCDatasetsExt/grid_reconstruction.jl
@@ -253,7 +253,7 @@ function netcdf_grid_constructor_info(grid::ImmersedBoundaryGrid)
 end
 
 function write_immersed_boundary_data!(ds, grid::ImmersedBoundaryGrid, immersed_grid_args, prefix)
-    group_name = "$(prefix)_immersed_grid_reconstruction_args"
+    group_name = "$(prefix)immersed_grid_reconstruction_args"
     if (grid.immersed_boundary isa GridFittedBottom) || (grid.immersed_boundary isa PartialCellBottom)
         bottom_height = pop!(immersed_grid_args, :bottom_height)
         ibg_group = defGroup(ds, group_name; attrib=convert_for_netcdf(immersed_grid_args))
@@ -270,14 +270,17 @@ end
 
 write_immersed_boundary_data!(ds, grid, immersed_grid_args, prefix) = nothing
 
+# When grid_index is nothing (single grid), use unprefixed group names
+# for backward compatibility with the legacy format.
+# When grid_index is an integer (multi-grid), prefix groups with "grid_N_".
 function write_grid_reconstruction_data!(ds, grid, grid_index; array_type=Array{eltype(grid)}, deflatelevel=0)
     underlying_grid_args, underlying_grid_kwargs, immersed_grid_args, grid_metadata = netcdf_grid_constructor_info(grid)
     underlying_grid_args, underlying_grid_kwargs, grid_metadata = map(convert_for_netcdf, (underlying_grid_args, underlying_grid_kwargs, grid_metadata))
 
-    prefix = "grid_$(grid_index)"
-    defGroup(ds, "$(prefix)_underlying_grid_reconstruction_args"; attrib = underlying_grid_args)
-    defGroup(ds, "$(prefix)_underlying_grid_reconstruction_kwargs"; attrib = underlying_grid_kwargs)
-    defGroup(ds, "$(prefix)_grid_reconstruction_metadata"; attrib = grid_metadata)
+    prefix = isnothing(grid_index) ? "" : "grid_$(grid_index)_"
+    defGroup(ds, "$(prefix)underlying_grid_reconstruction_args"; attrib = underlying_grid_args)
+    defGroup(ds, "$(prefix)underlying_grid_reconstruction_kwargs"; attrib = underlying_grid_kwargs)
+    defGroup(ds, "$(prefix)grid_reconstruction_metadata"; attrib = grid_metadata)
 
     write_immersed_boundary_data!(ds, grid, immersed_grid_args, prefix)
 
@@ -292,20 +295,20 @@ function reconstruct_grid(filename::String; grid_index=1, architecture=nothing)
 end
 
 function reconstruct_immersed_boundary(ds, ::Val{:GridFittedBoundary}, prefix)
-    ibg_group = ds.group["$(prefix)_immersed_grid_reconstruction_args"]
+    ibg_group = ds.group["$(prefix)immersed_grid_reconstruction_args"]
     mask = Array(ibg_group["mask"])
     return GridFittedBoundary(mask)
 end
 
 function reconstruct_immersed_boundary(ds, ::Val{:GridFittedBottom}, prefix)
-    ibg_group = ds.group["$(prefix)_immersed_grid_reconstruction_args"]
+    ibg_group = ds.group["$(prefix)immersed_grid_reconstruction_args"]
     bottom_height = Array(ibg_group["bottom_height"])
     immersed_condition = ibg_group.attrib["immersed_condition"] |> materialize_from_netcdf
     return GridFittedBottom(bottom_height, immersed_condition)
 end
 
 function reconstruct_immersed_boundary(ds, ::Val{:PartialCellBottom}, prefix)
-    ibg_group = ds.group["$(prefix)_immersed_grid_reconstruction_args"]
+    ibg_group = ds.group["$(prefix)immersed_grid_reconstruction_args"]
     bottom_height = Array(ibg_group["bottom_height"])
     minimum_fractional_cell_height = ibg_group.attrib["minimum_fractional_cell_height"] |> materialize_from_netcdf
     return PartialCellBottom(bottom_height, minimum_fractional_cell_height)
@@ -314,23 +317,25 @@ end
 reconstruct_immersed_boundary(ds, immersed_boundary_type, prefix) = error("Unsupported immersed boundary type: $immersed_boundary_type")
 
 function reconstruct_immersed_boundary(ds, prefix)
-    grid_reconstruction_metadata = ds.group["$(prefix)_grid_reconstruction_metadata"].attrib
+    grid_reconstruction_metadata = ds.group["$(prefix)grid_reconstruction_metadata"].attrib
     immersed_boundary_type = grid_reconstruction_metadata[:immersed_boundary_type]
     immersed_boundary = reconstruct_immersed_boundary(ds, Val(Symbol(immersed_boundary_type)), prefix)
     return immersed_boundary
 end
 
 function reconstruct_grid(ds; grid_index=1, architecture=nothing)
-    prefix = "grid_$(grid_index)"
+    # Try prefixed format (multi-grid) first, fall back to unprefixed format (single-grid / legacy)
+    prefixed_key = "grid_$(grid_index)_underlying_grid_reconstruction_args"
+    prefix = haskey(ds.group, prefixed_key) ? "grid_$(grid_index)_" : ""
 
     # Read back the grid reconstruction metadata
-    underlying_grid_reconstruction_args   = ds.group["$(prefix)_underlying_grid_reconstruction_args"].attrib |> Dict
+    underlying_grid_reconstruction_args   = ds.group["$(prefix)underlying_grid_reconstruction_args"].attrib |> Dict
     if !isnothing(architecture) # If architecture is specified, force it into the underlying grid reconstruction arguments before materializing
         underlying_grid_reconstruction_args["architecture"] = architecture
     end
     underlying_grid_reconstruction_args   = underlying_grid_reconstruction_args |> materialize_from_netcdf
-    underlying_grid_reconstruction_kwargs = ds.group["$(prefix)_underlying_grid_reconstruction_kwargs"].attrib |> materialize_from_netcdf
-    grid_reconstruction_metadata          = ds.group["$(prefix)_grid_reconstruction_metadata"].attrib |> materialize_from_netcdf
+    underlying_grid_reconstruction_kwargs = ds.group["$(prefix)underlying_grid_reconstruction_kwargs"].attrib |> materialize_from_netcdf
+    grid_reconstruction_metadata          = ds.group["$(prefix)grid_reconstruction_metadata"].attrib |> materialize_from_netcdf
 
     # Pop out information about the underlying grid
     underlying_grid_type = grid_reconstruction_metadata[:underlying_grid_type]

--- a/ext/OceananigansNCDatasetsExt/grid_reconstruction.jl
+++ b/ext/OceananigansNCDatasetsExt/grid_reconstruction.jl
@@ -191,32 +191,36 @@ Gather the construction parameters for the immersed boundary of the grid. This i
 strictly necessary for grid reconstruction, but it is implemented and used a quality of life improvement
 since it gives users easy access to relevant immersed boundary parameters when opening the NetCDF file.
 """
-function gather_immersed_boundary(grid::PCBorGFBIBG, indices, dim_name_generator)
+function gather_immersed_boundary(grid::PCBorGFBIBG, indices, dim_name_generator; grid_index=nothing)
     op_peripheral_nodes_ccc = KernelFunctionOperation{Center, Center, Center}(peripheral_node, grid, Center(), Center(), Center())
     op_peripheral_nodes_fcc = KernelFunctionOperation{Face, Center, Center}(peripheral_node, grid, Face(), Center(), Center())
     op_peripheral_nodes_cfc = KernelFunctionOperation{Center, Face, Center}(peripheral_node, grid, Center(), Face(), Center())
     op_peripheral_nodes_ccf = KernelFunctionOperation{Center, Center, Face}(peripheral_node, grid, Center(), Center(), Face())
 
-    return Dict("bottom_height" => Field(grid.immersed_boundary.bottom_height; indices),
-                "peripheral_nodes_ccc" => Field(op_peripheral_nodes_ccc; indices),
-                "peripheral_nodes_fcc" => Field(op_peripheral_nodes_fcc; indices),
-                "peripheral_nodes_cfc" => Field(op_peripheral_nodes_cfc; indices),
-                "peripheral_nodes_ccf" => Field(op_peripheral_nodes_ccf; indices))
+    ib_vars = Dict("bottom_height" => Field(grid.immersed_boundary.bottom_height; indices),
+                   "peripheral_nodes_ccc" => Field(op_peripheral_nodes_ccc; indices),
+                   "peripheral_nodes_fcc" => Field(op_peripheral_nodes_fcc; indices),
+                   "peripheral_nodes_cfc" => Field(op_peripheral_nodes_cfc; indices),
+                   "peripheral_nodes_ccf" => Field(op_peripheral_nodes_ccf; indices))
+
+    return suffix_grid_keys(ib_vars, grid_index)
 end
 
 const GFBoundaryIBG = ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:GridFittedBoundary}
 
-function gather_immersed_boundary(grid::GFBoundaryIBG, indices, dim_name_generator)
+function gather_immersed_boundary(grid::GFBoundaryIBG, indices, dim_name_generator; grid_index=nothing)
     op_peripheral_nodes_ccc = KernelFunctionOperation{Center, Center, Center}(peripheral_node, grid, Center(), Center(), Center())
     op_peripheral_nodes_fcc = KernelFunctionOperation{Face, Center, Center}(peripheral_node, grid, Face(), Center(), Center())
     op_peripheral_nodes_cfc = KernelFunctionOperation{Center, Face, Center}(peripheral_node, grid, Center(), Face(), Center())
     op_peripheral_nodes_ccf = KernelFunctionOperation{Center, Center, Face}(peripheral_node, grid, Center(), Center(), Face())
 
-    return Dict("mask" => Field(grid.immersed_boundary.mask; indices),
-                "peripheral_nodes_ccc" => Field(op_peripheral_nodes_ccc; indices),
-                "peripheral_nodes_fcc" => Field(op_peripheral_nodes_fcc; indices),
-                "peripheral_nodes_cfc" => Field(op_peripheral_nodes_cfc; indices),
-                "peripheral_nodes_ccf" => Field(op_peripheral_nodes_ccf; indices))
+    ib_vars = Dict("mask" => Field(grid.immersed_boundary.mask; indices),
+                   "peripheral_nodes_ccc" => Field(op_peripheral_nodes_ccc; indices),
+                   "peripheral_nodes_fcc" => Field(op_peripheral_nodes_fcc; indices),
+                   "peripheral_nodes_cfc" => Field(op_peripheral_nodes_cfc; indices),
+                   "peripheral_nodes_ccf" => Field(op_peripheral_nodes_ccf; indices))
+
+    return suffix_grid_keys(ib_vars, grid_index)
 end
 
 

--- a/ext/OceananigansNCDatasetsExt/grid_reconstruction.jl
+++ b/ext/OceananigansNCDatasetsExt/grid_reconstruction.jl
@@ -61,7 +61,7 @@ Gather the grid metrics for the grid. Not strictly necessary for grid reconstruc
 implemented and used as a quality of life improvement since it gives users easy access to relevant grid
 metrics when opening the NetCDF file.
 """
-function gather_grid_metrics(grid::RectilinearGrid, indices, dim_name_generator)
+function gather_grid_metrics(grid::RectilinearGrid, indices, dim_name_generator; grid_index=nothing)
     TX, TY, TZ = topology(grid)
 
     metrics = Dict()
@@ -99,10 +99,10 @@ function gather_grid_metrics(grid::RectilinearGrid, indices, dim_name_generator)
         metrics[Δzᵃᵃᶜ_name] = Δzᵃᵃᶜ_field
     end
 
-    return metrics
+    return suffix_grid_keys(metrics, grid_index)
 end
 
-function gather_grid_metrics(grid::LatitudeLongitudeGrid, indices, dim_name_generator)
+function gather_grid_metrics(grid::LatitudeLongitudeGrid, indices, dim_name_generator; grid_index=nothing)
     TΛ, TΦ, TZ = topology(grid)
 
     metrics = Dict()
@@ -170,14 +170,14 @@ function gather_grid_metrics(grid::LatitudeLongitudeGrid, indices, dim_name_gene
         metrics[Δzᵃᵃᶜ_name] = Δzᵃᵃᶜ_field
     end
 
-    return metrics
+    return suffix_grid_keys(metrics, grid_index)
 end
 
 #####
 ##### Gathering of immersed boundary fields
 #####
 
-gather_grid_metrics(grid::ImmersedBoundaryGrid, args...) = gather_grid_metrics(grid.underlying_grid, args...)
+gather_grid_metrics(grid::ImmersedBoundaryGrid, args...; kw...) = gather_grid_metrics(grid.underlying_grid, args...; kw...)
 
 # TODO: Proper masks for 2D models?
 flat_loc(T, L) = T == Flat ? nothing : L
@@ -248,8 +248,8 @@ function netcdf_grid_constructor_info(grid::ImmersedBoundaryGrid)
     return underlying_grid_args, underlying_grid_kwargs, immersed_grid_args, grid_metadata
 end
 
-function write_immersed_boundary_data!(ds, grid::ImmersedBoundaryGrid, immersed_grid_args)
-    group_name = "immersed_grid_reconstruction_args"
+function write_immersed_boundary_data!(ds, grid::ImmersedBoundaryGrid, immersed_grid_args, prefix)
+    group_name = "$(prefix)_immersed_grid_reconstruction_args"
     if (grid.immersed_boundary isa GridFittedBottom) || (grid.immersed_boundary isa PartialCellBottom)
         bottom_height = pop!(immersed_grid_args, :bottom_height)
         ibg_group = defGroup(ds, group_name; attrib=convert_for_netcdf(immersed_grid_args))
@@ -264,68 +264,71 @@ function write_immersed_boundary_data!(ds, grid::ImmersedBoundaryGrid, immersed_
     return ds
 end
 
-write_immersed_boundary_data!(ds, grid, immersed_grid_args) = nothing
+write_immersed_boundary_data!(ds, grid, immersed_grid_args, prefix) = nothing
 
-function write_grid_reconstruction_data!(ds, grid; array_type=Array{eltype(grid)}, deflatelevel=0)
+function write_grid_reconstruction_data!(ds, grid, grid_index; array_type=Array{eltype(grid)}, deflatelevel=0)
     underlying_grid_args, underlying_grid_kwargs, immersed_grid_args, grid_metadata = netcdf_grid_constructor_info(grid)
     underlying_grid_args, underlying_grid_kwargs, grid_metadata = map(convert_for_netcdf, (underlying_grid_args, underlying_grid_kwargs, grid_metadata))
 
-    defGroup(ds, "underlying_grid_reconstruction_args"; attrib = underlying_grid_args)
-    defGroup(ds, "underlying_grid_reconstruction_kwargs"; attrib = underlying_grid_kwargs)
-    defGroup(ds, "grid_reconstruction_metadata"; attrib = grid_metadata)
+    prefix = "grid_$(grid_index)"
+    defGroup(ds, "$(prefix)_underlying_grid_reconstruction_args"; attrib = underlying_grid_args)
+    defGroup(ds, "$(prefix)_underlying_grid_reconstruction_kwargs"; attrib = underlying_grid_kwargs)
+    defGroup(ds, "$(prefix)_grid_reconstruction_metadata"; attrib = grid_metadata)
 
-    write_immersed_boundary_data!(ds, grid, immersed_grid_args)
+    write_immersed_boundary_data!(ds, grid, immersed_grid_args, prefix)
 
     return ds
 end
 
-function reconstruct_grid(filename::String)
+function reconstruct_grid(filename::String; grid_index=1, architecture=nothing)
     ds = NCDataset(filename, "r")
-    grid = reconstruct_grid(ds)
+    grid = reconstruct_grid(ds; grid_index, architecture)
     close(ds)
     return grid
 end
 
-function reconstruct_immersed_boundary(ds, ::Val{:GridFittedBoundary})
-    ibg_group = ds.group["immersed_grid_reconstruction_args"]
+function reconstruct_immersed_boundary(ds, ::Val{:GridFittedBoundary}, prefix)
+    ibg_group = ds.group["$(prefix)_immersed_grid_reconstruction_args"]
     mask = Array(ibg_group["mask"])
     return GridFittedBoundary(mask)
 end
 
-function reconstruct_immersed_boundary(ds, ::Val{:GridFittedBottom})
-    ibg_group = ds.group["immersed_grid_reconstruction_args"]
+function reconstruct_immersed_boundary(ds, ::Val{:GridFittedBottom}, prefix)
+    ibg_group = ds.group["$(prefix)_immersed_grid_reconstruction_args"]
     bottom_height = Array(ibg_group["bottom_height"])
     immersed_condition = ibg_group.attrib["immersed_condition"] |> materialize_from_netcdf
     return GridFittedBottom(bottom_height, immersed_condition)
 end
 
-function reconstruct_immersed_boundary(ds, ::Val{:PartialCellBottom})
-    ibg_group = ds.group["immersed_grid_reconstruction_args"]
+function reconstruct_immersed_boundary(ds, ::Val{:PartialCellBottom}, prefix)
+    ibg_group = ds.group["$(prefix)_immersed_grid_reconstruction_args"]
     bottom_height = Array(ibg_group["bottom_height"])
     minimum_fractional_cell_height = ibg_group.attrib["minimum_fractional_cell_height"] |> materialize_from_netcdf
     return PartialCellBottom(bottom_height, minimum_fractional_cell_height)
 end
 
-reconstruct_immersed_boundary(ds, immersed_boundary_type) = error("Unsupported immersed boundary type: $immersed_boundary_type")
+reconstruct_immersed_boundary(ds, immersed_boundary_type, prefix) = error("Unsupported immersed boundary type: $immersed_boundary_type")
 
-function reconstruct_immersed_boundary(ds)
-    grid_reconstruction_metadata = ds.group["grid_reconstruction_metadata"].attrib
+function reconstruct_immersed_boundary(ds, prefix)
+    grid_reconstruction_metadata = ds.group["$(prefix)_grid_reconstruction_metadata"].attrib
     immersed_boundary_type = grid_reconstruction_metadata[:immersed_boundary_type]
-    immersed_boundary = reconstruct_immersed_boundary(ds, Val(Symbol(immersed_boundary_type)))
+    immersed_boundary = reconstruct_immersed_boundary(ds, Val(Symbol(immersed_boundary_type)), prefix)
     return immersed_boundary
 end
 
-function reconstruct_grid(ds; architecture=nothing)
+function reconstruct_grid(ds; grid_index=1, architecture=nothing)
+    prefix = "grid_$(grid_index)"
+
     # Read back the grid reconstruction metadata
-    underlying_grid_reconstruction_args   = ds.group["underlying_grid_reconstruction_args"].attrib |> Dict
+    underlying_grid_reconstruction_args   = ds.group["$(prefix)_underlying_grid_reconstruction_args"].attrib |> Dict
     if !isnothing(architecture) # If architecture is specified, force it into the underlying grid reconstruction arguments before materializing
         underlying_grid_reconstruction_args["architecture"] = architecture
     end
     underlying_grid_reconstruction_args   = underlying_grid_reconstruction_args |> materialize_from_netcdf
-    underlying_grid_reconstruction_kwargs = ds.group["underlying_grid_reconstruction_kwargs"].attrib |> materialize_from_netcdf
-    grid_reconstruction_metadata          = ds.group["grid_reconstruction_metadata"].attrib |> materialize_from_netcdf
+    underlying_grid_reconstruction_kwargs = ds.group["$(prefix)_underlying_grid_reconstruction_kwargs"].attrib |> materialize_from_netcdf
+    grid_reconstruction_metadata          = ds.group["$(prefix)_grid_reconstruction_metadata"].attrib |> materialize_from_netcdf
 
-    # Pop out infomration about the underlying grid
+    # Pop out information about the underlying grid
     underlying_grid_type = grid_reconstruction_metadata[:underlying_grid_type]
     underlying_grid = underlying_grid_type(values(underlying_grid_reconstruction_args)...; underlying_grid_reconstruction_kwargs...)
 
@@ -333,7 +336,7 @@ function reconstruct_grid(ds; architecture=nothing)
     if isnothing(grid_reconstruction_metadata[:immersed_boundary_type])
         grid = underlying_grid
     else
-        immersed_boundary = reconstruct_immersed_boundary(ds)
+        immersed_boundary = reconstruct_immersed_boundary(ds, prefix)
         immersed_boundary = on_architecture(Architectures.architecture(underlying_grid), immersed_boundary)
         grid = ImmersedBoundaryGrid(underlying_grid, immersed_boundary)
     end

--- a/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
+++ b/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
@@ -213,10 +213,14 @@ function initialize_nc_file(model,
     # Open the NetCDF dataset file
     dataset = NCDataset(filepath, mode, attrib=sort(collect(pairs(global_attributes)), by=first))
 
+    # Only suffix dimension names when there are multiple grids;
+    # for a single grid, use nothing so add_grid_suffix is a no-op.
+    dim_grid_suffix(idx) = length(grids) == 1 ? nothing : idx
+
     # Merge default dimension attributes from all unique grids
     all_dim_attributes = Dict()
     for (grid_index, grid) in enumerate(grids)
-        merge!(all_dim_attributes, default_dimension_attributes(grid, dimension_name_generator; grid_index))
+        merge!(all_dim_attributes, default_dimension_attributes(grid, dimension_name_generator; grid_index=dim_grid_suffix(grid_index)))
     end
     output_attributes = merge(all_dim_attributes, default_output_attributes(model), output_attributes)
 
@@ -231,26 +235,27 @@ function initialize_nc_file(model,
 
         # Per-grid: dimensions, reconstruction data, metrics, immersed boundary
         time_independent_vars = Dict()
-        time_independent_grid_map = Dict{String, Int}()
+        time_independent_grid_map = Dict{String, Any}()
 
         for (grid_index, grid) in enumerate(grids)
-            dims = gather_dimensions(outputs, grid, indices, with_halos, dimension_name_generator; grid_index)
+            suffix = dim_grid_suffix(grid_index)
+            dims = gather_dimensions(outputs, grid, indices, with_halos, dimension_name_generator; grid_index=suffix)
             create_spatial_dimensions!(dataset, dims, output_attributes; deflatelevel=1, dimension_type)
 
             write_grid_reconstruction_data!(dataset, grid, grid_index; array_type, deflatelevel)
 
             if include_grid_metrics
-                metrics = gather_grid_metrics(grid, indices, dimension_name_generator; grid_index)
+                metrics = gather_grid_metrics(grid, indices, dimension_name_generator; grid_index=suffix)
                 for name in keys(metrics)
-                    time_independent_grid_map[name] = grid_index
+                    time_independent_grid_map[name] = suffix
                 end
                 merge!(time_independent_vars, metrics)
             end
 
             if grid isa ImmersedBoundaryGrid
-                ib_vars = gather_immersed_boundary(grid, indices, dimension_name_generator; grid_index)
+                ib_vars = gather_immersed_boundary(grid, indices, dimension_name_generator; grid_index=suffix)
                 for name in keys(ib_vars)
-                    time_independent_grid_map[name] = grid_index
+                    time_independent_grid_map[name] = suffix
                 end
                 merge!(time_independent_vars, ib_vars)
             end
@@ -283,9 +288,9 @@ function initialize_nc_file(model,
         end
 
         for (output_name, output) in sort(collect(pairs(outputs)), by=first)
-            grid_index = output_grid_map[output_name]
+            grid_index = dim_grid_suffix(output_grid_map[output_name])
             attrib = haskey(output_attributes, output_name) ? output_attributes[output_name] : Dict()
-            attrib = merge(attrib, Dict("grid_index" => grid_index))
+            attrib = merge(attrib, Dict("grid_index" => output_grid_map[output_name]))
             materialized = materialize_output(output, model)
 
             define_output_variable!(model,

--- a/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
+++ b/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
@@ -23,11 +23,12 @@ function defVar(ds::AbstractDataset, field_name, fd::AbstractField;
                 with_halos=false,
                 dimension_name_generator = trilocation_dim_name,
                 dimension_type=Float64,
+                grid_index=nothing,
                 write_data=true,
                 kwargs...)
 
     # effective_dim_names are the dimensions that will be used to write the field data (excludes reduced and dimensions where location is Nothing)
-    effective_dim_names = create_field_dimensions!(ds, fd, dimension_name_generator; time_dependent, with_halos, array_type, dimension_type)
+    effective_dim_names = create_field_dimensions!(ds, fd, dimension_name_generator; time_dependent, with_halos, array_type, dimension_type, grid_index)
 
     # Add location to attributes
     if :attrib ∈ keys(kwargs)
@@ -68,7 +69,6 @@ end
 function NetCDFWriter(model::AbstractModel, outputs;
                       filename,
                       schedule,
-                      grid = model.grid,
                       dir = ".",
                       array_type = Array{Float32},
                       indices = (:, :, :),
@@ -116,6 +116,11 @@ function NetCDFWriter(model::AbstractModel, outputs;
 
     outputs = Dict(string(name) => construct_output(outputs[name], indices, with_halos) for name in keys(outputs))
 
+    # Extract grids from outputs, falling back to model grid for non-field outputs
+    output_grids = Dict(name => (try grid(output) catch; grid(model) end) for (name, output) in outputs)
+    unique_grids = Tuple(unique(objectid, collect(values(output_grids))))
+    output_grid_map = Dict(name => findfirst(gr -> gr === output_grids[name], unique_grids) for name in keys(outputs))
+
     output_attributes = dictify(output_attributes)
     global_attributes = dictify(global_attributes)
     dimensions = dictify(dimensions)
@@ -124,7 +129,8 @@ function NetCDFWriter(model::AbstractModel, outputs;
     global_attributes = Dict{Any, Any}(global_attributes)
 
     dataset, outputs, schedule = initialize_nc_file(model,
-                                                    grid,
+                                                    unique_grids,
+                                                    output_grid_map,
                                                     filepath,
                                                     outputs,
                                                     schedule,
@@ -140,7 +146,8 @@ function NetCDFWriter(model::AbstractModel, outputs;
                                                     dimension_name_generator,
                                                     dimension_type)
 
-    return NetCDFWriter(grid,
+    return NetCDFWriter(unique_grids,
+                        output_grid_map,
                         filepath,
                         dataset,
                         outputs,
@@ -166,7 +173,8 @@ end
 #####
 
 function initialize_nc_file(model,
-                            grid,
+                            grids,
+                            output_grid_map,
                             filepath,
                             outputs,
                             schedule,
@@ -202,44 +210,55 @@ function initialize_nc_file(model,
     # schedule::AveragedTimeInterval
     schedule, outputs = time_average_outputs(schedule, outputs, model)
 
-    dims = gather_dimensions(outputs, grid, indices, with_halos, dimension_name_generator)
-
     # Open the NetCDF dataset file
     dataset = NCDataset(filepath, mode, attrib=sort(collect(pairs(global_attributes)), by=first))
 
-    # Merge the default with any user-supplied output attributes, ensuring the user-supplied ones
-    # can overwrite the defaults.
-    output_attributes = merge(default_dimension_attributes(grid, dimension_name_generator),
-                              default_output_attributes(model),
-                              output_attributes)
+    # Merge default dimension attributes from all unique grids
+    all_dim_attributes = Dict()
+    for (grid_index, grid) in enumerate(grids)
+        merge!(all_dim_attributes, default_dimension_attributes(grid, dimension_name_generator; grid_index))
+    end
+    output_attributes = merge(all_dim_attributes, default_output_attributes(model), output_attributes)
 
     # Define variables for each dimension and attributes if this is a new file.
     if mode == "c"
-        # This metadata is to support `FieldTimeSeries`.
-        write_grid_reconstruction_data!(dataset, grid; array_type, deflatelevel)
-
         # DateTime and TimeDate are both <: AbstractTime
         time_attrib = model.clock.time isa AbstractTime ?
             Dict("long_name" => "Time", "units" => "seconds since 2000-01-01 00:00:00") :
             Dict("long_name" => "Time", "units" => "seconds")
 
         create_time_dimension!(dataset, attrib=time_attrib, dimension_type=dimension_type)
-        create_spatial_dimensions!(dataset, dims, output_attributes; deflatelevel=1, dimension_type=dimension_type)
 
+        # Per-grid: dimensions, reconstruction data, metrics, immersed boundary
         time_independent_vars = Dict()
+        time_independent_grid_map = Dict{String, Int}()
 
-        if include_grid_metrics
-            grid_metrics = gather_grid_metrics(grid, indices, dimension_name_generator)
-            merge!(time_independent_vars, grid_metrics)
-        end
+        for (grid_index, grid) in enumerate(grids)
+            dims = gather_dimensions(outputs, grid, indices, with_halos, dimension_name_generator; grid_index)
+            create_spatial_dimensions!(dataset, dims, output_attributes; deflatelevel=1, dimension_type)
 
-        if grid isa ImmersedBoundaryGrid
-            immersed_boundary_vars = gather_immersed_boundary(grid, indices, dimension_name_generator)
-            merge!(time_independent_vars, immersed_boundary_vars)
+            write_grid_reconstruction_data!(dataset, grid, grid_index; array_type, deflatelevel)
+
+            if include_grid_metrics
+                metrics = gather_grid_metrics(grid, indices, dimension_name_generator; grid_index)
+                for name in keys(metrics)
+                    time_independent_grid_map[name] = grid_index
+                end
+                merge!(time_independent_vars, metrics)
+            end
+
+            if grid isa ImmersedBoundaryGrid
+                ib_vars = gather_immersed_boundary(grid, indices, dimension_name_generator; grid_index)
+                for name in keys(ib_vars)
+                    time_independent_grid_map[name] = grid_index
+                end
+                merge!(time_independent_vars, ib_vars)
+            end
         end
 
         if !isempty(time_independent_vars)
             for (output_name, output) in sort(collect(pairs(time_independent_vars)), by=first)
+                grid_index = time_independent_grid_map[output_name]
                 output = construct_output(output, indices, with_halos)
                 attrib = haskey(output_attributes, output_name) ? output_attributes[output_name] : Dict()
                 materialized = materialize_output(output, model)
@@ -254,6 +273,7 @@ function initialize_nc_file(model,
                                         dimensions,
                                         filepath, # for better error messages
                                         dimension_name_generator,
+                                        grid_index,
                                         time_dependent = false,
                                         with_halos,
                                         dimension_type)
@@ -263,7 +283,9 @@ function initialize_nc_file(model,
         end
 
         for (output_name, output) in sort(collect(pairs(outputs)), by=first)
+            grid_index = output_grid_map[output_name]
             attrib = haskey(output_attributes, output_name) ? output_attributes[output_name] : Dict()
+            attrib = merge(attrib, Dict("grid_index" => grid_index))
             materialized = materialize_output(output, model)
 
             define_output_variable!(model,
@@ -276,6 +298,7 @@ function initialize_nc_file(model,
                                     dimensions,
                                     filepath, # for better error messages
                                     dimension_name_generator,
+                                    grid_index,
                                     time_dependent = true,
                                     with_halos,
                                     dimension_type)
@@ -290,7 +313,8 @@ function initialize_nc_file(model,
 end
 
 initialize_nc_file(ow::NetCDFWriter, model) = initialize_nc_file(model,
-                                                                 ow.grid,
+                                                                 ow.grids,
+                                                                 ow.output_grid_map,
                                                                  ow.filepath,
                                                                  ow.outputs,
                                                                  ow.schedule,
@@ -338,7 +362,7 @@ end
 """ Defines empty field variable. """
 function define_output_variable!(model, dataset, output::AbstractField, output_name; array_type,
                                  deflatelevel, attrib, dimension_name_generator,
-                                 time_dependent, with_halos,
+                                 time_dependent, with_halos, grid_index=nothing,
                                  dimensions, filepath, dimension_type=Float64)
 
     # If the output is the free surface, we need to handle it differently since it will be writen as a 3D array with a singleton dimension for the z-coordinate
@@ -348,7 +372,7 @@ function define_output_variable!(model, dataset, output::AbstractField, output_n
             dimension_name_generator = (var_name, grid, LX, LY, LZ, dim) -> dimension_name_generator_free_surface(default_dimension_name_generator, var_name, grid, LX, LY, LZ, dim)
         end
     end
-    defVar(dataset, output_name, output; array_type, time_dependent, with_halos, dimension_name_generator, deflatelevel, attrib, dimension_type, write_data=false)
+    defVar(dataset, output_name, output; array_type, time_dependent, with_halos, dimension_name_generator, deflatelevel, attrib, dimension_type, grid_index, write_data=false)
     return nothing
 end
 

--- a/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
+++ b/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
@@ -242,7 +242,7 @@ function initialize_nc_file(model,
             dims = gather_dimensions(outputs, grid, indices, with_halos, dimension_name_generator; grid_index=suffix)
             create_spatial_dimensions!(dataset, dims, output_attributes; deflatelevel=1, dimension_type)
 
-            write_grid_reconstruction_data!(dataset, grid, grid_index; array_type, deflatelevel)
+            write_grid_reconstruction_data!(dataset, grid, suffix; array_type, deflatelevel)
 
             if include_grid_metrics
                 metrics = gather_grid_metrics(grid, indices, dimension_name_generator; grid_index=suffix)

--- a/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
+++ b/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
@@ -347,7 +347,7 @@ materialize_output(output::WindowedTimeAverage{<:AbstractField}, model) = output
 """ Defines empty variables for 'custom' user-supplied `output`. """
 function define_output_variable!(model, dataset, output, output_name; array_type,
                                  deflatelevel, attrib, dimension_name_generator,
-                                 time_dependent, with_halos,
+                                 time_dependent, with_halos, grid_index=nothing,
                                  dimensions, filepath, dimension_type=Float64)
 
     if output_name ∉ keys(dimensions)

--- a/ext/OceananigansNCDatasetsExt/output_readers.jl
+++ b/ext/OceananigansNCDatasetsExt/output_readers.jl
@@ -34,7 +34,8 @@ function FieldTimeSeries(typed_path::NetCDFPath, name::String;
     end
 
     # Read the grid from the file on the correct architecture
-    isnothing(grid) && (grid = reconstruct_grid(file; architecture))
+    grid_index = try file[name].attrib["grid_index"] catch; 1 end
+    isnothing(grid) && (grid = reconstruct_grid(file; grid_index, architecture))
 
     isnothing(location) && (location = file[name].attrib["location"] |> materialize_from_netcdf)
     LX, LY, LZ = location
@@ -208,7 +209,8 @@ function Field(location, file::NCDataset, name::String, iter;
         end
     end
 
-    isnothing(grid) && (grid = reconstruct_grid(file))
+    grid_index = try file[name].attrib["grid_index"] catch; 1 end
+    isnothing(grid) && (grid = reconstruct_grid(file; grid_index))
     variable_dimensions = dimnames(file[name])
     time_slice = (ntuple(_ -> :, length(variable_dimensions)-1)..., iter)
     raw_data = file[name][time_slice...]

--- a/src/Fields/abstract_field.jl
+++ b/src/Fields/abstract_field.jl
@@ -27,8 +27,11 @@ Base.IndexStyle(::AbstractField) = IndexCartesian()
 Base.eltype(::AbstractField{<:Any, <:Any, <:Any, <:Any, T}) where T = T
 Base.eltype(::Type{<:AbstractField{<:Any, <:Any, <:Any, <:Any, T}}) where T = T
 
+"Returns the grid on which `f` is defined."
+Grids.grid(f::AbstractField) = f.grid
+
 "Returns the architecture of on which `f` is defined."
-Architectures.architecture(f::AbstractField) = architecture(f.grid)
+Architectures.architecture(f::AbstractField) = architecture(grid(f))
 Architectures.child_architecture(f::AbstractField) = child_architecture(architecture(f))
 
 "Returns the topology of a fields' `grid`."

--- a/src/Fields/constant_field.jl
+++ b/src/Fields/constant_field.jl
@@ -1,4 +1,5 @@
 import Oceananigans: prognostic_state, restore_prognostic_state!
+import Oceananigans.Grids: grid
 
 struct ZeroField{T, N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, T, N} end
 struct OneField{T, N} <: AbstractField{Nothing, Nothing, Nothing, Nothing, T, N} end
@@ -20,6 +21,8 @@ ConstantField(constant) = ConstantField{3}(constant)
 @inline Base.getindex(f::ConstantField, ind...) = f.constant
 
 const CF = Union{ConstantField, ZeroField, OneField}
+
+grid(::CF) = nothing
 
 BoundaryConditions.fill_halo_regions!(::ZeroField, args...; kw...) = nothing
 BoundaryConditions.fill_halo_regions!(::ConstantField, args...; kw...) = nothing

--- a/src/Fields/scans.jl
+++ b/src/Fields/scans.jl
@@ -1,4 +1,5 @@
 using KernelAbstractions: @kernel, @index
+import Oceananigans.Grids: grid
 
 #####
 ##### "Scans" of AbstractField.
@@ -33,6 +34,8 @@ Base.summary(::Accumulating) = "Accumulating"
 
 const Reduction = Scan{<:AbstractReducing}
 const Accumulation = Scan{<:AbstractAccumulating}
+
+grid(s::Scan) = grid(s.operand)
 
 scan_indices(::AbstractReducing, indices, dims) = Tuple(i ∈ dims ? Colon() : indices[i] for i in 1:3)
 scan_indices(::AbstractAccumulating, indices, dims) = indices

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -6,7 +6,7 @@ export Periodic, Bounded, Flat, FullyConnected, LeftConnected, RightConnected
 export RightFaceFolded, RightCenterFolded
 export LeftConnectedRightCenterFolded, LeftConnectedRightFaceFolded
 export LeftConnectedRightCenterConnected, LeftConnectedRightFaceConnected
-export AbstractGrid, AbstractUnderlyingGrid, halo_size, total_size
+export AbstractGrid, AbstractUnderlyingGrid, grid, halo_size, total_size
 export RectilinearGrid
 export AbstractCurvilinearGrid, AbstractHorizontallyCurvilinearGrid
 export XFlatGrid, YFlatGrid, ZFlatGrid

--- a/src/Grids/abstract_grid.jl
+++ b/src/Grids/abstract_grid.jl
@@ -6,6 +6,8 @@ and `Arch`itecture.
 """
 abstract type AbstractGrid{FT, TX, TY, TZ, Arch} end
 
+grid(g::AbstractGrid) = g
+
 """
     AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch}
 

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -206,15 +206,15 @@ default_nan_checker(::OnlyParticleTrackingModel) = nothing
 import Oceananigans.OutputWriters: default_included_properties,
                                    checkpointer_address
 
-default_included_properties(::NonhydrostaticModel) = [:grid, :coriolis, :buoyancy, :closure]
-default_included_properties(::HydrostaticFreeSurfaceModel) = [:grid, :coriolis, :buoyancy, :closure]
-default_included_properties(::ShallowWaterModel) = [:grid, :coriolis, :closure]
+default_included_properties(::NonhydrostaticModel) = [:coriolis, :buoyancy, :closure]
+default_included_properties(::HydrostaticFreeSurfaceModel) = [:coriolis, :buoyancy, :closure]
+default_included_properties(::ShallowWaterModel) = [:coriolis, :closure]
 
 checkpointer_address(::ShallowWaterModel) = "ShallowWaterModel"
 checkpointer_address(::NonhydrostaticModel) = "NonhydrostaticModel"
 checkpointer_address(::HydrostaticFreeSurfaceModel) = "HydrostaticFreeSurfaceModel"
 
-default_included_properties(::OceananigansModels) = [:grid]
+default_included_properties(::OceananigansModels) = Symbol[]
 
 # Specialized output attributes for velocity and tracer fields
 include("output_attributes.jl")

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -24,6 +24,7 @@ using Oceananigans.Units: Time
 
 import Oceananigans: initialize!
 import Oceananigans.Architectures: architecture
+import Oceananigans.Grids: grid
 import Oceananigans.Fields: set!
 import Oceananigans.Solvers: iteration
 import Oceananigans.OutputWriters: default_included_properties
@@ -39,6 +40,7 @@ import Oceananigans.TimeSteppers: reset!
 iteration(model::AbstractModel) = model.clock.iteration
 Base.time(model::AbstractModel) = model.clock.time
 Base.eltype(model::AbstractModel) = Float64
+grid(model::AbstractModel) = model.grid
 architecture(model::AbstractModel) = nothing
 initialize!(model::AbstractModel) = nothing
 total_velocities(model::AbstractModel) = nothing

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -792,7 +792,7 @@ function FieldTimeSeries(file::JLD2.JLDFile, name::String;
     end
 
     if isnothing(grid)
-        grid = handle["timeseries/$name/serialized/serialized/grid"]
+        grid = handle["timeseries/$name/serialized/grid"]
     end
 
     # If isreconstructed(grid), it probably means that the data was generated prior to

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -607,12 +607,13 @@ end
     reconstruct_legacy_grid(grid, file, architecture)
 
 Reconstruct a grid from legacy JLD2 output files (prior to Oceananigans 0.95.0)
-that did not serialize grids properly.
+that did not serialize grids properly. Reads raw grid data from the top-level
+`grid/` path written by `saveproperties!`.
 """
-function reconstruct_legacy_grid(grid, file, name, architecture)
+function reconstruct_legacy_grid(grid, file, architecture)
     isibg = grid isa ImmersedBoundaryGrid
     test_grid = isibg ? grid.underlying_grid : grid
-    address = isibg ? "timeseries/$name/grid/underlying_grid" : "timeseries/$name/grid"
+    address = isibg ? "grid/underlying_grid" : "grid"
     Nx = file["$address/Nx"]
     Ny = file["$address/Ny"]
     Nz = file["$address/Nz"]
@@ -648,7 +649,7 @@ function reconstruct_legacy_grid(grid, file, name, architecture)
     end
 
     if isibg
-        bottom_height = file["timeseries/$name/grid/immersed_boundary/bottom_height"]
+        bottom_height = file["grid/immersed_boundary/bottom_height"]
         bottom_height = view(bottom_height, 1+Hx:Nx+Hx, 1+Hy:Ny+Hy, 1)
         grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bottom_height))
     else
@@ -663,23 +664,24 @@ end
 
 Manually reconstruct a RectilinearGrid from file data when `on_architecture` fails.
 This is a fallback for grids saved with CuArrays or generated with a different Julia version.
+Reads raw grid data from the top-level `grid/` path.
 """
-function manually_reconstruct_rectilinear_grid(grid, file, name, architecture)
+function manually_reconstruct_rectilinear_grid(grid, file, architecture)
     @info "Initial attempt to transfer grid to $architecture failed."
     @info "Attempting to reconstruct RectilinearGrid on $architecture manually..."
 
-    Nx = file["timeseries/$name/grid/Nx"]
-    Ny = file["timeseries/$name/grid/Ny"]
-    Nz = file["timeseries/$name/grid/Nz"]
-    Hx = file["timeseries/$name/grid/Hx"]
-    Hy = file["timeseries/$name/grid/Hy"]
-    Hz = file["timeseries/$name/grid/Hz"]
-    xᶠᵃᵃ = file["timeseries/$name/grid/xᶠᵃᵃ"]
-    yᵃᶠᵃ = file["timeseries/$name/grid/yᵃᶠᵃ"]
-    zᵃᵃᶠ = file["timeseries/$name/grid/zᵃᵃᶠ"]
-    x = file["timeseries/$name/grid/Δxᶠᵃᵃ"] isa Number ? (xᶠᵃᵃ[1], xᶠᵃᵃ[Nx+1]) : xᶠᵃᵃ
-    y = file["timeseries/$name/grid/Δyᵃᶠᵃ"] isa Number ? (yᵃᶠᵃ[1], yᵃᶠᵃ[Ny+1]) : yᵃᶠᵃ
-    z = file["timeseries/$name/grid/Δzᵃᵃᶠ"] isa Number ? (zᵃᵃᶠ[1], zᵃᵃᶠ[Nz+1]) : zᵃᵃᶠ
+    Nx = file["grid/Nx"]
+    Ny = file["grid/Ny"]
+    Nz = file["grid/Nz"]
+    Hx = file["grid/Hx"]
+    Hy = file["grid/Hy"]
+    Hz = file["grid/Hz"]
+    xᶠᵃᵃ = file["grid/xᶠᵃᵃ"]
+    yᵃᶠᵃ = file["grid/yᵃᶠᵃ"]
+    zᵃᵃᶠ = file["grid/zᵃᵃᶠ"]
+    x = file["grid/Δxᶠᵃᵃ"] isa Number ? (xᶠᵃᵃ[1], xᶠᵃᵃ[Nx+1]) : xᶠᵃᵃ
+    y = file["grid/Δyᵃᶠᵃ"] isa Number ? (yᵃᶠᵃ[1], yᵃᶠᵃ[Ny+1]) : yᵃᶠᵃ
+    z = file["grid/Δzᵃᵃᶠ"] isa Number ? (zᵃᵃᶠ[1], zᵃᵃᶠ[Nz+1]) : zᵃᵃᶠ
     topo = topology(grid)
 
     N = (Nx, Ny, Nz)
@@ -822,14 +824,14 @@ function FieldTimeSeries(file::JLD2.JLDFile, name::String;
     # and LatitudeLongitudeGrid (but not OrthogonalSphericalShellGrid) and we also assume
     # GridFittedBottom if the grid is an ImmersedBoundaryGrid. If these assumptions can be relaxed
     # in the future, they should.
-    isreconstructed(grid) && (grid = reconstruct_legacy_grid(grid, handle, name, architecture))
+    isreconstructed(grid) && (grid = reconstruct_legacy_grid(grid, handle, architecture))
 
     # This should be removed eventually... (4/5/2022)
     grid = try
         on_architecture(architecture, grid)
     catch err # Likely, the grid was saved with CuArrays or generated with a different Julia version.
         if grid isa RectilinearGrid # we can try...
-            manually_reconstruct_rectilinear_grid(grid, handle, name, architecture)
+            manually_reconstruct_rectilinear_grid(grid, handle, architecture)
         else
             throw(err)
         end

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -588,10 +588,10 @@ struct UnspecifiedBoundaryConditions end
 Reconstruct a grid from legacy JLD2 output files (prior to Oceananigans 0.95.0)
 that did not serialize grids properly.
 """
-function reconstruct_legacy_grid(grid, file, architecture)
+function reconstruct_legacy_grid(grid, file, name, architecture)
     isibg = grid isa ImmersedBoundaryGrid
     test_grid = isibg ? grid.underlying_grid : grid
-    address = isibg ? "grid/underlying_grid" : "grid"
+    address = isibg ? "timeseries/$name/grid/underlying_grid" : "timeseries/$name/grid"
     Nx = file["$address/Nx"]
     Ny = file["$address/Ny"]
     Nz = file["$address/Nz"]
@@ -627,7 +627,7 @@ function reconstruct_legacy_grid(grid, file, architecture)
     end
 
     if isibg
-        bottom_height = file["grid/immersed_boundary/bottom_height"]
+        bottom_height = file["timeseries/$name/grid/immersed_boundary/bottom_height"]
         bottom_height = view(bottom_height, 1+Hx:Nx+Hx, 1+Hy:Ny+Hy, 1)
         grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bottom_height))
     else
@@ -643,22 +643,22 @@ end
 Manually reconstruct a RectilinearGrid from file data when `on_architecture` fails.
 This is a fallback for grids saved with CuArrays or generated with a different Julia version.
 """
-function manually_reconstruct_rectilinear_grid(grid, file, architecture)
+function manually_reconstruct_rectilinear_grid(grid, file, name, architecture)
     @info "Initial attempt to transfer grid to $architecture failed."
     @info "Attempting to reconstruct RectilinearGrid on $architecture manually..."
 
-    Nx = file["grid/Nx"]
-    Ny = file["grid/Ny"]
-    Nz = file["grid/Nz"]
-    Hx = file["grid/Hx"]
-    Hy = file["grid/Hy"]
-    Hz = file["grid/Hz"]
-    xᶠᵃᵃ = file["grid/xᶠᵃᵃ"]
-    yᵃᶠᵃ = file["grid/yᵃᶠᵃ"]
-    zᵃᵃᶠ = file["grid/zᵃᵃᶠ"]
-    x = file["grid/Δxᶠᵃᵃ"] isa Number ? (xᶠᵃᵃ[1], xᶠᵃᵃ[Nx+1]) : xᶠᵃᵃ
-    y = file["grid/Δyᵃᶠᵃ"] isa Number ? (yᵃᶠᵃ[1], yᵃᶠᵃ[Ny+1]) : yᵃᶠᵃ
-    z = file["grid/Δzᵃᵃᶠ"] isa Number ? (zᵃᵃᶠ[1], zᵃᵃᶠ[Nz+1]) : zᵃᵃᶠ
+    Nx = file["timeseries/$name/grid/Nx"]
+    Ny = file["timeseries/$name/grid/Ny"]
+    Nz = file["timeseries/$name/grid/Nz"]
+    Hx = file["timeseries/$name/grid/Hx"]
+    Hy = file["timeseries/$name/grid/Hy"]
+    Hz = file["timeseries/$name/grid/Hz"]
+    xᶠᵃᵃ = file["timeseries/$name/grid/xᶠᵃᵃ"]
+    yᵃᶠᵃ = file["timeseries/$name/grid/yᵃᶠᵃ"]
+    zᵃᵃᶠ = file["timeseries/$name/grid/zᵃᵃᶠ"]
+    x = file["timeseries/$name/grid/Δxᶠᵃᵃ"] isa Number ? (xᶠᵃᵃ[1], xᶠᵃᵃ[Nx+1]) : xᶠᵃᵃ
+    y = file["timeseries/$name/grid/Δyᵃᶠᵃ"] isa Number ? (yᵃᶠᵃ[1], yᵃᶠᵃ[Ny+1]) : yᵃᶠᵃ
+    z = file["timeseries/$name/grid/Δzᵃᵃᶠ"] isa Number ? (zᵃᵃᶠ[1], zᵃᵃᶠ[Nz+1]) : zᵃᵃᶠ
     topo = topology(grid)
 
     N = (Nx, Ny, Nz)
@@ -792,7 +792,7 @@ function FieldTimeSeries(file::JLD2.JLDFile, name::String;
     end
 
     if isnothing(grid)
-        grid = handle["serialized/grid"]
+        grid = handle["timeseries/$name/serialized/serialized/grid"]
     end
 
     # If isreconstructed(grid), it probably means that the data was generated prior to
@@ -801,14 +801,14 @@ function FieldTimeSeries(file::JLD2.JLDFile, name::String;
     # and LatitudeLongitudeGrid (but not OrthogonalSphericalShellGrid) and we also assume
     # GridFittedBottom if the grid is an ImmersedBoundaryGrid. If these assumptions can be relaxed
     # in the future, they should.
-    isreconstructed(grid) && (grid = reconstruct_legacy_grid(grid, handle, architecture))
+    isreconstructed(grid) && (grid = reconstruct_legacy_grid(grid, handle, name, architecture))
 
     # This should be removed eventually... (4/5/2022)
     grid = try
         on_architecture(architecture, grid)
     catch err # Likely, the grid was saved with CuArrays or generated with a different Julia version.
         if grid isa RectilinearGrid # we can try...
-            manually_reconstruct_rectilinear_grid(grid, handle, architecture)
+            manually_reconstruct_rectilinear_grid(grid, handle, name, architecture)
         else
             throw(err)
         end

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -583,6 +583,27 @@ end
 struct UnspecifiedBoundaryConditions end
 
 """
+    load_serialized_grid(file, name)
+
+Load the grid associated with the output variable `name` from a JLD2 `file`.
+
+Grids are looked up in the following order:
+
+1. If `timeseries/\$name/serialized/grid_index` is present, use it to select
+   `serialized/grid_\$i` (multi-grid JLD2Writer output).
+2. `serialized/grid` (single-grid JLD2Writer output, or the legacy path
+   written by the `including` mechanism).
+"""
+function load_serialized_grid(file, name)
+    if haskey(file, "timeseries/$name/serialized/grid_index")
+        grid_index = file["timeseries/$name/serialized/grid_index"]
+        return file["serialized/grid_$grid_index"]
+    end
+
+    return file["serialized/grid"]
+end
+
+"""
     reconstruct_legacy_grid(grid, file, architecture)
 
 Reconstruct a grid from legacy JLD2 output files (prior to Oceananigans 0.95.0)
@@ -792,7 +813,7 @@ function FieldTimeSeries(file::JLD2.JLDFile, name::String;
     end
 
     if isnothing(grid)
-        grid = handle["timeseries/$name/serialized/grid"]
+        grid = load_serialized_grid(handle, name)
     end
 
     # If isreconstructed(grid), it probably means that the data was generated prior to
@@ -969,7 +990,7 @@ function Field(location, file::JLD2.JLDFile, name::String, iter;
         end
     end
 
-    isnothing(grid) && (grid = file["serialized/grid"])
+    isnothing(grid) && (grid = load_serialized_grid(file, name))
     raw_data = file["timeseries/$name/$iter"]
 
     # Change grid to specified architecture?

--- a/src/OutputWriters/jld2_writer.jl
+++ b/src/OutputWriters/jld2_writer.jl
@@ -218,11 +218,16 @@ function initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, mode
 
     # Serialize the location and boundary conditions of each output.
     for (name, field) in pairs(outputs)
-        try
-            jldopen(filepath, "a+"; jld2_kw...) do file
-                file["timeseries/$name/serialized/location"] = location(field)
+        jldopen(filepath, "a+"; jld2_kw...) do file
+            try 
+                serializeproperty!(file, "timeseries/$name/serialized/grid", field.grid)
+            catch 
+            end
+            try
+                file["timeseries/$name/serialized/location"] = location(field); 
                 file["timeseries/$name/serialized/indices"] = indices(field)
                 serializeproperty!(file, "timeseries/$name/serialized/boundary_conditions", boundary_conditions(field))
+            catch
             end
         catch
         end

--- a/src/OutputWriters/jld2_writer.jl
+++ b/src/OutputWriters/jld2_writer.jl
@@ -229,7 +229,6 @@ function initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, mode
                 serializeproperty!(file, "timeseries/$name/serialized/boundary_conditions", boundary_conditions(field))
             catch
             end
-        catch
         end
     end
 

--- a/src/OutputWriters/jld2_writer.jl
+++ b/src/OutputWriters/jld2_writer.jl
@@ -220,8 +220,9 @@ function initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, mode
     for (name, field) in pairs(outputs)
         jldopen(filepath, "a+"; jld2_kw...) do file
             try 
-                serializeproperty!(file, "timeseries/$name/serialized/grid", field.grid)
-            catch 
+                serializeproperty!(file, "timeseries/$name/serialized/grid", grid(field))
+            catch err
+                @warn "error $err thrown when trying to serialize the grid of $(summary(field))"
             end
             try
                 file["timeseries/$name/serialized/location"] = location(field); 

--- a/src/OutputWriters/jld2_writer.jl
+++ b/src/OutputWriters/jld2_writer.jl
@@ -3,6 +3,7 @@ using JLD2
 using Oceananigans.Utils
 using Oceananigans.Utils: TimeInterval, prettykeys, materialize_schedule
 using Oceananigans.Fields: indices
+using Oceananigans.Grids: grid
 
 default_included_properties(model) = []
 
@@ -137,7 +138,7 @@ JLD2Writer scheduled on TimeInterval(20 minutes):
 ├── filepath: some_data.jld2
 ├── 3 outputs: (u, v, w)
 ├── array_type: Array{Float32}
-├── including: [:grid, :coriolis, :buoyancy, :closure]
+├── including: [:coriolis, :buoyancy, :closure]
 ├── file_splitting: NoFileSplitting
 └── file size: 0 bytes (file not yet created)
 ```
@@ -156,7 +157,7 @@ JLD2Writer scheduled on TimeInterval(20 minutes):
 ├── filepath: some_averaged_data.jld2
 ├── 1 outputs: c averaged on AveragedTimeInterval(window=5 minutes, stride=1, interval=20 minutes)
 ├── array_type: Array{Float32}
-├── including: [:grid, :coriolis, :buoyancy, :closure]
+├── including: [:coriolis, :buoyancy, :closure]
 ├── file_splitting: NoFileSplitting
 └── file size: 0 bytes (file not yet created)
 ```
@@ -216,16 +217,40 @@ function initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, mode
         @warn """Failed to save and serialize $including in $filepath because $(typeof(err)): $(sprint(showerror, err))"""
     end
 
-    # Serialize the location and boundary conditions of each output.
+    # Extract grids from outputs, falling back to `nothing` for non-field outputs
+    output_grids = Dict(string(name) => (try grid(output) catch; nothing end) for (name, output) in pairs(outputs))
+    unique_grids = Tuple(unique(objectid, filter(!isnothing, collect(values(output_grids)))))
+    single_grid  = length(unique_grids) == 1
+
+    # Serialize the unique grids. With a single grid it is stored at `serialized/grid`
+    # (no suffix); with multiple grids they are stored at `serialized/grid_1`, `grid_2`, ...
+    # and each output gets a `grid_index` entry under its own `timeseries/$name/serialized/`.
+    jldopen(filepath, "a+"; jld2_kw...) do file
+        for (i, grid) in enumerate(unique_grids)
+            address = single_grid ? "serialized/grid" : "serialized/grid_$i"
+            try
+                serializeproperty!(file, address, grid)
+            catch err
+                @warn "error $err thrown when trying to serialize the grid at $address"
+            end
+        end
+    end
+
+    # Serialize the grid index, location, indices, and boundary conditions of each output.
     for (name, field) in pairs(outputs)
         jldopen(filepath, "a+"; jld2_kw...) do file
-            try 
-                serializeproperty!(file, "timeseries/$name/serialized/grid", grid(field))
-            catch err
-                @warn "error $err thrown when trying to serialize the grid of $(summary(field))"
+            # Only write a grid index when we actually have multiple grids to choose from;
+            # otherwise all outputs use the single grid at `serialized/grid`.
+            if !single_grid && !isnothing(output_grids[string(name)])
+                grid_index = findfirst(gr -> gr === output_grids[string(name)], unique_grids)
+                try
+                    file["timeseries/$name/serialized/grid_index"] = grid_index
+                catch err
+                    @warn "error $err thrown when trying to write grid_index for $name"
+                end
             end
             try
-                file["timeseries/$name/serialized/location"] = location(field); 
+                file["timeseries/$name/serialized/location"] = location(field)
                 file["timeseries/$name/serialized/indices"] = indices(field)
                 serializeproperty!(file, "timeseries/$name/serialized/boundary_conditions", boundary_conditions(field))
             catch

--- a/src/OutputWriters/netcdf_writer.jl
+++ b/src/OutputWriters/netcdf_writer.jl
@@ -236,7 +236,7 @@ NetCDFWriter scheduled on TimeInterval(1 minute):
 ├── 2 outputs: (c, u)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 32.7 KiB
+└── file size: 32.8 KiB
 ```
 
 ```jldoctest netcdf1
@@ -252,7 +252,7 @@ NetCDFWriter scheduled on TimeInterval(1 minute):
 ├── 2 outputs: (c, u)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 32.6 KiB
+└── file size: 32.8 KiB
 ```
 
 ```jldoctest netcdf1
@@ -269,7 +269,7 @@ NetCDFWriter scheduled on TimeInterval(1 minute):
 ├── 2 outputs: (c, u) averaged on AveragedTimeInterval(window=20 seconds, stride=1, interval=1 minute)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 33.9 KiB
+└── file size: 34.5 KiB
 ```
 
 `NetCDFWriter` also accepts output functions that write scalars and arrays to disk,
@@ -320,7 +320,7 @@ NetCDFWriter scheduled on IterationInterval(1):
 ├── 3 outputs: (profile, slice, scalar)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 34.1 KiB
+└── file size: 34.8 KiB
 ```
 
 `NetCDFWriter` supports outputs that live on different grids within a single writer.

--- a/src/OutputWriters/netcdf_writer.jl
+++ b/src/OutputWriters/netcdf_writer.jl
@@ -152,9 +152,6 @@ Required keyword arguments
 Optional keyword arguments
 ==========================
 
-- `grid`: The grid associated with `outputs`. Default: `model.grid`.
-          Use this to specify a different grid when outputs are interpolated or regridded.
-
 - `dir`: Directory to save output to. Default: `"."`.
 
 - `array_type`: Type to convert outputs to before saving. Default: `Array{Float32}`.
@@ -326,13 +323,12 @@ NetCDFWriter scheduled on IterationInterval(1):
 └── file size: 34.1 KiB
 ```
 
-`NetCDFWriter` can also be configured for `outputs` that are interpolated or regridded
-to a different grid than `model.grid`. To use this functionality, include the keyword argument
-`grid = output_grid`.
+`NetCDFWriter` supports outputs that live on different grids within a single writer.
+The grid is automatically extracted from each output field. When multiple grids are
+present, dimensions are suffixed (e.g., `_grid1`, `_grid2`) to avoid conflicts.
 
 ```jldoctest netcdf3
 using Oceananigans, NCDatasets
-using Oceananigans.Fields: interpolate!
 
 grid = RectilinearGrid(size=(1, 1, 8), extent=(1, 1, 1));
 model = NonhydrostaticModel(grid)
@@ -340,23 +336,22 @@ model = NonhydrostaticModel(grid)
 coarse_grid = RectilinearGrid(size=(grid.Nx, grid.Ny, grid.Nz÷2), extent=(grid.Lx, grid.Ly, grid.Lz))
 coarse_u = Field{Face, Center, Center}(coarse_grid)
 
-interpolate_u(model) = interpolate!(coarse_u, model.velocities.u)
-outputs = (; u = interpolate_u)
+# u lives on coarse_grid, w lives on model.grid — both in the same file
+outputs = (; u = coarse_u, w = model.velocities.w)
 
 output_writer = NetCDFWriter(model, outputs;
-                             grid = coarse_grid,
-                             filename = "coarse_u.nc",
+                             filename = "multi_grid.nc",
                              schedule = IterationInterval(1))
 
 # output
 
 NetCDFWriter scheduled on IterationInterval(1):
-├── filepath: coarse_u.nc
-├── dimensions: time(0), y_afa(1), x_faa(1), x_caa(1), y_aca(1), z_aaf(5), z_aac(4)
-├── 1 outputs: u
+├── filepath: multi_grid.nc
+├── dimensions: time(0), y_afa_grid1(1), x_faa_grid1(1), x_caa_grid1(1), y_aca_grid1(1), z_aaf_grid1(5), z_aac_grid1(4), y_afa_grid2(1), x_faa_grid2(1), x_caa_grid2(1), y_aca_grid2(1), z_aaf_grid2(9), z_aac_grid2(8)
+├── 2 outputs: (u, w)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 31.4 KiB
+└── file size: 36.7 KiB
 ```
 """
 function NetCDFWriter(model, outputs; kw...)

--- a/src/OutputWriters/netcdf_writer.jl
+++ b/src/OutputWriters/netcdf_writer.jl
@@ -66,8 +66,12 @@ trilocation_dim_name(var_name, grid::ImmersedBoundaryGrid, args...) = trilocatio
 dimension_name_generator_free_surface(dimension_name_generator, var_name, grid, LX, LY, LZ, dim) = dimension_name_generator(var_name, grid, LX, LY, LZ, dim)
 dimension_name_generator_free_surface(dimension_name_generator, var_name, grid, LX, LY, LZ, dim::Val{:z}) = dimension_name_generator(var_name, grid, LX, LY, LZ, dim) * "_displacement"
 
-mutable struct NetCDFWriter{G, D, O, T, A, FS, DN, DT} <: AbstractOutputWriter
-    grid :: G
+add_grid_suffix(name, grid_index) = isempty(name) ? name : name * "_grid$(grid_index)"
+add_grid_suffix(name, ::Nothing) = name
+
+mutable struct NetCDFWriter{G, GM, D, O, T, A, FS, DN, DT} <: AbstractOutputWriter
+    grids :: G
+    output_grid_map :: GM
     filepath :: String
     dataset :: D
     outputs :: O
@@ -93,7 +97,6 @@ end
     NetCDFWriter(model::AbstractModel, outputs;
                  filename,
                  schedule,
-                 grid = model.grid,
                  dir = ".",
                  array_type = Array{Float32},
                  indices = (:, :, :),

--- a/src/OutputWriters/netcdf_writer.jl
+++ b/src/OutputWriters/netcdf_writer.jl
@@ -336,22 +336,21 @@ model = NonhydrostaticModel(grid)
 coarse_grid = RectilinearGrid(size=(grid.Nx, grid.Ny, grid.Nz÷2), extent=(grid.Lx, grid.Ly, grid.Lz))
 coarse_u = Field{Face, Center, Center}(coarse_grid)
 
-# u lives on coarse_grid, w lives on model.grid — both in the same file
-outputs = (; u = coarse_u, w = model.velocities.w)
+outputs = (; u = coarse_u)
 
 output_writer = NetCDFWriter(model, outputs;
-                             filename = "multi_grid.nc",
+                             filename = "coarse_u.nc",
                              schedule = IterationInterval(1))
 
 # output
 
 NetCDFWriter scheduled on IterationInterval(1):
-├── filepath: multi_grid.nc
-├── dimensions: time(0), y_afa_grid1(1), x_faa_grid1(1), x_caa_grid1(1), y_aca_grid1(1), z_aaf_grid1(5), z_aac_grid1(4), y_afa_grid2(1), x_faa_grid2(1), x_caa_grid2(1), y_aca_grid2(1), z_aaf_grid2(9), z_aac_grid2(8)
-├── 2 outputs: (u, w)
+├── filepath: coarse_u.nc
+├── dimensions: time(0), y_afa(1), x_faa(1), x_caa(1), y_aca(1), z_aaf(5), z_aac(4)
+├── 1 outputs: u
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 36.7 KiB
+└── file size: 31.7 KiB
 ```
 """
 function NetCDFWriter(model, outputs; kw...)

--- a/src/OutputWriters/netcdf_writer.jl
+++ b/src/OutputWriters/netcdf_writer.jl
@@ -269,7 +269,7 @@ NetCDFWriter scheduled on TimeInterval(1 minute):
 ├── 2 outputs: (c, u) averaged on AveragedTimeInterval(window=20 seconds, stride=1, interval=1 minute)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 34.5 KiB
+└── file size: 34.4 KiB
 ```
 
 `NetCDFWriter` also accepts output functions that write scalars and arrays to disk,
@@ -320,7 +320,7 @@ NetCDFWriter scheduled on IterationInterval(1):
 ├── 3 outputs: (profile, slice, scalar)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 34.8 KiB
+└── file size: 34.7 KiB
 ```
 
 `NetCDFWriter` supports outputs that live on different grids within a single writer.

--- a/src/OutputWriters/output_construction.jl
+++ b/src/OutputWriters/output_construction.jl
@@ -31,7 +31,7 @@ end
 #####
 
 intersect_indices(output, indices) = indices
-intersect_indices(output::Field, indices) = map(intersect_index_range, indices, output.indices)
+intersect_indices(output::AbstractField, indices) = map(intersect_index_range, indices, Oceananigans.Fields.indices(output))
 
 intersect_index_range(::Colon, ::Colon) = Colon()
 intersect_index_range(range::UnitRange, ::Colon) = range

--- a/src/OutputWriters/windowed_time_average.jl
+++ b/src/OutputWriters/windowed_time_average.jl
@@ -6,6 +6,7 @@ using Dates: Period, Second, value
 
 import Oceananigans: run_diagnostic!, prognostic_state, restore_prognostic_state!, initialize!
 import Oceananigans.Utils: TimeInterval, SpecifiedTimes
+import Oceananigans.Grids: grid
 import Oceananigans.Fields: location, indices, set!
 
 """
@@ -190,7 +191,8 @@ end
 get_default_time(schedule::AveragedTimeInterval) = zero(typeof(schedule.interval))
 get_default_time(schedule::AveragedSpecifiedTimes) = zero(eltype(schedule.specified_times.times))
 
-# Time-averaging doesn't change spatial location
+# Time-averaging doesn't change spatial location or grid
+grid(wta::WindowedTimeAverage) = grid(wta.operand)
 location(wta::WindowedTimeAverage) = location(wta.operand)
 indices(wta::WindowedTimeAverage) = indices(wta.operand)
 set!(u::Field, wta::WindowedTimeAverage) = set!(u, wta.result)

--- a/src/OutputWriters/windowed_time_average.jl
+++ b/src/OutputWriters/windowed_time_average.jl
@@ -81,7 +81,7 @@ JLD2Writer scheduled on TimeInterval(4 days):
 ├── filepath: averaged_velocity_data.jld2
 ├── 3 outputs: (u, v, w) averaged on AveragedTimeInterval(window=2 days, stride=2, interval=4 days)
 ├── array_type: Array{Float32}
-├── including: [:grid, :coriolis, :buoyancy, :closure]
+├── including: [:coriolis, :buoyancy, :closure]
 ├── file_splitting: NoFileSplitting
 └── file size: 0 bytes (file not yet created)
 ```

--- a/test/test_grid_reconstruction.jl
+++ b/test/test_grid_reconstruction.jl
@@ -265,7 +265,7 @@ function test_netcdf_grid_reconstruction(original_grid)
     # Create NetCDF dataset and write grid reconstruction data
     filename = "test_netcdf_grid_reconstruction.nc"
     ds = NCDataset(filename, "c")
-    write_grid_reconstruction_data!(ds, original_grid)
+    write_grid_reconstruction_data!(ds, original_grid, 1)
     close(ds)
 
     # Read back the grid reconstruction metadata

--- a/test/test_netcdf_writer.jl
+++ b/test/test_netcdf_writer.jl
@@ -2992,17 +2992,15 @@ function test_netcdf_writer_different_grid(arch)
     coarse_grid = RectilinearGrid(arch, size=(grid.Nx, grid.Ny, grid.Nz÷2), extent=(grid.Lx, grid.Ly, grid.Lz))
     coarse_u = Field{Face, Center, Center}(coarse_grid)
 
-    interpolate_u(model) = interpolate!(coarse_u, model.velocities.u)
-    outputs = (; u = interpolate_u)
+    outputs = (; u = coarse_u)
 
     Arch = typeof(arch)
     filepath = "test_coarse_u_$Arch.nc"
     isfile(filepath) && rm(filepath)
 
-    # This should work: NetCDFWriter should use coarse_grid for dimensions
-    # when grid parameter is provided, not model.grid
+    # NetCDFWriter should automatically use coarse_grid for dimensions
+    # since coarse_u is a field on coarse_grid
     output_writer = NetCDFWriter(model, outputs;
-                                 grid = coarse_grid,
                                  filename = filepath,
                                  schedule = IterationInterval(1),
                                  overwrite_existing = true)


### PR DESCRIPTION
This PR adds a serialized local grid for each saved field in the `JLD2Writer` such that each output can be independently parsed in a FieldTimeseries. The motivation for this PR is here https://github.com/NumericalEarth/NumericalEarth.jl/pull/157

This PR requires defining a `grid()` accessor (the same that we have for `location` and `indices`) which was missing for the grid. In this way we can safely dispatch on different types to get their grid. We can also have dispatch on the model for example.

I need to think a second on how to do it for NetCDF, but I think it would be similar

# Structural changes to JLD2 Output files:

### main — single grid (multi-grid not supported)

```
  output.jld2
  ├── grid/                                   # Legacy top-level (from `saveproperties!`)
  │   ├── Nx, Ny, Nz, Hx, Hy, Hz
  │   ├── Lx, Ly, Lz
  │   ├── Δxᶠᵃᵃ, Δyᵃᶠᵃ, ...
  │   └── ...
  │
  ├── serialized/
  │   ├── grid                                # Full grid (from `serializeproperty!`)
  │   ├── coriolis
  │   ├── buoyancy
  │   └── closure
  │
  └── timeseries/
      ├── t/
      │   ├── 0       → 0.0
      │   ├── 10      → 600.0
      │   └── ...
      ├── u/
      │   ├── 0       → Array{Float32}(Nx, Ny, Nz)
      │   ├── 10      → Array{Float32}(Nx, Ny, Nz)
      │   └── serialized/
      │       ├── location             → (Face, Center, Center)
      │       ├── indices              → (:, :, :)
      │       └── boundary_conditions/ → ...
      ├── v/
      │   └── ... (same structure)
      └── w/
          └── ... (same structure)
```
  Note: `:grid` was part of default_included_properties, so it was serialized both at the legacy top-level path (grid/Nx, grid/Ny, ...) and under serialized/grid.
  Multiple grids were not supported — all outputs were assumed to live on model.grid.

### This PR — single grid

```
  output.jld2
  ├── serialized/
  │   ├── grid                                # Extracted from outputs (deduplicated)
  │   ├── coriolis
  │   ├── buoyancy
  │   └── closure
  │
  └── timeseries/
      ├── t/
      │   ├── 0       → 0.0
      │   ├── 10      → 600.0
      │   └── ...
      ├── u/
      │   ├── 0       → Array{Float32}(Nx, Ny, Nz)
      │   ├── 10      → Array{Float32}(Nx, Ny, Nz)
      │   └── serialized/
      │       ├── location             → (Face, Center, Center)
      │       ├── indices              → (:, :, :)
      │       └── boundary_conditions/ → ...
      ├── v/
      │   └── ...
      └── w/
          └── ...
```

  When all outputs share the same grid, the file structure is nearly identical to main except:
  - `:grid` is no longer in default_included_properties — no legacy top-level grid/ group
  - The grid is extracted directly from the output fields and stored at serialized/grid
  - No grid_index is written (single grid → all outputs implicitly use serialized/grid)

  ### This PR — multiple grids

```
  output.jld2
  ├── serialized/
  │   ├── grid_1                              # First unique grid
  │   ├── grid_2                              # Second unique grid
  │   ├── coriolis
  │   ├── buoyancy
  │   └── closure
  │
  └── timeseries/
      ├── t/
      │   ├── 0       → 0.0
      │   ├── 10      → 600.0
      │   └── ...
      ├── u/
      │   ├── 0       → Array{Float32}(Nx1, Ny1, Nz1)
      │   ├── 10      → Array{Float32}(Nx1, Ny1, Nz1)
      │   └── serialized/
      │       ├── grid_index           → 1     # Points to serialized/grid_1
      │       ├── location             → (Face, Center, Center)
      │       ├── indices              → (:, :, :)
      │       └── boundary_conditions/ → ...
      ├── T/
      │   ├── 0       → Array{Float32}(Nx2, Ny2, Nz2)
      │   └── serialized/
      │       ├── grid_index           → 2     # Points to serialized/grid_2
      │       ├── location             → (Center, Center, Center)
      │       ├── indices              → (:, :, :)
      │       └── boundary_conditions/ → ...
      └── w/
          └── serialized/
              ├── grid_index           → 1     # Also on grid_1
              └── ...
```

  Key features of multi-grid support:
  - Unique grids are deduplicated by objectid — if two fields share the same grid object, it's stored only once
  - Each unique grid is stored as serialized/grid_1, serialized/grid_2, ...
  - Each output gets a grid_index entry pointing to its grid
  - Non-field outputs (functions, reductions) that have no grid simply skip grid_index

# Structural changes to NetCDF Output files:

### main — single grid (multi-grid not supported)

```
  output.nc
  │
  ├── Global attributes:
  │   ├── date, Julia, Oceananigans
  │   └── schedule_interval, ...
  │
  ├── Groups (grid reconstruction):
  │   ├── underlying_grid_reconstruction_args
  │   ├── underlying_grid_reconstruction_kwargs
  │   └── grid_reconstruction_metadata
  │
  ├── Dimensions:
  │   ├── x_faa(Nx+1), x_caa(Nx)
  │   ├── y_afa(Ny+1), y_aca(Ny)
  │   ├── z_aaf(Nz+1), z_aac(Nz)
  │   └── time(unlimited)
  │
  ├── Grid metrics:
  │   ├── Δx_faa, Δx_caa
  │   ├── Δy_afa, Δy_aca
  │   └── Δz_aaf, Δz_aac
  │
  └── Output variables:
      ├── u(x_faa, y_aca, z_aac, time)
      │   └── attributes: {location, indices}
      ├── v(x_caa, y_afa, z_aac, time)
      │   └── attributes: {location, indices}
      └── w(x_caa, y_aca, z_aaf, time)
          └── attributes: {location, indices}
```

###  This PR — single grid

```
  output.nc
  │
  ├── Global attributes:
  │   ├── date, Julia, Oceananigans
  │   └── schedule_interval, ...
  │
  ├── Groups (grid reconstruction — unprefixed, same as main):
  │   ├── underlying_grid_reconstruction_args
  │   ├── underlying_grid_reconstruction_kwargs
  │   └── grid_reconstruction_metadata
  │
  ├── Dimensions (unsuffixed, same as main):
  │   ├── x_faa(Nx+1), x_caa(Nx)
  │   ├── y_afa(Ny+1), y_aca(Ny)
  │   ├── z_aaf(Nz+1), z_aac(Nz)
  │   └── time(unlimited)
  │
  ├── Grid metrics (unsuffixed, same as main):
  │   ├── Δx_faa, Δx_caa
  │   ├── Δy_afa, Δy_aca
  │   └── Δz_aaf, Δz_aac
  │
  └── Output variables:
      ├── u(x_faa, y_aca, z_aac, time)
      │   └── attributes: {location, indices, grid_index=1}
      ├── v(x_caa, y_afa, z_aac, time)
      │   └── attributes: {location, indices, grid_index=1}
      └── w(x_caa, y_aca, z_aaf, time)
          └── attributes: {location, indices, grid_index=1}
```

Fully backward compatible with main. Only difference: outputs carry an extra grid_index attribute which is a throw-away.

###  This PR — multiple grids

```
  output.nc
  │
  ├── Global attributes:
  │   ├── date, Julia, Oceananigans
  │   └── schedule_interval, ...
  │
  ├── Groups (per-grid reconstruction, prefixed):
  │   ├── grid_1_underlying_grid_reconstruction_args
  │   ├── grid_1_underlying_grid_reconstruction_kwargs
  │   ├── grid_1_grid_reconstruction_metadata
  │   ├── grid_2_underlying_grid_reconstruction_args
  │   ├── grid_2_underlying_grid_reconstruction_kwargs
  │   └── grid_2_grid_reconstruction_metadata
  │
  ├── Dimensions (suffixed per grid):
  │   ├── x_faa_grid1(Nx1+1), x_caa_grid1(Nx1)
  │   ├── y_afa_grid1(Ny1+1), y_aca_grid1(Ny1)
  │   ├── z_aaf_grid1(Nz1+1), z_aac_grid1(Nz1)
  │   ├── x_faa_grid2(Nx2+1), x_caa_grid2(Nx2)
  │   ├── y_afa_grid2(Ny2+1), y_aca_grid2(Ny2)
  │   ├── z_aaf_grid2(Nz2+1), z_aac_grid2(Nz2)
  │   └── time(unlimited)
  │
  ├── Grid metrics (suffixed per grid):
  │   ├── Δx_faa_grid1, Δx_caa_grid1, ...
  │   └── Δx_faa_grid2, Δx_caa_grid2, ...
  │
  └── Output variables:
      ├── u(x_faa_grid1, y_aca_grid1, z_aac_grid1, time)
      │   └── attributes: {location, indices, grid_index=1}
      ├── v(x_caa_grid1, y_afa_grid1, z_aac_grid1, time)
      │   └── attributes: {location, indices, grid_index=1}
      └── T(x_caa_grid2, y_aca_grid2, z_aac_grid2, time)
          └── attributes: {location, indices, grid_index=2}
```