### PR TITLE
Add `CosineRampMask` forcing mask

### DIFF
--- a/src/Forcings/Forcings.jl
+++ b/src/Forcings/Forcings.jl
@@ -1,6 +1,6 @@
 module Forcings
 
-export Forcing, ContinuousForcing, DiscreteForcing, Relaxation, GaussianMask, PiecewiseLinearMask, LinearTarget, AdvectiveForcing
+export Forcing, ContinuousForcing, DiscreteForcing, Relaxation, GaussianMask, PiecewiseLinearMask, CosineRampMask, LinearTarget, AdvectiveForcing
 
 using Oceananigans.Fields: field, location
 using Oceananigans.OutputReaders: FlavorOfFTS

--- a/src/Forcings/relaxation.jl
+++ b/src/Forcings/relaxation.jl
@@ -255,16 +255,14 @@ struct CosineRampMask{D, T}
     end
 end
 
-@inline _cosine_ramp(r) = (one(r) - cos(π * r)) / 2
-
-@inline function _ramp(m::CosineRampMask, ξ)
-    r = clamp((ξ - m.start) / (m.stop - m.start), zero(ξ), one(ξ))
-    return _cosine_ramp(r)
+@inline function cosine_ramp(m::CosineRampMask, ξ)
+    r = clamp((ξ - m.start) / (m.stop - m.start), 0, 1))
+    return (1 - cos(π * r)) / 2
 end
 
-@inline (m::CosineRampMask{:x})(x, y, z) = _ramp(m, x)
-@inline (m::CosineRampMask{:y})(x, y, z) = _ramp(m, y)
-@inline (m::CosineRampMask{:z})(x, y, z) = _ramp(m, z)
+@inline (m::CosineRampMask{:x})(x, y, z) = cosine_ramp(m, x)
+@inline (m::CosineRampMask{:y})(x, y, z) = cosine_ramp(m, y)
+@inline (m::CosineRampMask{:z})(x, y, z) = cosine_ramp(m, z)
 
 Base.summary(m::CosineRampMask{D}) where D =
     "cosine_ramp($D, start=$(m.start), stop=$(m.stop))"

--- a/src/Forcings/relaxation.jl
+++ b/src/Forcings/relaxation.jl
@@ -256,7 +256,7 @@ struct CosineRampMask{D, T}
 end
 
 @inline function cosine_ramp(m::CosineRampMask, ξ)
-    r = clamp((ξ - m.start) / (m.stop - m.start), 0, 1))
+    r = clamp((ξ - m.start) / (m.stop - m.start), 0, 1)
     return (1 - cos(π * r)) / 2
 end
 

--- a/src/Forcings/relaxation.jl
+++ b/src/Forcings/relaxation.jl
@@ -214,6 +214,62 @@ Base.summary(p::PiecewiseLinearMask{D}) where D =
     "piecewise_linear($D, center=$(p.center), width=$(p.width))"
 
 
+"""
+    CosineRampMask{D}(start, stop)
+
+Callable object that returns a half-cosine ramp masking function varying
+between `0` at coordinate `start` and `1` at coordinate `stop`, along
+direction `D`. Outside the interval the mask is clamped to its endpoint
+values. Inside the interval the mask is
+
+```
+(1 - cos(π * (D - start) / (stop - start))) / 2
+```
+
+The sign of `stop - start` flips the ramp direction, so the same struct
+covers upward (`start < stop`) and downward (`start > stop`) ramps —
+useful for upper/lower sponge layers and Davies-style lateral nudging
+zones.
+
+Example
+=======
+
+Create a z-ramp that smoothly transitions from 0 at `z = 1500` to 1 at
+`z = 2500`.
+
+```jldoctest
+julia> using Oceananigans
+
+julia> mask = CosineRampMask{:z}(start=1500, stop=2500)
+CosineRampMask{:z, Int64}(1500, 2500)
+```
+"""
+struct CosineRampMask{D, T}
+    start :: T
+     stop :: T
+
+    function CosineRampMask{D}(; start, stop) where D
+        start == stop && throw(ArgumentError("CosineRampMask{$D}: start ≠ stop required"))
+        T = promote_type(typeof(start), typeof(stop))
+        return new{D, T}(start, stop)
+    end
+end
+
+@inline _cosine_ramp(r) = (one(r) - cos(π * r)) / 2
+
+@inline function _ramp(m::CosineRampMask, ξ)
+    r = clamp((ξ - m.start) / (m.stop - m.start), zero(ξ), one(ξ))
+    return _cosine_ramp(r)
+end
+
+@inline (m::CosineRampMask{:x})(x, y, z) = _ramp(m, x)
+@inline (m::CosineRampMask{:y})(x, y, z) = _ramp(m, y)
+@inline (m::CosineRampMask{:z})(x, y, z) = _ramp(m, z)
+
+Base.summary(m::CosineRampMask{D}) where D =
+    "cosine_ramp($D, start=$(m.start), stop=$(m.stop))"
+
+
 #####
 ##### Linear target functions
 #####

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -48,7 +48,7 @@ export
     interior, set!, compute!, regrid!,
 
     # Forcing functions
-    Forcing, Relaxation, LinearTarget, GaussianMask, PiecewiseLinearMask, AdvectiveForcing,
+    Forcing, Relaxation, LinearTarget, GaussianMask, PiecewiseLinearMask, CosineRampMask, AdvectiveForcing,
 
     # Coriolis forces
     FPlane, ConstantCartesianCoriolis, BetaPlane, NonTraditionalBetaPlane, HydrostaticSphericalCoriolis,

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -147,14 +147,14 @@ function time_step_with_field_time_series_forcing(arch)
     return true
 end
 
