### PR TITLE
Fix wrong/stale signatures in developer-facing docstrings

### DIFF
--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -21,9 +21,9 @@ export
     EnstrophyConserving
 
 using Adapt: Adapt
-using OffsetArrays: OffsetArray
-using MuladdMacro: @muladd
 using DocStringExtensions: SIGNATURES
+using MuladdMacro: @muladd
+using OffsetArrays: OffsetArray
 
 using Oceananigans: Oceananigans, fully_supported_float_types
 using Oceananigans.Architectures: Architectures, architecture, on_architecture, CPU

--- a/src/Advection/Advection.jl
+++ b/src/Advection/Advection.jl
@@ -23,6 +23,7 @@ export
 using Adapt: Adapt
 using OffsetArrays: OffsetArray
 using MuladdMacro: @muladd
+using DocStringExtensions: SIGNATURES
 
 using Oceananigans: Oceananigans, fully_supported_float_types
 using Oceananigans.Architectures: Architectures, architecture, on_architecture, CPU

--- a/src/Advection/reconstruction_coefficients.jl
+++ b/src/Advection/reconstruction_coefficients.jl
@@ -39,10 +39,13 @@ Return coefficients for finite-volume polynomial reconstruction of order `order`
 Positional Arguments
 ====================
 
+- `FT`: the floating-point type of the returned coefficients (e.g. `Float32` or `Float64`).
+- `i`: the index around which the reconstruction stencil is centered.
+- `r`: the stencil number.
+- `xr`: the opposite of the reconstruction location desired, i.e., if a reconstruction at
+  `Center`s is required xr is the face coordinate
 - `xi`: the locations of the reconstructing value, i.e. either the center coordinate,
   for centered quantities or face coordinate for staggered
-- `xr`: the opposite of the reconstruction location desired, i.e., if a recostruction at
-  `Center`s is required xr is the face coordinate
 
 On a uniform `grid`, the coefficients are independent of the `xr` and `xi` values.
 """

--- a/src/Advection/reconstruction_coefficients.jl
+++ b/src/Advection/reconstruction_coefficients.jl
@@ -32,7 +32,7 @@ num_prod(i, m, l, r, xr, xi, shift, op, order, ::SecondDerivative) = 2
 end
 
 """
-    stencil_coefficients(i, r, xr, xi; shift = 0, op = Base.:(-), order = 3, der = nothing)
+    stencil_coefficients(FT, i, r, xr, xi; shift = 0, op = Base.:(-), order = 3, der = nothing)
 
 Return coefficients for finite-volume polynomial reconstruction of order `order` at stencil `r`.
 

--- a/src/Advection/reconstruction_coefficients.jl
+++ b/src/Advection/reconstruction_coefficients.jl
@@ -47,6 +47,16 @@ Positional Arguments
 - `xi`: the locations of the reconstructing value, i.e. either the center coordinate,
   for centered quantities or face coordinate for staggered
 
+Keyword Arguments
+=================
+
+- `shift`: offset added to the index `i` when locating the reconstruction point `xr[i+shift]`. Default: `0`.
+- `op`: operation combining `i` with the stencil offset to index `xi`/`xr` (e.g. `Base.:(-)` for a
+  left-biased stencil). Default: `Base.:(-)`.
+- `order`: order of the polynomial reconstruction, equal to the number of returned coefficients. Default: `3`.
+- `der`: quantity the coefficients reconstruct — `nothing` for the function value, or `FirstDerivative()`,
+  `SecondDerivative()`, or `Primitive()` (the integral). Default: `nothing`.
+
 On a uniform `grid`, the coefficients are independent of the `xr` and `xi` values.
 """
 @inline function stencil_coefficients(FT, i, r, xr, xi; shift = 0, op = Base.:(-), order = 3, der = nothing)

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -328,7 +328,7 @@ end
 @inline global_smoothness_indicator(::Val{6}, β) = @inbounds abs(β[1] + 36β[2] + 135β[3] - 135β[4] - 36β[5] - β[6])
 
 """
-    function biased_weno_weights(ψ, scheme::WENO{N, FT}, args...)
+    function biased_weno_weights(ψ, grid, scheme::WENO{N, FT}, args...)
 
 Biased weno weights ω used to weight the WENO reconstruction of the different stencils.
 We use here a Z-WENO formulation where
