### PR TITLE
Fill all halo cells for Flux, Value/Gradient, and Open BCs

### DIFF
--- a/src/BoundaryConditions/fill_halo_regions_flux.jl
+++ b/src/BoundaryConditions/fill_halo_regions_flux.jl
@@ -19,9 +19,38 @@
 ##### Combined halo filling functions
 #####
 
-@inline _fill_west_halo!(j, k, grid, c, ::FBC, args...)   =   _fill_flux_west_halo!(1, j, k, grid, c)
-@inline _fill_east_halo!(j, k, grid, c, ::FBC, args...)   =   _fill_flux_east_halo!(1, j, k, grid, c)
-@inline _fill_south_halo!(i, k, grid, c, ::FBC, args...)  =  _fill_flux_south_halo!(i, 1, k, grid, c)
-@inline _fill_north_halo!(i, k, grid, c, ::FBC, args...)  =  _fill_flux_north_halo!(i, 1, k, grid, c)
-@inline _fill_bottom_halo!(i, j, grid, c, ::FBC, args...) = _fill_flux_bottom_halo!(i, j, 1, grid, c)
-@inline _fill_top_halo!(i, j, grid, c, ::FBC, args...)    =    _fill_flux_top_halo!(i, j, 1, grid, c)
+@inline function _fill_west_halo!(j, k, grid, c, ::FBC, args...)
+    @inbounds for h in 1:grid.Hx
+        _fill_flux_west_halo!(h, j, k, grid, c)
+    end
+end
+
+@inline function _fill_east_halo!(j, k, grid, c, ::FBC, args...)
+    @inbounds for h in 1:grid.Hx
+        _fill_flux_east_halo!(h, j, k, grid, c)
+    end
+end
+
+@inline function _fill_south_halo!(i, k, grid, c, ::FBC, args...)
+    @inbounds for h in 1:grid.Hy
+        _fill_flux_south_halo!(i, h, k, grid, c)
+    end
+end
+
+@inline function _fill_north_halo!(i, k, grid, c, ::FBC, args...)
+    @inbounds for h in 1:grid.Hy
+        _fill_flux_north_halo!(i, h, k, grid, c)
+    end
+end
+
+@inline function _fill_bottom_halo!(i, j, grid, c, ::FBC, args...)
+    @inbounds for h in 1:grid.Hz
+        _fill_flux_bottom_halo!(i, j, h, grid, c)
+    end
+end
+
+@inline function _fill_top_halo!(i, j, grid, c, ::FBC, args...)
+    @inbounds for h in 1:grid.Hz
+        _fill_flux_top_halo!(i, j, h, grid, c)
+    end
+end

--- a/src/BoundaryConditions/fill_halo_regions_open.jl
+++ b/src/BoundaryConditions/fill_halo_regions_open.jl
@@ -1,10 +1,45 @@
-# Open boundary fill
-@inline   _fill_west_halo!(j, k, grid, c, bc::OBC, loc, args...) = @inbounds c[1, j, k]           = getbc(bc, j, k, grid, args...)
-@inline   _fill_east_halo!(j, k, grid, c, bc::OBC, loc, args...) = @inbounds c[grid.Nx + 1, j, k] = getbc(bc, j, k, grid, args...)
-@inline  _fill_south_halo!(i, k, grid, c, bc::OBC, loc, args...) = @inbounds c[i, 1, k]           = getbc(bc, i, k, grid, args...)
-@inline  _fill_north_halo!(i, k, grid, c, bc::OBC, loc, args...) = @inbounds c[i, grid.Ny + 1, k] = getbc(bc, i, k, grid, args...)
-@inline _fill_bottom_halo!(i, j, grid, c, bc::OBC, loc, args...) = @inbounds c[i, j, 1]           = getbc(bc, i, j, grid, args...)
-@inline    _fill_top_halo!(i, j, grid, c, bc::OBC, loc, args...) = @inbounds c[i, j, grid.Nz + 1] = getbc(bc, i, j, grid, args...)
+# Open boundary fill — set the boundary value, then extrapolate (zero gradient) into deeper halo cells
+@inline function _fill_west_halo!(j, k, grid, c, bc::OBC, loc, args...)
+    @inbounds c[1, j, k] = getbc(bc, j, k, grid, args...)
+    @inbounds for h in 1:grid.Hx
+        c[1 - h, j, k] = c[1, j, k]
+    end
+end
+
+@inline function _fill_east_halo!(j, k, grid, c, bc::OBC, loc, args...)
+    @inbounds c[grid.Nx + 1, j, k] = getbc(bc, j, k, grid, args...)
+    @inbounds for h in 2:grid.Hx
+        c[grid.Nx + h, j, k] = c[grid.Nx + 1, j, k]
+    end
+end
+
+@inline function _fill_south_halo!(i, k, grid, c, bc::OBC, loc, args...)
+    @inbounds c[i, 1, k] = getbc(bc, i, k, grid, args...)
+    @inbounds for h in 1:grid.Hy
+        c[i, 1 - h, k] = c[i, 1, k]
+    end
+end
+
+@inline function _fill_north_halo!(i, k, grid, c, bc::OBC, loc, args...)
+    @inbounds c[i, grid.Ny + 1, k] = getbc(bc, i, k, grid, args...)
+    @inbounds for h in 2:grid.Hy
+        c[i, grid.Ny + h, k] = c[i, grid.Ny + 1, k]
+    end
+end
+
+@inline function _fill_bottom_halo!(i, j, grid, c, bc::OBC, loc, args...)
+    @inbounds c[i, j, 1] = getbc(bc, i, j, grid, args...)
+    @inbounds for h in 1:grid.Hz
+        c[i, j, 1 - h] = c[i, j, 1]
+    end
+end
+
+@inline function _fill_top_halo!(i, j, grid, c, bc::OBC, loc, args...)
+    @inbounds c[i, j, grid.Nz + 1] = getbc(bc, i, j, grid, args...)
+    @inbounds for h in 2:grid.Hz
+        c[i, j, grid.Nz + h] = c[i, j, grid.Nz + 1]
+    end
+end
 
 @inline function fill_halo_event!(c, kernel!, bcs::Tuple{<:OBC, <:OBC}, loc, grid, args...; fill_open_bcs=true, kwargs...)
     if fill_open_bcs

