### PR TITLE
Allow changing schedule from `TimeInterval` --> `IterationInterval` on pickup

### DIFF
--- a/src/Utils/schedules.jl
+++ b/src/Utils/schedules.jl
@@ -156,6 +156,7 @@ next_actuation_time(schedule::IterationInterval) = Inf
 
 # IterationInterval has no state
 prognostic_state(schedule::IterationInterval) = nothing
+restore_prognostic_state!(restored::IterationInterval, from) = restored
 restore_prognostic_state!(restored::IterationInterval, from::Nothing) = nothing
 
 #####

--- a/test/test_schedules.jl
+++ b/test/test_schedules.jl
@@ -94,6 +94,12 @@ using Oceananigans: initialize!, prognostic_state, restore_prognostic_state!
     @test ii(fake_model_at_iter_3)
     @test initialize!(ii, fake_model_at_iter_0)
 
+    old_time_interval_state = (first_actuation_time = 0.0, actuations = 7, interval = 2.0)
+    restore_prognostic_state!(ii, old_time_interval_state)
+    @test ii.interval == 3
+    @test ii.offset == 0
+    @test ii(fake_model_at_iter_3)
+
     # OrSchedule
     ti_and_ii = AndSchedule(TimeInterval(2), IterationInterval(3))
     @test ti_and_ii(fake_model_at_time_2)


### PR DESCRIPTION
Currently, `restore_prognostic_state!()` errors if the `OutputWriter` schedule is changed from a `TimeInterval` to an `IterationInterval`. This PR addresses this incompatibility. 