### PR TITLE
Append distributed rank suffix to checkpointer filenames

### DIFF
--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -42,6 +42,7 @@ Keyword arguments
 - `dir`: Directory to save output to. Default: `"."` (current working directory).
 
 - `prefix`: Descriptive filename prefixed to all output files. Default: `"checkpoint"`.
+            On distributed architectures, `"_rank{local_rank}"` is appended automatically.
 
 - `overwrite_existing`: Remove existing files if their filenames conflict. Default: `false`.
 
@@ -59,6 +60,8 @@ function Checkpointer(model; schedule,
                       cleanup = false)
 
     mkpath(dir)
+    filename = with_architecture_suffix(architecture(model), string(prefix, ".jld2"), ".jld2")
+    prefix = chop(filename, tail=length(".jld2"))
 
     return Checkpointer(schedule, dir, prefix, overwrite_existing, verbose, cleanup)
 end

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -61,7 +61,7 @@ function Checkpointer(model; schedule,
 
     mkpath(dir)
     filename = with_architecture_suffix(architecture(model), string(prefix, ".jld2"), ".jld2")
-    prefix = chop(filename, tail=length(".jld2"))
+    prefix = String(chop(filename, tail=length(".jld2")))
 
     return Checkpointer(schedule, dir, prefix, overwrite_existing, verbose, cleanup)
 end


### PR DESCRIPTION
## Summary
- append `"_rank{local_rank}"` to checkpointer filenames on distributed architectures
- reuse the existing `with_architecture_suffix` behavior used by output writers
- keep checkpoint pickup and cleanup scoped per-rank by storing the suffixed prefix in the checkpointer

## Why
Distributed runs were writing checkpoints with shared filenames across ranks. This change mirrors output writer naming and avoids rank collisions.

## Changes
- update `Checkpointer(model; ...)` to derive a rank-suffixed prefix from architecture-aware filename suffixing
- add a short doc note that distributed checkpointer prefixes automatically append `"_rank{local_rank}"`

## Testing
- not run in this change
