### PR TITLE
(0.109.2) Apply tracer open boundary conditions in `NonhydrostaticModel`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.109.1"
+version = "0.109.2"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/Models/NonhydrostaticModels/update_nonhydrostatic_model_state.jl
+++ b/src/Models/NonhydrostaticModels/update_nonhydrostatic_model_state.jl
@@ -31,8 +31,12 @@ function update_state!(model::NonhydrostaticModel, callbacks=[])
     # Update the boundary conditions
     update_boundary_conditions!(fields(model), model)
 
-    # Fill halos for velocities and tracers
-    fill_halo_regions!(merge(model.velocities, model.tracers), model.clock, fields(model); fill_open_bcs=false, async=true)
+    # Fill halos for velocities and tracers. Velocity open boundaries are deferred to
+    # compute_pressure_correction! (they need the pressure-corrected state), so skip them
+    # here. Tracers have no such deferral, so fill their open boundaries now — as
+    # HydrostaticFreeSurfaceModel does — otherwise tracer open BCs never fire.
+    fill_halo_regions!(model.velocities, model.clock, fields(model); fill_open_bcs=false, async=true)
+    fill_halo_regions!(model.tracers, model.clock, fields(model); async=true)
 
     # Compute auxiliary fields
     for aux_field in model.auxiliary_fields

--- a/test/test_boundary_conditions_integration.jl
+++ b/test/test_boundary_conditions_integration.jl
@@ -258,6 +258,36 @@ function test_perturbation_advection_tracer_radiation_formula(arch, FT)
     @test Array(parent(model.tracers.c))[Nx + 1 + Hx, 1, Hz + 1] ≈ expected
 end
 
+function test_nonhydrostatic_tracer_open_boundary_is_applied(arch, FT)
+    # A tracer open BC must be re-applied every update_state!, exactly like a velocity
+    # open BC. Poke a sentinel into the east boundary cell of both a tracer and a velocity
+    # (each with a prescribed-value open BC), step without any manual halo fill, and check
+    # both recover. That cell is a halo the tendency never writes, so it can only return to
+    # its prescribed value if the open-boundary fill actually runs during stepping.
+    grid = RectilinearGrid(arch, FT; size = 16, x = (0, 1), topology = (Bounded, Flat, Flat), halo = 4)
+
+    u_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition( 1), east = OpenBoundaryCondition( 1))
+    c_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(-1), east = OpenBoundaryCondition(-1))
+
+    model = NonhydrostaticModel(grid; tracers = :c, advection = Centered(order = 2),
+                                boundary_conditions = (u = u_bcs, c = c_bcs))
+    set!(model, u = 1, c = 0.5)
+
+    east = grid.Hx + grid.Nx + 1  # parent index of the east boundary cell (Nx + 1)
+    view(parent(model.tracers.c),    east, 1, 1) .= 999
+    view(parent(model.velocities.u), east, 1, 1) .= 999
+
+    for _ in 1:5
+        time_step!(model, 1e-4)
+    end
+
+    east_tracer   = Array(view(parent(model.tracers.c),    east, 1, 1))[]
+    east_velocity = Array(view(parent(model.velocities.u), east, 1, 1))[]
+
+    @test east_tracer   ≈ -1   # tracer open BC applied during stepping (regression target)
+    @test east_velocity ≈  1   # velocity open BC was already applied — sanity control
+end
+
 function test_open_boundary_condition_mass_conservation(arch, FT, boundary_conditions; N = 8)
     grid = RectilinearGrid(arch, FT, size=(N, N, N), extent=(1, 1, 1),
                            topology=(Bounded, Bounded, Bounded))
