### PR TITLE
Add `show` method for `PerturbationAdvection`

### DIFF
--- a/docs/src/models/boundary_conditions.md
+++ b/docs/src/models/boundary_conditions.md
@@ -371,7 +371,11 @@ with a mean velocity ``U=1`` and damp the exiting flow to this speed we can setu
 
 ```jldoctest
 julia> scheme = PerturbationAdvection(; outflow_timescale=10, inflow_timescale=1)
-PerturbationAdvection{Float64, Nothing}(1.0, 10.0, 0.0, nothing)
+PerturbationAdvection{Float64}
+├── inflow_timescale: 1.0
+├── outflow_timescale: 10.0
+├── gravity_wave_speed: 0.0
+└── density: Nothing
 
 julia> open_boundary = OpenBoundaryCondition(1; scheme)
 OpenBoundaryCondition{PerturbationAdvection{Float64, Nothing}}: 1

--- a/src/BoundaryConditions/perturbation_advection.jl
+++ b/src/BoundaryConditions/perturbation_advection.jl
@@ -1,5 +1,6 @@
 using Oceananigans.Operators: Δxᶠᶜᶜ, Δyᶜᶠᶜ, Δzᶜᶜᶠ
 using Oceananigans: defaults
+using Oceananigans.Utils: prettysummary
 
 struct PerturbationAdvection{FT, D}
     inflow_timescale :: FT
@@ -113,6 +114,16 @@ Adapt.adapt_structure(to, pe::PerturbationAdvection) =
                           adapt(to, pe.outflow_timescale),
                           adapt(to, pe.gravity_wave_speed),
                           adapt(to, pe.density))
+
+Base.summary(::PerturbationAdvection{FT}) where FT = "PerturbationAdvection{$FT}"
+
+function Base.show(io::IO, pe::PerturbationAdvection)
+    print(io, summary(pe), '\n')
+    print(io, "├── inflow_timescale: ", prettysummary(pe.inflow_timescale), '\n')
+    print(io, "├── outflow_timescale: ", prettysummary(pe.outflow_timescale), '\n')
+    print(io, "├── gravity_wave_speed: ", prettysummary(pe.gravity_wave_speed), '\n')
+    print(io, "└── density: ", prettysummary(pe.density))
+end
 
 const PAOBC = BoundaryCondition{<:Open{<:PerturbationAdvection}}
 


### PR DESCRIPTION
## Summary

`PerturbationAdvection` previously had no custom display method, so it fell back to Julia's default struct printing:

```julia
PerturbationAdvection{Float64, Nothing}(1.0, 10.0, 0.0, nothing)
```

This is hard to read — the four positional values give no hint of which field is which.

This PR adds `Base.summary` and a tree-style `Base.show`, modeled on the existing `RiBasedVerticalDiffusivity` show method:

```julia
PerturbationAdvection{Float64}
├── inflow_timescale: 1.0
├── outflow_timescale: 10.0
├── gravity_wave_speed: 0.0
└── density: Nothing
```

## Changes

- `src/BoundaryConditions/perturbation_advection.jl`: add `Base.summary` and `Base.show`, plus an explicit `using Oceananigans.Utils: prettysummary` import.
- `docs/src/models/boundary_conditions.md`: update the existing `jldoctest` output to match the new display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)