### PR TITLE
Simplify definition of at-binary not to require loads of imports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.107.2"
+version = "0.107.3"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -57,43 +57,43 @@ choose_location(::Nothing, Lb::ConcreteLocationType, Lc) = Lb #
 """Return an expression that defines an abstract `BinaryOperator` named `op` for `AbstractField`."""
 function define_binary_operator(op)
     return quote
-        import Oceananigans.Grids: AbstractGrid
-        import Oceananigans.Fields: AbstractField
-
-        local location = Oceananigans.Fields.location
-        local FunctionField = Oceananigans.Fields.FunctionField
-        local ConstantField = Oceananigans.Fields.ConstantField
-        local AF = AbstractField
+        local BinaryOperation = $(Oceananigans.AbstractOperations).BinaryOperation
+        local GridMetric = $(Oceananigans.AbstractOperations).GridMetric
+        local AbstractField = $(Oceananigans.Fields).AbstractField
+        local location = $(Oceananigans.Fields).location
+        local FunctionField = $(Oceananigans.Fields).FunctionField
+        local ConstantField = $(Oceananigans.Fields).ConstantField
+        local AbstractGrid = $(Oceananigans.Grids).AbstractGrid
 
         @inline $op(i, j, k, grid::AbstractGrid, ▶a, ▶b, a, b) =
-            @inbounds apply_op($op, ▶a(i, j, k, grid, a), ▶b(i, j, k, grid, b))
+            @inbounds $(apply_op)($op, ▶a(i, j, k, grid, a), ▶b(i, j, k, grid, b))
 
         # These shenanigans seem to help / encourage the compiler to infer types of objects
         # buried in deep AbstractOperations trees.
         @inline function $op(i, j, k, grid::AbstractGrid, ▶a, ▶b, A::BinaryOperation, B::BinaryOperation)
-            @inline a(ii, jj, kk, grid) = apply_op(A.op, A.▶a(ii, jj, kk, grid, A.a), A.▶b(ii, jj, kk, grid, A.b))
-            @inline b(ii, jj, kk, grid) = apply_op(B.op, B.▶a(ii, jj, kk, grid, B.a), B.▶b(ii, jj, kk, grid, B.b))
-            return @inbounds apply_op($op, ▶a(i, j, k, grid, a), ▶b(i, j, k, grid, b))
+            @inline a(ii, jj, kk, grid) = $(apply_op)(A.op, A.▶a(ii, jj, kk, grid, A.a), A.▶b(ii, jj, kk, grid, A.b))
+            @inline b(ii, jj, kk, grid) = $(apply_op)(B.op, B.▶a(ii, jj, kk, grid, B.a), B.▶b(ii, jj, kk, grid, B.b))
+            return @inbounds $(apply_op)($op, ▶a(i, j, k, grid, a), ▶b(i, j, k, grid, b))
         end
 
         @inline function $op(i, j, k, grid::AbstractGrid, ▶a, ▶b, A::BinaryOperation, B::AbstractField)
-            @inline a(ii, jj, kk, grid) = apply_op(A.op, A.▶a(ii, jj, kk, grid, A.a), A.▶b(ii, jj, kk, grid, A.b))
-            return @inbounds apply_op($op, ▶a(i, j, k, grid, a), ▶b(i, j, k, grid, B))
+            @inline a(ii, jj, kk, grid) = $(apply_op)(A.op, A.▶a(ii, jj, kk, grid, A.a), A.▶b(ii, jj, kk, grid, A.b))
+            return @inbounds $(apply_op)($op, ▶a(i, j, k, grid, a), ▶b(i, j, k, grid, B))
         end
 
         @inline function $op(i, j, k, grid::AbstractGrid, ▶a, ▶b, A::AbstractField, B::BinaryOperation)
-            @inline b(ii, jj, kk, grid) = apply_op(B.op, B.▶a(ii, jj, kk, grid, B.a), B.▶b(ii, jj, kk, grid, B.b))
-            return @inbounds apply_op($op, ▶a(i, j, k, grid, A), ▶b(i, j, k, grid, b))
+            @inline b(ii, jj, kk, grid) = $(apply_op)(B.op, B.▶a(ii, jj, kk, grid, B.a), B.▶b(ii, jj, kk, grid, B.b))
+            return @inbounds $(apply_op)($op, ▶a(i, j, k, grid, A), ▶b(i, j, k, grid, b))
         end
 
         @inline function $op(i, j, k, grid::AbstractGrid, ▶a, ▶b, A::BinaryOperation, B::Number)
-            @inline a(ii, jj, kk, grid) = apply_op(A.op, A.▶a(ii, jj, kk, grid, A.a), A.▶b(ii, jj, kk, grid, A.b))
-            return @inbounds apply_op($op, ▶a(i, j, k, grid, a), B)
+            @inline a(ii, jj, kk, grid) = $(apply_op)(A.op, A.▶a(ii, jj, kk, grid, A.a), A.▶b(ii, jj, kk, grid, A.b))
+            return @inbounds $(apply_op)($op, ▶a(i, j, k, grid, a), B)
         end
 
         @inline function $op(i, j, k, grid::AbstractGrid, ▶a, ▶b, A::Number, B::BinaryOperation)
-            @inline b(ii, jj, kk, grid) = apply_op(B.op, B.▶a(ii, jj, kk, grid, B.a), B.▶b(ii, jj, kk, grid, B.b))
-            return @inbounds apply_op($op, A, ▶b(i, j, k, grid, b))
+            @inline b(ii, jj, kk, grid) = $(apply_op)(B.op, B.▶a(ii, jj, kk, grid, B.a), B.▶b(ii, jj, kk, grid, B.b))
+            return @inbounds $(apply_op)($op, A, ▶b(i, j, k, grid, b))
         end
 
         """
@@ -105,9 +105,9 @@ function define_binary_operator(op)
         if that is also Nothing, `Lc`.
         """
         function $op(Lc::Tuple{<:$Location, <:$Location, <:$Location}, a, b)
