### PR TITLE
Remove reference to machine learning deployment paper

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -145,8 +145,6 @@ If you have work using Oceananigans that you would like to have listed here, ple
 
 1. Wang, S., Kang, W., and Li, C. (2026). [A tug-of-war between baroclinic eddies and convection: implications for icy moon oceans](https://doi.org/10.48550/arXiv.2603.17185), _arXiv preprint_, arXiv:2603.17185. DOI: [10.48550/arXiv.2603.17185](https://doi.org/10.48550/arXiv.2603.17185)
 
-1. Barge, A., Le Sommer, J., Storto, A., and Valcke, S. (2026) [Deploying Machine Learning components coupled to Earth System Models with OASIS3-MCT (v6) and Eophis (v1.1)](https://doi.org/10.5194/egusphere-2026-854). EGUsphere [preprint]. DOI: [10.5194/egusphere-2026-854](https://doi.org/10.5194/egusphere-2026-854)
-
 1. De Abreu, S. and Timmermans, M.-L. (2026). [Mixed-layer deepening and internal wave generation under sea ice in free drift](https://doi.org/10.1175/JPO-D-25-0165.1), _Journal of Physical Oceanography_, **56(4)**, 823-837. DOI: [10.1175/JPO-D-25-0165.1](https://doi.org/10.1175/JPO-D-25-0165.1)
 
 1. Markmann, Τ., Straat, Μ., Peitz, S., Hammer, B. (2026). [Fourier neural operators as data-driven surrogates for two- and three-dimensional Rayleigh–bénard convection](https://doi.org/10.1016/j.neucom.2026.133201), _Neurocomputing_, 133201. DOI: [10.1016/j.neucom.2026.133201](https://doi.org/10.1016/j.neucom.2026.133201)


### PR DESCRIPTION
Removed a reference to a paper on deploying machine learning components with OASIS3-MCT and Eophis.
They don't use Oceananigans; only cite it.
