### PR TITLE
Make Az on LatitudeLongitudeGrid Flat-safe via trig identity

### DIFF
--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -454,7 +454,7 @@ end
 ####
 
 # Use the trig identity sin(φ+Δ/2) - sin(φ-Δ/2) = 2 cos(φ) sin(Δ/2), which is exact and
-# only reads φᵃᶜᵃ[j] / φᵃᶠᵃ[j] plus the Flat-safe Δφᵃᶜᵃ / Δφᵃᶠᵃ operators (no [j±1]).
+# only reads φᵃᶜᵃ[j] / φᵃᶠᵃ[j] plus the Flat-safe Δφᵃᶜᵃ / Δφᵃᶠᵃ operators (no φ[j±1]).
 @inline Azᶠᶜᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * 2 * hack_cosd(grid.φᵃᶜᵃ[j]) * hack_sind(Δφᵃᶜᵃ(i, j, k, grid) / 2)
 @inline Azᶜᶠᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * 2 * hack_cosd(grid.φᵃᶠᵃ[j]) * hack_sind(Δφᵃᶠᵃ(i, j, k, grid) / 2)
 @inline Azᶠᶠᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * 2 * hack_cosd(grid.φᵃᶠᵃ[j]) * hack_sind(Δφᵃᶠᵃ(i, j, k, grid) / 2)

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -453,15 +453,17 @@ end
 #### Special 2D z Areas for LatitudeLongitudeGrid and OrthogonalSphericalShellGrid
 ####
 
-@inline Azᶠᶜᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
-@inline Azᶜᶠᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶠᶠᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶜᶜᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+# Use the trig identity sin(φ+Δ/2) - sin(φ-Δ/2) = 2 cos(φ) sin(Δ/2), which is exact and
+# only reads φᵃᶜᵃ[j] / φᵃᶠᵃ[j] plus the Flat-safe Δφᵃᶜᵃ / Δφᵃᶠᵃ operators (no [j±1]).
+@inline Azᶠᶜᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * 2 * hack_cosd(grid.φᵃᶜᵃ[j]) * hack_sind(Δφᵃᶜᵃ(i, j, k, grid) / 2)
+@inline Azᶜᶠᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * 2 * hack_cosd(grid.φᵃᶠᵃ[j]) * hack_sind(Δφᵃᶠᵃ(i, j, k, grid) / 2)
+@inline Azᶠᶠᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * 2 * hack_cosd(grid.φᵃᶠᵃ[j]) * hack_sind(Δφᵃᶠᵃ(i, j, k, grid) / 2)
+@inline Azᶜᶜᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * 2 * hack_cosd(grid.φᵃᶜᵃ[j]) * hack_sind(Δφᵃᶜᵃ(i, j, k, grid) / 2)
 
-@inline Azᶠᶜᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
-@inline Azᶜᶠᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶠᶠᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶜᶜᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+@inline Azᶠᶜᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ)    * 2 * hack_cosd(grid.φᵃᶜᵃ[j]) * hack_sind(Δφᵃᶜᵃ(i, j, k, grid) / 2)
+@inline Azᶜᶠᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ)    * 2 * hack_cosd(grid.φᵃᶠᵃ[j]) * hack_sind(Δφᵃᶠᵃ(i, j, k, grid) / 2)
+@inline Azᶠᶠᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ)    * 2 * hack_cosd(grid.φᵃᶠᵃ[j]) * hack_sind(Δφᵃᶠᵃ(i, j, k, grid) / 2)
+@inline Azᶜᶜᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ)    * 2 * hack_cosd(grid.φᵃᶜᵃ[j]) * hack_sind(Δφᵃᶜᵃ(i, j, k, grid) / 2)
 
 for LX in (:ᶠ, :ᶜ), LY in (:ᶠ, :ᶜ)
 


### PR DESCRIPTION
## Summary

Fixes #5547. The on-the-fly `Azᶠᶜᵃ` / `Azᶜᶠᵃ` / `Azᶠᶠᵃ` / `Azᶜᶜᵃ` for `LLGF` / `LLGFX` index `grid.φᵃᶠᵃ[j+1]` (or `grid.φᵃᶜᵃ[j-1]`) without a `Flat`-y dispatch. On a `(Flat, Flat, Bounded)` `LatitudeLongitudeGrid` with `size = 1` — a typical single-column setup — that index is out of bounds. The `@inbounds` annotation hides it on default builds, but `--check-bounds=yes` reproduces it as a `BoundsError`, and on GPU it surfaces asynchronously as a `KernelException`.

## Repro (before)

```julia
using Oceananigans
using Oceananigans.Operators: Azᶠᶜᵃ
g = LatitudeLongitudeGrid(CPU(); size=1, latitude=10, longitude=10, z=(-1,0), topology=(Flat,Flat,Bounded))
# julia --check-bounds=yes
Azᶠᶜᵃ(1, 1, 1, g)
# ERROR: BoundsError: attempt to access 1-element StepRangeLen{...} at index [2]
```

In practice this fires from `compute_z_bottom_bc!` whenever a velocity component has a flux BC (e.g. quadratic bottom drag) on a Flat-`LatitudeLongitudeGrid` column model.

## Fix

Use the exact identity

$$\sin(\varphi + \Delta/2) - \sin(\varphi - \Delta/2) = 2 \cos(\varphi)~\sin(\Delta/2)$$

so each `Az*` formula only needs `φ` at the cell center / face plus `Δφ` via the existing `Δφᵃᶜᵃ` / `Δφᵃᶠᵃ` operators (which are already specialized for Flat axes via `YRegularLLG` — `Δφ` is stored as a scalar on Flat-y).

Diff is 8 modified lines (4 `LLGF`, 4 `LLGFX`) plus a one-line comment.

## Verification

- **Bit-exact regression on a 1°×1° global grid.** Compared `Azᶠᶜᵃ(i, j, 1, g)` against the original `R² · Δλ · (sind(φᵃᶠᵃ[j+1]) - sind(φᵃᶠᵃ[j]))` formula at i ∈ {1, 100, 360}, j ∈ {2, 90, 170, 179}; relative difference is exactly `0.0` for all sampled points (the identity is algebraically exact, so any FP differences come down to evaluation order, which happened to match here).
- **Flat-Flat repro now passes.** All four `Az*` evaluate to a sensible non-NaN value on the size=1 `(Flat, Flat, Bounded)` grid above (≈ R² · cos(10°) · 1° · 1° ≈ 1.22e10 m²).
- **No new methods, no new type aliases, no import changes.** Existing dispatches keep their existing specificity ordering.

## Test plan

- [x] `BoundsError` repro fixed locally on `--check-bounds=yes`.
- [x] Bit-exact regression check vs. the previous formula on a 1°×1° global grid.
- [ ] Full Oceananigans test suite (CI).
- [ ] Confirm CUDA path (the original report was a `KernelException` on an L4 GPU; same code path on CPU was the deterministic repro used here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)