### PR TITLE
Fix misleading docstring descriptions

### DIFF
--- a/src/BoundaryConditions/continuous_boundary_function.jl
+++ b/src/BoundaryConditions/continuous_boundary_function.jl
@@ -30,14 +30,14 @@ interpolation_code(::BoundaryAdjacent, ::Nothing) = :ᵃ
 interpolation_code(::Nothing, ::BoundaryAdjacent) = :ᵃ
 
 """
-    struct ContinuousBoundaryFunction{X, Y, Z, I, F, P, D, N, ℑ} <: Function
+    struct ContinuousBoundaryFunction{X, Y, Z, S, F, P, D, N, ℑ} <: Function
 
 A wrapper for the user-defined boundary condition function `func` at location
-`X, Y, Z`. `I` denotes the boundary-normal index (`I=1` at western boundaries,
-`I=grid.Nx` at eastern boundaries, etc). `F, P, D, N, ℑ` are, respectively, the
-user-defined function, parameters, field dependencies, indices of the field dependencies
-in `model_fields`, and interpolation operators for interpolating `model_fields` to the
-location at which the boundary condition is applied.
+`X, Y, Z`. `S` denotes the boundary side (`LeftBoundary` or `RightBoundary`).
+`F, P, D, N, ℑ` are, respectively, the user-defined function, parameters, field
+dependencies, indices of the field dependencies in `model_fields`, and interpolation
+operators for interpolating `model_fields` to the location at which the boundary
+condition is applied.
 """
 struct ContinuousBoundaryFunction{X, Y, Z, S, F, P, D, N, ℑ}
                           func :: F

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -166,7 +166,7 @@ derived from a model's prognostic fields) on `grid` and at `location`.
 Keyword arguments
 =================
 
-Keyword arguments specify boundary conditions on the 6 possible boundaries:
+Keyword arguments specify boundary conditions on the 7 possible boundaries:
 
 - `west`, left end point in the `x`-direction where `i = 1`
 - `east`, right end point in the `x`-direction where `i = grid.Nx`

--- a/src/BoundaryConditions/fill_halo_regions.jl
+++ b/src/BoundaryConditions/fill_halo_regions.jl
@@ -10,10 +10,11 @@ fill_halo_regions!(::Ref, args...; kwargs...) = nothing # a lot of Refs are pass
 fill_halo_regions!(::Nothing, args...; kwargs...) = nothing
 
 """
-    fill_halo_regions!(fields::Union{Tuple, NamedTuple}, arch, args...)
+    fill_halo_regions!(field)
 
-Fill halo regions for each field in the tuple `fields` according to their boundary
-conditions, possibly recursing into `fields` if it is a nested tuple-of-tuples.
+Fill the halo regions of `field` (or its underlying `data`) according to its boundary
+conditions. Fields with `nothing` boundary conditions (such as `FunctionField` and
+`ZeroField`) are left unchanged.
 """
 fill_halo_regions!(c::OffsetArray, ::Nothing, args...; kwargs...) = nothing # Some fields have `nothing` boundary conditions, such as `FunctionField` and `ZeroField`.
 

--- a/src/BoundaryConditions/fill_halo_regions.jl
+++ b/src/BoundaryConditions/fill_halo_regions.jl
@@ -10,13 +10,12 @@ fill_halo_regions!(::Ref, args...; kwargs...) = nothing # a lot of Refs are pass
 fill_halo_regions!(::Nothing, args...; kwargs...) = nothing
 
 """
-    fill_halo_regions!(field)
+    fill_halo_regions!(c::OffsetArray, ::Nothing, args...; kwargs...)
 
-Fill the halo regions of `field` (or its underlying `data`) according to its boundary
-conditions. Fields with `nothing` boundary conditions (such as `FunctionField` and
-`ZeroField`) are left unchanged.
+Do nothing: data `c` whose boundary conditions are `nothing` has no halos to fill. Some fields
+carry `nothing` boundary conditions, such as `FunctionField` and `ZeroField`.
 """
-fill_halo_regions!(c::OffsetArray, ::Nothing, args...; kwargs...) = nothing # Some fields have `nothing` boundary conditions, such as `FunctionField` and `ZeroField`.
+fill_halo_regions!(c::OffsetArray, ::Nothing, args...; kwargs...) = nothing
 
 "Fill halo regions in ``x``, ``y``, and ``z`` for a given field's data."
 function fill_halo_regions!(c::OffsetArray, boundary_conditions, indices, loc, grid, args...; kwargs...)

--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -28,8 +28,8 @@ const GFBIBG = ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:GridFit
 
 Return a bottom immersed boundary.
 
-Keyword Arguments
-=================
+Arguments
+=========
 
 * `bottom_height`: an array or function that gives the height of the
                    bottom in absolute ``z`` coordinates.

