### PR TITLE
Support z-areas on single-column latitude-longitude grids

### DIFF
--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -453,12 +453,6 @@ end
 #### Special 2D z Areas for LatitudeLongitudeGrid and OrthogonalSphericalShellGrid
 ####
 
-# Latitudinal sine differences entering the exact spherical z-areas. On single-column
-# grids (both horizontal directions Flat) the neighboring latitude faces do not exist —
-# Flat dimensions carry a single coordinate — so the difference degenerates to a unit
-# factor, mirroring the Δ = 1 convention for Flat spacings. This is consistent: with
-# both horizontal directions Flat every horizontal flux divergence vanishes, and a
-# constant Az cancels between the vertical flux areas and the volume.
 const XYFlatLLG = LatitudeLongitudeGrid{<:Any, <:Flat, <:Flat}
 
 @inline Δsindφᵃᶠᵃ(j, grid) = @inbounds hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j])

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -453,15 +453,29 @@ end
 #### Special 2D z Areas for LatitudeLongitudeGrid and OrthogonalSphericalShellGrid
 ####
 
-@inline Azᶠᶜᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
-@inline Azᶜᶠᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶠᶠᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶜᶜᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+# Latitudinal sine differences entering the exact spherical z-areas. On single-column
+# grids (both horizontal directions Flat) the neighboring latitude faces do not exist —
+# Flat dimensions carry a single coordinate — so the difference degenerates to a unit
+# factor, mirroring the Δ = 1 convention for Flat spacings. This is consistent: with
+# both horizontal directions Flat every horizontal flux divergence vanishes, and a
+# constant Az cancels between the vertical flux areas and the volume.
+const XYFlatLLG = LatitudeLongitudeGrid{<:Any, <:Flat, <:Flat}
 
-@inline Azᶠᶜᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
-@inline Azᶜᶠᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶠᶠᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶜᶜᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+@inline Δsindφᵃᶠᵃ(j, grid) = @inbounds hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j])
+@inline Δsindφᵃᶜᵃ(j, grid) = @inbounds hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1])
+
+@inline Δsindφᵃᶠᵃ(j, grid::XYFlatLLG) = one(grid)
+@inline Δsindφᵃᶜᵃ(j, grid::XYFlatLLG) = one(grid)
+
+@inline Azᶠᶜᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * Δsindφᵃᶠᵃ(j, grid)
+@inline Azᶜᶠᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * Δsindφᵃᶜᵃ(j, grid)
+@inline Azᶠᶠᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * Δsindφᵃᶜᵃ(j, grid)
+@inline Azᶜᶜᵃ(i, j, k, grid::LLGF)  = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * Δsindφᵃᶠᵃ(j, grid)
+
+@inline Azᶠᶜᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ) * Δsindφᵃᶠᵃ(j, grid)
+@inline Azᶜᶠᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ) * Δsindφᵃᶜᵃ(j, grid)
+@inline Azᶠᶠᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ) * Δsindφᵃᶜᵃ(j, grid)
+@inline Azᶜᶜᵃ(i, j, k, grid::LLGFX) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ) * Δsindφᵃᶠᵃ(j, grid)
 
 for LX in (:ᶠ, :ᶜ), LY in (:ᶠ, :ᶜ)
 

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -2,6 +2,7 @@ include("dependencies_for_runtests.jl")
 
 using Oceananigans.Operators: Δxᶠᵃᵃ, Δxᶜᵃᵃ, Δxᶠᶠᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶜᶜᵃ
 using Oceananigans.Operators: Δyᵃᶠᵃ, Δyᵃᶜᵃ, Δyᶠᶠᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Δyᶜᶜᵃ
+using Oceananigans.Operators: Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ
 
 
 function test_three_dimensional_differences(T=Float64)
@@ -302,5 +303,36 @@ end
             @test δzᵃᵃᶜ(idx..., grid_xz, A2xz) ≈ δzᵃᵃᶜ(idx..., grid_xz, A3)
             @test δzᵃᵃᶠ(idx..., grid_xz, A2xz) ≈ δzᵃᵃᶠ(idx..., grid_xz, A3)
         end
+    end
+end
+
+@testset "Horizontal areas of single-column latitude-longitude grids" begin
+    @info "Testing z-areas on single-column latitude-longitude grids..."
+
+    for FT in (Float32, Float64)
+        column_grid = LatitudeLongitudeGrid(FT;
+                                            size = 1,
+                                            longitude = 10,
+                                            latitude = 10,
+                                            z = (-1, 0),
+                                            topology = (Flat, Flat, Bounded))
+
+        # Flat horizontal directions contribute unit factors (the Δ = 1 convention),
+        # so the z-areas are finite and constant rather than reading latitude
+        # neighbors that single-column grids do not carry.
+        for Az in (Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ)
+            @test Az(1, 1, 1, column_grid) ≈ column_grid.radius^2 * deg2rad(1)
+        end
+
+        # The areas enter closure tendencies: a single-column model with an explicit
+        # closure must construct and step (regression test for the BoundsError on
+        # `φᵃᶠᵃ[j+1]`).
+        closure = VerticalScalarDiffusivity(κ = FT(1e-3))
+        model = HydrostaticFreeSurfaceModel(column_grid; closure,
+                                            buoyancy = BuoyancyTracer(),
+                                            tracers = :b)
+        set!(model, b = FT(1))
+        time_step!(model, FT(60))
+        @test all(isfinite, interior(model.tracers.b))
     end
 end


### PR DESCRIPTION
The exact spherical z-area formulas for latitude-longitude grids with on-the-fly metrics read neighboring latitude faces (`sin φ[j+1] − sin φ[j]`). This throws a BoundsError on single-column grids.

The latitudinal sine differences are factored into `Δsindφᵃᶠᵃ / Δsindφᵃᶜᵃ` helpers that degenerate to a unit factor when both horizontal directions are Flat, mirroring the `Δ = 1` convention for Flat spacings.