### PR TITLE
StokesDrift: accept uˢ, vˢ, ∂t_uˢ, ∂t_vˢ Fields directly

### DIFF
--- a/src/StokesDrifts.jl
+++ b/src/StokesDrifts.jl
@@ -13,6 +13,7 @@ export
 using Adapt: adapt
 
 using Oceananigans.Fields
+using Oceananigans.Fields: AbstractField
 using Oceananigans.Operators
 using Oceananigans.Grids: AbstractGrid, node
 using Oceananigans.Utils: prettysummary
@@ -176,7 +177,7 @@ const f = Face()
     - ℑxzᶜᵃᶠ(i, j, k, grid, U.u) * ∂z_Uᵃᵃᶠ(i, j, k, grid, sd, sd.∂z_uˢ, time)
     - ℑyzᵃᶜᶠ(i, j, k, grid, U.v) * ∂z_Uᵃᵃᶠ(i, j, k, grid, sd, sd.∂z_vˢ, time))
 
-struct StokesDrift{P, VX, WX, UY, WY, UZ, VZ, UT, VT, WT}
+struct StokesDrift{P, VX, WX, UY, WY, UZ, VZ, UT, VT, WT, US, VS}
     ∂x_vˢ :: VX
     ∂x_wˢ :: WX
     ∂y_uˢ :: UY
@@ -186,6 +187,8 @@ struct StokesDrift{P, VX, WX, UY, WY, UZ, VZ, UT, VT, WT}
     ∂t_uˢ :: UT
     ∂t_vˢ :: VT
     ∂t_wˢ :: WT
+    uˢ    :: US
+    vˢ    :: VS
     parameters :: P
 end
 
@@ -198,6 +201,8 @@ adapt_structure(to, sd::StokesDrift) = StokesDrift(adapt(to, sd.∂x_vˢ),
                                                    adapt(to, sd.∂t_uˢ),
                                                    adapt(to, sd.∂t_vˢ),
                                                    adapt(to, sd.∂t_wˢ),
+                                                   adapt(to, sd.uˢ),
+                                                   adapt(to, sd.vˢ),
                                                    adapt(to, sd.parameters))
 
 Base.summary(::StokesDrift{Nothing}) = "StokesDrift{Nothing}"
@@ -217,7 +222,9 @@ function Base.show(io::IO, sd::StokesDrift)
     print(io, "├── ∂z_vˢ: ", prettysummary(sd.∂z_vˢ, false), '\n')
     print(io, "├── ∂t_uˢ: ", prettysummary(sd.∂t_uˢ, false), '\n')
     print(io, "├── ∂t_vˢ: ", prettysummary(sd.∂t_vˢ, false), '\n')