@@ -369,7 +369,7 @@ end
 end
 
 """
-    load_weno_stencil(buffer, shift, dir, func::Bool = false)
+    load_weno_stencil(buffer, dir, func::Bool = false)
 
 Stencils for WENO reconstruction calculations
 
@@ -488,14 +488,14 @@ end
 end
 
 """
-    weno_reconstruction(scheme::WENO{buffer}, bias, ψ, ω, cT, val, idx, loc)
+    weno_reconstruction(scheme::WENO{buffer}, bias, ψ, ω)
 
 `bias`ed reconstruction of stencils `ψ` for a WENO scheme of order `buffer * 2 - 1` weighted by WENO
 weights `ω`. `ψ` is a `Tuple` of `buffer` stencils of size `buffer` and `ω` is a `Tuple` of size `buffer`
 containing the computed weights for each of the reconstruction stencils.
 
-The additional inputs are only used for stretched WENO directions that require the knowledge of the location `loc`
-and the index `idx`.
+The location `loc` and index `idx` that appear in the unrolled example below are used internally by
+[`biased_p`](@ref) for stretched WENO directions.
 
 The calculation of the reconstruction is metaprogrammed in the `metaprogrammed_weno_reconstruction` function which, for
 `buffer == 4` (seventh order WENO), unrolls to:

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -328,7 +328,7 @@ end
 @inline global_smoothness_indicator(::Val{6}, β) = @inbounds abs(β[1] + 36β[2] + 135β[3] - 135β[4] - 36β[5] - β[6])
 
 """
-    function biased_weno_weights(ψ, grid, scheme::WENO{N, FT}, args...)
+    $(SIGNATURES)
 
 Biased weno weights ω used to weight the WENO reconstruction of the different stencils.
 We use here a Z-WENO formulation where

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -328,7 +328,7 @@ end
 @inline global_smoothness_indicator(::Val{6}, β) = @inbounds abs(β[1] + 36β[2] + 135β[3] - 135β[4] - 36β[5] - β[6])
 
 """
-    $(SIGNATURES)
+$(SIGNATURES)
 
 Biased weno weights ω used to weight the WENO reconstruction of the different stencils.
 We use here a Z-WENO formulation where

--- a/src/Diagnostics/state_checker.jl
+++ b/src/Diagnostics/state_checker.jl
@@ -7,7 +7,7 @@ struct StateChecker{T, F} <: AbstractDiagnostic
 end
 
 """
-    StateChecker(; schedule, fields)
+    StateChecker(model; schedule, fields=fields(model))
 
 Returns a `StateChecker` that logs field information (minimum, maximum, mean)
 for each field in a named tuple of `fields` when `schedule` actuates.

--- a/src/DistributedComputations/partition_assemble.jl
+++ b/src/DistributedComputations/partition_assemble.jl
@@ -76,12 +76,11 @@ function partition_coordinate(c::Tuple, n, arch, dim)
 end
 
 """
-    assemble_coordinate(c::AbstractVector, n, R, r, r1, r2, comm)
+    assemble_coordinate(c_local::AbstractVector, n, arch, dim)
 
-Builds a linear global coordinate vector given a local coordinate vector `c_local`
-a local number of elements `Nc`, number of ranks `Nr`, rank `r`,
-and `arch`itecture. Since we use a global reduction, only ranks at positions
-1 in the other two directions `r1 == 1` and `r2 == 1` fill the 1D array.
+Builds a linear global coordinate vector along dimension `dim` given a local coordinate
+vector `c_local`, the local sizes `n`, and the architecture `arch`. Since we use a global
+reduction, only ranks at position 1 in the other two directions fill the 1D array.
 """
 function assemble_coordinate(c_local::AbstractVector, n, arch, dim)
     nl = concatenate_local_sizes(n, arch, dim)

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -12,7 +12,7 @@ using Oceananigans.Utils: interpolator, _interpolate
 @inline middle_point(l, h) = Base.unsafe_trunc(Int, (l + h) / 2)
 
 """
-    index_binary_search(val, vec, N)
+    index_binary_search(vec, val, N)
 
 Return indices `low, high` of `vec`tor for which
 
