### PR TITLE
Avoid use of at-doc macro inside structs

### DIFF
--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -8,17 +8,19 @@ struct BinaryOperation{LX, LY, LZ, O, A, B, IA, IB, G, T} <: AbstractOperation{L
     ▶b :: IB
     grid :: G
 
-    @doc """
-        BinaryOperation{LX, LY, LZ}(op, a, b, ▶a, ▶b, grid)
-
-    Return an abstract representation of the binary operation `op(▶a(a), ▶b(b))` on
-    `grid`, where `▶a` and `▶b` interpolate `a` and `b` to locations `(LX, LY, LZ)`.
-    """
     function BinaryOperation{LX, LY, LZ}(op::O, a::A, b::B, ▶a::IA, ▶b::IB, grid::G,
                                          ::Type{T}=Base.promote_op(op, eltype(a), eltype(b))) where {LX, LY, LZ, O, A, B, IA, IB, G, T}
         return new{LX, LY, LZ, O, A, B, IA, IB, G, T}(op, a, b, ▶a, ▶b, grid)
     end
 end
+
+"""
+    BinaryOperation{LX, LY, LZ}(op, a, b, ▶a, ▶b, grid)
+
+Return an abstract representation of the binary operation `op(▶a(a), ▶b(b))` on
+`grid`, where `▶a` and `▶b` interpolate `a` and `b` to locations `(LX, LY, LZ)`.
+"""
+BinaryOperation
 
 @inline Base.getindex(β::BinaryOperation, i, j, k) = β.op(i, j, k, β.grid, β.▶a, β.▶b, β.a, β.b)
 

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -1,5 +1,11 @@
 const binary_operators = Set()
 
+"""
+    BinaryOperation{LX, LY, LZ}(op, a, b, ▶a, ▶b, grid)
+
+Return an abstract representation of the binary operation `op(▶a(a), ▶b(b))` on
+`grid`, where `▶a` and `▶b` interpolate `a` and `b` to locations `(LX, LY, LZ)`.
+"""
 struct BinaryOperation{LX, LY, LZ, O, A, B, IA, IB, G, T} <: AbstractOperation{LX, LY, LZ, G, T}
     op :: O
     a :: A
@@ -13,14 +19,6 @@ struct BinaryOperation{LX, LY, LZ, O, A, B, IA, IB, G, T} <: AbstractOperation{L
         return new{LX, LY, LZ, O, A, B, IA, IB, G, T}(op, a, b, ▶a, ▶b, grid)
     end
 end
-
-"""
-    BinaryOperation{LX, LY, LZ}(op, a, b, ▶a, ▶b, grid)
-
-Return an abstract representation of the binary operation `op(▶a(a), ▶b(b))` on
-`grid`, where `▶a` and `▶b` interpolate `a` and `b` to locations `(LX, LY, LZ)`.
-"""
-BinaryOperation
 
 @inline Base.getindex(β::BinaryOperation, i, j, k) = β.op(i, j, k, β.grid, β.▶a, β.▶b, β.a, β.b)
 

--- a/src/AbstractOperations/derivatives.jl
+++ b/src/AbstractOperations/derivatives.jl
@@ -7,18 +7,20 @@ struct Derivative{LX, LY, LZ, D, A, IN, AD, G, T} <: AbstractOperation{LX, LY, L
       abstract_∂ :: AD
             grid :: G
 
-    @doc """
-        Derivative{LX, LY, LZ}(∂, arg, ▶, grid)
-
-    Return an abstract representation of the derivative `∂` on `arg`,
-    and subsequent interpolation by `▶` on `grid`.
-    """
     function Derivative{LX, LY, LZ}(∂::D, arg::A, ▶::IN, abstract_∂::AD,
                                     grid::G) where {LX, LY, LZ, D, A, IN, AD, G}
         T = eltype(grid)
         return new{LX, LY, LZ, D, A, IN, AD, G, T}(∂, arg, ▶, abstract_∂, grid)
     end
 end
+
+"""
+    Derivative{LX, LY, LZ}(∂, arg, ▶, grid)
+
+Return an abstract representation of the derivative `∂` on `arg`,
+and subsequent interpolation by `▶` on `grid`.
+"""
+Derivative
 
 @inline Base.getindex(d::Derivative, i, j, k) = d.▶(i, j, k, d.grid, d.∂, d.arg)
 

--- a/src/AbstractOperations/derivatives.jl
+++ b/src/AbstractOperations/derivatives.jl
@@ -1,5 +1,11 @@
 using Oceananigans.Operators: Operators, interpolation_code
 
+"""
+    Derivative{LX, LY, LZ}(∂, arg, ▶, grid)
+
+Return an abstract representation of the derivative `∂` on `arg`,
+and subsequent interpolation by `▶` on `grid`.
+"""
 struct Derivative{LX, LY, LZ, D, A, IN, AD, G, T} <: AbstractOperation{LX, LY, LZ, G, T}
                ∂ :: D
              arg :: A
@@ -13,14 +19,6 @@ struct Derivative{LX, LY, LZ, D, A, IN, AD, G, T} <: AbstractOperation{LX, LY, L
         return new{LX, LY, LZ, D, A, IN, AD, G, T}(∂, arg, ▶, abstract_∂, grid)
     end
 end
-
-"""
-    Derivative{LX, LY, LZ}(∂, arg, ▶, grid)
-
-Return an abstract representation of the derivative `∂` on `arg`,
-and subsequent interpolation by `▶` on `grid`.
-"""
-Derivative
 
 @inline Base.getindex(d::Derivative, i, j, k) = d.▶(i, j, k, d.grid, d.∂, d.arg)
 

--- a/src/AbstractOperations/kernel_function_operation.jl
+++ b/src/AbstractOperations/kernel_function_operation.jl
@@ -1,17 +1,5 @@
 using Oceananigans.Utils: shortsummary, construct_regionally, prettysummary
 
-struct KernelFunctionOperation{LX, LY, LZ, G, T, K, D} <: AbstractOperation{LX, LY, LZ, G, T}
-    kernel_function :: K
-    grid :: G
-    arguments :: D
-
-    function KernelFunctionOperation{LX, LY, LZ}(kernel_function::K, grid::G, arguments::D,
-                                                 ::Type{T}=eltype(grid)) where {LX, LY, LZ, G, T, K, D<:Tuple}
-        return new{LX, LY, LZ, G, T, K, D}(kernel_function, grid, arguments)
-    end
-
-end
-
 """
     KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid, arguments...)
 
@@ -62,7 +50,17 @@ KernelFunctionOperation at (Face, Face, Center)
 └── arguments: ("Field", "Field")
 ```
 """
-KernelFunctionOperation
+struct KernelFunctionOperation{LX, LY, LZ, G, T, K, D} <: AbstractOperation{LX, LY, LZ, G, T}
+    kernel_function :: K
+    grid :: G
+    arguments :: D
+
+    function KernelFunctionOperation{LX, LY, LZ}(kernel_function::K, grid::G, arguments::D,
+                                                 ::Type{T}=eltype(grid)) where {LX, LY, LZ, G, T, K, D<:Tuple}
+        return new{LX, LY, LZ, G, T, K, D}(kernel_function, grid, arguments)
+    end
+
+end
 
 # Convenience outer constructor: splat arguments into a tuple.
 # T defaults to eltype(grid) via the inner constructor.

--- a/src/AbstractOperations/kernel_function_operation.jl
+++ b/src/AbstractOperations/kernel_function_operation.jl
@@ -5,62 +5,64 @@ struct KernelFunctionOperation{LX, LY, LZ, G, T, K, D} <: AbstractOperation{LX, 
     grid :: G
     arguments :: D
 
-    @doc """
-        KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid, arguments...)
-
-    Construct a `KernelFunctionOperation` at location `(LX, LY, LZ)` on `grid` with `arguments`.
-
-    `kernel_function` is called with
-
-    ```julia
-    kernel_function(i, j, k, grid, arguments...)
-    ```
-
-    Note that `compute!(kfo::KernelFunctionOperation)` calls `compute!` on all `kfo.arguments`.
-
-    Examples
-    ========
-
-    Construct a `KernelFunctionOperation` that returns random numbers:
-
-    ```jldoctest kfo
-    using Oceananigans
-
-    grid = RectilinearGrid(size=(1, 8, 8), extent=(1, 1, 1));
-
-    random_kernel_function(i, j, k, grid) = rand();
-    kernel_op = KernelFunctionOperation{Center, Center, Center}(random_kernel_function, grid)
-
-    # output
-    KernelFunctionOperation at (Center, Center, Center)
-    ├── grid: 1×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×3×3 halo
-    ├── kernel_function: random_kernel_function (generic function with 1 method)
-    └── arguments: ()
-    ```
-
-    Construct a `KernelFunctionOperation` using the vertical vorticity operator used internally
-    to compute vertical vorticity on all grids:
-
-    ```jldoctest kfo
-    using Oceananigans.Operators: ζ₃ᶠᶠᶜ # called with signature ζ₃ᶠᶠᶜ(i, j, k, grid, u, v)
-
-    model = HydrostaticFreeSurfaceModel(grid)
-    u, v, w = model.velocities
-    ζ_op = KernelFunctionOperation{Face, Face, Center}(ζ₃ᶠᶠᶜ, grid, u, v)
-
-    # output
-    KernelFunctionOperation at (Face, Face, Center)
-    ├── grid: 1×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×3×3 halo
-    ├── kernel_function: ζ₃ᶠᶠᶜ (generic function with 1 method)
-    └── arguments: ("Field", "Field")
-    ```
-    """
     function KernelFunctionOperation{LX, LY, LZ}(kernel_function::K, grid::G, arguments::D,
                                                  ::Type{T}=eltype(grid)) where {LX, LY, LZ, G, T, K, D<:Tuple}
         return new{LX, LY, LZ, G, T, K, D}(kernel_function, grid, arguments)
     end
 
 end
+
+"""
+    KernelFunctionOperation{LX, LY, LZ}(kernel_function, grid, arguments...)
+
+Construct a `KernelFunctionOperation` at location `(LX, LY, LZ)` on `grid` with `arguments`.
+
+`kernel_function` is called with
+
+```julia
+kernel_function(i, j, k, grid, arguments...)
+```
+
+Note that `compute!(kfo::KernelFunctionOperation)` calls `compute!` on all `kfo.arguments`.
+
+Examples
+========
+
+Construct a `KernelFunctionOperation` that returns random numbers:
+
+```jldoctest kfo
+using Oceananigans
+
+grid = RectilinearGrid(size=(1, 8, 8), extent=(1, 1, 1));
+
+random_kernel_function(i, j, k, grid) = rand();
+kernel_op = KernelFunctionOperation{Center, Center, Center}(random_kernel_function, grid)
+
+# output
+KernelFunctionOperation at (Center, Center, Center)
+├── grid: 1×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×3×3 halo
+├── kernel_function: random_kernel_function (generic function with 1 method)
+└── arguments: ()
+```
+
+Construct a `KernelFunctionOperation` using the vertical vorticity operator used internally
+to compute vertical vorticity on all grids:
+
+```jldoctest kfo
+using Oceananigans.Operators: ζ₃ᶠᶠᶜ # called with signature ζ₃ᶠᶠᶜ(i, j, k, grid, u, v)
+
+model = HydrostaticFreeSurfaceModel(grid)
+u, v, w = model.velocities
+ζ_op = KernelFunctionOperation{Face, Face, Center}(ζ₃ᶠᶠᶜ, grid, u, v)
+
+# output
+KernelFunctionOperation at (Face, Face, Center)
+├── grid: 1×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×3×3 halo
+├── kernel_function: ζ₃ᶠᶠᶜ (generic function with 1 method)
+└── arguments: ("Field", "Field")
+```
+"""
+KernelFunctionOperation
 
 # Convenience outer constructor: splat arguments into a tuple.
 # T defaults to eltype(grid) via the inner constructor.

--- a/src/AbstractOperations/unary_operations.jl
+++ b/src/AbstractOperations/unary_operations.jl
@@ -9,17 +9,19 @@ struct UnaryOperation{LX, LY, LZ, O, A, IN, G, T} <: AbstractOperation{LX, LY, L
     ▶ :: IN
     grid :: G
 
-    @doc """
-        UnaryOperation{LX, LY, LZ}(op, arg, ▶, grid)
-
-    Returns an abstract `UnaryOperation` representing the action of `op` on `arg`,
-    and subsequent interpolation by `▶` on `grid`.
-    """
     function UnaryOperation{LX, LY, LZ}(op::O, arg::A, ▶::IN, grid::G,
                                         ::Type{T}=Base.promote_op(op, eltype(arg))) where {LX, LY, LZ, O, A, IN, G, T}
         return new{LX, LY, LZ, O, A, IN, G, T}(op, arg, ▶, grid)
     end
 end
+
+"""
+    UnaryOperation{LX, LY, LZ}(op, arg, ▶, grid)
+
+Returns an abstract `UnaryOperation` representing the action of `op` on `arg`,
+and subsequent interpolation by `▶` on `grid`.
+"""
+UnaryOperation
 
 @inline Base.getindex(υ::UnaryOperation, i, j, k) = υ.▶(i, j, k, υ.grid, υ.op, υ.arg)
 

--- a/src/AbstractOperations/unary_operations.jl
+++ b/src/AbstractOperations/unary_operations.jl
@@ -3,6 +3,12 @@ using Oceananigans.Fields: AbstractField, instantiated_location
 
 const unary_operators = Set()
 
+"""
+    UnaryOperation{LX, LY, LZ}(op, arg, ▶, grid)
+
+Returns an abstract `UnaryOperation` representing the action of `op` on `arg`,
+and subsequent interpolation by `▶` on `grid`.
+"""
 struct UnaryOperation{LX, LY, LZ, O, A, IN, G, T} <: AbstractOperation{LX, LY, LZ, G, T}
     op :: O
     arg :: A
@@ -14,14 +20,6 @@ struct UnaryOperation{LX, LY, LZ, O, A, IN, G, T} <: AbstractOperation{LX, LY, L
         return new{LX, LY, LZ, O, A, IN, G, T}(op, arg, ▶, grid)
     end
 end
-
-"""
-    UnaryOperation{LX, LY, LZ}(op, arg, ▶, grid)
-
-Returns an abstract `UnaryOperation` representing the action of `op` on `arg`,
-and subsequent interpolation by `▶` on `grid`.
-"""
-UnaryOperation
 
 @inline Base.getindex(υ::UnaryOperation, i, j, k) = υ.▶(i, j, k, υ.grid, υ.op, υ.arg)
 

--- a/src/Fields/function_field.jl
+++ b/src/Fields/function_field.jl
@@ -1,3 +1,15 @@
+"""
+    FunctionField{LX, LY, LZ}(func, grid; clock=nothing, parameters=nothing) where {LX, LY, LZ}
+
+Returns a `FunctionField` on `grid` and at location `LX, LY, LZ`.
+
+If `clock` is not specified, then `func` must be a function with signature
+`func(x, y, z)`. If clock is specified, `func` must be a function with signature
+`func(x, y, z, t)`, where `t` is internally determined from `clock.time`.
+
+A `FunctionField` will return the result of `func(x, y, z [, t])` at `LX, LY, LZ` on
+`grid` when indexed at `i, j, k`.
+"""
 struct FunctionField{LX, LY, LZ, C, P, F, G, T} <: AbstractField{LX, LY, LZ, G, T, 3}
           func :: F
           grid :: G
@@ -21,20 +33,6 @@ struct FunctionField{LX, LY, LZ, C, P, F, G, T} <: AbstractField{LX, LY, LZ, G, 
         return new{LX, LY, LZ, C, P, F, G, T}(f.func, grid, clock, f.parameters)
     end
 end
-
-"""
-    FunctionField{LX, LY, LZ}(func, grid; clock=nothing, parameters=nothing) where {LX, LY, LZ}
-
-Returns a `FunctionField` on `grid` and at location `LX, LY, LZ`.
-
-If `clock` is not specified, then `func` must be a function with signature
-`func(x, y, z)`. If clock is specified, `func` must be a function with signature
-`func(x, y, z, t)`, where `t` is internally determined from `clock.time`.
-
-A `FunctionField` will return the result of `func(x, y, z [, t])` at `LX, LY, LZ` on
-`grid` when indexed at `i, j, k`.
-"""
-FunctionField
 
 Adapt.parent_type(T::Type{<:FunctionField}) = T
 

--- a/src/Fields/function_field.jl
+++ b/src/Fields/function_field.jl
@@ -4,18 +4,6 @@ struct FunctionField{LX, LY, LZ, C, P, F, G, T} <: AbstractField{LX, LY, LZ, G, 
          clock :: C
     parameters :: P
 
-    @doc """
-        FunctionField{LX, LY, LZ}(func, grid; clock=nothing, parameters=nothing) where {LX, LY, LZ}
-
-    Returns a `FunctionField` on `grid` and at location `LX, LY, LZ`.
-
-    If `clock` is not specified, then `func` must be a function with signature
-    `func(x, y, z)`. If clock is specified, `func` must be a function with signature
-    `func(x, y, z, t)`, where `t` is internally determined from `clock.time`.
-
-    A `FunctionField` will return the result of `func(x, y, z [, t])` at `LX, LY, LZ` on
-    `grid` when indexed at `i, j, k`.
-    """
     @inline function FunctionField{LX, LY, LZ}(func::F,
                                                grid::G;
                                                clock::C=nothing,
@@ -33,6 +21,20 @@ struct FunctionField{LX, LY, LZ, C, P, F, G, T} <: AbstractField{LX, LY, LZ, G, 
         return new{LX, LY, LZ, C, P, F, G, T}(f.func, grid, clock, f.parameters)
     end
 end
+
+"""
+    FunctionField{LX, LY, LZ}(func, grid; clock=nothing, parameters=nothing) where {LX, LY, LZ}
+
+Returns a `FunctionField` on `grid` and at location `LX, LY, LZ`.
+
+If `clock` is not specified, then `func` must be a function with signature
+`func(x, y, z)`. If clock is specified, `func` must be a function with signature
+`func(x, y, z, t)`, where `t` is internally determined from `clock.time`.
+
+A `FunctionField` will return the result of `func(x, y, z [, t])` at `LX, LY, LZ` on
+`grid` when indexed at `i, j, k`.
+"""
+FunctionField
 
 Adapt.parent_type(T::Type{<:FunctionField}) = T
 

--- a/src/Models/boundary_mean.jl
+++ b/src/Models/boundary_mean.jl
@@ -6,15 +6,6 @@ using Oceananigans.BoundaryConditions: BoundaryCondition, Open
 
 import Oceananigans.BoundaryConditions: update_boundary_condition!
 
-struct BoundaryAdjacentMean{FF, BV}
-    flux_field :: FF
-         value :: BV
-
-    BoundaryAdjacentMean(grid, side;
-                         flux_field::FF = boundary_reduced_field(Val(side), grid),
-                         value::BV = Ref(zero(grid))) where {FF, BV} =
-        new{FF, BV}(flux_field, value)
-end
 
 """
     BoundaryAdjacentMean(grid, side;
@@ -43,7 +34,15 @@ julia> abs(bam.value[]) < 1e-10  # essentially zero
 true
 ```
 """
-BoundaryAdjacentMean
+struct BoundaryAdjacentMean{FF, BV}
+    flux_field :: FF
+         value :: BV
+
+    BoundaryAdjacentMean(grid, side;
+                         flux_field::FF = boundary_reduced_field(Val(side), grid),
+                         value::BV = Ref(zero(grid))) where {FF, BV} =
+        new{FF, BV}(flux_field, value)
+end
 
 @inline (bam::BoundaryAdjacentMean)(args...) = bam.value[]
 

--- a/src/Models/boundary_mean.jl
+++ b/src/Models/boundary_mean.jl
@@ -10,38 +10,40 @@ struct BoundaryAdjacentMean{FF, BV}
     flux_field :: FF
          value :: BV
 
-    @doc """
-        BoundaryAdjacentMean(grid, side;
-                             flux_field::FF = boundary_reduced_field(Val(side), grid),
-                             value::BV = Ref(zero(grid)))
-
-    Store the boundary mean `value` of a `Field`. Updated by calling
-
-    ```jldoctest
-    julia> using Oceananigans
-
-    julia> using Oceananigans.Models: BoundaryAdjacentMean
-
-    julia> grid = RectilinearGrid(size = (16, 16, 16), extent = (3, 4, 5));
-
-    julia> cf = CenterField(grid);
-
-    julia> set!(cf, (x, y, z) -> sin(2π * y / 4)); # hide output
-
-    julia> bam = BoundaryAdjacentMean(grid, :east)
-    BoundaryAdjacentMean: (0.0)
-
-    julia> bam(:east, cf); # computes boundary-adjacent mean
-
-    julia> abs(bam.value[]) < 1e-10  # essentially zero
-    true
-    ```
-    """
     BoundaryAdjacentMean(grid, side;
                          flux_field::FF = boundary_reduced_field(Val(side), grid),
                          value::BV = Ref(zero(grid))) where {FF, BV} =
         new{FF, BV}(flux_field, value)
 end
+
+"""
+    BoundaryAdjacentMean(grid, side;
+                         flux_field::FF = boundary_reduced_field(Val(side), grid),
+                         value::BV = Ref(zero(grid)))
+
+Store the boundary mean `value` of a `Field`. Updated by calling
+
+```jldoctest
+julia> using Oceananigans
+
+julia> using Oceananigans.Models: BoundaryAdjacentMean
+
+julia> grid = RectilinearGrid(size = (16, 16, 16), extent = (3, 4, 5));
+
+julia> cf = CenterField(grid);
+
+julia> set!(cf, (x, y, z) -> sin(2π * y / 4)); # hide output
+
+julia> bam = BoundaryAdjacentMean(grid, :east)
+BoundaryAdjacentMean: (0.0)
+
+julia> bam(:east, cf); # computes boundary-adjacent mean
+
+julia> abs(bam.value[]) < 1e-10  # essentially zero
+true
+```
+"""
+BoundaryAdjacentMean
 
 @inline (bam::BoundaryAdjacentMean)(args...) = bam.value[]
 

--- a/src/MultiRegion/cubed_sphere_connectivity.jl
+++ b/src/MultiRegion/cubed_sphere_connectivity.jl
@@ -38,24 +38,9 @@ The connectivity among various regions for a cubed sphere grid. Parameter `R`
 denotes the rotation of the `from_rank` region to the current region.
 
 $(TYPEDFIELDS)
-"""
-struct CubedSphereRegionalConnectivity{S, FS, R} <: AbstractConnectivity
-    "the current region rank"
-            rank :: Int
-    "the region from which boundary condition comes from"
-       from_rank :: Int
-    "the current region side"
-            side :: S
-    "the side of the region from which boundary condition comes from"
-       from_side :: FS
-    "rotation of the region from which boundary condition comes from compare to host region"
-        rotation :: R
 
-    CubedSphereRegionalConnectivity(rank, from_rank, side, from_side, rotation=nothing) =
-        new{typeof(side), typeof(from_side), typeof(rotation)}(rank, from_rank, side, from_side, rotation)
-end
+---
 
-"""
     CubedSphereRegionalConnectivity(rank, from_rank, side, from_side, rotation=nothing)
 
 Return a `CubedSphereRegionalConnectivity`: `from_rank :: Int` → `rank :: Int` and
@@ -92,7 +77,21 @@ CubedSphereRegionalConnectivity
 └── counter-clockwise rotation ↺
 ```
 """
-CubedSphereRegionalConnectivity
+struct CubedSphereRegionalConnectivity{S, FS, R} <: AbstractConnectivity
+    "the current region rank"
+            rank :: Int
+    "the region from which boundary condition comes from"
+       from_rank :: Int
+    "the current region side"
+            side :: S
+    "the side of the region from which boundary condition comes from"
+       from_side :: FS
+    "rotation of the region from which boundary condition comes from compare to host region"
+        rotation :: R
+
+    CubedSphereRegionalConnectivity(rank, from_rank, side, from_side, rotation=nothing) =
+        new{typeof(side), typeof(from_side), typeof(rotation)}(rank, from_rank, side, from_side, rotation)
+end
 
 function Base.summary(c::CubedSphereRegionalConnectivity)
     return "CubedSphereRegionalConnectivity: from $(typeof(c.from_side)) region #$(c.from_rank) → $(typeof(c.side)) region #$(c.rank)"

--- a/src/MultiRegion/cubed_sphere_connectivity.jl
+++ b/src/MultiRegion/cubed_sphere_connectivity.jl
@@ -51,46 +51,48 @@ struct CubedSphereRegionalConnectivity{S, FS, R} <: AbstractConnectivity
     "rotation of the region from which boundary condition comes from compare to host region"
         rotation :: R
 
-    @doc """
-        CubedSphereRegionalConnectivity(rank, from_rank, side, from_side, rotation=nothing)
-
-    Return a `CubedSphereRegionalConnectivity`: `from_rank :: Int` → `rank :: Int` and
-    `from_side` → `side`. The rotation of
-    the adjacent region relative to the host region is prescribed via `rotation` argument
-    (default `rotation=nothing`).
-
-    Example
-    =======
-
-    A connectivity that implies that the boundary condition for the
-    east side of region 1 comes from the west side of region 2 is:
-
-    ```jldoctest cubedsphereconnectivity
-    julia> using Oceananigans
-
-    julia> using Oceananigans.MultiRegion: CubedSphereRegionalConnectivity, East, West, North, South, ↺, ↻
-
-    julia> CubedSphereRegionalConnectivity(1, 2, East(), West())
-    CubedSphereRegionalConnectivity
-    ├── from: Oceananigans.BoundaryConditions.West side, region 2
-    ├── to:   Oceananigans.BoundaryConditions.East side, region 1
-    └── no rotation
-    ```
-
-    A connectivity that implies that the boundary condition for the
-    north side of region 1 comes from the east side of region 3 is
-
-    ```jldoctest cubedsphereconnectivity
-    julia> CubedSphereRegionalConnectivity(1, 3, North(), East(), ↺())
-    CubedSphereRegionalConnectivity
-    ├── from: Oceananigans.BoundaryConditions.East side, region 3
-    ├── to:   Oceananigans.BoundaryConditions.North side, region 1
-    └── counter-clockwise rotation ↺
-    ```
-    """
     CubedSphereRegionalConnectivity(rank, from_rank, side, from_side, rotation=nothing) =
         new{typeof(side), typeof(from_side), typeof(rotation)}(rank, from_rank, side, from_side, rotation)
 end
+
+"""
+    CubedSphereRegionalConnectivity(rank, from_rank, side, from_side, rotation=nothing)
+
+Return a `CubedSphereRegionalConnectivity`: `from_rank :: Int` → `rank :: Int` and
+`from_side` → `side`. The rotation of
+the adjacent region relative to the host region is prescribed via `rotation` argument
+(default `rotation=nothing`).
+
+Example
+=======
+
+A connectivity that implies that the boundary condition for the
+east side of region 1 comes from the west side of region 2 is:
+
+```jldoctest cubedsphereconnectivity
+julia> using Oceananigans
+
+julia> using Oceananigans.MultiRegion: CubedSphereRegionalConnectivity, East, West, North, South, ↺, ↻
+
+julia> CubedSphereRegionalConnectivity(1, 2, East(), West())
+CubedSphereRegionalConnectivity
+├── from: Oceananigans.BoundaryConditions.West side, region 2
+├── to:   Oceananigans.BoundaryConditions.East side, region 1
+└── no rotation
+```
+
+A connectivity that implies that the boundary condition for the
+north side of region 1 comes from the east side of region 3 is
+
+```jldoctest cubedsphereconnectivity
+julia> CubedSphereRegionalConnectivity(1, 3, North(), East(), ↺())
+CubedSphereRegionalConnectivity
+├── from: Oceananigans.BoundaryConditions.East side, region 3
+├── to:   Oceananigans.BoundaryConditions.North side, region 1
+└── counter-clockwise rotation ↺
+```
+"""
+CubedSphereRegionalConnectivity
 
 function Base.summary(c::CubedSphereRegionalConnectivity)
     return "CubedSphereRegionalConnectivity: from $(typeof(c.from_side)) region #$(c.from_rank) → $(typeof(c.side)) region #$(c.rank)"


### PR DESCRIPTION
In Julia v1.13, using at-doc inside struct to attach the docstring to an inner constructor [causes an extra hidden field to be added to the struct itself](https://github.com/JuliaLang/julia/issues/60681#issuecomment-4280636832), due to macro expansion rules.  Doesn't look like this is going to be changed upstream, so we have to work around it: luckily the fix is backward compatible, we only lose the convenience of having the docstring right above the constructor definition.

PR best reviewed by [ignoring whitespace changes](https://github.com/CliMA/Oceananigans.jl/pull/5527/changes?w=1).
