### PR TITLE
Allow set! to copy between reduced and windowed single-layer fields

### DIFF
--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -162,15 +162,27 @@ function set_to_field!(u, v)
 end
 
 function matching_field_discretization(u, v)
-    return size(u) == size(v) &&
-           location(u) == location(v) &&
-           equivalent_indices(indices(u), indices(v), size(u))
+    sz = size(u)
+    sz == size(v) || return false
+    ℓu = location(u)
+    ℓv = location(v)
+    iu = indices(u)
+    iv = indices(v)
+    return matching_field_dimension(ℓu[1], ℓv[1], iu[1], iv[1], sz[1]) &&
+           matching_field_dimension(ℓu[2], ℓv[2], iu[2], iv[2], sz[2]) &&
+           matching_field_dimension(ℓu[3], ℓv[3], iu[3], iv[3], sz[3])
 end
 
-@inline equivalent_indices(ui::Tuple, vi::Tuple, sz::Tuple) =
-    equivalent_index(ui[1], vi[1], sz[1]) &&
-    equivalent_index(ui[2], vi[2], sz[2]) &&
-    equivalent_index(ui[3], vi[3], sz[3])
+# Two fields share their discretization along a dimension when they have the same
+# location and equivalent indices there. The exception is a reduced (`Nothing`) location
+# in a singleton dimension: a `Nothing` dimension carries no node, so there is nothing
+# to interpolate to and the single slab may be copied directly regardless of the other
+# field's location or absolute index (e.g. a reduced field set from a windowed
+# single-layer field, whose locations are `Nothing` vs `Center` and indices `:` vs `k:k`).
+@inline matching_field_dimension(ℓu, ℓv, iu, iv, N) =
+    (ℓu == ℓv && equivalent_index(iu, iv, N)) || reduced_singleton_dimension(ℓu, ℓv, N)
+
+@inline reduced_singleton_dimension(ℓu, ℓv, N) = N == 1 && (ℓu === Nothing || ℓv === Nothing)
 
 @inline equivalent_index(a, b, N) = a == b
 @inline equivalent_index(::Colon, r::AbstractUnitRange, N) = first(r) == 1 && last(r) == N

--- a/test/test_set_field_interpolation.jl
+++ b/test/test_set_field_interpolation.jl
@@ -35,3 +35,36 @@
         @test Array(interior(big_halo_c)) == Array(interior(coarse))
     end
 end
+
+@testset "set! between reduced and windowed single-layer fields" begin
+    for arch in archs, FT in float_types
+        grid = RectilinearGrid(arch, FT; size=(4, 4, 4), x=(0, 1), y=(0, 1), z=(0, 1))
+        Nz = size(grid, 3)
+
+        # A windowed single-layer field at the surface, as produced by output with
+        # `indices = (:, :, Nz)` and reloaded as a `FieldTimeSeries` slice. Its z-location
+        # is `Center`, but it spans a single vertical level.
+        surface_u = Field{Face, Center, Center}(grid, indices=(:, :, Nz:Nz))
+        set!(surface_u, (x, y, z) -> x + 2y)
+
+        # Setting a reduced (`Nothing`-z) field from the single-layer 3D field must copy
+        # the single slab directly, not attempt to interpolate across the `Nothing`/`Center`
+        # location and `:`/`Nz:Nz` index mismatch in the degenerate vertical dimension.
+        reduced_u = Field{Face, Center, Nothing}(grid)
+        set!(reduced_u, surface_u)
+        @test Array(interior(reduced_u)) == Array(interior(surface_u))
+
+        # The reverse direction (located single-layer field from a reduced field) too.
+        surface_back = Field{Face, Center, Center}(grid, indices=(:, :, Nz:Nz))
+        set!(surface_back, reduced_u)
+        @test Array(interior(surface_back)) == Array(interior(reduced_u))
+
+        # Two *located* single-layer fields windowed at different levels do NOT share a
+        # discretization (the index is meaningful), so this still routes to interpolation.
+        if Nz > 1
+            bottom_u = Field{Face, Center, Center}(grid, indices=(:, :, 1:1))
+            top_u    = Field{Face, Center, Center}(grid, indices=(:, :, Nz:Nz))
+            @test !Oceananigans.Fields.matching_field_discretization(bottom_u, top_u)
+        end
+    end
+end


### PR DESCRIPTION
## Summary

`set!(u::Field, v::Field)` routes to `interpolate!` whenever `matching_field_discretization(u, v)` is `false`. For a **reduced field** set from a **windowed single-layer field** this misfires:

| | `u` (dest) | `v` (src) |
|---|---|---|
| size | `(Nx, Ny, 1)` | `(Nx, Ny, 1)` |
| location | `(Face, Center, Nothing)` | `(Face, Center, Center)` |
| z-index | `:` | `Nz:Nz` |

`size` matches, but the z-`location` (`Nothing` vs `Center`) and z-index (`:` vs `Nz:Nz`) differ, so it's declared "not matching" and routed to `interpolate!` — which cannot bridge a 2-coordinate node against a 3-location source and errors:

```
ERROR: MethodError: no method matching _fractional_indices(::Tuple{Float64, Float64}, ::RectilinearGrid{...}, ::Face, ::Center, ::Center)
```

This is hit in practice when setting a 2D field from a surface slice of a 3D output (`indices = (:, :, Nz)`) reloaded as a `FieldTimeSeries`, e.g. when assembling surface-speed plots. (Surfaced via [NumericalEarth.jl#319](https://github.com/NumericalEarth/NumericalEarth.jl/issues/319).)

## Fix

A `Nothing` dimension carries **no node**, so in a singleton dimension there is nothing to interpolate *to* and the single slab should simply be copied. `matching_field_discretization` now treats a reduced (`Nothing`) location in a size-1 dimension as matching regardless of the other field's location or absolute index, while preserving the full `location == location && equivalent_index` check for every genuinely located dimension.

In particular this keeps interpolation (not copy) for:
- staggered fields in a multi-point dimension (`Face` vs `Center`, `N > 1`),
- a genuine multi-layer 3D → 2D reduction (`size` differs),
- two *located* single-layer fields windowed at different levels (`1:1` vs `Nz:Nz`) — the index is meaningful there.

## Test

Adds a `@testset` to `test/test_set_field_interpolation.jl` covering set! between a reduced field and a windowed single-layer field (both directions), and asserting that two located single-layer fields windowed at different levels are still *not* considered matching. Verified the original `MethodError` reproduces on `main` and is resolved by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)