@@ -191,10 +191,10 @@ struct FractionalIndices{I, J, K}
 end
 
 """
-    FractionalIndices(x, y, z, grid, loc...)
+    FractionalIndices(at_node, grid, ℓx, ℓy, ℓz)
 
-Convert the coordinates `(x, y, z)` to _fractional_ indices on a regular rectilinear grid
-located at `loc`, where `loc` is a 3-tuple of `Center` and `Face`. Fractional indices are
+Convert the coordinate tuple `at_node` to _fractional_ indices on a regular rectilinear grid
+located at `(ℓx, ℓy, ℓz)`, a triplet of `Center` and `Face`. Fractional indices are
 floats indicating a location between grid points.
 """
 @inline FractionalIndices(at_node, grid, ℓx, ℓy, ℓz) = _fractional_indices(at_node, grid, ℓx, ℓy, ℓz)

--- a/src/Grids/vertical_discretization.jl
+++ b/src/Grids/vertical_discretization.jl
@@ -17,15 +17,16 @@ Represent a static one-dimensional vertical coordinate.
 Fields
 ======
 
-- `cᵃᵃᶠ::C`: Face-centered coordinate.
-- `cᵃᵃᶜ::D`: Cell-centered coordinate.
-- `Δᵃᵃᶠ::E`: Face-centered grid spacing.
-- `Δᵃᵃᶜ::F`: Cell-centered grid spacing.
+$(FIELDS)
 """
 struct StaticVerticalDiscretization{C, D, E, F} <: AbstractVerticalCoordinate
+    "Face-centered coordinate"
     cᵃᵃᶠ :: C
+    "Cell-centered coordinate"
     cᵃᵃᶜ :: D
+    "Face-centered grid spacing"
     Δᵃᵃᶠ :: E
+    "Cell-centered grid spacing"
     Δᵃᵃᶜ :: F
 end
 

--- a/src/Grids/vertical_discretization.jl
+++ b/src/Grids/vertical_discretization.jl
@@ -17,10 +17,10 @@ Represent a static one-dimensional vertical coordinate.
 Fields
 ======
 
-- `cᶜ::C`: Cell-centered coordinate.
-- `cᶠ::D`: Face-centered coordinate.
-- `Δᶜ::E`: Cell-centered grid spacing.
-- `Δᶠ::F`: Face-centered grid spacing.
+- `cᵃᵃᶠ::C`: Face-centered coordinate.
+- `cᵃᵃᶜ::D`: Cell-centered coordinate.
+- `Δᵃᵃᶠ::E`: Face-centered grid spacing.
+- `Δᵃᵃᶜ::F`: Cell-centered grid spacing.
 """
 struct StaticVerticalDiscretization{C, D, E, F} <: AbstractVerticalCoordinate
     cᵃᵃᶠ :: C

--- a/src/Models/LagrangianParticleTracking/lagrangian_particle_advection.jl
+++ b/src/Models/LagrangianParticleTracking/lagrangian_particle_advection.jl
@@ -110,7 +110,7 @@ rightmost_interface_index(::Periodic, N) = N + 1
 rightmost_interface_index(::Flat, N) = N
 
 """
-    advect_particle((x, y, z), p, restitution, grid, Δt, velocities)
+    advect_particle((x, y, z), particles, p, restitution, grid, Δt, velocities)
 
 Return new position `(x⁺, y⁺, z⁺)` for a particle at current position (x, y, z),
 given `velocities`, time-step `Δt, and coefficient of `restitution`.

--- a/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
+++ b/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
@@ -106,7 +106,7 @@ fields(model::NonhydrostaticModel) = merge(model.velocities,
                                            biogeochemical_auxiliary_fields(model.biogeochemistry))
 
 """
-    prognostic_fields(model::HydrostaticFreeSurfaceModel)
+    prognostic_fields(model::NonhydrostaticModel)
 
 Return a flattened `NamedTuple` of the prognostic fields associated with `NonhydrostaticModel`.
 """

--- a/src/Operators/divergence_operators.jl
+++ b/src/Operators/divergence_operators.jl
@@ -19,18 +19,13 @@ which ends up at the cell centers `ccc`.
                              δzᶜᶜᶜ(i, j, k, grid, Az_qᶜᶜᶠ, w))
 
 """
-    div_xyᶜᶜᵃ(i, j, k, grid, u, v)
+    flux_div_xyᶜᶜᶜ(i, j, k, grid, u, v)
 
