### PR TITLE
(0.107.5) Bugfix `with_tracers` for `IsopycnalSkewSymmetricDiffusivity`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.107.4"
+version = "0.107.5"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
@@ -76,13 +76,13 @@ end
 IsopycnalSkewSymmetricDiffusivity(FT::DataType; kw...) =
     IsopycnalSkewSymmetricDiffusivity(VerticallyImplicitTimeDiscretization(), FT; kw...)
 
-function Utils.with_tracers(tracers, closure::ISSD{TD, A, N}) where {TD, A<:DiffusiveFormulation, N}
+function Utils.with_tracers(tracers, closure::ISSD{TD, A, <:Any, <:Any, <:Any, <:Any, N}) where {TD, A<:DiffusiveFormulation, N}
     κ_skew = !isa(closure.κ_skew, NamedTuple) ? closure.κ_skew : tracer_diffusivities(tracers, closure.κ_skew)
     κ_symmetric = !isa(closure.κ_symmetric, NamedTuple) ? closure.κ_symmetric : tracer_diffusivities(tracers, closure.κ_symmetric)
     return IsopycnalSkewSymmetricDiffusivity{TD, A, N}(κ_skew, κ_symmetric, closure.isopycnal_tensor, closure.slope_limiter)
 end
 
-function Utils.with_tracers(tracers, closure::ISSD{TD, A, N}) where {TD, A<:AdvectiveFormulation, N}
+function Utils.with_tracers(tracers, closure::ISSD{TD, A, <:Any, <:Any, <:Any, <:Any, N}) where {TD, A<:AdvectiveFormulation, N}
     κ_skew = closure.κ_skew
     κ_symmetric = !isa(closure.κ_symmetric, NamedTuple) ? closure.κ_symmetric : tracer_diffusivities(tracers, closure.κ_symmetric)
     return IsopycnalSkewSymmetricDiffusivity{TD, A, N}(κ_skew, κ_symmetric, closure.isopycnal_tensor, closure.slope_limiter)

--- a/test/test_diffusion_stencils.jl
+++ b/test/test_diffusion_stencils.jl
@@ -1,9 +1,10 @@
 include("dependencies_for_runtests.jl")
 
-using Oceananigans.Grids: MutableVerticalDiscretization
+using Oceananigans.Grids: MutableVerticalDiscretization, required_halo_size_x, required_halo_size_y, required_halo_size_z
 using Oceananigans.Models: ZStarCoordinate, ZCoordinate, surface_kernel_parameters
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: _update_zstar_scaling!
-using Oceananigans.TurbulenceClosures: IsopycnalSkewSymmetricDiffusivity,
+using Oceananigans.TurbulenceClosures: with_tracers,
+                                       IsopycnalSkewSymmetricDiffusivity,
                                        TriadIsopycnalSkewSymmetricDiffusivity,
                                        DiffusiveFormulation, AdvectiveFormulation
 using Oceananigans.Operators: ∂xᶠᶜᶜ, ∂xᵣᶠᶜᶜ, Axᶠᶜᶜ, Vᶜᶜᶜ
@@ -196,6 +197,19 @@ end
 
 @testset "Isopycnal closures with r-based derivatives" begin
     @info "Testing isopycnal closures with r-based derivatives..."
+
+    @testset "IsopycnalSkewSymmetricDiffusivity required_halo_size_x" begin
+        eddy_closure = IsopycnalSkewSymmetricDiffusivity(κ_skew=1e3, κ_symmetric=1e3, skew_flux_formulation=AdvectiveFormulation())
+        @test required_halo_size_x(eddy_closure) == 1
+        @test required_halo_size_y(eddy_closure) == 1
+        @test required_halo_size_z(eddy_closure) == 1
+        
+        eddy_closure = with_tracers((:T, :S), eddy_closure)
+        @test required_halo_size_x(eddy_closure) == 1
+        @test required_halo_size_y(eddy_closure) == 1
+        @test required_halo_size_z(eddy_closure) == 1
+    end
+
 
     for arch in archs
         issd_closures = [

--- a/test/test_diffusion_stencils.jl
+++ b/test/test_diffusion_stencils.jl
@@ -203,7 +203,7 @@ end
         @test required_halo_size_x(eddy_closure) == 1
         @test required_halo_size_y(eddy_closure) == 1
         @test required_halo_size_z(eddy_closure) == 1
-        
+
         eddy_closure = with_tracers((:T, :S), eddy_closure)
         @test required_halo_size_x(eddy_closure) == 1
         @test required_halo_size_y(eddy_closure) == 1


### PR DESCRIPTION
The type parameters in `IsopycnalSkewSymmetricDiffusivity` were scrambled after passing the `with_tracers` method. Leading to `required_halo_size` returning the type of the diffusivity rather than the actual required halo.

This PR fixes the bug

Found by @lgloege and @tlangfor when running distributed NumericalEarth simulations