--- a/src/Models/HydrostaticFreeSurfaceModels/compute_hydrostatic_free_surface_buffers.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/compute_hydrostatic_free_surface_buffers.jl
@@ -19,7 +19,7 @@ Complete halo communication and compute momentum tendencies in the buffer region
 
 This method is called after interior momentum tendencies are computed to:
 1. synchronize halo communication for tracers and velocities,
-2. compute diagnostic fields (buoyancy gradients, vertical velocity, pressure, closure_fields) in the buffer regions, and
+2. compute diagnostic fields (buoyancy gradients, pressure, closure_fields) in the buffer regions, and
 3. compute momentum tendencies in cells that depend on halo data.
 """
 function complete_communication_and_compute_momentum_buffer!(model::HydrostaticFreeSurfaceModel, ::DistributedGrid, ::AsynchronousDistributed)

--- a/src/Models/HydrostaticFreeSurfaceModels/compute_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/compute_hydrostatic_free_surface_tendencies.jl
@@ -17,8 +17,7 @@ Compute tendencies for horizontal velocity fields `u` and `v`.
 This function:
 1. Computes interior momentum tendencies (advection, Coriolis, pressure gradient, diffusion, forcing)
 2. Completes halo communication and computes buffer tendencies for distributed grids
-3. Computes flux boundary condition contributions
-4. Executes any callbacks with `TendencyCallsite`
+3. Executes any callbacks with `TendencyCallsite`
 
 Momentum tendencies are stored in `model.timestepper.Gⁿ.u` and `model.timestepper.Gⁿ.v`.
 """

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_tendency_kernel_functions.jl
@@ -52,7 +52,7 @@ implicitly during time-stepping.
 end
 
 """
-Return the tendency for the horizontal velocity in the ``y``-direction, or the east-west
+Return the tendency for the horizontal velocity in the ``y``-direction, or the north-south
 direction, ``v``, at grid point `i, j, k` for a `HydrostaticFreeSurfaceModel`.
 
 The tendency for ``v`` is called ``G_v`` and defined via

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -389,11 +389,11 @@ end
 
 Manually checkpoint `simulation` state to a JLD2 file.
 
-If `simulation.output_writers` contains a `Checkpointer`, it will be used
-(respecting its `dir`, `prefix`, `cleanup`, and `verbose` settings).
-
-Otherwise, the checkpoint is written to `filepath`, or to
-`"checkpoint_iteration{N}.jld2"` in the current directory if `filepath` is not specified.
+If `filepath` is provided, the checkpoint is written there. Otherwise, if
+`simulation.output_writers` contains a single `Checkpointer`, it is used
+(respecting its `dir`, `prefix`, `cleanup`, and `verbose` settings); if no
+`filepath` is given and there is no single `Checkpointer`, the checkpoint is
+written to `"checkpoint_iteration{N}.jld2"` in the current directory.
 """
 function checkpoint(simulation; filepath=nothing)
     checkpointers = filter(w -> w isa Checkpointer, collect(values(simulation.output_writers)))

--- a/src/Utils/schedules.jl
+++ b/src/Utils/schedules.jl
@@ -182,7 +182,7 @@ other than the moment `WallTimeInterval` is constructed.
 """
 function WallTimeInterval(interval; start_time = time_ns() * 1e-9)
     FT = Oceananigans.defaults.FloatType
-    return WallTimeInterval(convert(FT, interval), convert(FT, interval))
+    return WallTimeInterval(convert(FT, interval), convert(FT, start_time))
 end
 
 function (schedule::WallTimeInterval)(model)


### PR DESCRIPTION
Fixes docstring prose that contradicted the code. Doc-only **except** one one-line behavior fix (noted below).

- v-velocity tendency: the `y`-direction is **north-south** (was "east-west")
- `checkpoint`: an explicit `filepath` **takes precedence** over a `Checkpointer` (precedence was stated backwards)
- `ContinuousBoundaryFunction`: the 4th type param is the boundary side `S` (`LeftBoundary`/`RightBoundary`), not a boundary-normal index `I`
- `fill_halo_regions!`: documents the actual field interface (the documented `Tuple/NamedTuple` recursion method does not exist; the docstring sat on the `nothing`-BC no-op)
- `GridFittedBottom`: arguments are positional, not "Keyword Arguments"
- `FieldBoundaryConditions`: **7** possible boundaries, not 6 (it lists 7)
- `compute_momentum_tendencies!`: drops the "flux boundary condition" step it does not perform
- momentum buffer: drops "vertical velocity" from the listed diagnostic fields (not computed there)

**Behavior change (1 line):** `WallTimeInterval` documented a `start_time` kwarg that was silently ignored (`previous_actuation_time` was seeded from `interval`). It now seeds from `start_time`, so the documented behavior holds. Note this changes first-actuation timing: actuation now first occurs `interval` seconds after `start_time` (≈ construction) rather than on the first check. Happy to split this line into a separate PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)