@@ -469,6 +499,7 @@ test_boundary_conditions(C, FT, ArrayType) = (integer_bc(C, FT, ArrayType),
             test_perturbation_advection_open_boundary_conditions(arch, FT)
             test_perturbation_advection_tracer_open_boundary_conditions(arch, FT)
             test_perturbation_advection_tracer_radiation_formula(arch, FT)
+            test_nonhydrostatic_tracer_open_boundary_is_applied(arch, FT)
 
             # Only PerturbationAdvection OpenBoundaryCondition
             U₀ = 1

--- a/validation/open_boundaries/tracer_outflow.jl
+++ b/validation/open_boundaries/tracer_outflow.jl
@@ -3,45 +3,47 @@ using Oceananigans.BoundaryConditions: fill_halo_regions!
 using CairoMakie
 using Printf
 
+# Minimal 1D outflow test: a Gaussian blob in three tracers (background values
+# c̄ ∈ {+1, 0, −1}) is advected eastward by a constant U > 0 through the east open
+# boundary. The west boundary is an inflow at u = U, so the upstream tracer relaxes to c̄.
+# Centered(order = 4) advection is used because it leaves the boundary halo cell exposed
+# in the interior stencil (upwind/WENO mask it), so any spurious mode injected at the
+# boundary stays visible.
 function tracer_outflow_simulation(; arch = CPU(),
                                      Nx = 200,
-                                     Nz = 4,
                                      Lx = 10,
-                                     Lz = 1,
                                      U = 1,
                                      blob_centre = 2,
                                      blob_width = 0.5,
                                      stop_time = 12,
-                                     base_simulation_name = "tracer_outflow")
+                                     base_simulation_name = "tracer_outflow",
+                                     scheme = PerturbationAdvection(inflow_timescale = 0,
+                                                                    outflow_timescale = Inf))
 
-    grid = RectilinearGrid(arch; topology = (Bounded, Flat, Bounded),
-                           size = (Nx, Nz), x = (0, Lx), z = (-Lz, 0), halo = (4, 4))
+    grid = RectilinearGrid(arch; topology = (Bounded, Flat, Flat), size = Nx, x = (0, Lx))
 
-    scheme = PerturbationAdvection(inflow_timescale = 0, outflow_timescale = Inf)
+    tracer_bcs(c̄) = FieldBoundaryConditions(west = OpenBoundaryCondition(c̄; scheme),
+                                            east = OpenBoundaryCondition(c̄; scheme))
 
-    tracer_bcs(c̄) = FieldBoundaryConditions(west = OpenBoundaryCondition(c̄; scheme), east = OpenBoundaryCondition(c̄; scheme))
-
-    boundary_conditions = (u     = FieldBoundaryConditions(west = OpenBoundaryCondition(U), east = OpenBoundaryCondition(U)),
+    boundary_conditions = (u     = FieldBoundaryConditions(west = OpenBoundaryCondition(U),
+                                                           east = OpenBoundaryCondition(U)),
                            cpos  = tracer_bcs( 1),
                            czero = tracer_bcs( 0),
                            cneg  = tracer_bcs(-1))
 
-    # Centered advection is essential here: an upwind/WENO scheme effectively
-    # ignores the halo at the outflow face (smoothness indicators downweight the
-    # discontinuous halo cell), hiding the BC's behavior from the interior.
     model = NonhydrostaticModel(grid; tracers = (:cpos, :czero, :cneg),
                                 advection = Centered(order = 4),
                                 boundary_conditions)
 
-    blob(x, z) = exp(-((x - blob_centre) / blob_width)^2)
+    blob(x) = exp(-((x - blob_centre) / blob_width)^2)
     set!(model, u = U,
-                cpos  = (x, z) -> blob(x, z) + 1,
-                czero = (x, z) -> blob(x, z),
-                cneg  = (x, z) -> blob(x, z) - 1)
+                cpos  = x -> blob(x) + 1,
+                czero = x -> blob(x),
+                cneg  = x -> blob(x) - 1)
 
-    # NonhydrostaticModel fills tracer halos with fill_open_bcs=false, so the
-    # PerturbationAdvection BC never fires without manually refilling — once here
-    # for the initial state, and via the per-step callback below.
+    # NonhydrostaticModel fills tracer halos with fill_open_bcs=false, so the open BC
+    # never fires automatically — fire it here for the initial state and once per
+    # iteration via the callback below.
     fill_halo_regions!(model.tracers, model.clock, fields(model))
 
     Δt = 0.5 * minimum_xspacing(grid) / abs(U)
@@ -75,22 +77,30 @@ function plot_tracer_outflow_animation(filepath; framerate = 12, compression = 2
               ("c̄ =  0", FieldTimeSeries(filepath, "czero"),  0),
               ("c̄ = -1", FieldTimeSeries(filepath, "cneg"),  -1))
 
