### PR TITLE
Update number of ambiguities

### DIFF
--- a/test/test_quality_assurance.jl
+++ b/test/test_quality_assurance.jl
@@ -34,7 +34,8 @@ end
     # Until we resolve all ambiguities, we make sure we don't increase them.
     # Do not increase this number. If ambiguities increase, resolve them before merging.
     number_of_ambiguities = length(detect_ambiguities(Oceananigans; recursive=true))
-    @test number_of_ambiguities <= 323
+    # When ambiguities are resolved, update the cap accordingly.
+    @test number_of_ambiguities == 321
     @info "Number of ambiguities: $number_of_ambiguities"
 
     modules = (


### PR DESCRIPTION
Also, check for exact equality, so that we remember to update the cap as soon as new ambiguities are fixed.  In #5634 we were lucky there were 6 new ambiguities: if they were only 2, they'd have snuck in silently.