### PR TITLE
Set `JULIA_CUDA_USE_COMPAT=false` in tests

### DIFF
--- a/.buildkite/pipeline-benchmarks.yml
+++ b/.buildkite/pipeline-benchmarks.yml
@@ -13,6 +13,7 @@ env:
   BENCHMARK_SCRIPT: "benchmarking/run_benchmarks.jl"
   OUTPUT_FILE: "benchmark_results.json"
   OUTPUT_FILE_GPU2: "benchmark_results_gpu2.json"
+  JULIA_CUDA_USE_COMPAT: false
 
 steps:
   - label: "🏕️ Initialize tartarus environment"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,6 @@ env:
   XLA_REACTANT_GPU_PREALLOCATE: false
   OCEANANIGANS_DIR: "$HOME/Oceananigans.jl-$BUILDKITE_BUILD_NUMBER"
   JULIA_CUDA_USE_COMPAT: false
-  
 agents:
   queue: "Oceananigans"
 with:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,8 @@ env:
   JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
   XLA_REACTANT_GPU_PREALLOCATE: false
   OCEANANIGANS_DIR: "$HOME/Oceananigans.jl-$BUILDKITE_BUILD_NUMBER"
-
+  JULIA_CUDA_USE_COMPAT: false
+  
 agents:
   queue: "Oceananigans"
 with:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -80,6 +80,8 @@ steps:
       else
         export CUDA_VISIBLE_DEVICES="0"
         export TEST_ARCHITECTURE="GPU"
+
+        julia +$JULIA_VERSION -O0 --color=yes --project=test --check-bounds=yes -e 'using CUDA; CUDA.versioninfo()'
       fi
 
       # Strip emoji for environment variable

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -80,8 +80,6 @@ steps:
       else
         export CUDA_VISIBLE_DEVICES="0"
         export TEST_ARCHITECTURE="GPU"
-
-        julia +$JULIA_VERSION -O0 --color=yes --project=test --check-bounds=yes -e 'using CUDA; CUDA.versioninfo()'
       fi
 
       # Strip emoji for environment variable

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,6 +26,10 @@ steps:
       rsync -a . "$OCEANANIGANS_DIR/"
       cd "$OCEANANIGANS_DIR"
 
+      # On Nautilus we have old GPUs which require CUDA toolkit v12, can't
+      # use v13.
+      echo -e '[CUDA_Runtime_jll]\nversion = "12.9"' > test/LocalPreferences.toml
+
       julia +$JULIA_VERSION -O0 --color=yes --project -e 'using Pkg; Pkg.test()'
       # After we have instantiated the general environment, move manifest to the
       # version-specific filename, not to clash with the manifest for Enzyme.
@@ -46,6 +50,10 @@ steps:
       juliaup add $JULIA_VERSION_ENZYME
       cd "$OCEANANIGANS_DIR"
 
+      # On Nautilus we have old GPUs which require CUDA toolkit v12, can't
+      # use v13.
+      echo -e '[CUDA_Runtime_jll]\nversion = "12.9"' > test/LocalPreferences.toml
+
       julia +$JULIA_VERSION_ENZYME -O0 --color=yes --project -e 'using Pkg; Pkg.test(julia_args=["--check-bounds=auto"])' # Remove --check-bounds=auto when https://github.com/EnzymeAD/Reactant.jl/issues/2347 is fixed
       # After we have instantiated the Enzyme environment, move manifest to the
       # version-specific filename, not to clash with the general manifest.
@@ -63,6 +71,11 @@ steps:
       CUDA_VISIBLE_DEVICES: "0" # GPU for docs
     command: |
       cd "$OCEANANIGANS_DIR"
+
+      # On Nautilus we have old GPUs which require CUDA toolkit v12, can't
+      # use v13.
+      echo -e '[CUDA_Runtime_jll]\nversion = "12.9"' > docs/LocalPreferences.toml
+
       julia +$JULIA_VERSION --color=yes --project=docs/ -e \
         'using Pkg; Pkg.instantiate()'
       julia +$JULIA_VERSION --color=yes --project=docs/ docs/make.jl
@@ -86,6 +99,10 @@ steps:
       group="{{ matrix.group }}"
       export TEST_GROUP="\${group#* }"
       echo $TEST_GROUP
+
+      # On Nautilus we have old GPUs which require CUDA toolkit v12, can't
+      # use v13.
+      echo -e '[CUDA_Runtime_jll]\nversion = "12.9"' > test/LocalPreferences.toml
 
       # Run tests (but don't exit immediately so we can upload coverage even if tests fail)
       set +e
@@ -167,6 +184,10 @@ steps:
       group="{{ matrix.group }}"
       export TEST_GROUP="\${group#* }"
       echo $TEST_GROUP
+
+      # On Nautilus we have old GPUs which require CUDA toolkit v12, can't
+      # use v13.
+      echo -e '[CUDA_Runtime_jll]\nversion = "12.9"' > test/LocalPreferences.toml
 
       # Run tests (but don't exit immediately so we can upload coverage even if tests fail)
       set +e

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -35,3 +35,6 @@ Literate = "2.9"
 MPI = "0.20"
 Pkg = "<0.0.1, 1"
 Polynomials = "4"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -72,12 +72,15 @@ SafeTestsets = "0.1"
 SeawaterPolynomials = "0.3.9"
 SparseArrays = "<0.0.1, 1"
 Statistics = "<0.0.1, 1"
+StructArrays = "0.4, 0.5, 0.6, 0.7"
 Test = "<0.0.1, 1"
 TimesDates = "0.3"
-StructArrays = "0.4, 0.5, 0.6, 0.7"
 XESMF = "0.1.5"
 julia = "1.10"
 oneAPI = "2.0.1"
 
 [preferences.Reactant]
 xla_runtime = "IFRT"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,10 @@ end
 ##### Run tests
 #####
 
+if CUDA.functional()
+    CUDA.versioninfo()
+end
+
 CUDA.allowscalar() do
 
 @testset "Oceananigans" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,10 +18,6 @@ end
 ##### Run tests
 #####
 
-if CUDA.functional()
-    CUDA.versioninfo()
-end
-
 CUDA.allowscalar() do
 
 @testset "Oceananigans" begin


### PR DESCRIPTION
This PR adds JULIA_CUDA_USE_COMPAT=false to both test and docs to get around the compatibility issues between CUDA drivers and older GPUs like Titan V GPUs