-    times = panels[1][2].times
+    times       = panels[1][2].times
+    # x coordinates with halos so the OBC's boundary halo cells are visible alongside the
+    # interior (JLD2Writer used with_halos = true, so parent(ts[n]) carries them).
+    xs          = collect(xnodes(panels[1][2][1], with_halos = true))
+    xs_interior = xnodes(panels[1][2][1])
+    Δx          = minimum(diff(xs))
+    domain_edges = [first(xs_interior) - 0.5Δx, last(xs_interior) + 0.5Δx]
+
     n = Observable(1)
-    fig = Figure(size = (700, 600))
+    fig = Figure(size = (800, 700))
 
     title = @lift @sprintf("t = %.2f", times[$n])
-    Label(fig[0, 1:2], title, fontsize = 16, tellwidth = false)
+    Label(fig[0, 1], title, fontsize = 16, tellwidth = false)
 
     for (i, (label, ts, c̄)) in enumerate(panels)
-        ax = Axis(fig[i, 1], xlabel = "x", ylabel = "z", title = label,
-                  width = 550, height = 130)
-        c_plt = @lift ts[$n]
-        hm = heatmap!(ax, c_plt, colorrange = (-2, 2), colormap = :balance)
-        Colorbar(fig[i, 2], hm, tellwidth = false, height = Relative(0.8))
+        ax = Axis(fig[i, 1], xlabel = "x", ylabel = "c", title = label,
+                  width = 700, height = 180)
+        c_plt = @lift Array(parent(ts[$n]))[:, 1, 1]
+        lines!(ax, xs, c_plt, color = :dodgerblue, linewidth = 1.5)
+        vlines!(ax, domain_edges, color = (:black, 0.4), linestyle = :dot)
+        hlines!(ax, [c̄], color = (:black, 0.3), linestyle = :dash)
+        ylims!(ax, c̄ - 1.5, c̄ + 1.5)
     end
 
-    colsize!(fig.layout, 2, Fixed(30))
     resize_to_layout!(fig)
 
     frames = 1:length(times)
