### PR TITLE
Explicit imports in `Advection`

### DIFF
--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -17,25 +17,19 @@ export
     EnergyConserving,
     EnstrophyConserving
 
-using DocStringExtensions
-
-using Adapt
-using OffsetArrays
+using Adapt: Adapt
+using OffsetArrays: OffsetArray
 using MuladdMacro: @muladd
 
-using Oceananigans
-using Oceananigans.Grids
-using Oceananigans.Operators
-
-using Oceananigans: fully_supported_float_types
-using Oceananigans.Architectures: architecture, CPU
-using Oceananigans.Grids: with_halo
-using Oceananigans.Operators: flux_div_xyᶜᶜᶜ, ∂t_σ
-using Oceananigans.Grids: XFlatGrid, YFlatGrid, ZFlatGrid
-
-import Base: summary, Callable
-import Oceananigans.Grids: required_halo_size_x, required_halo_size_y, required_halo_size_z
-import Oceananigans.Architectures: on_architecture
+using Oceananigans: Oceananigans, fully_supported_float_types
+using Oceananigans.Architectures: Architectures, architecture, on_architecture, CPU
+using Oceananigans.Grids: Grids, AbstractGrid, Center, Face, Flat, XFlatGrid, YFlatGrid, ZFlatGrid, with_halo,
+    required_halo_size_x, required_halo_size_y, required_halo_size_z
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
+using Oceananigans.Operators: flux_div_xyᶜᶜᶜ, ∂t_σ, Ax_qᶠᶜᶜ, Axᶠᶜᶜ, Ay_qᶜᶠᶜ, Ayᶜᶠᶜ, Az_qᶜᶜᶠ,
+    Azᶜᶜᶜ, Azᶜᶜᶠ, Az⁻¹ᶜᶠᶜ, Az⁻¹ᶠᶜᶜ, V⁻¹ᶜᶜᶠ, V⁻¹ᶜᶠᶜ, V⁻¹ᶠᶜᶜ, Δx_qᶜᶠᶜ, Δx⁻¹ᶠᶜᶜ, Δy_qᶠᶜᶜ,
+    Δy⁻¹ᶜᶠᶜ, δxᶜᵃᵃ, δxᶠᵃᵃ, δyᵃᶜᵃ, δyᵃᶠᵃ, δzᵃᵃᶜ, ℑxᶜᵃᵃ, ℑyᵃᶜᵃ, ℑzᵃᵃᶜ, ℑzᵃᵃᶠ
+using Base: Callable
 
 abstract type AbstractAdvectionScheme{B, FT} end
 abstract type AbstractCenteredAdvectionScheme{B, FT} <: AbstractAdvectionScheme{B, FT} end
@@ -53,9 +47,9 @@ const advection_buffers = [1, 2, 3, 4, 5, 6]
 
 @inline Base.eltype(::AbstractAdvectionScheme{<:Any, FT}) where FT = FT
 
-@inline required_halo_size_x(::AbstractAdvectionScheme{B}) where B = B
-@inline required_halo_size_y(::AbstractAdvectionScheme{B}) where B = B
-@inline required_halo_size_z(::AbstractAdvectionScheme{B}) where B = B
+@inline Grids.required_halo_size_x(::AbstractAdvectionScheme{B}) where B = B
+@inline Grids.required_halo_size_y(::AbstractAdvectionScheme{B}) where B = B
+@inline Grids.required_halo_size_z(::AbstractAdvectionScheme{B}) where B = B
 
 struct DecreasingOrderAdvectionScheme end
 

--- a/src/Advection/cell_advection_timescale.jl
+++ b/src/Advection/cell_advection_timescale.jl
@@ -1,4 +1,5 @@
 using Oceananigans.AbstractOperations: KernelFunctionOperation
