### PR TITLE
Skip `checkpoint_at_end` when NaN-triggered stop occurs

### DIFF
--- a/src/Diagnostics/nan_checker.jl
+++ b/src/Diagnostics/nan_checker.jl
@@ -30,7 +30,7 @@ a container with key-value pairs like a dictionary or `NamedTuple`.
 
 If `erroring=true`, the `NaNChecker` will throw an error on NaN detection.
 """
-NaNChecker(; fields, erroring=false) = NaNChecker(fields, erroring, false)
+NaNChecker(; fields, erroring=false, nan_detected=false) = NaNChecker(fields, erroring, nan_detected)
 
 nan_detected(::Any) = false
 nan_detected(nc::NaNChecker) = nc.nan_detected

--- a/src/Diagnostics/nan_checker.jl
+++ b/src/Diagnostics/nan_checker.jl
@@ -22,21 +22,25 @@ end
 Base.show(io::IO, nc::NaNChecker) = print(io, summary(nc))
 
 """
-    NaNChecker(; fields, erroring=false, nan_detected=false)
+    NaNChecker(; fields, erroring=false)
 
 Return a `NaNChecker`, which sets `sim.running=false` if a `NaN` is detected
 in any member of `fields` when `NaNChecker(sim)` is called. `fields` should be
 a container with key-value pairs like a dictionary or `NamedTuple`.
 
 If `erroring=true`, the `NaNChecker` will throw an error on NaN detection.
+NaN detection state is tracked internally and can be queried with
+`nan_detected(nan_checker)`.
 """
-NaNChecker(; fields, erroring=false, nan_detected=false) = NaNChecker(fields, erroring, nan_detected)
+NaNChecker(; fields, erroring=false) = NaNChecker(fields, erroring, false)
 
+# Allow `:nan_checker` callbacks that are not `NaNChecker` to integrate with
+# simulation logic that queries and resets NaN detection state.
 nan_detected(::Any) = false
 nan_detected(nc::NaNChecker) = nc.nan_detected
 
-reset_nan_detected!(::Any) = nothing
-function reset_nan_detected!(nc::NaNChecker)
+reset_nan_checker!(::Any) = nothing
+function reset_nan_checker!(nc::NaNChecker)
     nc.nan_detected = false
     return nothing
 end

--- a/src/Diagnostics/nan_checker.jl
+++ b/src/Diagnostics/nan_checker.jl
@@ -22,7 +22,7 @@ end
 Base.show(io::IO, nc::NaNChecker) = print(io, summary(nc))
 
 """
-    NaNChecker(; fields, erroring=false)
+    NaNChecker(; fields, erroring=false, nan_detected=false)
 
 Return a `NaNChecker`, which sets `sim.running=false` if a `NaN` is detected
 in any member of `fields` when `NaNChecker(sim)` is called. `fields` should be

--- a/src/Diagnostics/nan_checker.jl
+++ b/src/Diagnostics/nan_checker.jl
@@ -4,9 +4,10 @@ using Oceananigans.Solvers: iteration
 mutable struct NaNChecker{F}
     fields :: F
     erroring :: Bool
+    nan_detected :: Bool
 end
 
-NaNChecker(fields) = NaNChecker(fields, false) # default
+NaNChecker(fields) = NaNChecker(fields, false, false) # default
 default_nan_checker(model) = nothing
 
 function Base.summary(nc::NaNChecker)
