### PR TITLE
Fix `set!(::DistributedField, ::Field)` regression from #5586

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.108.0"
+version = "0.108.1"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -150,8 +150,11 @@ function set_to_field!(u, v)
     if matching_field_discretization(u, v)
         copy_to_field!(u, v)
     else
+        # Fill halos on v's native architecture so distributed dispatch (if any) is used;
+        # on_architecture would strip Distributed{CPU} to CPU while keeping distributed
+        # boundary conditions, mismatching fill_halo_regions! dispatch.
+        fill_halo_regions!(v)
         v_on_u = on_architecture(child_architecture(u), v)
-        fill_halo_regions!(v_on_u)
         interpolate!(u, v_on_u)
     end
 
@@ -161,8 +164,17 @@ end
 function matching_field_discretization(u, v)
     return size(u) == size(v) &&
            location(u) == location(v) &&
-           indices(u) == indices(v)
+           equivalent_indices(indices(u), indices(v), size(u))
 end
+
+@inline equivalent_indices(ui::Tuple, vi::Tuple, sz::Tuple) =
+    equivalent_index(ui[1], vi[1], sz[1]) &&
+    equivalent_index(ui[2], vi[2], sz[2]) &&
+    equivalent_index(ui[3], vi[3], sz[3])
+
+@inline equivalent_index(a, b, N) = a == b
+@inline equivalent_index(::Colon, r::AbstractUnitRange, N) = first(r) == 1 && last(r) == N
+@inline equivalent_index(r::AbstractUnitRange, ::Colon, N) = first(r) == 1 && last(r) == N
 
 function copy_to_field!(u, v)
     # We implement some niceities in here that attempt to copy halo data,


### PR DESCRIPTION
#5586 routed `set_to_field!` through `on_architecture(child_architecture(u), v)`
+ `fill_halo_regions!(v_on_u)` + `interpolate!` whenever `matching_field_discretization` is false. On distributed fields that path is broken in two ways:

1. `indices(u) == indices(v)` rejects equivalent windows like `(:, :, :)` vs `(1:Nx, 1:Ny, 1:Nz)`, sending well-formed `set!` calls down the else branch unnecessarily. `TransposableField` constructs zfield/yfield/xfield with explicit unit-range indices, so `set!(Φ.zfield, ϕ)` in `test_distributed_transpose.jl` always falls through.

2. `on_architecture(child_architecture(u), v)` strips `Distributed{CPU}` to `CPU` on the grid but leaves the `DistributedCommunicationBoundaryCondition`s (and the precompiled `DistributedFillHalo` kernels) intact. The subsequent `fill_halo_regions!(v_on_u)` then dispatches to the non-distributed path and invokes `DistributedFillHalo{WestAndEast}` with 6 args via the inlined `fill_halo_event!`, when the only method takes 7 (`c, bc1, bc2, loc, grid, arch, buffers`) — MethodError.

Fixes:

* `matching_field_discretization` now treats `Colon` and the equivalent full `UnitRange` as the same window (per-dimension, parameterized by size). Same size + same location + equivalent windows now correctly takes the cheap copy path.

* `set_to_field!` fills halos on `v`'s native architecture before migrating, so distributed dispatch is used when `v` is distributed. The post-migration `interpolate!` then samples a field whose halos are already populated.

Repros via `test/test_distributed_transpose.jl` (passed at parent of #5586, failed at the merge of #5586).