+using Oceananigans.Operators: Δz⁻¹ᶜᶜᶠ
 
 """
     cell_advection_timescale(grid, velocities)

--- a/src/Advection/centered_advective_fluxes.jl
+++ b/src/Advection/centered_advective_fluxes.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Operators: Axᶜᶜᶜ, Axᶠᶜᶠ, Axᶠᶠᶜ, Ayᶜᶜᶜ, Ayᶜᶠᶠ, Ayᶠᶠᶜ, Azᶜᶠᶠ, Azᶠᶜᶠ
+
 #####
 ##### Momentum and advective tracer flux operators for centered advection schemes
 #####

--- a/src/Advection/centered_reconstruction.jl
+++ b/src/Advection/centered_reconstruction.jl
@@ -34,7 +34,7 @@ Base.show(io::IO, a::Centered{N, FT}) where {N, FT} =
 
 
 Adapt.adapt_structure(to, scheme::Centered{N, FT}) where {N, FT} = Centered{N, FT}(Adapt.adapt(to, scheme.buffer_scheme))
-on_architecture(to, scheme::Centered{N, FT}) where {N, FT} = Centered{N, FT}(on_architecture(to, scheme.buffer_scheme))
+Architectures.on_architecture(to, scheme::Centered{N, FT}) where {N, FT} = Centered{N, FT}(on_architecture(to, scheme.buffer_scheme))
 
 const ACAS = AbstractCenteredAdvectionScheme
 

--- a/src/Advection/curvature_metric_terms.jl
+++ b/src/Advection/curvature_metric_terms.jl
@@ -1,6 +1,5 @@
 using Oceananigans.Grids: AbstractHorizontallyCurvilinearGrid
-using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
-using Oceananigans.Operators
+using Oceananigans.Operators: Δxᶜᶜᶜ, Δxᶠᶠᶜ, Δyᶜᶜᶜ, Δyᶠᶠᶜ
 
 #####
 ##### Curvature metric terms for flux-form momentum advection

--- a/src/Advection/flat_advective_fluxes.jl
+++ b/src/Advection/flat_advective_fluxes.jl
@@ -1,5 +1,3 @@
-using Oceananigans.ImmersedBoundaries
-
 #####
 ##### Flat Topologies
 #####

--- a/src/Advection/flux_form_advection.jl
+++ b/src/Advection/flux_form_advection.jl
@@ -37,9 +37,9 @@ Base.show(io::IO, scheme::FluxFormAdvection) =
               "├── y: ", summary(scheme.y), "\n",
               "└── z: ", summary(scheme.z))
 
-@inline required_halo_size_x(scheme::FluxFormAdvection) = required_halo_size_x(scheme.x)
-@inline required_halo_size_y(scheme::FluxFormAdvection) = required_halo_size_y(scheme.y)
-@inline required_halo_size_z(scheme::FluxFormAdvection) = required_halo_size_z(scheme.z)
+@inline Grids.required_halo_size_x(scheme::FluxFormAdvection) = required_halo_size_x(scheme.x)
+@inline Grids.required_halo_size_y(scheme::FluxFormAdvection) = required_halo_size_y(scheme.y)
+@inline Grids.required_halo_size_z(scheme::FluxFormAdvection) = required_halo_size_z(scheme.z)
 
 Adapt.adapt_structure(to, scheme::FluxFormAdvection{N, FT}) where {N, FT} =
     FluxFormAdvection{N, FT}(Adapt.adapt(to, scheme.x),

--- a/src/Advection/immersed_advective_fluxes.jl
+++ b/src/Advection/immersed_advective_fluxes.jl
@@ -193,7 +193,7 @@ for bias in (:symmetric, :biased)
     for (d, ξ) in enumerate((:x, :y, :z))
         code = [:ᵃ, :ᵃ, :ᵃ]
 
-        for loc in (:ᶜ, :ᶠ), alt in (:_, :__, :___, :____, :_____)
+        for loc in (:ᶜ, :ᶠ)
             code[d] = loc
             interp = Symbol(bias, :_interpolate_, ξ, code...)
             @eval begin

--- a/src/Advection/immersed_advective_fluxes.jl
+++ b/src/Advection/immersed_advective_fluxes.jl
@@ -1,4 +1,3 @@
-using Oceananigans.ImmersedBoundaries
 using Oceananigans.ImmersedBoundaries: immersed_peripheral_node, inactive_node
 using Oceananigans.Fields: ZeroField
 
@@ -197,9 +196,7 @@ for bias in (:symmetric, :biased)
         for loc in (:ᶜ, :ᶠ), alt in (:_, :__, :___, :____, :_____)
             code[d] = loc
             interp = Symbol(bias, :_interpolate_, ξ, code...)
-            alt_interp = Symbol(alt, interp)
             @eval begin
-                import Oceananigans.Advection: $alt_interp
                 using Oceananigans.Advection: $interp
             end
         end

--- a/src/Advection/immersed_advective_fluxes.jl
+++ b/src/Advection/immersed_advective_fluxes.jl
@@ -193,14 +193,6 @@ for bias in (:symmetric, :biased)
     for (d, ξ) in enumerate((:x, :y, :z))
         code = [:ᵃ, :ᵃ, :ᵃ]
 
-        for loc in (:ᶜ, :ᶠ)
-            code[d] = loc
-            interp = Symbol(bias, :_interpolate_, ξ, code...)
-            @eval begin
-                using Oceananigans.Advection: $interp
-            end
-        end
-
         for loc in (:ᶜ, :ᶠ), (alt1, alt2) in zip((:_, :__, :___, :____, :_____), (:_____, :_, :__, :___, :____))
             code[d] = loc
             interp = Symbol(bias, :_interpolate_, ξ, code...)

--- a/src/Advection/materialize_advection.jl
+++ b/src/Advection/materialize_advection.jl
@@ -1,5 +1,3 @@
-import Oceananigans: architecture
-
 """
     materialize_advection(advection, grid)
 

