### PR TITLE
Add `::Nothing` methods to avoid type piracy in other packages

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -211,8 +211,8 @@ function initialize! end # for initializing models, simulations, etc
 function location end
 function instantiated_location end
 function tupleit end
-function fields end
-function prognostic_fields end
+fields(::Nothing) = NamedTuple()
+prognostic_fields(::Nothing) = NamedTuple()
 function prognostic_state end
 function restore_prognostic_state! end
 function tracer_tendency_kernel_function end


### PR DESCRIPTION
This PR just adds the `::Nothing` methods so they don't become type-piracies if they are added by a different package.

x-ref: https://github.com/CliMA/ClimaSeaIce.jl/pull/144