### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline-juliagpu.yml
+++ b/.buildkite/pipeline-juliagpu.yml
@@ -20,8 +20,7 @@ steps:
 
       TEST_GROUP=amdgpu julia --project -O0 --color=yes -e 'using Pkg; Pkg.test()'
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
     timeout_in_minutes: 30
     soft_fail:
       - exit_status: 3
@@ -42,8 +41,7 @@ steps:
 
       TEST_GROUP=oneapi julia --project -O0 --color=yes -e 'using Pkg; Pkg.test()'
     agents:
-      queue: "juliagpu"
-      intel: "*"
+      queue: "oneapi"
     timeout_in_minutes: 30
     soft_fail:
       - exit_status: 3


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `rocm`/`intel` tag.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)