-Return the discrete `div_xy = ∂x u + ∂y v` of velocity field `u, v` defined as
+Return the discrete horizontal flux divergence `δxᶜᶜᶜ(Ax * u) + δyᶜᶜᶜ(Ay * v)` of the
+velocity field `u, v`, where `Ax` and `Ay` are the areas of the cell faces in `x` and `y`.
+Unlike `div_xyᶜᶜᶜ`, this is _not_ divided by the cell volume.
 
-```julia
-1 / Azᶜᶜᵃ * [δxᶜᵃᵃ(Δyᵃᶜᵃ * u) + δyᵃᶜᵃ(Δxᶜᵃᵃ * v)]
-```
-
-at `i, j, k`, where `Azᶜᶜᵃ` is the area of the cell centered on (Center, Center, Any) --- a tracer cell,
-`Δy` is the length of the cell centered on (Face, Center, Any) in `y` (a `u` cell),
-and `Δx` is the length of the cell centered on (Center, Face, Any) in `x` (a `v` cell).
-`div_xyᶜᶜᵃ` ends up at the location `cca`.
+`flux_div_xyᶜᶜᶜ` ends up at the location `ccc`.
 """
 @inline flux_div_xyᶜᶜᶜ(i, j, k, grid, u, v) = (δxᶜᶜᶜ(i, j, k, grid, Ax_qᶠᶜᶜ, u) +
                                                δyᶜᶜᶜ(i, j, k, grid, Ay_qᶜᶠᶜ, v))

--- a/src/Solvers/conjugate_gradient_solver.jl
+++ b/src/Solvers/conjugate_gradient_solver.jl
@@ -36,11 +36,12 @@ Base.summary(::ConjugateGradientSolver) = "ConjugateGradientSolver"
 """
     ConjugateGradientSolver(linear_operation;
                             template_field,
-                            maxiter = size(template_field.grid),
+                            maxiter = prod(size(template_field)),
                             reltol = sqrt(eps(template_field.grid)),
                             abstol = 0,
                             preconditioner = nothing,
-                            enforce_gauge_condition! = no_gauge_enforcement!)
+                            enforce_gauge_condition! = no_gauge_enforcement!,
+                            residual_norm = norm)
 
 Return a `ConjugateGradientSolver` that solves the linear equation ``A x = b``
 using a iterative conjugate gradient method with optional preconditioning.
@@ -80,6 +81,8 @@ Arguments
                               gradient iteration to ensure that the solution remains consistent
                               with the gauge condition.
                               The default is `no_gauge_enforcement!`, which does not enforce a gauge condition.
+
+* `residual_norm`: Function used to compute the norm of the residual for convergence checks. Default: `norm`.
 
 See [`solve!`](@ref) for more information about the preconditioned conjugate-gradient algorithm.
 """

--- a/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
+++ b/src/TurbulenceClosures/abstract_scalar_diffusivity_closure.jl
@@ -57,7 +57,7 @@ Returns the scalar viscosity associated with `closure`.
 function viscosity end
 
 """
-    diffusivity(closure, tracer_index, closure_fields)
+    diffusivity(closure, closure_fields, tracer_index)
 
 Returns the scalar diffusivity associated with `closure` and `tracer_index`.
 """

--- a/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
@@ -151,7 +151,7 @@ struct FluxTapering{FT}
 end
 
 """
-    taper_factor(i, j, k, grid, closure, tracers, buoyancy)
+    tapering_factor(i, j, k, grid, closure, tracers, buoyancy)
 
 Return the tapering factor `min(1, Sₘₐₓ² / slope²)`, where `slope² = slope_x² + slope_y²`
 that multiplies all components of the isopycnal slope tensor. The tapering factor is calculated on all the

--- a/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity_with_triads.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity_with_triads.jl
@@ -20,7 +20,7 @@ const TISSDVector{TD} = AbstractVector{<:TISSD{TD}} where TD
 const FlavorOfTISSD{TD} = Union{TISSD{TD}, TISSDVector{TD}} where TD
 
 """
-    TriadIsopycnalSkewSymmetricDiffusivity([time_disc=VerticallyImplicitTimeDiscretization(), FT=Float64;]
+    TriadIsopycnalSkewSymmetricDiffusivity([time_disc=ExplicitTimeDiscretization(), FT=Float64;]
                                            κ_skew = 0,
                                            κ_symmetric = 0,
                                            isopycnal_tensor = SmallSlopeIsopycnalTensor(),

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -192,7 +192,7 @@ is_vertically_implicit(closure) = TimeSteppers.time_discretization(closure) isa 
 
 """
     implicit_step!(field, implicit_solver::BatchedTridiagonalSolver,
-                   closure, closure_fields, tracer_index, clock, Δt)
+                   closure, closure_fields, tracer_index, clock, fields, Δt)
 
 Initialize the right hand side array `solver.batched_tridiagonal_solver.f`, and then solve the
 tridiagonal system for vertically-implicit diffusion, passing the arguments into the coefficient

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -146,13 +146,9 @@ worksize(grid) = size(grid)
     interior_work_layout(grid, dims, location)
 
 Returns the `workgroup` and `worksize` for launching a kernel over `dims`
