### PR TITLE
Use DOI URL for Oceananigans JOSS paper

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -119,7 +119,7 @@ the features they describe! Also, if you have developed a new feature in Oceanan
   *This paper describes the development of `CATKEVerticalDiffusivity()`, including how it was automatically calibrated to
   a suite of 35 large eddy simulations (also run with Oceananigans). It additionally features solutions from `TKEDissipationVerticalDiffusivity` (also known as "k-epsilon").*
 
-* **Ramadhan et al. (2020), ["Oceananigans.jl: Fast and friendly geophysical fluid dynamics on GPUs"](https://par.nsf.gov/servlets/purl/10200806).**
+* **Ramadhan et al. (2020), ["Oceananigans.jl: Fast and friendly geophysical fluid dynamics on GPUs"](https://doi.org/10.21105/joss.02018).**
 
   *This Journal of Open Source Software article describes an early version of Oceananigans' `NonhydrostaticModel`.*
 


### PR DESCRIPTION
https://buildkite.com/clima/oceananigans/builds/30914#019d9a72-a779-4c00-b00f-1a3c8bddef61/L3903
```
┌ Error: linkcheck 'https://par.nsf.gov/servlets/purl/10200806' status: 502.
└ @ Documenter ~/.julia/packages/Documenter/AXNMp/src/utilities/utilities.jl:47
```
Not sure why this URL was used when the paper has a DOI :slightly_smiling_face: 

Spotted in https://github.com/CliMA/Oceananigans.jl/pull/5491#issuecomment-4269203886