### PR TITLE
Bugfix `actuations` for `TimeInterval`

### DIFF
--- a/src/Utils/schedules.jl
+++ b/src/Utils/schedules.jl
@@ -106,7 +106,6 @@ function prognostic_state(schedule::TimeInterval)
 end
 
 function restore_prognostic_state!(restored::TimeInterval, from)
-    # Phase across restart is only meaningful if the interval is the same.
     if hasproperty(from, :interval) && from.interval == restored.interval
         restored.first_actuation_time = from.first_actuation_time
         restored.actuations = from.actuations

--- a/src/Utils/schedules.jl
+++ b/src/Utils/schedules.jl
@@ -72,15 +72,28 @@ function next_actuation_time(schedule::TimeInterval)
     return add_time_interval(t₀, T, N + 1)
 end
 
+#  Return `Inf` if we exhausted the actuations in a TimeInterval(::SpecifiedTimes)
+function next_actuation_time(schedule::TimeInterval{<:AbstractArray})
+    schedule.actuations ≥ length(schedule.interval) && return Inf
+    return add_time_interval(schedule.first_actuation_time, schedule.interval, schedule.actuations + 1)
+end
+
 function (schedule::TimeInterval)(model)
     t = model.clock.time
     t★ = next_actuation_time(schedule)
 
-    if t >= t★
+    # Array-interval schedules return `Inf` once exhausted; never fire again.
+    t★ === Inf && return false
+
+    if t ≥ t★
         if schedule.actuations < typemax(Int)
             schedule.actuations += 1
             # Advance actuations so the next actuation is strictly in the future.
-            while schedule.actuations < typemax(Int) && next_actuation_time(schedule) <= t
+            while schedule.actuations < typemax(Int)
+                tN = next_actuation_time(schedule)
+                if tN === Inf || tN > t
+                    break
+                end
                 schedule.actuations += 1
             end
         else # re-initialize the schedule to t★
@@ -94,6 +107,7 @@ end
 
 function schedule_aligned_time_step(schedule::TimeInterval, clock, Δt)
     t★ = next_actuation_time(schedule)
+    t★ === Inf && return Δt
     t = clock.time
     δt = time_difference_seconds(t★, t)
     return min(Δt, δt)

--- a/src/Utils/schedules.jl
+++ b/src/Utils/schedules.jl
@@ -79,6 +79,10 @@ function (schedule::TimeInterval)(model)
     if t >= t★
         if schedule.actuations < typemax(Int)
             schedule.actuations += 1
+            # Advance actuations so the next actuation is strictly in the future.
+            while schedule.actuations < typemax(Int) && next_actuation_time(schedule) <= t
+                schedule.actuations += 1
+            end
         else # re-initialize the schedule to t★
             initialize!(schedule, t★)
         end

--- a/src/Utils/schedules.jl
+++ b/src/Utils/schedules.jl
@@ -101,12 +101,16 @@ end
 
 function prognostic_state(schedule::TimeInterval)
     return (first_actuation_time = schedule.first_actuation_time,
-            actuations = schedule.actuations)
+            actuations = schedule.actuations,
+            interval = schedule.interval)
 end
 
 function restore_prognostic_state!(restored::TimeInterval, from)
-    restored.first_actuation_time = from.first_actuation_time
-    restored.actuations = from.actuations
+    # Phase across restart is only meaningful if the interval is the same.
+    if hasproperty(from, :interval) && from.interval == restored.interval
+        restored.first_actuation_time = from.first_actuation_time
+        restored.actuations = from.actuations
+    end
     return restored
 end
 

--- a/test/test_schedules.jl
+++ b/test/test_schedules.jl
@@ -1,7 +1,7 @@
 include("dependencies_for_runtests.jl")
 
 using Oceananigans.Utils: TimeInterval, IterationInterval, WallTimeInterval, SpecifiedTimes, ConsecutiveIterations
-using Oceananigans.Utils: schedule_aligned_time_step
+using Oceananigans.Utils: schedule_aligned_time_step, next_actuation_time
 using Oceananigans.TimeSteppers: Clock
 using Oceananigans: initialize!
 
@@ -29,6 +29,22 @@ using Oceananigans: initialize!
     @test ti(fake_model_at_time_2)
     @test !(ti(fake_model_at_time_3))
     @test initialize!(ti, fake_model_at_iter_0)
+
+    # Catchup behavior
+    ti_catchup = TimeInterval(2)
+    initialize!(ti_catchup, fake_model_at_iter_0)
+    far_future_model = (; clock=Clock(time=100.0, iteration=1000))
+
+    @test ti_catchup(far_future_model)            
+    @test !(ti_catchup(far_future_model))         
+    @test next_actuation_time(ti_catchup) > 100.0 
+
+    # Normal one-firing-per-crossing is preserved
+    ti_normal = TimeInterval(2)
+    initialize!(ti_normal, fake_model_at_iter_0)
+    @test ti_normal((; clock=Clock(time=2.5, iteration=1)))
+    @test !(ti_normal((; clock=Clock(time=2.5, iteration=1))))
+    @test ti_normal.actuations == 1
 
     # IterationInterval
     ii = IterationInterval(3)