-            La = Oceananigans.Fields.instantiated_location(a)
-            Lb = Oceananigans.Fields.instantiated_location(b)
-            Lab = choose_location.(La, Lb, Lc)
+            La = $(Oceananigans.Fields).instantiated_location(a)
+            Lb = $(Oceananigans.Fields).instantiated_location(b)
+            Lab = $(choose_location).(La, Lb, Lc)
 
             grid = $(validate_grid)(a, b)
 
@@ -121,8 +121,8 @@ function define_binary_operator(op)
         $op(Lc::Tuple{<:$Location, <:$Location, <:$Location}, f::Function, b::AbstractField) = $op(Lc, FunctionField(location(b), f, b.grid), b)
         $op(Lc::Tuple{<:$Location, <:$Location, <:$Location}, a::AbstractField, f::Function) = $op(Lc, a, FunctionField(location(a), f, a.grid))
 
-        $op(Lc::Tuple{<:$Location, <:$Location, <:$Location}, m::GridMetric, b::AbstractField) = $op(Lc, grid_metric_operation(Oceananigans.Fields.instantiated_location(b), m, b.grid), b)
-        $op(Lc::Tuple{<:$Location, <:$Location, <:$Location}, a::AbstractField, m::GridMetric) = $op(Lc, a, grid_metric_operation(Oceananigans.Fields.instantiated_location(a), m, a.grid))
+        $op(Lc::Tuple{<:$Location, <:$Location, <:$Location}, m::GridMetric, b::AbstractField) = $op(Lc, $(grid_metric_operation)($(Oceananigans.Fields).instantiated_location(b), m, b.grid), b)
+        $op(Lc::Tuple{<:$Location, <:$Location, <:$Location}, a::AbstractField, m::GridMetric) = $op(Lc, a, $(grid_metric_operation)($(Oceananigans.Fields).instantiated_location(a), m, a.grid))
 
         # instantiate location if types are passed
         $op(Lc::Tuple, a, b) = $op((Lc[1](), Lc[2](), Lc[3]()), a, b)
@@ -134,15 +134,15 @@ function define_binary_operator(op)
         $op(Lc::Tuple, a::AbstractField, m::GridMetric) = $op((Lc[1](), Lc[2](), Lc[3]()), a, m)
 
         # Sugary versions with default locations
-        $op(a::AF, b::AF) = $op(Oceananigans.Fields.instantiated_location(a), a, b)
-        $op(a::AF, b) = $op(Oceananigans.Fields.instantiated_location(a), a, b)
-        $op(a, b::AF) = $op(Oceananigans.Fields.instantiated_location(b), a, b)
+        $op(a::AbstractField, b::AbstractField) = $op($(Oceananigans.Fields).instantiated_location(a), a, b)
+        $op(a::AbstractField, b) = $op($(Oceananigans.Fields).instantiated_location(a), a, b)
+        $op(a, b::AbstractField) = $op($(Oceananigans.Fields).instantiated_location(b), a, b)
 
-        $op(a::AF, b::Number) = $op(Oceananigans.Fields.instantiated_location(a), a, b)
-        $op(a::Number, b::AF) = $op(Oceananigans.Fields.instantiated_location(b), a, b)
+        $op(a::AbstractField, b::Number) = $op($(Oceananigans.Fields).instantiated_location(a), a, b)
+        $op(a::Number, b::AbstractField) = $op($(Oceananigans.Fields).instantiated_location(b), a, b)
 
-        $op(a::AF, b::ConstantField) = $op(Oceananigans.Fields.instantiated_location(a), a, b.constant)
-        $op(a::ConstantField, b::AF) = $op(Oceananigans.Fields.instantiated_location(b), a.constant, b)
+        $op(a::AbstractField, b::ConstantField) = $op($(Oceananigans.Fields).instantiated_location(a), a, b.constant)
+        $op(a::ConstantField, b::AbstractField) = $op($(Oceananigans.Fields).instantiated_location(b), a.constant, b)
 
         $op(a::Number, b::ConstantField) = ConstantField($op(a, b.constant))
         $op(a::ConstantField, b::Number) = ConstantField($op(a.constant, b))


### PR DESCRIPTION
In order to use `@binary` you need to also bring a bunch of other symbols into scope unnecessarily.

Before this PR:
```julia-repl
julia> using Oceananigans.AbstractOperations: @binary

julia> @binary Base.atand
ERROR: UndefVarError: `Oceananigans` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Hint: Oceananigans is loaded but not imported in the active module Main.
```

After this PR:
```julia-repl
julia> using Oceananigans.AbstractOperations: @binary

julia> @binary Base.atand
Set{Any} with 10 elements:
  :+
  :/
  :^
  :atand
  :-
  :>=
  :>
  :<=
  :*
  :<
```

Inlining the symbols is similar to what done for unary symbols https://github.com/CliMA/Oceananigans.jl/blob/77268ec6169f4c1f4f1a3e0b70d62bcf3b236f98/src/AbstractOperations/unary_operations.jl#L93-L118 (I wonder [who did that](https://github.com/CliMA/Oceananigans.jl/pull/4997) :innocent:).  Other similar PRs: #4178, #4994.

Spotted in https://github.com/NumericalEarth/Breeze.jl/pull/644 which had to do
```julia
using Oceananigans: Oceananigans
using Oceananigans.AbstractOperations: @binary, BinaryOperation, GridMetric, choose_location
using Oceananigans.AbstractOperations: apply_op, grid_metric_operation

@binary Base.atand
```
which felt very excessive.  CC @ewquon.