### PR TITLE
Pin CUDA.jl to v6.0 in tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -43,7 +43,7 @@ Oceananigans = {path = ".."}
 AMDGPU = "1.3.6, 2"
 Adapt = "4.1.1"
 Aqua = "0.8"
-CUDA = "=5.8.5, 5.9.1, 6"
+CUDA = "=5.8.5, 5.9.1, ~6.0"
 CairoMakie = "0.15"
 DataDeps = "0.7"
 Dates = "<0.0.1, 1"


### PR DESCRIPTION
CUDA.jl v6.1 breaks compatibility with Reactant as it uses a CUDA specific intrinsic. See [here](https://github.com/NumericalEarth/Breeze.jl/pull/670) and [here](https://github.com/JuliaGPU/CUDA.jl/pull/3077).