@@ -104,9 +114,10 @@ function plot_tracer_outflow_animation(filepath; framerate = 12, compression = 2
     return fig
 end
 
-# Combined Hovmöller (x–t) of all three tracers in one figure. Boundary noise / pileup
-# / wrong-branch behavior shows up as vertical striations or sharp colour jumps near
-# the domain edges — easier to see here than in single-snapshot animation frames.
+# Combined Hovmöller (x–t) of all three tracers in one figure with a shared colorbar, so
+# the panels are directly comparable across c̄. Boundary noise / pileup / wrong-branch
+# behavior shows up as vertical striations or sharp colour jumps near the domain edges —
+# easier to spot here than in single animation frames.
 function plot_tracer_outflow_hovmollers(filepath)
     @info "Plotting Hovmöllers from $filepath"
 
@@ -119,24 +130,19 @@ function plot_tracer_outflow_hovmollers(filepath)
     xs_interior = xnodes(panels[1][2][1])
     Δx          = minimum(diff(xs))
     domain_edges = [first(xs_interior) - 0.5Δx, last(xs_interior) + 0.5Δx]
-    # The field is uniform in z by construction, so a single representative z slice
-    # carries all the dynamical information.
-    z_index = size(parent(panels[1][2][1]), 3) ÷ 2 + 1
 
-    fig = Figure(size = (800, 800))
+    fig = Figure(size = (800, 900))
     Label(fig[0, 1:2], "Hovmöller — $(basename(filepath))", fontsize = 16, tellwidth = false)
 
+    hm = nothing
     for (i, (label, ts, c̄)) in enumerate(panels)
-        field_xt = stack([Array(parent(ts[n]))[:, 1, z_index] for n in 1:length(times)]; dims = 2)
-        ax = Axis(fig[i, 1], xlabel = "x", ylabel = "t", title = label,
-                  width = 650, height = 200)
-        hm = heatmap!(ax, xs, times, field_xt;
-                      colormap = :balance, colorrange = (-1.8, 1.8))
+        field_xt = stack([Array(parent(ts[n]))[:, 1, 1] for n in 1:length(times)]; dims = 2)
+        ax = Axis(fig[i, 1], xlabel = "x", ylabel = "t", title = label)
+        hm = heatmap!(ax, xs, times, field_xt; colormap = :balance, colorrange = (-1.8, 1.8))
         vlines!(ax, domain_edges, color = (:black, 0.6), linestyle = :dash)
-        Colorbar(fig[i, 2], hm, tellwidth = false, height = Relative(0.8))
     end
+    Colorbar(fig[1:length(panels), 2], hm)
 
-    resize_to_layout!(fig)
     out = "$filepath" * "_hovmoller.png"
     save(out, fig)
     @info "Saved $out"

--- a/validation/open_boundaries/tracer_outflow.jl
+++ b/validation/open_boundaries/tracer_outflow.jl
@@ -1,5 +1,4 @@
 using Oceananigans
-using Oceananigans.BoundaryConditions: fill_halo_regions!
 using CairoMakie
 using Printf
 
@@ -41,17 +40,8 @@ function tracer_outflow_simulation(; arch = CPU(),
                 czero = x -> blob(x),
                 cneg  = x -> blob(x) - 1)
 
-    # NonhydrostaticModel fills tracer halos with fill_open_bcs=false, so the open BC
-    # never fires automatically — fire it here for the initial state and once per
-    # iteration via the callback below.
-    fill_halo_regions!(model.tracers, model.clock, fields(model))
-
     Δt = 0.5 * minimum_xspacing(grid) / abs(U)
     simulation = Simulation(model; Δt, stop_time, verbose = false)
-
-    fill_tracer_open_halos!(sim) =
-        fill_halo_regions!(sim.model.tracers, sim.model.clock, fields(sim.model))
-    add_callback!(simulation, fill_tracer_open_halos!, IterationInterval(1))
 
     function progress(sim)
         @printf("Iteration: %05d, time: %s, Δt: %s\n",

--- a/validation/open_boundaries/tracer_outflow.jl
+++ b/validation/open_boundaries/tracer_outflow.jl
@@ -77,13 +77,7 @@ function plot_tracer_outflow_animation(filepath; framerate = 12, compression = 2
               ("c̄ =  0", FieldTimeSeries(filepath, "czero"),  0),
               ("c̄ = -1", FieldTimeSeries(filepath, "cneg"),  -1))
 
-    times       = panels[1][2].times
-    # x coordinates with halos so the OBC's boundary halo cells are visible alongside the
-    # interior (JLD2Writer used with_halos = true, so parent(ts[n]) carries them).
-    xs          = collect(xnodes(panels[1][2][1], with_halos = true))
-    xs_interior = xnodes(panels[1][2][1])
-    Δx          = minimum(diff(xs))
-    domain_edges = [first(xs_interior) - 0.5Δx, last(xs_interior) + 0.5Δx]
+    times = panels[1][2].times
 
     n = Observable(1)
     fig = Figure(size = (800, 700))
@@ -92,11 +86,9 @@ function plot_tracer_outflow_animation(filepath; framerate = 12, compression = 2
     Label(fig[0, 1], title, fontsize = 16, tellwidth = false)
 
     for (i, (label, ts, c̄)) in enumerate(panels)
-        ax = Axis(fig[i, 1], xlabel = "x", ylabel = "c", title = label,
-                  width = 700, height = 180)
-        c_plt = @lift Array(parent(ts[$n]))[:, 1, 1]
-        lines!(ax, xs, c_plt, color = :dodgerblue, linewidth = 1.5)
-        vlines!(ax, domain_edges, color = (:black, 0.4), linestyle = :dot)
+        ax = Axis(fig[i, 1], xlabel = "x", ylabel = "c", title = label, width = 700, height = 180)
+        c_plt = @lift ts[$n]
+        lines!(ax, c_plt, color = :dodgerblue, linewidth = 1.5)
         hlines!(ax, [c̄], color = (:black, 0.3), linestyle = :dash)
         ylims!(ax, c̄ - 1.5, c̄ + 1.5)
     end
@@ -125,21 +117,17 @@ function plot_tracer_outflow_hovmollers(filepath)
               ("c̄ =  0", FieldTimeSeries(filepath, "czero"),  0),
               ("c̄ = -1", FieldTimeSeries(filepath, "cneg"),  -1))
 
-    times       = panels[1][2].times
-    xs          = collect(xnodes(panels[1][2][1], with_halos = true))
-    xs_interior = xnodes(panels[1][2][1])
-    Δx          = minimum(diff(xs))
-    domain_edges = [first(xs_interior) - 0.5Δx, last(xs_interior) + 0.5Δx]
+    times = panels[1][2].times
+    xs    = collect(xnodes(panels[1][2][1]))
 
     fig = Figure(size = (800, 900))
     Label(fig[0, 1:2], "Hovmöller — $(basename(filepath))", fontsize = 16, tellwidth = false)
 
     hm = nothing
     for (i, (label, ts, c̄)) in enumerate(panels)
-        field_xt = stack([Array(parent(ts[n]))[:, 1, 1] for n in 1:length(times)]; dims = 2)
+        field_xt = stack([Array(interior(ts[n]))[:, 1, 1] for n in 1:length(times)]; dims = 2)
         ax = Axis(fig[i, 1], xlabel = "x", ylabel = "t", title = label)
         hm = heatmap!(ax, xs, times, field_xt; colormap = :balance, colorrange = (-1.8, 1.8))
-        vlines!(ax, domain_edges, color = (:black, 0.6), linestyle = :dash)
     end
     Colorbar(fig[1:length(panels), 2], hm)
 


### PR DESCRIPTION
## Summary

Tracer `OpenBoundaryCondition`s are **silently never applied** during `NonhydrostaticModel` time stepping. The prescribed boundary value — or a matching scheme such as `PerturbationAdvection` — is ignored after the initial `set!`. The same open BC works on a velocity, and the same tracer open BC works in `HydrostaticFreeSurfaceModel`. No error, no warning.

## Root cause

In `NonhydrostaticModel`'s `update_state!`, velocities and tracers were halo-filled together with `fill_open_bcs = false`:

```julia
# src/Models/NonhydrostaticModels/update_nonhydrostatic_model_state.jl
fill_halo_regions!(merge(model.velocities, model.tracers), model.clock, fields(model);
                   fill_open_bcs = false, async = true)
```

`fill_open_bcs = false` turns the open-boundary kernels into no-ops (`fill_halo_event!` in `fill_halo_regions_open.jl`). Velocities recover because they're re-filled with open BCs later, in `compute_pressure_correction!` (which must run after the pressure-corrected state is known). **Tracers were never re-filled**, so their open boundaries never updated during stepping.

`HydrostaticFreeSurfaceModel` already does it correctly — its `update_state!` fills tracers with the default `fill_open_bcs = true` and defers only the velocity/free-surface fill. The deferral is intentional and velocity-specific; the nonhydrostatic model simply lumped tracers into the velocity (`fill_open_bcs = false`) call by mistake.

## Why it matters now

`PerturbationAdvection` recently gained `Center`-located methods (#5617), so Oceananigans now ships a tracer-capable open-boundary scheme that nevertheless never fired in a `NonhydrostaticModel`. A plain `OpenBoundaryCondition(value)` on a tracer is affected too.

**Downstream symptom:** in a stratified run, the unapplied tracer open boundary lets the near-boundary tracer (hence density) drift, driving a spurious pressure gradient. The velocity field then grows without bound, even when the interior is initialized in exact balance with the prescribed exterior. The blow-up is delayed (slowly-growing), making it easy to misattribute to advection/CFL.

## Fix

Mirror `HydrostaticFreeSurfaceModel`: keep the velocity fill deferred, but fill tracer halos with the default `fill_open_bcs = true`:

```julia
fill_halo_regions!(model.velocities, model.clock, fields(model); fill_open_bcs=false, async=true)
fill_halo_regions!(model.tracers,    model.clock, fields(model); async=true)
```

This also means `compute_tendencies!` now sees the correct open-boundary tracer value rather than a stale halo.

**Cadence note:** `update_state!` runs once per RK substage, so tracer open BCs are applied per substage — matching `HydrostaticFreeSurfaceModel`. Fine for relaxation/radiation schemes; stateful schemes with per-step history should be aware of the cadence.

## Test

Adds `test_nonhydrostatic_tracer_open_boundary_is_applied` (in the `Open boundary conditions` testset): pokes a sentinel into the east boundary cell of a tracer and a velocity (each with a prescribed-value open BC), steps 5× with no manual halo fill, and asserts both recover. The boundary cell is a halo the tendency never writes, so it can only return to its prescribed value if the open-boundary fill runs.

Verified locally (CPU):
- **without** the fix → `1 Pass, 1 Fail` (tracer stuck at the sentinel `999`, velocity recovers to `1`)
- **with** the fix → `2 Pass` (tracer recovers to `-1`, velocity to `1`)

GPU-safe accessors (`Array(view(parent(c), i, 1, 1))[]`, `grid.Hx`) so it runs under `TEST_ARCHITECTURE=GPU` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
