### PR TITLE
Make benchmarks compatible with both CUDA.jl v5 and v6

### DIFF
--- a/benchmarking/src/OceananigansBenchmarks.jl
+++ b/benchmarking/src/OceananigansBenchmarks.jl
@@ -30,6 +30,12 @@ using NCDatasets
 using DataDeps
 
 using CUDA: CUDA
+# Compatibility for CUDA v5 and v6
+if isdefined(CUDA, :CUDACore)
+    using CUDA: CUDACore
+else
+    const CUDACore = CUDA
+end
 
 const BATHYMETRY_URL = "https://github.com/simone-silvestri/OceananigansArtifacts.jl/raw/ss/bathymetry-for-benchmarks/bathymetry_for_benchmarks"
 

--- a/benchmarking/src/utils.jl
+++ b/benchmarking/src/utils.jl
@@ -63,7 +63,7 @@ function benchmark_time_stepping(model;
     steps_per_second = time_steps / total_time_seconds
     grid_points_per_second = total_points / time_per_step_seconds
 
-    gpu_memory_used = arch isa GPU ? CUDA.MemoryInfo().pool_used_bytes : 0
+    gpu_memory_used = arch isa GPU ? CUDACore.MemoryInfo().pool_used_bytes : 0
     metadata = BenchmarkMetadata(arch)
 
     result = BenchmarkResult(
@@ -211,7 +211,7 @@ function run_benchmark_simulation(model;
     steps_per_second = time_steps / wall_time_seconds
     grid_points_per_second = total_points / time_per_step_seconds
 
-    gpu_memory_used = arch isa GPU ? CUDA.MemoryInfo().pool_used_bytes : 0
+    gpu_memory_used = arch isa GPU ? CUDACore.MemoryInfo().pool_used_bytes : 0
     metadata = BenchmarkMetadata(arch)
 
     result = SimulationResult(
@@ -374,7 +374,7 @@ function run_io_benchmark(model;
     # Compute total output file size
     total_output_size_bytes = isfile(output_filename) ? filesize(output_filename) : 0
 
-    gpu_memory_used = arch isa GPU ? CUDA.MemoryInfo().pool_used_bytes : 0
+    gpu_memory_used = arch isa GPU ? CUDACore.MemoryInfo().pool_used_bytes : 0
     metadata = BenchmarkMetadata(arch)
 
     result = IOBenchmarkResult(


### PR DESCRIPTION
Alternative to #5531 (but #5531 could also be merged first anyway as a stop-gap solution), but requires actual testing