### PR TITLE
Use the correct function to compute the rotation angle

### DIFF
--- a/src/Operators/vector_rotation_operators.jl
+++ b/src/Operators/vector_rotation_operators.jl
@@ -77,12 +77,8 @@ the grid's intrinsic coordinates in order to match the grid's extrinsic coordina
     Rcosθ =   (Rcosθ₁ + Rcosθ₂) / 2
     Rsinθ = - (deg2rad(φᶠᶠᵃ⁺⁺ - φᶠᶠᵃ⁻⁺) / Δxᶜᶠᵃ⁺ + deg2rad(φᶠᶠᵃ⁺⁻ - φᶠᶠᵃ⁻⁻) / Δxᶜᶠᵃ⁻) / 2
 
-    # Normalization for the rotation angles
-    R = sqrt(Rcosθ^2 + Rsinθ^2)
-
-    cosθ, sinθ = Rcosθ / R, Rsinθ / R
-
-    θ = atan(sinθ / cosθ)
+    θ = atan(Rsinθ, Rcosθ)
+    
     return θ
 end
 

--- a/src/Operators/vector_rotation_operators.jl
+++ b/src/Operators/vector_rotation_operators.jl
@@ -78,7 +78,7 @@ the grid's intrinsic coordinates in order to match the grid's extrinsic coordina
     Rsinθ = - (deg2rad(φᶠᶠᵃ⁺⁺ - φᶠᶠᵃ⁻⁺) / Δxᶜᶠᵃ⁺ + deg2rad(φᶠᶠᵃ⁺⁻ - φᶠᶠᵃ⁻⁻) / Δxᶜᶠᵃ⁻) / 2
 
     θ = atan(Rsinθ, Rcosθ)
-    
+
     return θ
 end
 

--- a/test/test_vector_rotation_operators.jl
+++ b/test/test_vector_rotation_operators.jl
@@ -92,7 +92,7 @@ end
                 # that geometric factors related with spherical geometry don't come into play.
                 Δ = 1e-3
 
-                angles_degrees = [-22.5, 30, 45, 60]
+                angles_degrees = [-150, -135, -22.5, 30, 45, 60, 120, 135, 160]
                 angles = angles_degrees .* (π / 180) # Convert to Radians
 
                 for θᵢ in angles


### PR DESCRIPTION
`atan(sin / cos)` might change the sign of the cosine function, `atan(sin, cos)` retains the sign, MWE:
```julia
function test_signs(θtrue)
    cosθ, sinθ = cos(θtrue), sin(θtrue)        
    θ1 = atan(sinθ / cosθ)                         
    θ2 = atan(sinθ, cosθ)                         
    @info θtrue, θ1, θ2
end
```
returns 
```julia
julia> test_signs(deg2rad(30))
[ Info: (0.5235987755982988, 0.5235987755982987, 0.5235987755982987)

julia> test_signs(deg2rad(170))
[ Info: (2.9670597283903604, -0.17453292519943292, 2.9670597283903604)

julia> test_signs(deg2rad(-135))
[ Info: (-2.356194490192345, 0.7853981633974484, -2.356194490192345)
```