### PR TITLE
Fix broadcasting for operations that are not part of `AbstractOperations.operations`

### DIFF
--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -82,6 +82,8 @@ Base.:<(::AbstractField, ::Missing) = missing
 Base.:<(::Missing, ::AbstractField) = missing
 
 @multiary +
+@multiary Base.min 
+@multiary Base.max
 
 # For unknown reasons, the operator definition macros @binary and @multiary fail to work
 # properly for :*. We thus manually define :* for fields.

--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -82,7 +82,7 @@ Base.:<(::AbstractField, ::Missing) = missing
 Base.:<(::Missing, ::AbstractField) = missing
 
 @multiary +
-@multiary Base.min 
+@multiary Base.min
 @multiary Base.max
 
 # For unknown reasons, the operator definition macros @binary and @multiary fail to work

--- a/src/AbstractOperations/broadcasting_abstract_operations.jl
+++ b/src/AbstractOperations/broadcasting_abstract_operations.jl
@@ -18,7 +18,7 @@ end
 @inline broadcasted_to_abstract_operation(loc, grid, op::AbstractOperation) = at(loc, op)
 
 @inline function broadcasted_to_abstract_operation(loc, grid, bc::Broadcasted{<:Any, <:Any, <:Any, <:Any})
-    if Symbol(bc.f) ∈ AbstractOperations.operators
+    if Symbol(bc.f) ∈ operators
         abstract_op = bc.f(loc, Tuple(broadcasted_to_abstract_operation(loc, grid, a) for a in bc.args)...)
         return interpolate_operation(loc, abstract_op) # For "stubborn" BinaryOperations
     else

--- a/src/AbstractOperations/broadcasting_abstract_operations.jl
+++ b/src/AbstractOperations/broadcasting_abstract_operations.jl
@@ -18,6 +18,10 @@ end
 @inline broadcasted_to_abstract_operation(loc, grid, op::AbstractOperation) = at(loc, op)
 
 @inline function broadcasted_to_abstract_operation(loc, grid, bc::Broadcasted{<:Any, <:Any, <:Any, <:Any})
-    abstract_op = bc.f(loc, Tuple(broadcasted_to_abstract_operation(loc, grid, a) for a in bc.args)...)
-    return interpolate_operation(loc, abstract_op) # For "stubborn" BinaryOperations
+    if bc.f ∈ AbstractOperations.operators
+        abstract_op = bc.f(loc, Tuple(broadcasted_to_abstract_operation(loc, grid, a) for a in bc.args)...)
+        return interpolate_operation(loc, abstract_op) # For "stubborn" BinaryOperations
+    else
+        return bc
+    end
 end

--- a/src/AbstractOperations/broadcasting_abstract_operations.jl
+++ b/src/AbstractOperations/broadcasting_abstract_operations.jl
@@ -18,7 +18,7 @@ end
 @inline broadcasted_to_abstract_operation(loc, grid, op::AbstractOperation) = at(loc, op)
 
 @inline function broadcasted_to_abstract_operation(loc, grid, bc::Broadcasted{<:Any, <:Any, <:Any, <:Any})
-    if bc.f ∈ AbstractOperations.operators
+    if Symbol(bc.f) ∈ AbstractOperations.operators
         abstract_op = bc.f(loc, Tuple(broadcasted_to_abstract_operation(loc, grid, a) for a in bc.args)...)
         return interpolate_operation(loc, abstract_op) # For "stubborn" BinaryOperations
     else

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -140,8 +140,10 @@ BinaryOperation at (Center, Center, Center)
 julia> @multiary harmonic_plus
 Set{Any} with 3 elements:
   :+
+  :max
   :harmonic_plus
   :*
+  :min
 
 julia> harmonic_plus(c, d, e)
 MultiaryOperation at (Center, Center, Center)

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -138,7 +138,7 @@ BinaryOperation at (Center, Center, Center)
             └── 1×1×1 Field{Center, Center, Center} on RectilinearGrid on CPU
 
 julia> @multiary harmonic_plus
-Set{Any} with 3 elements:
+Set{Any} with 5 elements:
   :+
   :max
   :harmonic_plus

--- a/src/Fields/broadcasting_abstract_fields.jl
+++ b/src/Fields/broadcasting_abstract_fields.jl
@@ -68,13 +68,10 @@ end
 end
 
 @inline function Base.copyto!(dest::Field, bc::Broadcasted{Nothing})
-
     grid = dest.grid
     arch = architecture(dest)
     bc′ = broadcasted_to_abstract_operation(location(dest), grid, bc)
-
     param = KernelParameters(size(dest), map(offset_index, dest.indices))
-    launch!(arch, grid, param, _broadcast_kernel!, dest, bc′)
-
+    launch!(arch, grid, param, _broadcast_kernel!, dest, bc)
     return dest
 end

--- a/src/Fields/broadcasting_abstract_fields.jl
+++ b/src/Fields/broadcasting_abstract_fields.jl
@@ -72,6 +72,6 @@ end
     arch = architecture(dest)
     bc′ = broadcasted_to_abstract_operation(location(dest), grid, bc)
     param = KernelParameters(size(dest), map(offset_index, dest.indices))
-    launch!(arch, grid, param, _broadcast_kernel!, dest, bc)
+    launch!(arch, grid, param, _broadcast_kernel!, dest, bc′)
     return dest
 end


### PR DESCRIPTION
For operations that are not registered as abstract operations, we do not want to spawn an abstract operation but just pass through the broadcast pipeline with a simple broadcast. 
The example is:
```julia
using Oceananigans
grid = RectilinearGrid(size = (4, 4), topology = (Bounded, Bounded, Flat), x = (0, 1), y = (0, 1), halo = (1, 1))
field = CenterField(grid)
set!(field, 1.0)
Oceananigans.fill_halo_regions!(field)
field .= min.(field, 0.5) 
```
The last broadcast does not work in main but works when we bypass the abstract operations pipeline.
However, I have also added `min` as a `@multiary` operation (together with `max`) so that it can operate correctly on multiple fields.
