### PR TITLE
Avoid deprecation warning about `CUFFT` in `CUDA` extension

### DIFF
--- a/ext/OceananigansCUDAExt.jl
+++ b/ext/OceananigansCUDAExt.jl
@@ -3,12 +3,17 @@ module OceananigansCUDAExt
 using InteractiveUtils: versioninfo
 using CUDA: CUDA, CuArray, CuContext, CuDevice, CuDeviceArray, CuPtr, context,
     context!, cu, CUDA.CUDABackend
-# TODO: when we'll support CUDA.jl v6 only, add `cuSPARSE`/`CUDACore` to list of
-# triggers of this extensions, and simplify the condition below.
+# TODO: when we'll support CUDA.jl v6 only, add `cuSPARSE`/`CUDACore`/`cuFFT` to
+# list of triggers of this extensions, and simplify the conditions below.
 if isdefined(CUDA, :cuSPARSE)
     using CUDA.cuSPARSE: CuSparseMatrixCSC
 else
     using CUDA.CUSPARSE: CuSparseMatrixCSC
+end
+if isdefined(CUDA, :cuFFT)
+    using CUDA.cuFFT: cuFFT
+else
+    const cuFFT = CUDA.CUFFT
 end
 using GPUArraysCore: allowscalar
 using GPUArrays: unsafe_free!
@@ -112,7 +117,7 @@ BC.validate_boundary_condition_architecture(::CuArray, ::AC.CPU, bc, side) =
 
 function SO.plan_forward_transform(A::CuArray, ::Union{GD.Bounded, GD.Periodic}, dims, planner_flag)
     length(dims) == 0 && return nothing
-    return CUDA.CUFFT.plan_fft!(A, dims)
+    return cuFFT.plan_fft!(A, dims)
 end
 
 FD.set!(v::FD.Field, a::CuArray) = FD.set_to_array!(v, a)
@@ -120,7 +125,7 @@ FD.set!(v::DC.DistributedField, a::CuArray) = FD.set_to_array!(v, a)
 
 function SO.plan_backward_transform(A::CuArray, ::Union{GD.Bounded, GD.Periodic}, dims, planner_flag)
     length(dims) == 0 && return nothing
-    return CUDA.CUFFT.plan_ifft!(A, dims)
+    return cuFFT.plan_ifft!(A, dims)
 end
 
 # CUDA version, the indices are passed implicitly


### PR DESCRIPTION
`CUDA.CUFFT` is [deprecated](https://github.com/JuliaGPU/CUDA.jl/blob/0ad0204a2e4b65dfaae6d699deb978e2247226cb/lib/cufft/src/cuFFT.jl#L61) in favour of `CUDA.cuFFT`.