### PR TITLE
Limit pass through to target extension for auto_extension

### DIFF
--- a/src/OutputReaders/OutputReaders.jl
+++ b/src/OutputReaders/OutputReaders.jl
@@ -27,8 +27,7 @@ end
 If `filename` ends in `ext`, return `filename`. Otherwise return `filename * ext`.
 """
 function auto_extension(filename, ext)
-    if endswith(filename, ext) || endswith(filename, ".nc") || endswith(filename, ".jld2") ||
-       endswith(filename, ".zarr") || endswith(filename, ".zip")
+    if endswith(filename, ext)
         return filename
     else
         return filename * ext

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -926,7 +926,9 @@ end
 ext(path) = splitext(path) |> last
 
 function FieldTimeSeries(path::String, args...; reader_kw = NamedTuple(), kwargs...)
-    path = auto_extension(path, ".jld2") # JLD2 is the default extension
+    # JLD2 is the default; don't append .jld2 to paths that already carry a recognised extension
+    path = (endswith(path, ".nc") || endswith(path, ".zarr") || endswith(path, ".zip")) ?
+           path : auto_extension(path, ".jld2")
     typed_path = if ext(path) == ".jld2"
                      JLD2Path(path)
                  elseif ext(path) == ".nc"


### PR DESCRIPTION
This pull request modifies `auto_extension` so that the check for any pass-through extensions is the responsibility of the calling code. I think this is a worthwhile change because the current form passes through errors silently.

For example, if a filename with a `.nc` extension is given to [JLD2Writer](https://github.com/CliMA/Oceananigans.jl/blob/4f182a1a413587a6c8d8e6f52af9a027d284b0d3/src/OutputWriters/jld2_writer.jl#L179-L181), it passes through, the architecture suffix is not added, and the resulting `.nc` file is actually a JLD2 file. It’s an easy situation to have happen if you switch between netcdf and jld2 writers. Furthermore, this change makes `auto_extension` and subsequent file filtering more explicit.