### PR TITLE
Avoid redundant call to `compute!` in few examples

### DIFF
--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -573,37 +573,26 @@ For example, suppose we want to compute and store the vertical vorticity
 u = XFaceField(grid)
 v = YFaceField(grid)
 
+set!(u, (x, y, z) -> x * y^2)
+set!(v, (x, y, z) -> x^2 * y)
+
 ωₛ = Field(∂x(v) - ∂y(u), indices=(:, :, grid.Nz))
 
 # output
-4×5×1 Field{Face, Face, Center} on RectilinearGrid on CPU
-├── grid: 4×5×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
+4×4×1 Field{Face, Face, Center} on RectilinearGrid on CPU
+├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── boundary conditions: FieldBoundaryConditions
 │   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: Nothing, top: Nothing, immersed: Nothing
 ├── indices: (:, :, 4:4)
 ├── operand: BinaryOperation at (Face, Face, Center)
 ├── status: time=0.0
-└── data: 6×7×1 OffsetArray(::Array{Float64, 3}, 0:5, 0:6, 4:4) with eltype Float64 with indices 0:5×0:6×4:4
-    └── max=0.0, min=0.0, mean=0.0
+└── data: 6×6×1 OffsetArray(::Array{Float64, 3}, 0:5, 0:5, 4:4) with eltype Float64 with indices 0:5×0:5×4:4
+    └── max=0.046875, min=-0.046875, mean=0.0
 ```
 
-Computing `ωₛ` with `compute!` evaluates the expression `∂x(v) - ∂y(u)` and
-stores the result _only_ at the surface slice:
-
-```jldoctest fields
-compute!(ωₛ)
-
-# output
-4×5×1 Field{Face, Face, Center} on RectilinearGrid on CPU
-├── grid: 4×5×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
-├── boundary conditions: FieldBoundaryConditions
-│   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: Nothing, top: Nothing, immersed: Nothing
-├── indices: (:, :, 4:4)
-├── operand: BinaryOperation at (Face, Face, Center)
-├── status: time=0.0
-└── data: 6×7×1 OffsetArray(::Array{Float64, 3}, 0:5, 0:6, 4:4) with eltype Float64 with indices 0:5×0:6×4:4
-    └── max=0.0, min=0.0, mean=0.0
-```
+Note that `ωₛ` is already computed, that is, [`compute!`](@ref) has been called upon
+construction, the expression `∂x(v) - ∂y(u)` has been evaluated and the result is
+stored _only_ at the surface slice.
 
 This is useful both to save memory (only one vertical level is allocated)
 and for output: reduced fields can be passed directly to an `OutputWriter`

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -573,8 +573,8 @@ For example, suppose we want to compute and store the vertical vorticity
 u = XFaceField(grid)
 v = YFaceField(grid)
 
-set!(u, (x, y, z) -> x * y^2)
-set!(v, (x, y, z) -> x^2 * y)
+set!(u, (x, y, z) -> x * y^2) # set u to something non-trivial
+set!(v, (x, y, z) -> x^2 * y) # set v to something non-trivial
 
 ωₛ = Field(∂x(v) - ∂y(u), indices=(:, :, grid.Nz))
 

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -595,5 +595,5 @@ construction, the expression `∂x(v) - ∂y(u)` has been evaluated and the resu
 stored _only_ at the surface slice.
 
 This is useful both to save memory (only one vertical level is allocated)
-and for output: reduced fields can be passed directly to an `OutputWriter`
+and for output: reduced fields can be passed directly to an [`OutputWriter`](@ref output_writers)
 so that only the desired slice is saved to disk.

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -194,7 +194,7 @@ set_theme!(Theme(fontsize=20))
 CairoMakie.activate!(type="png")
 
 grid = RectilinearGrid(topology = (Periodic, Periodic, Bounded),
-                       size = (4, 4, 4),
+                       size = (4, 5, 4),
                        halo = (1, 1, 1),
                        x = (0, 1),
                        y = (0, 1),
@@ -452,7 +452,7 @@ c[:, :, 1]
 
 The way the halo regions are filled depends on `c.boundary_conditions`:
 
-```julia
+```jldoctest fields
 c.boundary_conditions
 
 # output
@@ -579,15 +579,15 @@ set!(v, (x, y, z) -> x^2 * y)
 ωₛ = Field(∂x(v) - ∂y(u), indices=(:, :, grid.Nz))
 
 # output
-4×4×1 Field{Face, Face, Center} on RectilinearGrid on CPU
-├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
+4×5×1 Field{Face, Face, Center} on RectilinearGrid on CPU
+├── grid: 4×5×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
 ├── boundary conditions: FieldBoundaryConditions
 │   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: Nothing, top: Nothing, immersed: Nothing
 ├── indices: (:, :, 4:4)
 ├── operand: BinaryOperation at (Face, Face, Center)
 ├── status: time=0.0
-└── data: 6×6×1 OffsetArray(::Array{Float64, 3}, 0:5, 0:5, 4:4) with eltype Float64 with indices 0:5×0:5×4:4
-    └── max=0.046875, min=-0.046875, mean=0.0
+└── data: 6×7×1 OffsetArray(::Array{Float64, 3}, 0:5, 0:6, 4:4) with eltype Float64 with indices 0:5×0:6×4:4
+    └── max=0.05, min=-0.0375, mean=0.0025
 ```
 
 Note that `ωₛ` is already computed, that is, [`compute!`](@ref) has been called upon