--- a/src/Advection/momentum_advection_operators.jl
+++ b/src/Advection/momentum_advection_operators.jl
@@ -1,4 +1,5 @@
 using Oceananigans.Fields: ZeroField
+using Oceananigans.Operators: δzᵃᵃᶠ
 
 #####
 ##### Momentum advection operators

--- a/src/Advection/topologically_conditional_interpolation.jl
+++ b/src/Advection/topologically_conditional_interpolation.jl
@@ -15,7 +15,11 @@ using Oceananigans.Grids: AbstractGrid,
                           RightConnected,
                           LeftConnected,
                           topology,
-                          architecture
+                          architecture,
+                          LeftConnectedRightCenterConnected,
+                          LeftConnectedRightCenterFolded,
+                          LeftConnectedRightFaceConnected,
+                          LeftConnectedRightFaceFolded
 
 const AG = AbstractGrid
 

--- a/src/Advection/topologically_conditional_interpolation.jl
+++ b/src/Advection/topologically_conditional_interpolation.jl
@@ -90,7 +90,6 @@ for bias in (:symmetric, :biased)
 
         for loc in (:ᶜ, :ᶠ), (alt1, alt2) in zip((:_, :__, :___, :____, :_____), (:_____, :_, :__, :___, :____))
             code[d] = loc
-            second_order_interp = Symbol(:ℑ, ξ, code...)
             interp = Symbol(bias, :_interpolate_, ξ, code...)
             alt1_interp = Symbol(alt1, interp)
             alt2_interp = Symbol(alt2, interp)

--- a/src/Advection/tracer_advection_operators.jl
+++ b/src/Advection/tracer_advection_operators.jl
@@ -1,3 +1,4 @@
+using Oceananigans.Operators: V⁻¹ᶜᶜᶜ
 
 @inline _advective_tracer_flux_x(i, j, k, grid, scheme, U, c) = advective_tracer_flux_x(i, j, k, grid, scheme, U, c)
 @inline _advective_tracer_flux_y(i, j, k, grid, scheme, V, c) = advective_tracer_flux_y(i, j, k, grid, scheme, V, c)

