### PR TITLE
Increment benchmarking commit history

### DIFF
--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -307,7 +307,7 @@ jobs:
           alert-threshold: "110%"
           fail-on-alert: false
           auto-push: true
-          max-items-in-chart: 50
+          max-items-in-chart: 5000
           comment-on-alert: true
 
       # For PRs: comment benchmark comparison on the PR


### PR DESCRIPTION
Oceananigans moves quite fast compared to other repos, so having only a 50 commit window in the benchmarks is quite restrictive. This data is simple text so it will not blow up the OceananigansBenchmarks repo too much. 

This PR increases the history from 50 commits to 5000 commits