### PR TITLE
Bugfix distributed immersed boundary

### DIFF
--- a/src/DistributedComputations/distributed_immersed_boundaries.jl
+++ b/src/DistributedComputations/distributed_immersed_boundaries.jl
@@ -2,6 +2,8 @@ using Oceananigans.Utils: getnamewrapper
 using Oceananigans.ImmersedBoundaries
 using Oceananigans.ImmersedBoundaries:
     AbstractGridFittedBottom,
+    GridFittedBottom,
+    PartialCellBottom,
     GridFittedBoundary,
     compute_mask,
     has_active_cells_map,
@@ -25,8 +27,25 @@ function reconstruct_global_grid(grid::ImmersedBoundaryGrid)
     arch      = grid.architecture
     local_ib  = grid.immersed_boundary
     global_ug = reconstruct_global_grid(grid.underlying_grid)
-    global_ib = getnamewrapper(local_ib)(construct_global_array(local_ib.bottom_height, arch, size(grid)))
+    global_ib = reconstruct_global_immersed_boundary(local_ib, arch, grid)
     return ImmersedBoundaryGrid(global_ug, global_ib; active_cells_map, active_z_columns)
+end
+
+function reconstruct_global_immersed_boundary(ib::GridFittedBottom, arch, grid)
+    Nx, Ny, _ = size(grid)
+    global_bottom_height = construct_global_array(ib.bottom_height, arch, (Nx, Ny, 1))
+    return GridFittedBottom(global_bottom_height, ib.immersed_condition)
+end
+
+function reconstruct_global_immersed_boundary(ib::PartialCellBottom, arch, grid)
+    Nx, Ny, _ = size(grid)
+    global_bottom_height = construct_global_array(ib.bottom_height, arch, (Nx, Ny, 1))
+    return PartialCellBottom(global_bottom_height, ib.minimum_fractional_cell_height)
+end
+
+function reconstruct_global_immersed_boundary(ib::GridFittedBoundary, arch, grid)
+    global_mask = construct_global_array(ib.mask, arch, size(grid))
+    return GridFittedBoundary(global_mask)
 end
 
 function with_halo(new_halo, grid::DistributedImmersedBoundaryGrid)
@@ -36,8 +55,7 @@ function with_halo(new_halo, grid::DistributedImmersedBoundaryGrid)
     underlying_grid       = grid.underlying_grid
     new_underlying_grid   = with_halo(new_halo, underlying_grid)
     new_immersed_boundary = resize_immersed_boundary(immersed_boundary, new_underlying_grid)
-    return ImmersedBoundaryGrid(new_underlying_grid, new_immersed_boundary;
-                                active_cells_map, active_z_columns)
+    return ImmersedBoundaryGrid(new_underlying_grid, new_immersed_boundary; active_cells_map, active_z_columns)
 end
 
 function scatter_local_grids(global_grid::ImmersedBoundaryGrid, arch::Distributed, local_size)

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -542,8 +542,9 @@ end
                                          z=(0, 1), radius=1)
         local_Ny = Ny ÷ 4
         rank = arch.local_rank
-        local_bh = fill(0.1 + 0.25 * rank, Nx, local_Ny)
-        local_mask = falses(Nx, local_Ny, Nz)
+        child_arch = child_architecture(arch)
+        local_bh = on_architecture(child_arch, fill(0.1 + 0.25 * rank, Nx, local_Ny))
+        local_mask = on_architecture(child_arch, falses(Nx, local_Ny, Nz))
 
         ibg_gfb = ImmersedBoundaryGrid(ug, GridFittedBottom(local_bh))
         ibg_pcb = ImmersedBoundaryGrid(ug,

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -542,7 +542,6 @@ end
                                          z=(0, 1), radius=1)
         local_Ny = Ny ÷ 4
         rank = arch.local_rank
-        child_arch = child_architecture(arch)
         local_bh = on_architecture(child_arch, fill(0.1 + 0.25 * rank, Nx, local_Ny))
         local_mask = on_architecture(child_arch, falses(Nx, local_Ny, Nz))
 

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -22,8 +22,9 @@ using MPI
 MPI.Init()
 
 using Oceananigans.BoundaryConditions: fill_halo_regions!, DCBC
-using Oceananigans.DistributedComputations: Distributed, index2rank, cpu_architecture, child_architecture
-using Oceananigans.Fields: AbstractField
+using Oceananigans.DistributedComputations: Distributed, index2rank, cpu_architecture, child_architecture, reconstruct_global_grid
+using Oceananigans.Fields: AbstractField, interior
+using Oceananigans.ImmersedBoundaries: GridFittedBottom, PartialCellBottom, GridFittedBoundary
 using Oceananigans.Grids:
     architecture,
     halo_size,
@@ -528,6 +529,48 @@ end
             @test minimum_yspacing(osg) == minimum_yspacing(osg)
             @test minimum_zspacing(osg) == minimum_zspacing(osg)
         end
+    end
+
+    @testset "reconstruct_global_grid(::ImmersedBoundaryGrid)" begin
+        @info "Testing reconstruct_global_grid for ImmersedBoundaryGrid…"
+        child_arch = get(ENV, "TEST_ARCHITECTURE", "CPU") == "GPU" ? GPU() : CPU()
+
+        arch = Distributed(child_arch; partition=Partition(1, 4))
+        Nx, Ny, Nz = 8, 16, 4
+        ug = LatitudeLongitudeGrid(arch, size=(Nx, Ny, Nz),
+                                         latitude=(0, 60), longitude=(0, 60),
+                                         z=(0, 1), radius=1)
+        local_Ny = Ny ÷ 4
+        rank = arch.local_rank
+        local_bh = fill(0.1 + 0.25 * rank, Nx, local_Ny)
+        local_mask = falses(Nx, local_Ny, Nz)
+
+        ibg_gfb = ImmersedBoundaryGrid(ug, GridFittedBottom(local_bh))
+        ibg_pcb = ImmersedBoundaryGrid(ug,
+                                       PartialCellBottom(local_bh; minimum_fractional_cell_height=0.3))
+        ibg_gfm = ImmersedBoundaryGrid(ug, GridFittedBoundary(local_mask))
+
+        # GridFittedBottom: shape, type and rank-wise stitching.
+        gfb = reconstruct_global_grid(ibg_gfb)
+        bh = Array(interior(gfb.immersed_boundary.bottom_height))
+        @test gfb.immersed_boundary isa GridFittedBottom
+        @test size(bh) == (Nx, Ny, 1)
+        for r in 0:3
+            j_lo = r * local_Ny + 1
+            j_hi = (r + 1) * local_Ny
+            expected_zface = (0.0, 0.25, 0.5, 0.75)[r + 1]
+            @test all(bh[:, j_lo:j_hi, 1] .== expected_zface)
+        end
+
+        pcb = reconstruct_global_grid(ibg_pcb)
+        @test pcb.immersed_boundary isa PartialCellBottom
+        @test size(interior(pcb.immersed_boundary.bottom_height)) == (Nx, Ny, 1)
+        @test pcb.immersed_boundary.minimum_fractional_cell_height == 0.3
+
+        # GridFittedBoundary: 3-D mask path
+        gfm = reconstruct_global_grid(ibg_gfm)
+        @test gfm.immersed_boundary isa GridFittedBoundary
+        @test size(gfm.immersed_boundary.mask) == (Nx, Ny, Nz)
     end
 
     @testset "Distributed reductions" begin


### PR DESCRIPTION
on main the global reconstruction of an immersed boundary grid is bugged and apparently only supports a `GridFittedBottom`. This PR fixes it.