--- a/src/Advection/upwind_biased_reconstruction.jl
+++ b/src/Advection/upwind_biased_reconstruction.jl
@@ -20,7 +20,7 @@ function UpwindBiased(FT::DataType = Float64;
     N = Int((order + 1) ÷ 2)
 
     if N > 1
-        coefficients = Tuple(nothing for i in 1:6)
+        # coefficients = Tuple(nothing for i in 1:6)
         # Stretched coefficient seem to be more unstable that constant spacing ones for
         # linear (non-WENO) upwind reconstruction. We keep constant coefficients for the moment
         # Some tests are needed to verify why this is the case (and if it is expected)

--- a/src/Advection/upwind_biased_reconstruction.jl
+++ b/src/Advection/upwind_biased_reconstruction.jl
@@ -75,7 +75,7 @@ Adapt.adapt_structure(to, scheme::UpwindBiased{N, FT}) where {N, FT} =
     UpwindBiased{N, FT}(Adapt.adapt(to, scheme.buffer_scheme),
                         Adapt.adapt(to, scheme.advecting_velocity_scheme))
 
-on_architecture(to, scheme::UpwindBiased{N, FT}) where {N, FT} =
+Architectures.on_architecture(to, scheme::UpwindBiased{N, FT}) where {N, FT} =
     UpwindBiased{N, FT}(on_architecture(to, scheme.buffer_scheme),
                         on_architecture(to, scheme.advecting_velocity_scheme))
 

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Operators: Vᶜᶠᶜ, Vᶠᶜᶜ, δxᶠᶜᶜ, δyᶜᶠᶜ, ζ₃ᶠᶠᶜ, ∂zᶜᶠᶠ, ∂zᶠᶜᶠ
+
 # These are also used in Coriolis/hydrostatic_spherical_coriolis.jl
 struct EnergyConserving{FT}    <: AbstractAdvectionScheme{1, FT} end
 struct EnstrophyConserving{FT} <: AbstractAdvectionScheme{1, FT} end
@@ -251,7 +253,7 @@ end
 
 # Since vorticity itself requires one halo, if we use an upwinding scheme (N > 1) we require one additional
 # halo for vector invariant advection
-@inline function required_halo_size_x(scheme::VectorInvariant)
+@inline function Grids.required_halo_size_x(scheme::VectorInvariant)
     Hx₁ = required_halo_size_x(scheme.vorticity_scheme)
     Hx₂ = required_halo_size_x(scheme.divergence_scheme)
     Hx₃ = required_halo_size_x(scheme.kinetic_energy_gradient_scheme)
@@ -260,8 +262,8 @@ end
     return Hx == 1 ? Hx : Hx + 1
 end
 
-@inline required_halo_size_y(scheme::VectorInvariant) = required_halo_size_x(scheme)
-@inline required_halo_size_z(scheme::VectorInvariant) = required_halo_size_z(scheme.vertical_advection_scheme)
+@inline Grids.required_halo_size_y(scheme::VectorInvariant) = required_halo_size_x(scheme)
+@inline Grids.required_halo_size_z(scheme::VectorInvariant) = required_halo_size_z(scheme.vertical_advection_scheme)
 
 Adapt.adapt_structure(to, scheme::VectorInvariant{N, FT, M}) where {N, FT, M} =
     VectorInvariant{N, FT, M}(Adapt.adapt(to, scheme.vorticity_scheme),
@@ -271,7 +273,7 @@ Adapt.adapt_structure(to, scheme::VectorInvariant{N, FT, M}) where {N, FT, M} =
                               Adapt.adapt(to, scheme.divergence_scheme),
                               Adapt.adapt(to, scheme.upwinding))
 
-on_architecture(to, scheme::VectorInvariant{N, FT, M}) where {N, FT, M} =
+Architectures.on_architecture(to, scheme::VectorInvariant{N, FT, M}) where {N, FT, M} =
     VectorInvariant{N, FT, M}(on_architecture(to, scheme.vorticity_scheme),
                               on_architecture(to, scheme.vorticity_stencil),
                               on_architecture(to, scheme.vertical_advection_scheme),

--- a/src/Advection/vector_invariant_advection.jl
+++ b/src/Advection/vector_invariant_advection.jl
@@ -137,7 +137,6 @@ Base.summary(a::MultiDimensionalVectorInvariant) = "VectorInvariant, multidimens
 function Base.summary(a::WENOVectorInvariant{N}) where N
     vorticity_order = weno_order(a.vorticity_scheme)
     vertical_order = weno_order(a.vertical_advection_scheme)
-    order = weno_order(a.vorticity_scheme)
     FT = eltype(a.vorticity_scheme)
     return string("WENOVectorInvariant{$N, $FT}(vorticity_order=$vorticity_order, vertical_order=$vertical_order)")
 end

--- a/src/Advection/vector_invariant_cross_upwinding.jl
+++ b/src/Advection/vector_invariant_cross_upwinding.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Operators: Δrᶜᶜᶜ
+
 #####
 ##### Cross upwinding results in the largest kinetic energy content,
 ##### but because of presence of mixed upwinding the truncation error of

--- a/src/Advection/vector_invariant_self_upwinding.jl
+++ b/src/Advection/vector_invariant_self_upwinding.jl
@@ -1,3 +1,5 @@
+using Oceananigans.Operators: δxᶜᶜᶜ, δxᶠᶠᶜ, δyᶜᶜᶜ, δyᶠᶠᶜ
+
 #####
 ##### Self Upwinding of Divergence Flux, the best option!
 #####

--- a/src/Advection/weno_reconstruction.jl
+++ b/src/Advection/weno_reconstruction.jl
@@ -1,5 +1,3 @@
-import Oceananigans
-
 #####
 ##### Weighted Essentially Non-Oscillatory (WENO) advection scheme
 #####
@@ -160,7 +158,7 @@ Adapt.adapt_structure(to, scheme::WENO{N, FT, WCT}) where {N, FT, WCT} =
                       Adapt.adapt(to, scheme.buffer_scheme),
                       Adapt.adapt(to, scheme.advecting_velocity_scheme))
 
-on_architecture(to, scheme::WENO{N, FT, WCT}) where {N, FT, WCT} =
+Architectures.on_architecture(to, scheme::WENO{N, FT, WCT}) where {N, FT, WCT} =
     WENO{N, FT, WCT}(on_architecture(to, scheme.bounds),
                      on_architecture(to, scheme.buffer_scheme),
                      on_architecture(to, scheme.advecting_velocity_scheme))

--- a/test/test_quality_assurance.jl
+++ b/test/test_quality_assurance.jl
@@ -55,7 +55,7 @@ end
 
     modules = (
         Oceananigans.AbstractOperations,
-        # Oceananigans.Advection,
+        Oceananigans.Advection,
         # Oceananigans.Architectures,
         Oceananigans.Biogeochemistry,
         # Oceananigans.BoundaryConditions,


### PR DESCRIPTION
This also solves https://buildkite.com/clima/oceananigans/builds/30940#019d9e7e-48d8-4d48-92a9-0dfd44e00187/L607
```
┌ Oceananigans
│  WARNING: Imported binding Oceananigans.architecture was undeclared at import time during import to Advection.
│  WARNING: ignoring conflicting import of Oceananigans.architecture into Advection
└  
```