### PR TITLE
(0.107.4) unify Simulation interface in ReactantExt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.107.3"
+version = "0.107.4"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/ext/OceananigansReactantExt/Simulations/simulation.jl
+++ b/ext/OceananigansReactantExt/Simulations/simulation.jl
@@ -19,7 +19,7 @@ function Simulation(model::ReactantModel; Δt,
    return Simulation(model,
                      Δt,
                      Float64(stop_iteration),
-                     stop_time,
+                     nothing, # disallow stop_time
                      Float64(wall_time_limit),
                      diagnostics,
                      output_writers,

--- a/ext/OceananigansReactantExt/Simulations/simulation.jl
+++ b/ext/OceananigansReactantExt/Simulations/simulation.jl
@@ -2,7 +2,13 @@ const ReactantSimulation = Simulation{<:ReactantModel}
 
 function Simulation(model::ReactantModel; Δt,
                     verbose = true,
-                    stop_iteration = Inf)
+                    stop_iteration = Inf,
+                    stop_time = nothing,
+                    wall_time_limit = Inf,
+                    align_time_step = false,
+                    minimum_relative_step = 0)
+
+   @assert isnothing(stop_time) "`stop_time` is not supported for ReactantModel"
 
    diagnostics = nothing
    output_writers = nothing
@@ -13,17 +19,17 @@ function Simulation(model::ReactantModel; Δt,
    return Simulation(model,
                      Δt,
                      Float64(stop_iteration),
-                     nothing, # disallow stop_time
-                     Inf,
+                     stop_time,
+                     Float64(wall_time_limit),
                      diagnostics,
                      output_writers,
                      callbacks,
                      0.0,
-                     false,
+                     align_time_step,
                      false,
                      false,
                      verbose,
-                     0.0)
+                     Float64(minimum_relative_step))
 end
 
 iteration(sim::ReactantSimulation) = Reactant.to_number(iteration(sim.model))


### PR DESCRIPTION
So that `Simulation` can be called with the same arguments whether the Reactant extension is loaded or not. This will fix the ReactantExt tests that have been failing in ClimaOcean since https://github.com/CliMA/ClimaOcean.jl/pull/778

Tag patch release so this can be used downstream