--- a/test/test_schedules.jl
+++ b/test/test_schedules.jl
@@ -46,6 +46,20 @@ using Oceananigans: initialize!, prognostic_state, restore_prognostic_state!
     @test !(ti_normal((; clock=Clock(time=2.5, iteration=1))))
     @test ti_normal.actuations == 1
 
+    # Array-interval TimeInterval (used by `TimeInterval(::AveragedSpecifiedTimes)`):
+    ti_array = TimeInterval([1.0])
+    @test ti_array((; clock=Clock(time=1.0, iteration=10)))
+    @test ti_array.actuations == 1
+    @test next_actuation_time(ti_array) === Inf
+    @test !(ti_array((; clock=Clock(time=2.0, iteration=20))))
+    @test schedule_aligned_time_step(ti_array, Clock(time=2.0, iteration=20), 0.1) == 0.1
+
+    ti_array_multi = TimeInterval([1.0, 2.0, 3.0])
+    @test ti_array_multi((; clock=Clock(time=5.0, iteration=50)))
+    @test ti_array_multi.actuations == 3
+    @test next_actuation_time(ti_array_multi) === Inf
+    @test !(ti_array_multi((; clock=Clock(time=6.0, iteration=60))))
+
     # Restore across pickup with the SAME interval: phase preserved.
     ti_old = TimeInterval(2)
     ti_old.first_actuation_time = 0.0

--- a/test/test_schedules.jl
+++ b/test/test_schedules.jl
@@ -3,7 +3,7 @@ include("dependencies_for_runtests.jl")
 using Oceananigans.Utils: TimeInterval, IterationInterval, WallTimeInterval, SpecifiedTimes, ConsecutiveIterations
 using Oceananigans.Utils: schedule_aligned_time_step, next_actuation_time
 using Oceananigans.TimeSteppers: Clock
-using Oceananigans: initialize!
+using Oceananigans: initialize!, prognostic_state, restore_prognostic_state!
 
 @testset "Schedules" begin
     @info "Testing schedules..."
@@ -45,6 +45,33 @@ using Oceananigans: initialize!
     @test ti_normal((; clock=Clock(time=2.5, iteration=1)))
     @test !(ti_normal((; clock=Clock(time=2.5, iteration=1))))
     @test ti_normal.actuations == 1
+
+    # Restore across pickup with the SAME interval: phase preserved.
+    ti_old = TimeInterval(2)
+    ti_old.first_actuation_time = 0.0
+    ti_old.actuations = 42
+    state = prognostic_state(ti_old)
+    @test haskey(state, :interval)
+
+    ti_same = TimeInterval(2)
+    restore_prognostic_state!(ti_same, state)
+    @test ti_same.first_actuation_time == 0.0
+    @test ti_same.actuations == 42
+    @test next_actuation_time(ti_same) == 86.0
+
+    # Restore across pickup with a different interval
+    ti_changed = TimeInterval(10)
+    restore_prognostic_state!(ti_changed, state)
+    @test ti_changed.first_actuation_time == 0.0
+    @test ti_changed.actuations == 0
+    @test ti_changed.interval == 10.0
+
+    # And that schedule, when called with a clock far in the future, fires
+    # once and aligns subsequent fires to the new interval's phase grid.
+    far_clock = (; clock=Clock(time=95.0, iteration=42))
+    @test ti_changed(far_clock)
+    @test !(ti_changed(far_clock))
+    @test next_actuation_time(ti_changed) == 100.0   
 
     # IterationInterval
     ii = IterationInterval(3)

--- a/test/test_schedules.jl
+++ b/test/test_schedules.jl
@@ -35,9 +35,9 @@ using Oceananigans: initialize!, prognostic_state, restore_prognostic_state!
     initialize!(ti_catchup, fake_model_at_iter_0)
     far_future_model = (; clock=Clock(time=100.0, iteration=1000))
 
-    @test ti_catchup(far_future_model)            
-    @test !(ti_catchup(far_future_model))         
-    @test next_actuation_time(ti_catchup) > 100.0 
+    @test ti_catchup(far_future_model)
+    @test !(ti_catchup(far_future_model))
+    @test next_actuation_time(ti_catchup) > 100.0
 
     # Normal one-firing-per-crossing is preserved
     ti_normal = TimeInterval(2)
@@ -71,7 +71,7 @@ using Oceananigans: initialize!, prognostic_state, restore_prognostic_state!
     far_clock = (; clock=Clock(time=95.0, iteration=42))
     @test ti_changed(far_clock)
     @test !(ti_changed(far_clock))
-    @test next_actuation_time(ti_changed) == 100.0   
+    @test next_actuation_time(ti_changed) == 100.0
 
     # IterationInterval
     ii = IterationInterval(3)


### PR DESCRIPTION
`schedule.actuations` are saved in the checkpointer, however, when restoring from the checkpointer on main, if the checkpointing `TimeInterval` has been changed, the `actuations` actually refer to the previous time interval so they might be out of sync.

Specifically, if we have decreased the checkpointing time interval, the checkpointer will fire at each time step until the `actuations` have synched up with `clock.time`. Much worse, If we have increased the checkpointing time interval, the actuations become too large for the new interval, pushing the new actuation well far in the future (the checkpointer will not fire until clock.time has catched up with the actuations).

This PR fixes this bug by not restoring schedule's details if we happen to have a situation where the `interval` changed, leaving the schedule without actuations (actuations = 0) and then skips ahead to catch up with clock.time in the first actuation.