-function relaxed_time_stepping(arch, mask_type)
-    x_relax = Relaxation(rate = 1/60,   mask = mask_type{:x}(center=0.5, width=0.1),
+function relaxed_time_stepping(arch, mask_type; mask_kwargs...)
+    x_relax = Relaxation(rate = 1/60,   mask = mask_type{:x}(; mask_kwargs...),
                                       target = LinearTarget{:x}(intercept=π, gradient=ℯ))
 
-    y_relax = Relaxation(rate = 1/60,   mask = mask_type{:y}(center=0.5, width=0.1),
+    y_relax = Relaxation(rate = 1/60,   mask = mask_type{:y}(; mask_kwargs...),
                                       target = LinearTarget{:y}(intercept=π, gradient=ℯ))
 
-    z_relax = Relaxation(rate = 1/60,   mask = mask_type{:z}(center=0.5, width=0.1),
+    z_relax = Relaxation(rate = 1/60,   mask = mask_type{:z}(; mask_kwargs...),
                                       target = π)
 
     grid = RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 1, 1))
@@ -463,6 +463,38 @@ end
 @testset "Forcings" begin
     @info "Testing forcings..."
 
+    @testset "CosineRampMask cosine ramp" begin
+        @info "  Testing CosineRampMask cosine ramp..."
+
+        for (D, eval_at) in ((:x, (m, ξ) -> m(ξ, 0, 0)),
+                             (:y, (m, ξ) -> m(0, ξ, 0)),
+                             (:z, (m, ξ) -> m(0, 0, ξ)))
+
+            m = CosineRampMask{D}(start=1500.0, stop=2500.0)
+
+            @test eval_at(m, 1400.0) == 0
+            @test eval_at(m, 1500.0) == 0
+            @test eval_at(m, 2500.0) ≈ 1
+            @test eval_at(m, 2600.0) ≈ 1
+            @test eval_at(m, 2000.0) ≈ 0.5
+
+            r₁ = eval_at(m, 1750.0)
+            r₃ = eval_at(m, 2250.0)
+            @test r₁ + r₃ ≈ 1
+            @test 0 < r₁ < 0.5 < r₃ < 1
+
+            weights = [eval_at(m, ξ) for ξ in range(1500, 2500, length=11)]
+            @test all(diff(weights) .> 0)
+
+            m_rev = CosineRampMask{D}(start=2500.0, stop=1500.0)
+            @test eval_at(m_rev, 1500.0) ≈ 1
+            @test eval_at(m_rev, 2500.0) == 0
+            @test eval_at(m_rev, 2000.0) ≈ 0.5
+        end
+
+        @test_throws ArgumentError CosineRampMask{:z}(start=1500, stop=1500)
+    end
+
     for arch in archs
         A = typeof(arch)
         @testset "Forcing function time stepping [$A]" begin
@@ -499,8 +531,9 @@ end
 
             @testset "Relaxation forcing functions [$A]" begin
                 @info "      Testing relaxation forcing functions [$A]..."
-                @test relaxed_time_stepping(arch, GaussianMask)
-                @test relaxed_time_stepping(arch, PiecewiseLinearMask)
+                @test relaxed_time_stepping(arch, GaussianMask;        center=0.5, width=0.1)
+                @test relaxed_time_stepping(arch, PiecewiseLinearMask; center=0.5, width=0.1)
+                @test relaxed_time_stepping(arch, CosineRampMask;      start=0.4, stop=0.6)
             end
 
             @testset "Advective and multiple forcing [$A]" begin


### PR DESCRIPTION
## Summary

- New `CosineRampMask{D}(; start, stop)` callable: half-cosine ramp from 0 at coordinate `start` to 1 at coordinate `stop` along direction `D`, clamped outside the interval.
- The sign of `stop - start` flips the direction, so the same struct covers upward and downward ramps — useful for upper/lower sponge layers and Davies-style lateral nudging zones.
- Sits next to `GaussianMask` / `PiecewiseLinearMask` in `src/Forcings/relaxation.jl`, exported from `Forcings.jl` and re-exported from `Oceananigans`.
- 3-arg `(x, y, z)` callables only, matching the existing mask precedent.
- No new dependencies; default `Adapt` covers the struct (concrete numeric fields).

## Why

The cosine ramp is the standard shape for sponge / nudging zones; users currently roll their own. Adding it as a first-class mask keeps the upstream `Relaxation` API self-contained for the common case. Lands as the first step in a small series that generalizes `Relaxation` to accept `FieldTimeSeries` targets — but the mask is independently useful and stands alone.

## Tests

- New `@testset "CosineRampMask cosine ramp"` in `test/test_forcings.jl` covers:
  - clamping outside `[start, stop]`
  - endpoint and mid-point values for all three `D ∈ (:x, :y, :z)`
  - cosine symmetry around the mid-point
  - monotonic interior
  - reversed ramp (`start > stop`)
  - `ArgumentError` on `start == stop`
- `relaxed_time_stepping` smoke helper generalized to forward arbitrary mask kwargs; `CosineRampMask` joins `GaussianMask` / `PiecewiseLinearMask` in the relaxation-forcing time-stepping test.

## Test plan

- [x] CPU unit tests pass locally (34/34)
- [x] CPU relaxation-forcing smoke tests pass locally (3/3, all three masks)
- [x] Doctest output verified to match
- [ ] CI green (CPU + GPU)