--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -102,7 +102,7 @@ always work on CPUs, but when their complexity is high (in terms of number of ab
 the compiler can't translate them into GPU code and they fail for GPU runs. (This limitation is summarized
 in [this Github issue](https://github.com/CliMA/Oceananigans.jl/issues/1886) and contributions are welcome.)
 For example, in the example below, calculating `u²` works in both CPUs and GPUs, but calculating
-`ε` will not compile on GPUs when its being computed (e.g. via [`compute!`](@ref)):
+`ε` will not compile on GPUs when being computed (e.g. via [`compute!`](@ref)):
 
 ```julia
 using Oceananigans

--- a/docs/src/simulation_tips.md
+++ b/docs/src/simulation_tips.md
@@ -102,7 +102,7 @@ always work on CPUs, but when their complexity is high (in terms of number of ab
 the compiler can't translate them into GPU code and they fail for GPU runs. (This limitation is summarized
 in [this Github issue](https://github.com/CliMA/Oceananigans.jl/issues/1886) and contributions are welcome.)
 For example, in the example below, calculating `u²` works in both CPUs and GPUs, but calculating
-`ε` will not compile on GPUs when we call [`compute!`](@ref):
+`ε` will not compile on GPUs when its being computed (e.g. via [`compute!`](@ref)):
 
 ```julia
 using Oceananigans
@@ -115,9 +115,6 @@ u, v, w = model.velocities
 
 u² = Field(u^2)
 ε = Field(ν*(∂x(u)^2 + ∂x(v)^2 + ∂x(w)^2 + ∂y(u)^2 + ∂y(v)^2 + ∂y(w)^2 + ∂z(u)^2 + ∂z(v)^2 + ∂z(w)^2))
-
-compute!(u²)
-compute!(ε)
 ```
 
 There are a few ways to work around this issue.
@@ -127,7 +124,6 @@ ddx² = Field(∂x(u)^2 + ∂x(v)^2 + ∂x(w)^2)
 ddy² = Field(∂y(u)^2 + ∂y(v)^2 + ∂y(w)^2)
 ddz² = Field(∂z(u)^2 + ∂z(v)^2 + ∂z(w)^2)
 ε = Field(ν * (ddx² + ddy² + ddz²))
-compute!(ε)
 ```
 
 This method increases the computational cost since it requires computing and storing 3 intermediate terms.
@@ -157,8 +153,6 @@ end
                                                        grid, u, v, w, ν)
 
 ε = Field(ε_op)
-
-compute!(ε)
 ```
 
 Writing kernel functions like `isotropic_viscous_dissipation_rate_ccc`

--- a/src/AbstractOperations/metric_field_reductions.jl
+++ b/src/AbstractOperations/metric_field_reductions.jl
@@ -126,14 +126,14 @@ julia> set!(f, (x, y, z) -> x * y * z)
 └── data: 14×14×14 OffsetArray(::Array{Float64, 3}, -2:11, -2:11, -2:11) with eltype Float64 with indices -2:11×-2:11×-2:11
     └── max=0.823975, min=0.000244141, mean=0.125
 
-julia> ∫f = Integral(f)
-Integral of BinaryOperation at (Center, Center, Center) over dims (1, 2, 3)
-└── operand: BinaryOperation at (Center, Center, Center)
-    └── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-
-julia> ∫f = Field(Integral(f));
-
-julia> compute!(∫f);
+julia> ∫f = Integral(f) |> Field
+1×1×1 Field{Nothing, Nothing, Nothing} reduced over dims = (1, 2, 3) on RectilinearGrid on CPU
+├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (1, 1, 1)
+├── grid: 8×8×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── operand: Integral of BinaryOperation at (Center, Center, Center) over dims (1, 2, 3)
+├── status: time=0.0
+└── data: 1×1×1 OffsetArray(::Array{Float64, 3}, 1:1, 1:1, 1:1) with eltype Float64 with indices 1:1×1:1×1:1
+    └── max=0.125, min=0.125, mean=0.125
 
 julia> ∫f[1, 1, 1]
 0.125
@@ -176,8 +176,7 @@ grid = RectilinearGrid(size=8, z=(0, 1), topology=(Flat, Flat, Bounded))
 c = CenterField(grid)
 set!(c, z -> z)
 
-∫ᶻc_ci = CumulativeIntegral(c, dims=3)
-∫ᶻc = Field(∫ᶻc_ci)
+∫ᶻc_ci = CumulativeIntegral(c, dims=3) |> Field
 
 # output
 1×1×9 Field{Center, Center, Face} on RectilinearGrid on CPU

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -153,6 +153,8 @@ at the fluid's surface ``z = 0``, which for `Center` corresponds to `k = Nz`.
 ```jldoctest fields
 julia> u = XFaceField(grid); v = YFaceField(grid);
 
+julia> set!(u, (x, y, z) -> x * y); set!(v, (x, y, z) -> x^2 * y);
+
 julia> ωₛ = Field(∂x(v) - ∂y(u), indices=(:, :, grid.Nz))
 2×3×1 Field{Face, Face, Center} on RectilinearGrid on CPU
 ├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
@@ -162,18 +164,7 @@ julia> ωₛ = Field(∂x(v) - ∂y(u), indices=(:, :, grid.Nz))
 ├── operand: BinaryOperation at (Face, Face, Center)
 ├── status: time=0.0
 └── data: 6×9×1 OffsetArray(::Array{Float64, 3}, -1:4, -2:6, 4:4) with eltype Float64 with indices -1:4×-2:6×4:4
-    └── max=0.0, min=0.0, mean=0.0
-
-julia> compute!(ωₛ)
-2×3×1 Field{Face, Face, Center} on RectilinearGrid on CPU
-├── grid: 2×3×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
-├── boundary conditions: FieldBoundaryConditions
-│   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: Nothing, top: Nothing, immersed: Nothing
-├── indices: (:, :, 4:4)
-├── operand: BinaryOperation at (Face, Face, Center)
-├── status: time=0.0
-└── data: 6×9×1 OffsetArray(::Array{Float64, 3}, -1:4, -2:6, 4:4) with eltype Float64 with indices -1:4×-2:6×4:4
-    └── max=0.0, min=0.0, mean=0.0
+    └── max=0.166667, min=-0.25, mean=-0.0208333
 ```
 """
 function Field{LX, LY, LZ}(grid::AbstractGrid,

--- a/src/Models/boundary_condition_operation.jl
+++ b/src/Models/boundary_condition_operation.jl
@@ -83,7 +83,6 @@ Next, we build a `Field` for the top flux, and compute it:
 
 ```jldoctest bc_op
 c_flux_field = Field(c_flux_op)
-compute!(c_flux_field)
 
 # output
 16×16×1 Field{Center, Center, Nothing} reduced over dims = (3,) on RectilinearGrid on CPU

--- a/src/Models/forcing_operation.jl
+++ b/src/Models/forcing_operation.jl
@@ -52,7 +52,6 @@ Next, we build a `ForcingField` for the damping, and compute it:
 using Oceananigans.Models: ForcingField
 set!(model, c=1)
 c_forcing_field = ForcingField(:c, model)
-compute!(c_forcing_field)
 
 # output
 16×16×16 Field{Center, Center, Center} on RectilinearGrid on CPU

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -114,13 +114,13 @@ for arch in archs
                 end
             end
 
-            @test compute!(Field(ZeroField() + u)) == u
-            @test compute!(Field(u + ZeroField())) == u
-            @test compute!(Field(-ZeroField() + u)) == u
-            @test compute!(Field(u - ZeroField())) == u
-            @test compute!(Field(ZeroField() * u)) == ZeroField()
-            @test compute!(Field(u * ZeroField())) == ZeroField()
-            @test compute!(Field(ZeroField() / u)) == ZeroField()
+            @test Field(ZeroField() + u) == u
+            @test Field(u + ZeroField()) == u
+            @test Field(-ZeroField() + u) == u
+            @test Field(u - ZeroField()) == u
+            @test Field(ZeroField() * u) == ZeroField()
+            @test Field(u * ZeroField()) == ZeroField()
+            @test Field(ZeroField() / u) == ZeroField()
             @test u / ZeroField() == ConstantField(Inf)
 
             @test ZeroField() + 1 == ConstantField(1)
@@ -136,10 +136,10 @@ for arch in archs
             @test ZeroField() - ZeroField() == ZeroField()
             @test ZeroField() * ZeroField() == ZeroField()
 
-            @test compute!(Field(ConstantField(1) + u)) == compute!(Field(1 + u))
-            @test compute!(Field(ConstantField(1) - u)) == compute!(Field(1 - u))
-            @test compute!(Field(ConstantField(1) * u)) == compute!(Field(1 * u))
-            @test compute!(Field(u / ConstantField(1))) == compute!(Field(u / 1))
+            @test Field(ConstantField(1) + u) == Field(1 + u)
+            @test Field(ConstantField(1) - u) == Field(1 - u)
+            @test Field(ConstantField(1) * u) == Field(1 * u)
+            @test Field(u / ConstantField(1)) == Field(u / 1)
 
             @test ConstantField(1) + 1 == ConstantField(2)
             @test ConstantField(1) - 1 == ConstantField(0)

--- a/test/test_model_diagnostics.jl
+++ b/test/test_model_diagnostics.jl
@@ -129,7 +129,7 @@ damping(x, y, z, t, c, τ) = - c / τ
 
         set!(model, c=1)
         c_forcing_field = ForcingField(:c, model)
-        compute!(c_forcing_field)
+
         @test c_forcing_field isa Field
         @test all(interior(c_forcing_field) .== - 1/60)
     end

--- a/test/test_model_diagnostics.jl
+++ b/test/test_model_diagnostics.jl
@@ -118,10 +118,10 @@ damping(x, y, z, t, c, τ) = - c / τ
                                z = (-1, 1),
                                topology=(Bounded, Bounded, Bounded))
 
-
         c_forcing = Forcing(damping, field_dependencies=:c, parameters=60)
         model = NonhydrostaticModel(grid; tracers=:c, forcing=(; c=c_forcing))
         c_forcing_op = ForcingOperation(:c, model)
+
         @test c_forcing_op isa KernelFunctionOperation
         @test c_forcing_op.kernel_function isa ForcingKernelFunction
         @test c_forcing_op.kernel_function.forcing isa ContinuousForcing


### PR DESCRIPTION
After https://github.com/CliMA/Oceananigans.jl/pull/4531 (I think) we don't need to explicitly call `compute!` on computed fields. This PR simplifies some of the examples.