--- a/src/BoundaryConditions/fill_halo_regions_value_gradient.jl
+++ b/src/BoundaryConditions/fill_halo_regions_value_gradient.jl
@@ -38,18 +38,20 @@ end
            #  -----  interior face
     iᴵ = 1 #    *    interior cell
     iᴮ = 1 #  =====  western boundary
-    iᴴ = 0 #    *    halo cell
+           #    *    halo cells (1 to Hx deep)
 
     LX, LY, LZ = loc
     Δ = Δx(iᴮ, j, k, grid, flip(LX), LY, LZ) # Δ between first interior and first west halo point, defined at cell face.
     @inbounds ∇c = left_gradient(bc, c[iᴵ, j, k], Δ, j, k, grid, args...)
-    @inbounds c[iᴴ, j, k] = linearly_extrapolate(c[iᴵ, j, k], ∇c, -Δ) # extrapolate westward in -x direction.
+    @inbounds for h in 1:grid.Hx
+        c[1 - h, j, k] = linearly_extrapolate(c[iᴵ, j, k], ∇c, -h * Δ) # extrapolate westward in -x direction.
+    end
 end
 
 @inline function _fill_east_halo!(j, k, grid, c, bc::Union{VBC, GBC, MBC}, loc, args...)
 
                      #  ↑ x ↑
-    iᴴ = grid.Nx + 1 #    *   halo cell
+                     #    *   halo cells (1 to Hx deep)
     iᴮ = grid.Nx + 1 #  ===== eastern boundary
     iᴵ = grid.Nx     #    *   interior cell
                      #  ----- interior face
@@ -58,7 +60,9 @@ end
     LX, LY, LZ = loc
     Δ = Δx(iᴮ, j, k, grid, flip(LX), LY, LZ) # Δ between last interior and first east halo point, defined at cell face.
     @inbounds ∇c = right_gradient(bc, c[iᴵ, j, k], Δ, j, k, grid, args...)
-    @inbounds c[iᴴ, j, k] = linearly_extrapolate(c[iᴵ, j, k], ∇c, Δ) # extrapolate eastward in +x direction.
+    @inbounds for h in 1:grid.Hx
+        c[grid.Nx + h, j, k] = linearly_extrapolate(c[iᴵ, j, k], ∇c, h * Δ) # extrapolate eastward in +x direction.
+    end
 end
 
 @inline function _fill_south_halo!(i, k, grid, c, bc::Union{VBC, GBC, MBC}, loc, args...)
@@ -67,18 +71,20 @@ end
            #  -----  interior face
     jᴵ = 1 #    *    interior cell
     jᴮ = 1 #  =====  southern boundary
-    jᴴ = 0 #    *    halo cell
+           #    *    halo cells (1 to Hy deep)
 
     LX, LY, LZ = loc
     Δ = Δy(i, jᴮ, k, grid, LX, flip(LY), LZ) # Δ between first interior and first south halo point, defined at cell face.
     @inbounds ∇c = left_gradient(bc, c[i, jᴵ, k], Δ, i, k, grid, args...)
-    @inbounds c[i, jᴴ, k] = linearly_extrapolate(c[i, jᴵ, k], ∇c, -Δ) # extrapolate southward in -y direction.
+    @inbounds for h in 1:grid.Hy
+        c[i, 1 - h, k] = linearly_extrapolate(c[i, jᴵ, k], ∇c, -h * Δ) # extrapolate southward in -y direction.
+    end
 end
 
 @inline function _fill_north_halo!(i, k, grid, c, bc::Union{VBC, GBC, MBC}, loc, args...)
 
                      #  ↑ y ↑
