### PR TITLE
Resolve some ambiguities

### DIFF
--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -18,7 +18,7 @@ tuple_string(tup::Tuple{}) = ""
 ##### set!
 #####
 
-set!(obj, ::Nothing) = nothing
+set!(obj::AbstractField, ::Nothing) = nothing
 
 function set!(Φ::NamedTuple; kwargs...)
     for (fldname, value) in kwargs

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -433,6 +433,7 @@ struct OffsetStaticSize{S} <: _Size
     end
 end
 
+@pure OffsetStaticSize(s::Tuple{}) = OffsetStaticSize{s}()
 @pure OffsetStaticSize(s::Tuple{Vararg{Int}}) = OffsetStaticSize{s}()
 @pure OffsetStaticSize(s::Int...) = OffsetStaticSize{s}()
 @pure OffsetStaticSize(s::Type{<:Tuple}) = OffsetStaticSize{tuple(s.parameters...)}()

--- a/test/test_quality_assurance.jl
+++ b/test/test_quality_assurance.jl
@@ -31,7 +31,7 @@ using Test: @testset, @test, detect_ambiguities
         # Oceananigans.Models,
         # Oceananigans.MultiRegion,
         # Oceananigans.Operators,
-        # Oceananigans.OrthogonalSphericalShellGrids,
+        Oceananigans.OrthogonalSphericalShellGrids,
         # Oceananigans.OutputReaders,
         # Oceananigans.OutputWriters,
         Oceananigans.Simulations,

--- a/test/test_quality_assurance.jl
+++ b/test/test_quality_assurance.jl
@@ -10,7 +10,7 @@ using Test: @testset, @test, detect_ambiguities
     # Until we resolve all ambiguities, we make sure we don't increase them.
     # Do not increase this number. If ambiguities increase, resolve them before merging.
     number_of_ambiguities = length(detect_ambiguities(Oceananigans; recursive=true))
-    @test number_of_ambiguities <= 329
+    @test number_of_ambiguities <= 328
     @info "Number of ambiguities: $number_of_ambiguities"
 
     modules = (
@@ -40,7 +40,7 @@ using Test: @testset, @test, detect_ambiguities
         Oceananigans.TimeSteppers,
         # Oceananigans.TurbulenceClosures,
         Oceananigans.Units,
-        # Oceananigans.Utils,
+        Oceananigans.Utils,
     )
 
     # In addition to capping the total number of ambiguities above, we make sure

--- a/test/test_quality_assurance.jl
+++ b/test/test_quality_assurance.jl
@@ -10,7 +10,7 @@ using Test: @testset, @test, detect_ambiguities
     # Until we resolve all ambiguities, we make sure we don't increase them.
     # Do not increase this number. If ambiguities increase, resolve them before merging.
     number_of_ambiguities = length(detect_ambiguities(Oceananigans; recursive=true))
-    @test number_of_ambiguities <= 328
+    @test number_of_ambiguities <= 326
     @info "Number of ambiguities: $number_of_ambiguities"
 
     modules = (
@@ -32,7 +32,7 @@ using Test: @testset, @test, detect_ambiguities
         # Oceananigans.MultiRegion,
         # Oceananigans.Operators,
         Oceananigans.OrthogonalSphericalShellGrids,
-        # Oceananigans.OutputReaders,
+        Oceananigans.OutputReaders,
         # Oceananigans.OutputWriters,
         Oceananigans.Simulations,
         # Oceananigans.Solvers,


### PR DESCRIPTION
Based on
```julia-repl
julia> for mod in filter(name -> getproperty(Oceananigans, name) isa Module, names(Oceananigans; all=true))
           n = length(Test.detect_ambiguities(getproperty(Oceananigans, mod); recursive=true))
           n == 0 && @info "$(mod) has $(n) ambiguities"
       end
[ Info: Architectures has 0 ambiguities
[ Info: Biogeochemistry has 0 ambiguities
[ Info: BuoyancyFormulations has 0 ambiguities
[ Info: Coriolis has 0 ambiguities
[ Info: Diagnostics has 0 ambiguities
[ Info: Forcings has 0 ambiguities
[ Info: Logger has 0 ambiguities
[ Info: OrthogonalSphericalShellGrids has 0 ambiguities
[ Info: Simulations has 0 ambiguities
[ Info: StokesDrifts has 0 ambiguities
[ Info: TimeSteppers has 0 ambiguities
[ Info: Units has 0 ambiguities
```
`OrthogonalSphericalShellGrids` shouldn't have ambiguities, let's make sure we don't introduce new ones.