-    print(io, "└── ∂t_wˢ: ", prettysummary(sd.∂t_wˢ, false))
+    print(io, "├── ∂t_wˢ: ", prettysummary(sd.∂t_wˢ, false), '\n')
+    print(io, "├── uˢ:    ", prettysummary(sd.uˢ,    false), '\n')
+    print(io, "└── vˢ:    ", prettysummary(sd.vˢ,    false))
 end
 
 """
@@ -320,50 +327,136 @@ function StokesDrift(; ∂x_vˢ = zerofunction,
                        ∂t_uˢ = zerofunction,
                        ∂t_vˢ = zerofunction,
                        ∂t_wˢ = zerofunction,
+                       uˢ = nothing,
+                       vˢ = nothing,
                        parameters = nothing)
 
-    return StokesDrift(∂x_vˢ, ∂x_wˢ, ∂y_uˢ, ∂y_wˢ, ∂z_uˢ, ∂z_vˢ, ∂t_uˢ, ∂t_vˢ, ∂t_wˢ, parameters)
+    return StokesDrift(∂x_vˢ, ∂x_wˢ, ∂y_uˢ, ∂y_wˢ, ∂z_uˢ, ∂z_vˢ,
+                       ∂t_uˢ, ∂t_vˢ, ∂t_wˢ, uˢ, vˢ, parameters)
 end
 
 const SD = StokesDrift
 const SDnoP = StokesDrift{<:Nothing}
 
-@inline ∂t_uˢ(i, j, k, grid, sw::SD, time) = sw.∂t_uˢ(node(i, j, k, grid, f, c, c)..., time, sw.parameters)
-@inline ∂t_vˢ(i, j, k, grid, sw::SD, time) = sw.∂t_vˢ(node(i, j, k, grid, c, f, c)..., time, sw.parameters)
-@inline ∂t_wˢ(i, j, k, grid, sw::SD, time) = sw.∂t_wˢ(node(i, j, k, grid, c, c, f)..., time, sw.parameters)
-
-@inline ∂t_uˢ(i, j, k, grid, sw::SDnoP, time) = sw.∂t_uˢ(node(i, j, k, grid, f, c, c)..., time)
-@inline ∂t_vˢ(i, j, k, grid, sw::SDnoP, time) = sw.∂t_vˢ(node(i, j, k, grid, c, f, c)..., time)
-@inline ∂t_wˢ(i, j, k, grid, sw::SDnoP, time) = sw.∂t_wˢ(node(i, j, k, grid, c, c, f)..., time)
-
 @inline parameters_tuple(sw::SDnoP) = tuple()
 @inline parameters_tuple(sw::SD) = tuple(sw.parameters)
+
+# Function-only path: evaluate the callable `sw.∂t_..ˢ` at the node. This
+# single method covers both the parametric (`SD`) and non-parametric (`SDnoP`)
+# function paths via `parameters_tuple`.
+@inline ∂t_uˢ(i, j, k, grid, sw::SD, time) = sw.∂t_uˢ(node(i, j, k, grid, f, c, c)..., time, parameters_tuple(sw)...)
+@inline ∂t_vˢ(i, j, k, grid, sw::SD, time) = sw.∂t_vˢ(node(i, j, k, grid, c, f, c)..., time, parameters_tuple(sw)...)
+@inline ∂t_wˢ(i, j, k, grid, sw::SD, time) = sw.∂t_wˢ(node(i, j, k, grid, c, c, f)..., time, parameters_tuple(sw)...)
+
+#####
+##### Per-derivative dispatch.
+#####
+##### Each `_∂{x,y,z}_{u,v,w}ˢ_<loc>(i, j, k, grid, sw, time)` returns the
+##### appropriate component of ∇·uˢ at node location <loc>. When
+##### `sw.uˢ === nothing` and `sw.vˢ === nothing` (the function-only path),
+##### the corresponding `sw.∂..._uˢ`/`sw.∂..._vˢ` callable is evaluated at
+##### the node. When `sw.uˢ` or `sw.vˢ` is a `Field` (or any object that
+##### satisfies the `getindex(uˢ, i, j, k)` contract), the spatial
+##### derivative is computed inline via the staggered finite-difference
+##### operators. `wˢ` is taken to be zero in the Field path.
+#####
+
+const SDFieldUˢ = StokesDrift{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+                              <:Any, <:Any, <:Any, <:AbstractField}
+const SDFieldVˢ = StokesDrift{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+                              <:Any, <:Any, <:Any, <:Any, <:AbstractField}
+const SDFieldUVˢ = StokesDrift{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+                               <:Any, <:Any, <:Any, <:AbstractField, <:AbstractField}
+
+# `∂t_uˢ`, `∂t_vˢ` may also be supplied as `AbstractField`s (at the
+# corresponding velocity location). When a Field is supplied, the value is
+# read directly via `getindex` at the node — no time-derivative is taken of
+# the Field; the user is expected to refresh the Field with the desired
+# time-derivative (e.g., from a wave model's analytic action tendency)
+# before each ocean step.
+const SDFieldDtUˢ = StokesDrift{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+                                <:AbstractField}
+const SDFieldDtVˢ = StokesDrift{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+                                <:Any, <:AbstractField}
+
+@inline ∂t_uˢ(i, j, k, grid, sw::SDFieldDtUˢ, time) = @inbounds sw.∂t_uˢ[i, j, k]
+@inline ∂t_vˢ(i, j, k, grid, sw::SDFieldDtVˢ, time) = @inbounds sw.∂t_vˢ[i, j, k]
+
+# ∂z uˢ
+@inline _∂z_uˢ_fcc(i, j, k, grid, sw, time) =
+    sw.∂z_uˢ(node(i, j, k, grid, f, c, c)..., time, parameters_tuple(sw)...)
+@inline _∂z_uˢ_fcc(i, j, k, grid, sw::SDFieldUˢ, time) =
+    ℑzᵃᵃᶜ(i, j, k, grid, ∂zᶠᶜᶠ, sw.uˢ)
+@inline _∂z_uˢ_ccf(i, j, k, grid, sw, time) =
+    sw.∂z_uˢ(node(i, j, k, grid, c, c, f)..., time, parameters_tuple(sw)...)
+@inline _∂z_uˢ_ccf(i, j, k, grid, sw::SDFieldUˢ, time) =
+    ℑxᶜᵃᵃ(i, j, k, grid, ∂zᶠᶜᶠ, sw.uˢ)
+
+# ∂z vˢ
+@inline _∂z_vˢ_cfc(i, j, k, grid, sw, time) =
+    sw.∂z_vˢ(node(i, j, k, grid, c, f, c)..., time, parameters_tuple(sw)...)
+@inline _∂z_vˢ_cfc(i, j, k, grid, sw::SDFieldVˢ, time) =
+    ℑzᵃᵃᶜ(i, j, k, grid, ∂zᶜᶠᶠ, sw.vˢ)
+@inline _∂z_vˢ_ccf(i, j, k, grid, sw, time) =
+    sw.∂z_vˢ(node(i, j, k, grid, c, c, f)..., time, parameters_tuple(sw)...)
+@inline _∂z_vˢ_ccf(i, j, k, grid, sw::SDFieldVˢ, time) =
+    ℑyᵃᶜᵃ(i, j, k, grid, ∂zᶜᶠᶠ, sw.vˢ)
+
+# ∂y uˢ
+@inline _∂y_uˢ_fcc(i, j, k, grid, sw, time) =
+    sw.∂y_uˢ(node(i, j, k, grid, f, c, c)..., time, parameters_tuple(sw)...)
+@inline _∂y_uˢ_fcc(i, j, k, grid, sw::SDFieldUˢ, time) =
+    ℑyᵃᶜᵃ(i, j, k, grid, ∂yᶠᶠᶜ, sw.uˢ)
+@inline _∂y_uˢ_cfc(i, j, k, grid, sw, time) =
+    sw.∂y_uˢ(node(i, j, k, grid, c, f, c)..., time, parameters_tuple(sw)...)
+@inline _∂y_uˢ_cfc(i, j, k, grid, sw::SDFieldUˢ, time) =
+    ℑxᶜᵃᵃ(i, j, k, grid, ∂yᶠᶠᶜ, sw.uˢ)
+
+# ∂x vˢ
+@inline _∂x_vˢ_fcc(i, j, k, grid, sw, time) =
+    sw.∂x_vˢ(node(i, j, k, grid, f, c, c)..., time, parameters_tuple(sw)...)
+@inline _∂x_vˢ_fcc(i, j, k, grid, sw::SDFieldVˢ, time) =
+    ℑyᵃᶜᵃ(i, j, k, grid, ∂xᶠᶠᶜ, sw.vˢ)
+@inline _∂x_vˢ_cfc(i, j, k, grid, sw, time) =
+    sw.∂x_vˢ(node(i, j, k, grid, c, f, c)..., time, parameters_tuple(sw)...)
+@inline _∂x_vˢ_cfc(i, j, k, grid, sw::SDFieldVˢ, time) =
+    ℑxᶜᵃᵃ(i, j, k, grid, ∂xᶠᶠᶜ, sw.vˢ)
+
+# ∂x wˢ and ∂y wˢ — wˢ has no Field counterpart on `StokesDrift`; the
+# function-only path stays callable, the Field path returns zero.
+@inline _∂x_wˢ(i, j, k, grid, sw, X, time) =
+    sw.∂x_wˢ(X..., time, parameters_tuple(sw)...)
+@inline _∂x_wˢ(i, j, k, grid, sw::SDFieldUˢ, X, time) = zero(grid)
+@inline _∂x_wˢ(i, j, k, grid, sw::SDFieldVˢ, X, time) = zero(grid)
+@inline _∂x_wˢ(i, j, k, grid, sw::SDFieldUVˢ, X, time) = zero(grid)
+@inline _∂y_wˢ(i, j, k, grid, sw, X, time) =
+    sw.∂y_wˢ(X..., time, parameters_tuple(sw)...)
+@inline _∂y_wˢ(i, j, k, grid, sw::SDFieldUˢ, X, time) = zero(grid)
+@inline _∂y_wˢ(i, j, k, grid, sw::SDFieldVˢ, X, time) = zero(grid)
+@inline _∂y_wˢ(i, j, k, grid, sw::SDFieldUVˢ, X, time) = zero(grid)
 
 @inline function x_curl_Uˢ_cross_U(i, j, k, grid, sw::SD, U, time)
     wᶠᶜᶜ = ℑxzᶠᵃᶜ(i, j, k, grid, U.w)
     vᶠᶜᶜ = ℑxyᶠᶜᵃ(i, j, k, grid, U.v)
 
-    pt = parameters_tuple(sw)
     X = node(i, j, k, grid, f, c, c)
-    ∂z_uˢ = sw.∂z_uˢ(X..., time, pt...)
-    ∂x_wˢ = sw.∂x_wˢ(X..., time, pt...)
-    ∂y_uˢ = sw.∂y_uˢ(X..., time, pt...)
-    ∂x_vˢ = sw.∂x_vˢ(X..., time, pt...)
+    ∂z_uˢ = _∂z_uˢ_fcc(i, j, k, grid, sw, time)
+    ∂x_wˢ = _∂x_wˢ(i, j, k, grid, sw, X, time)
+    ∂y_uˢ = _∂y_uˢ_fcc(i, j, k, grid, sw, time)
+    ∂x_vˢ = _∂x_vˢ_fcc(i, j, k, grid, sw, time)
 
     return wᶠᶜᶜ * (∂z_uˢ - ∂x_wˢ) - vᶠᶜᶜ * (∂x_vˢ - ∂y_uˢ)
 end
-
 
 @inline function y_curl_Uˢ_cross_U(i, j, k, grid, sw::SD, U, time)
     wᶜᶠᶜ = ℑyzᵃᶠᶜ(i, j, k, grid, U.w)
     uᶜᶠᶜ = ℑxyᶜᶠᵃ(i, j, k, grid, U.u)
 
-    pt = parameters_tuple(sw)
     X = node(i, j, k, grid, c, f, c)
-    ∂z_vˢ = sw.∂z_vˢ(X..., time, pt...)
-    ∂y_wˢ = sw.∂y_wˢ(X..., time, pt...)
-    ∂x_vˢ = sw.∂x_vˢ(X..., time, pt...)
-    ∂y_uˢ = sw.∂y_uˢ(X..., time, pt...)
+    ∂z_vˢ = _∂z_vˢ_cfc(i, j, k, grid, sw, time)
+    ∂y_wˢ = _∂y_wˢ(i, j, k, grid, sw, X, time)
+    ∂x_vˢ = _∂x_vˢ_cfc(i, j, k, grid, sw, time)
+    ∂y_uˢ = _∂y_uˢ_cfc(i, j, k, grid, sw, time)
 
     return uᶜᶠᶜ * (∂x_vˢ - ∂y_uˢ) - wᶜᶠᶜ * (∂y_wˢ - ∂z_vˢ)
 end
@@ -372,14 +465,14 @@ end
     uᶜᶜᶠ = ℑxzᶜᵃᶠ(i, j, k, grid, U.u)
     vᶜᶜᶠ = ℑyzᵃᶜᶠ(i, j, k, grid, U.v)
 
-    pt = parameters_tuple(sw)
     X = node(i, j, k, grid, c, c, f)
-    ∂x_wˢ = sw.∂x_wˢ(X..., time, pt...)
-    ∂z_uˢ = sw.∂z_uˢ(X..., time, pt...)
-    ∂y_wˢ = sw.∂y_wˢ(X..., time, pt...)
-    ∂z_vˢ = sw.∂z_vˢ(X..., time, pt...)
+    ∂x_wˢ = _∂x_wˢ(i, j, k, grid, sw, X, time)
+    ∂z_uˢ = _∂z_uˢ_ccf(i, j, k, grid, sw, time)
+    ∂y_wˢ = _∂y_wˢ(i, j, k, grid, sw, X, time)
+    ∂z_vˢ = _∂z_vˢ_ccf(i, j, k, grid, sw, time)
 
     return vᶜᶜᶠ * (∂y_wˢ - ∂z_vˢ) - uᶜᶜᶠ * (∂z_uˢ - ∂x_wˢ)
 end
+
 
 end # module

--- a/test/test_stokes_drift.jl
+++ b/test/test_stokes_drift.jl
@@ -56,4 +56,86 @@ end
             @test location(stokes_drift.∂t_vˢ) === (Nothing, Nothing, Center)
         end
     end
+
+    @testset "StokesDrift(; uˢ, vˢ)" begin
+        for arch in archs
+            grid = RectilinearGrid(arch; size=(4, 4, 8), halo=(3, 3, 3),
+                                   x=(0, 4), y=(0, 4), z=(-1, 0),
+                                   topology=(Periodic, Periodic, Bounded))
+
+            uˢ = Field{Face,   Center, Center}(grid)
+            vˢ = Field{Center, Face,   Center}(grid)
+            sd = StokesDrift(; uˢ, vˢ)
+
+            @test sd.uˢ === uˢ
+            @test sd.vˢ === vˢ
+            @test Oceananigans.StokesDrifts.∂t_uˢ(2, 2, 2, grid, sd, 0.0) == 0
+            @test Oceananigans.StokesDrifts.∂t_vˢ(2, 2, 2, grid, sd, 0.0) == 0
+            @test Oceananigans.StokesDrifts.∂t_wˢ(2, 2, 2, grid, sd, 0.0) == 0
+
+            fake_U = (u=Field{Face,   Center, Center}(grid),
+                      v=Field{Center, Face,   Center}(grid),
+                      w=Field{Center, Center, Face  }(grid))
+            @test Oceananigans.StokesDrifts.x_curl_Uˢ_cross_U(2, 2, 2, grid, sd, fake_U, 0.0) == 0
+            @test Oceananigans.StokesDrifts.y_curl_Uˢ_cross_U(2, 2, 2, grid, sd, fake_U, 0.0) == 0
+            @test Oceananigans.StokesDrifts.z_curl_Uˢ_cross_U(2, 2, 2, grid, sd, fake_U, 0.0) == 0
+
+            # Linear vertical shear uˢ = α·z and uniform w = W gives
+            # x_curl_Uˢ_cross_U = W·α at every interior point.
+            α, W = 0.7, 0.3
+            set!(uˢ, (x, y, z) -> α * z); Oceananigans.BoundaryConditions.fill_halo_regions!(uˢ)
+            set!(fake_U.w, W); Oceananigans.BoundaryConditions.fill_halo_regions!(fake_U.w)
+            for k in 2:grid.Nz - 1, j in 2:grid.Ny - 1, i in 2:grid.Nx - 1
+                @test Oceananigans.StokesDrifts.x_curl_Uˢ_cross_U(i, j, k, grid, sd, fake_U, 0.0) ≈ W * α atol=1e-12
+            end
+
+            # Cross-derivative term: uˢ = β·y, v = V, w = 0 →
+            # x_curl_Uˢ_cross_U = -V·(∂x vˢ - ∂y uˢ) = V·β.
+            # UniformStokesDrift would drop this term entirely.
+            β, V = 0.5, 0.2
+            set!(uˢ, (x, y, z) -> β * y); Oceananigans.BoundaryConditions.fill_halo_regions!(uˢ)
+            set!(fake_U.w, 0); Oceananigans.BoundaryConditions.fill_halo_regions!(fake_U.w)
+            set!(fake_U.v, V); Oceananigans.BoundaryConditions.fill_halo_regions!(fake_U.v)
+            for k in 2:grid.Nz - 1, j in 2:grid.Ny - 1, i in 2:grid.Nx - 1
+                @test Oceananigans.StokesDrifts.x_curl_Uˢ_cross_U(i, j, k, grid, sd, fake_U, 0.0) ≈ V * β atol=1e-12
+            end
+        end
+    end
+
+    @testset "StokesDrift(; ∂t_uˢ, ∂t_vˢ) as Fields" begin
+        for arch in archs
+            grid = RectilinearGrid(arch; size=(4, 4, 8), halo=(3, 3, 3),
+                                   x=(0, 4), y=(0, 4), z=(-1, 0),
+                                   topology=(Periodic, Periodic, Bounded))
+
+            ∂t_uˢ = Field{Face,   Center, Center}(grid)
+            ∂t_vˢ = Field{Center, Face,   Center}(grid)
+            sd = StokesDrift(; ∂t_uˢ, ∂t_vˢ)
+
+            @test sd.∂t_uˢ === ∂t_uˢ
+            @test sd.∂t_vˢ === ∂t_vˢ
+
+            # Zero fields → zero Stokes acceleration.
+            @test Oceananigans.StokesDrifts.∂t_uˢ(2, 2, 2, grid, sd, 0.0) == 0
+            @test Oceananigans.StokesDrifts.∂t_vˢ(2, 2, 2, grid, sd, 0.0) == 0
+
+            # Constant Field → that constant comes through at every interior point.
+            a_u, a_v = 0.13, -0.27
+            set!(∂t_uˢ, a_u); Oceananigans.BoundaryConditions.fill_halo_regions!(∂t_uˢ)
+            set!(∂t_vˢ, a_v); Oceananigans.BoundaryConditions.fill_halo_regions!(∂t_vˢ)
+            for k in 1:grid.Nz, j in 1:grid.Ny, i in 1:grid.Nx
+                @test Oceananigans.StokesDrifts.∂t_uˢ(i, j, k, grid, sd, 0.0) ≈ a_u atol=1e-14
+                @test Oceananigans.StokesDrifts.∂t_vˢ(i, j, k, grid, sd, 0.0) ≈ a_v atol=1e-14
+            end
+
+            # Field paths for ∂t and uˢ/vˢ compose without ambiguity.
+            uˢ = Field{Face,   Center, Center}(grid)
+            vˢ = Field{Center, Face,   Center}(grid)
+            sd2 = StokesDrift(; uˢ, vˢ, ∂t_uˢ, ∂t_vˢ)
+            @test sd2.uˢ === uˢ
+            @test sd2.∂t_uˢ === ∂t_uˢ
+            @test Oceananigans.StokesDrifts.∂t_uˢ(2, 2, 2, grid, sd2, 0.0) ≈ a_u atol=1e-14
+            @test Oceananigans.StokesDrifts.∂t_vˢ(2, 2, 2, grid, sd2, 0.0) ≈ a_v atol=1e-14
+        end
+    end
 end


### PR DESCRIPTION
## Summary

Extends the existing `StokesDrift` type with four optional `Field`
properties — `uˢ, vˢ, ∂t_uˢ, ∂t_vˢ` — and dispatches the derivative
evaluation on whether each is `nothing`/`zerofunction` (existing
function-only path, fully backward-compatible) or an `AbstractField`
(compute the spatial derivative inline via the staggered FD operators;
read the time-derivative directly via `getindex`).

```julia
uˢ    = Field{Face,   Center, Center}(grid)
vˢ    = Field{Center, Face,   Center}(grid)
∂t_uˢ = Field{Face,   Center, Center}(grid)
∂t_vˢ = Field{Center, Face,   Center}(grid)
# … fill from your wave model state and its analytic tendency …
stokes_drift = StokesDrift(; uˢ, vˢ, ∂t_uˢ, ∂t_vˢ)
model = NonhydrostaticModel(grid; stokes_drift, ...)
```

## Motivation

`StokesDrift` evaluates each of its seven spatial derivatives plus three
time derivatives by *calling them as functions* of
`(x, y, z, t, params...)`. That works fine for closed-form analytic
Stokes drift, but it fails the increasingly common case where the
Stokes drift and its time derivative come out of a wave-resolving model
as Oceananigans `Field`s. Users either wrote callable adapters that
interpolate from a `Field` at every `(x, y, z, t)` lookup, or fell back
to `UniformStokesDrift` (which accepts `Field`s for `∂z uˢ, ∂z vˢ,
∂t uˢ, ∂t vˢ` but silently drops every cross-derivative term in the
curl).

Developed against the wind-drift instability example in
[NumericalEarth/Ripple.jl](https://github.com/NumericalEarth/Ripple.jl),
where the wave-model pseudomomentum `p(z) = Q(z)·A·K` equals the
deep-water Stokes drift, and the analytic pseudomomentum tendency
`Q(z)·∂t(A·K)` equals the Stokes acceleration the ocean must see for
the wave-mean energy budget to close.

## Behavior when Fields are passed

For spatial Fields (`uˢ, vˢ`):
- Spatial derivatives in `x_curl_Uˢ_cross_U`, `y_curl_Uˢ_cross_U`, and
  `z_curl_Uˢ_cross_U` are computed inline via `∂xᶠᶠᶜ`, `∂yᶠᶠᶜ`, `∂zᶠᶜᶠ`,
  `∂zᶜᶠᶠ` and the matching `ℑ` interpolators. Both `∂z uˢ, ∂z vˢ` and the
  cross-derivative terms `∂y uˢ, ∂x vˢ` participate — no curl approximation
  drops them.
- `wˢ` is taken to be zero (good approximation for deep-water surface gravity
  waves; users who need `wˢ ≠ 0` can still pass `∂x_wˢ, ∂y_wˢ` as callable
  functions).

For time-derivative Fields (`∂t_uˢ, ∂t_vˢ`):
- The Stokes acceleration `+ ∂t_uˢ(i,j,k,...)` term in the momentum
  tendency reads `sw.∂t_uˢ[i, j, k]` directly at the velocity location.
  No time differentiation of the Field is performed by `StokesDrift` —
  the user refreshes the Field with the desired literal time derivative
  before each ocean step.

## Backward compatibility

When `uˢ === nothing && vˢ === nothing` and the time-derivative kwargs
are left at their default `zerofunction` (or any callable), every call
site takes exactly the same dispatch path as before. Existing user code
is unchanged.

## Implementation

Per-derivative dispatch helpers
`_∂{x,y,z}_{u,v,w}ˢ_<loc>(i, j, k, grid, sw, time)` cover

1. the function-only path (call the callable),
2. the `uˢ::Field` path (`∂` operator + `ℑ` interpolator),
3. the `vˢ::Field` path, and
4. the both-fields path.

The three `*_curl_Uˢ_cross_U` methods become uniform calls into those
helpers. Two new type aliases `SDFieldDtUˢ`, `SDFieldDtVˢ` specialize
the `∂t_uˢ`/`∂t_vˢ` getters when those slots hold an `AbstractField`.
The redundant `SDnoP` overloads of `∂t_uˢ`/`∂t_vˢ`/`∂t_wˢ` are unified
into the `SD` overload via `parameters_tuple`.

## Conventions for Field arguments

- `uˢ, ∂t_uˢ` are expected at `(Face,   Center, Center)` — the u-velocity location.
- `vˢ, ∂t_vˢ` are expected at `(Center, Face,   Center)` — the v-velocity location.

## Test plan

`test/test_stokes_drift.jl` gains two new testsets:

- [x] `StokesDrift(; uˢ, vˢ)` — zero state, linear vertical shear
      (`x_curl_Uˢ_cross_U = W·α`), and the cross-derivative term
      `uˢ = β·y, v = V → V·β` that `UniformStokesDrift` drops.
- [x] `StokesDrift(; ∂t_uˢ, ∂t_vˢ)` — zero Fields give zero Stokes
      acceleration; constant Fields are picked up at every interior
      point at machine precision; the field-`∂t` and field-`uˢ/vˢ`
      paths compose without ambiguity.

All 326 Stokes-drift tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)