-    jᴴ = grid.Ny + 1 #    *   halo cell
+                     #    *   halo cells (1 to Hy deep)
     jᴮ = grid.Ny + 1 #  ===== northern boundary
     jᴵ = grid.Ny     #    *   interior cell
                      #  ----- interior face
@@ -87,7 +93,9 @@ end
     LX, LY, LZ = loc
     Δ = Δy(i, jᴮ, k, grid, LX, flip(LY), LZ) # Δ between first interior and first north halo point, defined at cell face.
     @inbounds ∇c = right_gradient(bc, c[i, jᴵ, k], Δ, i, k, grid, args...)
-    @inbounds c[i, jᴴ, k] = linearly_extrapolate(c[i, jᴵ, k], ∇c, Δ) # extrapolate northward in +y direction.
+    @inbounds for h in 1:grid.Hy
+        c[i, grid.Ny + h, k] = linearly_extrapolate(c[i, jᴵ, k], ∇c, h * Δ) # extrapolate northward in +y direction.
+    end
 end
 
 @inline function _fill_bottom_halo!(i, j, grid, c, bc::Union{VBC, GBC, MBC}, loc, args...)
@@ -96,18 +104,20 @@ end
            #  -----  interior face
     kᴵ = 1 #    *    interior cell
     kᴮ = 1 #  =====  bottom boundary
-    kᴴ = 0 #    *    halo cell
+           #    *    halo cells (1 to Hz deep)
 
     LX, LY, LZ = loc
     Δ = Δz(i, j, kᴮ, grid, LX, LY, flip(LZ)) # Δ between first interior and first bottom halo point, defined at cell face.
     @inbounds ∇c = left_gradient(bc, c[i, j, kᴵ], Δ, i, j, grid, args...)
-    @inbounds c[i, j, kᴴ] = linearly_extrapolate(c[i, j, kᴵ], ∇c, -Δ) # extrapolate downward in -z direction.
+    @inbounds for h in 1:grid.Hz
+        c[i, j, 1 - h] = linearly_extrapolate(c[i, j, kᴵ], ∇c, -h * Δ) # extrapolate downward in -z direction.
+    end
 end
 
 @inline function _fill_top_halo!(i, j, grid, c, bc::Union{VBC, GBC, MBC}, loc, args...)
 
                      #  ↑ z ↑
-    kᴴ = grid.Nz + 1 #    *    halo cell
+                     #    *    halo cells (1 to Hz deep)
     kᴮ = grid.Nz + 1 #  =====  top boundary
     kᴵ = grid.Nz     #    *    interior cell
                      #  -----  interior face
@@ -115,5 +125,7 @@ end
     LX, LY, LZ = loc
     Δ = Δz(i, j, kᴮ, grid, LX, LY, flip(LZ)) # Δ between first interior and first top halo point, defined at cell face.
     @inbounds ∇c = right_gradient(bc, c[i, j, kᴵ], Δ, i, j, grid, args...)
-    @inbounds c[i, j, kᴴ] = linearly_extrapolate(c[i, j, kᴵ], ∇c, Δ) # extrapolate upward in +z direction.
+    @inbounds for h in 1:grid.Hz
+        c[i, j, grid.Nz + h] = linearly_extrapolate(c[i, j, kᴵ], ∇c, h * Δ) # extrapolate upward in +z direction.
+    end
 end


### PR DESCRIPTION
## Summary

- The `_fill_*_halo!` functions for Flux, Value/Gradient/Mixed, and Open BCs previously filled only **the first halo cell** (h=1). High-order schemes requiring large halos (e.g., WENO9 with halo=5) had outer halo cells left unfilled (stale or zero).
- This fix loops over all halo cells (`1:grid.Hx/Hy/Hz`) for each BC type:
  - **Flux BCs**: call the per-cell flux fill for each halo depth
  - **Value/Gradient/Mixed BCs**: linearly extrapolate from the boundary into all halo cells
  - **Open BCs**: set boundary value, then zero-gradient extrapolate into deeper cells

This bug was discovered while debugging NaN crashes with WENO9 (halo=5) on a neutral ABL simulation (see #5485). Diagnostic analysis confirmed that `ρw` halos were all-zero throughout the simulation. While fixing the halos alone did not resolve the NaN crash (which has a separate Float32 precision root cause), the unfilled halos affect correctness of stencil computations near bounded boundaries for any scheme with halo > 1.

## Test plan

- [ ] Existing boundary condition tests pass (these use small halos, so behavior is unchanged for halo=1)
- [ ] Verify halo fill with `halo=(5,5,5)`: all 5 halo cells should be properly filled for Flux, Value, Gradient, and Open BCs
- [ ] Run WENO9 simulation and confirm halo cells are non-zero near Bounded boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)