### PR TITLE
Add OrthogonalSphericalShellGrid zarr_field_dimension dispatch

### DIFF
--- a/ext/OceananigansZarrExt/OceananigansZarrExt.jl
+++ b/ext/OceananigansZarrExt/OceananigansZarrExt.jl
@@ -17,7 +17,7 @@ using Oceananigans.Architectures: architecture
 using Oceananigans.Fields: AbstractField, location, indices
 import Oceananigans.Grids: grid
 using Oceananigans.Grids:
-    AbstractGrid, RectilinearGrid, LatitudeLongitudeGrid,
+    AbstractGrid, RectilinearGrid, LatitudeLongitudeGrid, OrthogonalSphericalShellGrid,
     Center, Face, Flat, Periodic, Bounded,
     topology, constructor_arguments
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid

--- a/ext/OceananigansZarrExt/zarr_writer.jl
+++ b/ext/OceananigansZarrExt/zarr_writer.jl
@@ -688,6 +688,14 @@ function zarr_field_dimensions(field::AbstractField, grid::LatitudeLongitudeGrid
     return (name_λ, name_φ, name_z)
 end
 
+function zarr_field_dimensions(field::AbstractField, grid::OrthogonalSphericalShellGrid)
+    LΛ, LΦ, LZ = location(field)
+    name_λ = LΛ === Nothing ? "" : trilocation_dim_name("λ", grid, LΛ(), nothing, nothing, Val(:x))
+    name_φ = LΦ === Nothing ? "" : trilocation_dim_name("φ", grid, nothing, LΦ(), nothing, Val(:y))
+    name_z = LZ === Nothing ? "" : trilocation_dim_name("z", grid, nothing, nothing, LZ(), Val(:z))
+    return (name_λ, name_φ, name_z)
+end
+
 zarr_field_dimensions(field::AbstractField, grid::ImmersedBoundaryGrid) =
     zarr_field_dimensions(field, grid.underlying_grid)
 

--- a/test/test_zarr_writer.jl
+++ b/test/test_zarr_writer.jl
@@ -548,3 +548,63 @@ end
         rm(zippath; force=true)
     end
 end
+
+#####
+##### Phase 8 — TripolarGrid (OrthogonalSphericalShellGrid) round-trip
+#####
+
+using Oceananigans.OrthogonalSphericalShellGrids: TripolarGrid
+
+@testset "ZarrWriter [TripolarGrid round-trip]" begin
+    @info "  Testing ZarrWriter with TripolarGrid..."
+
+    for arch in archs
+        grid = TripolarGrid(arch; size=(20, 16, 4), z=(-100, 0))
+        fs   = SplitExplicitFreeSurface(grid; substeps=5)
+        model = HydrostaticFreeSurfaceModel(grid; free_surface=fs, tracers=(:T,))
+
+        zarrpath = abspath(joinpath(".", "test_zarr_tripolar.zarr"))
+        isdir(zarrpath) && rm(zarrpath; recursive=true, force=true)
+
+        simulation = Simulation(model; Δt=1, stop_iteration=2)
+        simulation.output_writers[:fields] = ZarrWriter(model,
+                                                        (; T=model.tracers.T, u=model.velocities.u);
+                                                        filename = "test_zarr_tripolar",
+                                                        dir = ".",
+                                                        schedule = IterationInterval(1),
+                                                        overwrite_existing = true,
+                                                        with_halos = false)
+        run!(simulation)
+
+        @test isdir(zarrpath)
+        g = Zarr.zopen(zarrpath)
+
+        # time axis
+        @test "time" in keys(g.arrays)
+        @test length(g["time"][:]) == 3   # initial + 2 iterations
+
+        # both fields were written
+        @test "T" in keys(g.arrays)
+        @test "u" in keys(g.arrays)
+
+        # spatial shape matches grid interior (no halos)
+        Nx, Ny, Nz = size(grid)
+        T_arr = g["T"]
+        u_arr = g["u"]
+        @test size(T_arr)[1:3] == (Nx, Ny, Nz)
+        @test size(u_arr)[1:3] == (Nx, Ny, Nz)
+
+        # _ARRAY_DIMENSIONS is set and includes "time"
+        T_dims = T_arr.attrs["_ARRAY_DIMENSIONS"]
+        @test "time" in T_dims
+        @test length(T_dims) == 4
+
+        # dim names use the λ/φ/z naming scheme from OrthogonalSphericalShellGrid
+        u_dims = u_arr.attrs["_ARRAY_DIMENSIONS"]
+        @test any(startswith(d, "λ") for d in u_dims)
+        @test any(startswith(d, "φ") for d in u_dims)
+        @test any(startswith(d, "z") for d in u_dims)
+
+        rm(zarrpath; recursive=true, force=true)
+    end
+end


### PR DESCRIPTION
fixes a `MethodError` when writing Zarr output on `OrthogonalSphericalShellGrid`. Adds `zarr_field_dimension` dispatch for this case. Addresses https://github.com/CliMA/Oceananigans.jl/issues/5625