@@ -29,7 +30,16 @@ a container with key-value pairs like a dictionary or `NamedTuple`.
 
 If `erroring=true`, the `NaNChecker` will throw an error on NaN detection.
 """
-NaNChecker(; fields, erroring=false) = NaNChecker(fields, erroring)
+NaNChecker(; fields, erroring=false) = NaNChecker(fields, erroring, false)
+
+nan_detected(::Any) = false
+nan_detected(nc::NaNChecker) = nc.nan_detected
+
+reset_nan_detected!(::Any) = nothing
+function reset_nan_detected!(nc::NaNChecker)
+    nc.nan_detected = false
+    return nothing
+end
 
 hasnan(field::AbstractArray) = any(isnan, parent(field))
 hasnan(model) = hasnan(first(fields(model)))
@@ -38,6 +48,7 @@ function (nc::NaNChecker)(simulation)
     for (name, field) in pairs(nc.fields)
         if hasnan(field)
             simulation.running = false
+            nc.nan_detected = true
             clock = simulation.model.clock
             t = time(simulation)
             iter = iteration(simulation)

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -2,6 +2,9 @@ using Dates: unix2datetime
 
 using Oceananigans.OutputWriters: WindowedTimeAverage
 using Oceananigans.TimeSteppers: update_state!, unit_time
+using Oceananigans.Diagnostics: nan_detected, reset_nan_detected!
+using Oceananigans.Grids: architecture
+using Oceananigans.DistributedComputations: all_reduce
 
 using Oceananigans: AbstractModel, run_diagnostic!, restore_prognostic_state!
 using Oceananigans.OutputWriters: checkpoint_path, load_checkpoint_state
@@ -168,17 +171,40 @@ function run!(sim; pickup=false, checkpoint_at_end=false)
     sim.initialized = false
     sim.running = true
     sim.run_wall_time = 0.0
+    reset_nan_detection!(sim)
 
     while sim.running
         time_step!(sim)
     end
 
-    checkpoint_at_end && checkpoint(sim)
+    if checkpoint_at_end
+        if stopped_due_to_nan(sim)
+            @info "NaNs were detected during this run. Skipping end-of-run checkpoint despite checkpoint_at_end=true."
+        else
+            checkpoint(sim)
+        end
+    end
 
     for callback in values(sim.callbacks)
         finalize!(callback, sim)
     end
 
+    return nothing
+end
+
+nan_checker(sim::Simulation) = get(sim.callbacks, :nan_checker, nothing)
+
+function stopped_due_to_nan(sim::Simulation)
+    cb = nan_checker(sim)
+    local_nan_detected = !isnothing(cb) && nan_detected(cb.func)
+    global_nan_detected = all_reduce(max, Int(local_nan_detected), architecture(sim.model)) == 1
+    return global_nan_detected
+end
+
+function reset_nan_detection!(sim::Simulation)
+    cb = nan_checker(sim)
+    isnothing(cb) && return nothing
+    reset_nan_detected!(cb.func)
     return nothing
 end
 

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -2,12 +2,13 @@ using Dates: unix2datetime
 
 using Oceananigans: AbstractModel, run_diagnostic!, restore_prognostic_state!
 using Oceananigans.Architectures: architecture
-using Oceananigans.Diagnostics: nan_detected, reset_nan_checker!
+using Oceananigans.Diagnostics: nan_detected
 using Oceananigans.DistributedComputations: all_reduce
 using Oceananigans.OutputWriters: WindowedTimeAverage, checkpoint_path, load_checkpoint_state
 using Oceananigans.TimeSteppers: update_state!, unit_time
 
 import Oceananigans: initialize!
+import Oceananigans.Diagnostics: reset_nan_checker!
 import Oceananigans.Fields: set!
 import Oceananigans.TimeSteppers: time_step!
 import Oceananigans.Utils: schedule_aligned_time_step

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -1,13 +1,11 @@
 using Dates: unix2datetime
 
-using Oceananigans.OutputWriters: WindowedTimeAverage
-using Oceananigans.TimeSteppers: update_state!, unit_time
-using Oceananigans.Diagnostics: nan_detected, reset_nan_detected!
-using Oceananigans.Grids: architecture
-using Oceananigans.DistributedComputations: all_reduce
-
 using Oceananigans: AbstractModel, run_diagnostic!, restore_prognostic_state!
-using Oceananigans.OutputWriters: checkpoint_path, load_checkpoint_state
+using Oceananigans.Architectures: architecture
+using Oceananigans.Diagnostics: nan_detected, reset_nan_detected!
+using Oceananigans.DistributedComputations: all_reduce
+using Oceananigans.OutputWriters: WindowedTimeAverage, checkpoint_path, load_checkpoint_state
+using Oceananigans.TimeSteppers: update_state!, unit_time
 
 import Oceananigans: initialize!
 import Oceananigans.Fields: set!

--- a/src/Simulations/run.jl
+++ b/src/Simulations/run.jl
@@ -2,7 +2,7 @@ using Dates: unix2datetime
 
 using Oceananigans: AbstractModel, run_diagnostic!, restore_prognostic_state!
 using Oceananigans.Architectures: architecture
-using Oceananigans.Diagnostics: nan_detected, reset_nan_detected!
+using Oceananigans.Diagnostics: nan_detected, reset_nan_checker!
 using Oceananigans.DistributedComputations: all_reduce
 using Oceananigans.OutputWriters: WindowedTimeAverage, checkpoint_path, load_checkpoint_state
 using Oceananigans.TimeSteppers: update_state!, unit_time
@@ -169,14 +169,14 @@ function run!(sim; pickup=false, checkpoint_at_end=false)
     sim.initialized = false
     sim.running = true
     sim.run_wall_time = 0.0
-    reset_nan_detection!(sim)
+    reset_nan_checker!(sim)
 
     while sim.running
         time_step!(sim)
     end
 
     if checkpoint_at_end
-        if stopped_due_to_nan(sim)
+        if nan_checker_detected_nan(sim)
             @info "NaNs were detected during this run. Skipping end-of-run checkpoint despite checkpoint_at_end=true."
         else
             checkpoint(sim)
@@ -192,17 +192,18 @@ end
 
 nan_checker(sim::Simulation) = get(sim.callbacks, :nan_checker, nothing)
 
-function stopped_due_to_nan(sim::Simulation)
+function nan_checker_detected_nan(sim::Simulation)
     cb = nan_checker(sim)
     local_nan_detected = !isnothing(cb) && nan_detected(cb.func)
+    # Reduce per-rank NaN flags so this is true when any rank detected a NaN.
     global_nan_detected = all_reduce(max, Int(local_nan_detected), architecture(sim.model)) == 1
     return global_nan_detected
 end
 
-function reset_nan_detection!(sim::Simulation)
+function reset_nan_checker!(sim::Simulation)
     cb = nan_checker(sim)
     isnothing(cb) && return nothing
-    reset_nan_detected!(cb.func)
+    reset_nan_checker!(cb.func)
     return nothing
 end
 

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -1726,6 +1726,9 @@ function test_checkpoint_at_end(arch)
     L = 1
     Δt = 0.1
     expected_filepath = "checkpoint_iteration5.jld2"
+    nan_expected_filepath = "checkpoint_iteration1.jld2"
+
+    rm.(glob("checkpoint_iteration*.jld2"), force=true)
 
     # Test with checkpoint_at_end=false (default) - should NOT create checkpoint
     grid = RectilinearGrid(arch, size=(N, N, N), extent=(L, L, L))
@@ -1746,6 +1749,17 @@ function test_checkpoint_at_end(arch)
 
     @test isfile(expected_filepath)
     rm(expected_filepath, force=true)
+
+    # Test with checkpoint_at_end=true and NaN-triggered stop - should NOT create checkpoint
+    grid3 = RectilinearGrid(arch, size=(N, N, N), extent=(L, L, L))
+    model3 = NonhydrostaticModel(grid3)
+    simulation3 = Simulation(model3, Δt=Δt, stop_iteration=5)
+    model3.velocities.u[1, 1, 1] = NaN
+
+    @test_logs (:info, r"NaN found in field") (:info, r"Skipping end-of-run checkpoint")
+               match_mode=:any run!(simulation3, checkpoint_at_end=true)
+    @test !isfile(nan_expected_filepath)
+    rm.(glob("checkpoint_iteration*.jld2"), force=true)
 
     return nothing
 end

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -1756,8 +1756,9 @@ function test_checkpoint_at_end(arch)
     simulation3 = Simulation(model3, Δt=Δt, stop_iteration=5)
     model3.velocities.u[1, 1, 1] = NaN
 
-    @test_logs (:info, r"NaN found in field") (:info, r"Skipping end-of-run checkpoint")
-               match_mode=:any run!(simulation3, checkpoint_at_end=true)
+    @test_logs match_mode=:any (:info, r"NaN found in field") (:info, r"Skipping end-of-run checkpoint") begin
+        run!(simulation3, checkpoint_at_end=true)
+    end
     @test !isfile(nan_expected_filepath)
     rm.(glob("checkpoint_iteration*.jld2"), force=true)
 

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -1762,6 +1762,17 @@ function test_checkpoint_at_end(arch)
     @test !isfile(nan_expected_filepath)
     rm.(glob("checkpoint_iteration*.jld2"), force=true)
 
+    # Test with checkpoint_at_end=true and non-NaNChecker :nan_checker callback.
+    # This exercises nan_detected(::Any) and reset_nan_checker!(::Any).
+    grid4 = RectilinearGrid(arch, size=(N, N, N), extent=(L, L, L))
+    model4 = NonhydrostaticModel(grid4)
+    simulation4 = Simulation(model4, Δt=Δt, stop_iteration=5)
+    simulation4.callbacks[:nan_checker] = Callback(_ -> nothing, IterationInterval(1))
+
+    @test_nowarn run!(simulation4, checkpoint_at_end=true)
+    @test isfile(expected_filepath)
+    rm.(glob("checkpoint_iteration*.jld2"), force=true)
+
     return nothing
 end
 


### PR DESCRIPTION
This PR skips checkpointing at simulation end when NaNs are detected. Under current behaviour, if NaNs are detected and `checkpoint_at_end=true`, the latest checkpoint file becomes full of NaNs. Restarting the simulation then just leads to NaNs being read. Worse, if `cleanup=true`, then the latest checkpoint file is replaced by all NaNs.

I don't really see a need to save a checkpoint file when exiting due to NaNs, so I added a flag that can be switched and skip checkpointing if NaNs are detected. 

with Codex. 