-on `grid` that excludes peripheral nodes.
+on `grid` that excludes peripheral nodes (determined from `location`).
 The `workgroup` is a tuple specifying the threads per block in each
 dimension. The `worksize` specifies the range of the loop in each dimension.
-
-Specifying `include_right_boundaries=true` will ensure the work layout includes the
-right face end points along bounded dimensions. This requires the field `location`
-to be specified.
 
 For more information, see: https://github.com/CliMA/Oceananigans.jl/pull/308
 """
@@ -190,15 +186,11 @@ For more information, see: https://github.com/CliMA/Oceananigans.jl/pull/308
 end
 
 """
-    work_layout(grid, dims, location)
+    work_layout(grid, dims, reduced_dimensions)
 
 Returns the `workgroup` and `worksize` for launching a kernel over `dims`
 on `grid`. The `workgroup` is a tuple specifying the threads per block in each
 dimension. The `worksize` specifies the range of the loop in each dimension.
-
-Specifying `include_right_boundaries=true` will ensure the work layout includes the
-right face end points along bounded dimensions. This requires the field `location`
-to be specified.
 
 For more information, see: https://github.com/CliMA/Oceananigans.jl/pull/308
 """
@@ -235,7 +227,7 @@ end
 """
     configure_kernel(arch, grid, workspec, kernel!;
                      active_cells_map = nothing,
-                     exclude_periphery = false;
+                     exclude_periphery = false,
                      reduced_dimensions = (),
                      location = nothing)
 
@@ -254,7 +246,7 @@ Keyword Arguments
 =================
 
 - `reduced_dimensions`: A tuple specifying the dimensions to be reduced in the work distribution. Default is an empty tuple.
-- `location`: The location of the kernel execution, needed for `include_right_boundaries`. Default is `nothing`.
+- `location`: The location of the kernel execution, used when `exclude_periphery = true`. Default is `nothing`.
 - `active_cells_map`: A map indicating the active cells in the grid. If the map is not a nothing, the workspec will be disregarded and
                       the kernel is configured as a linear kernel with a worksize equal to the length of the active cell map. Default is `nothing`.
 - `exclude_periphery`: A boolean indicating whether to exclude the periphery, used only for interior kernels.


### PR DESCRIPTION
Fixes hand-written docstring signatures and argument lists that didn't match the actual definitions (wrong argument names, order, count, or function name). Doc-only; no behavior change.

- `prognostic_fields`: documented `::NonhydrostaticModel` (was `::HydrostaticFreeSurfaceModel`)
- `index_binary_search` / `FractionalIndices`: corrected argument order
- `advect_particle`: added missing `particles` arg
- `StateChecker`: documented the positional `model` arg
- `assemble_coordinate`: real `(c_local, n, arch, dim)` signature
- `configure_kernel`: malformed double `;`; `interior_work_layout`/`work_layout` drop the nonexistent `include_right_boundaries` and fix `location`/`reduced_dimensions`
- `diffusivity`: `(closure, closure_fields, tracer_index)` order
- `implicit_step!`: added missing `fields` arg
- `tapering_factor` (was `taper_factor`)
- `flux_div_xyᶜᶜᶜ`: name/formula/location matched to the function it documents
- `StaticVerticalDiscretization`: field names/labels matched to the struct
- `ConjugateGradientSolver`: `maxiter` default; documented `residual_norm`
- `TriadIsopycnalSkewSymmetricDiffusivity`: `ExplicitTimeDiscretization` default
- WENO helpers (`biased_weno_weights`, `load_weno_stencil`, `weno_reconstruction`, `stencil_coefficients`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)