### PR TITLE
Allow `AveragedTimeInterval` with a `Dates` clock

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.107.5"
+version = "0.107.6"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/OutputWriters/windowed_time_average.jl
+++ b/src/OutputWriters/windowed_time_average.jl
@@ -1,11 +1,11 @@
 using Oceananigans.Diagnostics: AbstractDiagnostic
 using Oceananigans.OutputWriters: fetch_output
-using Oceananigans.Utils: AbstractSchedule, prettytime
+using Oceananigans.Utils: AbstractSchedule, prettytime, period_type, time_type
 using Oceananigans.TimeSteppers: Clock
 using Dates: Period, Second, value
 
 import Oceananigans: run_diagnostic!, prognostic_state, restore_prognostic_state!, initialize!
-import Oceananigans.Utils: TimeInterval, SpecifiedTimes
+import Oceananigans.Utils: TimeInterval, SpecifiedTimes, initialize_actuations!
 import Oceananigans.Grids: grid
 import Oceananigans.Fields: location, indices, set!
 
@@ -88,7 +88,12 @@ JLD2Writer scheduled on TimeInterval(4 days):
 """
 function AveragedTimeInterval(interval; window=interval, stride=1)
     window > interval && throw(ArgumentError("Averaging window $window is greater than the output interval $interval."))
-    return AveragedTimeInterval(Float64(interval), Float64(window), stride, 0.0, 0, false)
+    IT = period_type(interval)
+    interval = convert(IT, interval)
+    window = convert(IT, window)
+    TT = time_type(interval)
+    first_actuation_time = zero(TT)
+    return AveragedTimeInterval{IT, TT}(interval, window, stride, first_actuation_time, 0, false)
 end
 
 function next_actuation_time(sch::AveragedTimeInterval)
@@ -105,7 +110,21 @@ function (sch::AveragedTimeInterval)(model)
     return scheduled
 end
 
-initialize!(sch::AveragedTimeInterval, model) = nothing
+initialize!(sch::AveragedTimeInterval, model) = initialize_actuations!(sch, model.clock.time)
+
+function initialize_actuations!(schedule::AveragedTimeInterval, first_actuation_time)
+    if schedule.first_actuation_time isa Number && first_actuation_time isa Dates.AbstractDateTime
+        T = typeof(schedule.first_actuation_time)
+        msg = "Cannot use $T AveragedTimeInterval times with DateTime clock. Use a Dates.Period instead."
+        throw(ArgumentError(msg))
+    end
+
+    schedule.first_actuation_time = first_actuation_time
+    schedule.actuations = 0
+
+    return true
+end
+
 outside_window(sch::AveragedTimeInterval, clock) = clock.time <= next_actuation_time(sch) - sch.window
 initialize_schedule!(sch::AveragedTimeInterval, clock) = nothing
 

--- a/src/OutputWriters/windowed_time_average.jl
+++ b/src/OutputWriters/windowed_time_average.jl
@@ -2,7 +2,7 @@ using Oceananigans.Diagnostics: AbstractDiagnostic
 using Oceananigans.OutputWriters: fetch_output
 using Oceananigans.Utils: AbstractSchedule, prettytime, period_type, time_type
 using Oceananigans.TimeSteppers: Clock
-using Dates: Period, Second, value
+using Dates: Period, Second, value, AbstractDateTime
 
 import Oceananigans: run_diagnostic!, prognostic_state, restore_prognostic_state!, initialize!
 import Oceananigans.Utils: TimeInterval, SpecifiedTimes, initialize_actuations!
@@ -113,7 +113,7 @@ end
 initialize!(sch::AveragedTimeInterval, model) = initialize_actuations!(sch, model.clock.time)
 
 function initialize_actuations!(schedule::AveragedTimeInterval, first_actuation_time)
-    if schedule.first_actuation_time isa Number && first_actuation_time isa Dates.AbstractDateTime
+    if schedule.first_actuation_time isa Number && first_actuation_time isa AbstractDateTime
         T = typeof(schedule.first_actuation_time)
         msg = "Cannot use $T AveragedTimeInterval times with DateTime clock. Use a Dates.Period instead."
         throw(ArgumentError(msg))

--- a/src/Utils/times_and_datetimes.jl
+++ b/src/Utils/times_and_datetimes.jl
@@ -33,10 +33,14 @@ end
 @inline add_time_interval(base, interval::Array{<:Dates.Period}, count=1) = seconds_to_nanosecond(interval[count])
 @inline add_time_interval(base, interval::Array{Dates.DateTime}, count=1) = interval[count]
 
+period_type(interval::AbstractFloat) = typeof(interval)
+
 function period_type(interval::Number)
     FT = Oceananigans.defaults.FloatType
     return FT
 end
+
+period_type(interval::Array{<:AbstractFloat}) = Array{eltype(interval), 1}
 
 function period_type(interval::Array{<:Number})
     FT = Oceananigans.defaults.FloatType

--- a/test/test_datetime_clock.jl
+++ b/test/test_datetime_clock.jl
@@ -10,6 +10,7 @@ using Oceananigans.Simulations: Simulation, run!, Callback
 using Oceananigans.Units: hour, Time
 using Oceananigans.TimeSteppers: Clock, tick!
 using Oceananigans.Utils: TimeInterval, SpecifiedTimes, schedule_aligned_time_step, IterationInterval
+using Oceananigans.OutputWriters: AveragedTimeInterval
 import Oceananigans: initialize!
 
 struct DummyModel
@@ -68,6 +69,27 @@ function time_interval_schedule_checks(start_time)
     return true
 end
 
+function averaged_time_interval_schedule_checks(start_time)
+    schedule = AveragedTimeInterval(Dates.Hour(2), window=Dates.Hour(1))
+    @test schedule.interval isa Dates.Hour
+    @test schedule.window  isa Dates.Hour
+    @test schedule.first_actuation_time isa DateTime
+
+    clock = Clock(time=start_time)
+    model = DummyModel(clock)
+
+    initialize!(schedule, model)
+    @test schedule.first_actuation_time == start_time
+    @test !schedule(model)
+
+    tick!(clock, Dates.Hour(1) + Dates.Minute(1))  
+    @test schedule(model)
+
+    @test_throws ArgumentError initialize!(AveragedTimeInterval(1.0), DummyModel(Clock(time=start_time)))
+
+    return true
+end
+
 function specified_times_schedule_checks(start_time)
     schedule = SpecifiedTimes(start_time + Dates.Hour(1), start_time + Dates.Hour(3))
     clock = Clock(time=start_time)
@@ -120,6 +142,25 @@ function numeric_time_interval_schedule_checks(FT)
     tick!(clock, aligned)
     @test schedule(model)
     @test !schedule(model)
+
+    return true
+end
+
+function numeric_averaged_time_interval_schedule_checks(FT)
+    schedule = AveragedTimeInterval(FT(2), window=FT(1))
+    @test schedule.interval isa FT
+    @test schedule.window  isa FT
+    @test schedule.first_actuation_time isa FT
+
+    clock = Clock(time=zero(FT))
+    model = DummyModel(clock)
+
+    initialize!(schedule, model)
+    @test schedule.first_actuation_time == zero(FT)
+    @test !schedule(model)
+
+    tick!(clock, FT(1.5))
+    @test schedule(model)
 
     return true
 end
@@ -192,6 +233,10 @@ end
         @test time_interval_schedule_checks(start_time)
     end
 
+    @testset "AveragedTimeInterval schedule (DateTime)" begin
+        @test averaged_time_interval_schedule_checks(start_time)
+    end
+
     @testset "SpecifiedTimes schedule (DateTime)" begin
         @test specified_times_schedule_checks(start_time)
     end
@@ -199,6 +244,10 @@ end
     for FT in float_types
         @testset "TimeInterval schedule [$FT]" begin
             @test numeric_time_interval_schedule_checks(FT)
+        end
+
+        @testset "AveragedTimeInterval schedule [$FT]" begin
+            @test numeric_averaged_time_interval_schedule_checks(FT)
         end
 
         @testset "SpecifiedTimes schedule [$FT]" begin

--- a/test/test_datetime_clock.jl
+++ b/test/test_datetime_clock.jl
@@ -82,7 +82,7 @@ function averaged_time_interval_schedule_checks(start_time)
     @test schedule.first_actuation_time == start_time
     @test !schedule(model)
 
-    tick!(clock, Dates.Hour(1) + Dates.Minute(1))  
+    tick!(clock, Dates.Hour(1) + Dates.Minute(1))
     @test schedule(model)
 
     @test_throws ArgumentError initialize!(AveragedTimeInterval(1.0), DummyModel(Clock(time=start_time)))

--- a/test/test_datetime_clock.jl
+++ b/test/test_datetime_clock.jl
@@ -82,7 +82,7 @@ function averaged_time_interval_schedule_checks(start_time)
     @test schedule.first_actuation_time == start_time
     @test !schedule(model)
 
-    tick!(clock, Dates.Minute(61))
+    tick!(clock, hour + 60)
     @test schedule(model)
 
     @test_throws ArgumentError initialize!(AveragedTimeInterval(1.0), DummyModel(Clock(time=start_time)))

--- a/test/test_datetime_clock.jl
+++ b/test/test_datetime_clock.jl
@@ -82,7 +82,7 @@ function averaged_time_interval_schedule_checks(start_time)
     @test schedule.first_actuation_time == start_time
     @test !schedule(model)
 
-    tick!(clock, Dates.Hour(1) + Dates.Minute(1))
+    tick!(clock, Dates.Minute(61))
     @test schedule(model)
 
     @test_throws ArgumentError initialize!(AveragedTimeInterval(1.0), DummyModel(Clock(time=start_time)))


### PR DESCRIPTION
At the moment, `AveragedTimeInterval` does not support a `Dates` clock. This PR allows to use a `Dates` clock passing `Dates.Period` averaging times

MWE:
```julia
using Dates
using Oceananigans

grid  = RectilinearGrid(size=(1,1,1), extent=(1,1,1))
clock = Oceananigans.TimeSteppers.Clock(time=DateTime(2010, 1, 1))
model = HydrostaticFreeSurfaceModel(grid; clock)

# Works on main (TimeInterval supports Dates)
JLD2Writer(model, model.velocities; schedule=TimeInterval(Dates.Day(1)), filename="ti")

# Fails on main (works on this PR)
JLD2Writer(model, model.velocities; schedule=AveragedTimeInterval(Dates.Day(1)), filename="ati")
```