### PR TITLE
Regularize correctly `U` and `V` bc for a `TripolarGrid`

### DIFF
--- a/src/OrthogonalSphericalShellGrids/tripolar_field_extensions.jl
+++ b/src/OrthogonalSphericalShellGrids/tripolar_field_extensions.jl
@@ -52,7 +52,7 @@ function BoundaryConditions.regularize_field_boundary_conditions(bcs::FieldBound
                                                                  prognostic_names=nothing)
 
     loc  = assumed_field_location(field_name)
-    sign = field_name == :u || 
+    sign = field_name == :u ||
            field_name == :v ||
            field_name == :U ||
            field_name == :V ? -1 : 1

--- a/src/OrthogonalSphericalShellGrids/tripolar_field_extensions.jl
+++ b/src/OrthogonalSphericalShellGrids/tripolar_field_extensions.jl
@@ -52,7 +52,10 @@ function BoundaryConditions.regularize_field_boundary_conditions(bcs::FieldBound
                                                                  prognostic_names=nothing)
 
     loc  = assumed_field_location(field_name)
-    sign = field_name == :u || field_name == :v ? -1 : 1
+    sign = field_name == :u || 
+           field_name == :v ||
+           field_name == :U ||
+           field_name == :V ? -1 : 1
 
     west   = regularize_boundary_condition(bcs.west,   grid, loc, 1, LeftBoundary,  prognostic_names)
     east   = regularize_boundary_condition(bcs.east,   grid, loc, 1, RightBoundary, prognostic_names)


### PR DESCRIPTION
I think before we had a regularization that was made based on the location (i.e. fields on edges had sign -1 while fields on nodes and centers 1), I think we lost it along the way. It might make sense to bring it back since also ClimaSeaIce is now wrong.

However, this is a quickfix in the meantime that we still require.