### PR TITLE
Only allow CUDA.jl v5 in benchmarking environment

### DIFF
--- a/benchmarking/Project.toml
+++ b/benchmarking/Project.toml
@@ -21,7 +21,7 @@ Oceananigans = {path = ".."}
 
 [compat]
 ArgParse = "1"
-CUDA = "5, 6"
+CUDA = "5"
 DataDeps = "0.7"
 Dates = "<0.0.1, 1"
 JLD2 = "0.5, 0.6"


### PR DESCRIPTION
Quick solution for making the benchmarks work again.  Doesn't need testing, it's same set up as what we had before.