### PR TITLE
(0.110.2) Fix reading reduced fields from NetCDF as FieldTimeSeries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.1"
+version = "0.110.2"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/ext/OceananigansNCDatasetsExt/output_readers.jl
+++ b/ext/OceananigansNCDatasetsExt/output_readers.jl
@@ -95,7 +95,9 @@ function inflate_nothing_dimensions(data, location, grid)
     # 2. Grid topology is Flat (e.g., 2D simulation with no variation in that direction)
     inflated_dims = []
     for (i, loc) in enumerate(location)
-        if loc == Nothing || topology(grid, i) == Flat
+        # `loc` may be a type (`Nothing`) or an instance (`nothing`) depending on the caller,
+        # so test for both — `nothing == Nothing` is `false`.
+        if loc === Nothing || loc === nothing || topology(grid, i) == Flat
             push!(inflated_dims, i)
         end
     end

--- a/ext/OceananigansNCDatasetsExt/output_readers.jl
+++ b/ext/OceananigansNCDatasetsExt/output_readers.jl
@@ -63,17 +63,17 @@ iterations_from_file(file::NCDataset) = 1:length(keys(file["time"][:]))
 """
     inflate_nothing_dimensions(data, location, grid)
 
-Add singleton dimensions to `data` where `location` is `Nothing` or topology is `Flat`.
+Add singleton dimensions to `data` where `location` is `nothing` or topology is `Flat`.
 This is the inverse operation of `squeeze_nothing_dimensions` and it is done for compatibility
 with Oceananigans' internal representation of fields.
 
-For example, if `location = (Center, Center, Nothing)`, the data will have a singleton
+For example, if `location = (Center(), Center(), nothing)`, the data will have a singleton
 dimension added in the third (z) direction, transforming data of size `(Nx, Ny)` to
 size `(Nx, Ny, 1)`.
 
 # Arguments
 - `data`: Array data read from NetCDF file (may be 1D, 2D, or 3D)
-- `location`: Field's grid location tuple (e.g., `(Center, Face, Nothing)`)
+- `location`: Field's grid location tuple, as instantiated locations (e.g., `(Center(), Face(), nothing)`)
 - `grid`: Grid object to check topology
 
 # Returns
@@ -81,9 +81,9 @@ Reshaped array with singleton dimensions added where needed. Always returns 3D s
 
 # Example
 ```julia
-# Field with location (Center, Center, Nothing) on 100×200×1 grid
+# Field with location (Center(), Center(), nothing) on 100×200×1 grid
 data_from_file = rand(100, 200)  # NetCDF squeezed out z-dimension
-location = (Center, Center, Nothing)
+location = (Center(), Center(), nothing)
 inflated = inflate_nothing_dimensions(data_from_file, location, grid)
 size(inflated)  # (100, 200, 1) - z-dimension restored
 ```

--- a/test/test_netcdf_writer.jl
+++ b/test/test_netcdf_writer.jl
@@ -3163,10 +3163,12 @@ function test_netcdf_reduced_field_time_series(arch)
                                            filename=fp, schedule=IterationInterval(1),
                                            array_type=Array{Float64}, overwrite_existing=true)
 
-    # Snapshot the reduced fields in memory on the same schedule as the writer so the
-    # round-trip can be compared value-for-value.
+    # Snapshot the reduced fields (and the save times) in memory on the same schedule as
+    # the writer so the round-trip can be compared value-for-value.
+    save_times = Float64[]
     snaps = (cx=Array{Float64,3}[], cxy=Array{Float64,3}[], cyz=Array{Float64,3}[])
     save = s -> begin
+        push!(save_times, s.model.clock.time)
         push!(snaps.cx,  Array(interior(compute!(cx))))
         push!(snaps.cxy, Array(interior(compute!(cxy))))
         push!(snaps.cyz, Array(interior(compute!(cyz))))
@@ -3181,7 +3183,8 @@ function test_netcdf_reduced_field_time_series(arch)
         fts = FieldTimeSeries(fp, name; architecture=arch)
         @test fts isa FieldTimeSeries
         @test location(fts) == ref_loc
-        @test length(fts.times) == length(ref)
+        @test fts.times ≈ save_times
+        @test size(fts) == (size(ref[1])..., length(ref))
         for k in 1:length(ref)
             rec = Array(interior(fts[k]))
             @test size(rec) == size(ref[k])

--- a/test/test_netcdf_writer.jl
+++ b/test/test_netcdf_writer.jl
@@ -3138,6 +3138,61 @@ function test_singleton_dimension_behavior(arch)
     return nothing
 end
 
+function test_netcdf_reduced_field_time_series(arch)
+    # Regression test for reading reduced (Nothing-location) fields back as a
+    # FieldTimeSeries from NetCDF. The on-disk variable is squeezed to fewer than 3
+    # spatial dimensions, and the reader must re-inflate those dimensions (via
+    # `inflate_nothing_dimensions`) before building the OffsetArray — otherwise
+    # `offset_data` is handed a lower-dimensional array than the grid expects.
+    Nx, Ny, Nz = 4, 5, 6
+    grid = RectilinearGrid(arch, size=(Nx, Ny, Nz), extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid; tracers=:c)
+    set!(model, c=(x, y, z) -> x + 2y + 3z)
+
+    cx  = Field(Average(model.tracers.c, dims=1))        # (Nothing, Center, Center) → 2D on disk
+    cxy = Field(Average(model.tracers.c, dims=(1, 2)))   # (Nothing, Nothing, Center) → 1D on disk
+    cyz = Field(Average(model.tracers.c, dims=(2, 3)))   # (Center, Nothing, Nothing) → 1D on disk
+
+    Nt = 3
+    sim = Simulation(model; Δt=1e-3, stop_iteration=Nt)
+
+    Arch = typeof(arch)
+    fp = "test_reduced_fts_$Arch.nc"
+    isfile(fp) && rm(fp)
+    sim.output_writers[:nc] = NetCDFWriter(model, (; cx, cxy, cyz);
+                                           filename=fp, schedule=IterationInterval(1),
+                                           array_type=Array{Float64}, overwrite_existing=true)
+
+    # Snapshot the reduced fields in memory on the same schedule as the writer so the
+    # round-trip can be compared value-for-value.
+    snaps = (cx=Array{Float64,3}[], cxy=Array{Float64,3}[], cyz=Array{Float64,3}[])
+    save = s -> begin
+        push!(snaps.cx,  Array(interior(compute!(cx))))
+        push!(snaps.cxy, Array(interior(compute!(cxy))))
+        push!(snaps.cyz, Array(interior(compute!(cyz))))
+    end
+    sim.callbacks[:save] = Callback(save, IterationInterval(1))
+
+    run!(sim)
+
+    for (name, ref_loc, ref) in (("cx",  (Nothing, Center, Center), snaps.cx),
+                                 ("cxy", (Nothing, Nothing, Center), snaps.cxy),
+                                 ("cyz", (Center, Nothing, Nothing), snaps.cyz))
+        fts = FieldTimeSeries(fp, name; architecture=arch)
+        @test fts isa FieldTimeSeries
+        @test location(fts) == ref_loc
+        @test length(fts.times) == length(ref)
+        for k in 1:length(ref)
+            rec = Array(interior(fts[k]))
+            @test size(rec) == size(ref[k])
+            @test rec ≈ ref[k]
+        end
+    end
+
+    rm(fp)
+    return nothing
+end
+
 function test_netcdf_dimension_type(arch)
     grid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1))
     model = NonhydrostaticModel(grid)
@@ -3793,6 +3848,11 @@ end
         @testset "Singleton dimension behavior [$A]" begin
             @info "  Testing singleton dimension behavior [$A]..."
             test_singleton_dimension_behavior(arch)
+        end
+
+        @testset "Reduced FieldTimeSeries round-trip [$A]" begin
+            @info "  Testing reduced FieldTimeSeries round-trip [$A]..."
+            test_netcdf_reduced_field_time_series(arch)
         end
 
         @testset "Field defvar and dimension validation [$A]" begin


### PR DESCRIPTION
## Summary

`FieldTimeSeries("file.nc", "var")` threw `ArgumentError: tuple length should be ≥ 0, got -1` when reading a NetCDF variable written from a dimensionally-reduced field (e.g. `Average(c, dims=1)`, location `(Nothing, Center, Center)`).

The reader re-inflates squeezed dimensions via `inflate_nothing_dimensions`, but that check used `loc == Nothing` while the caller passes *instantiated* locations (`nothing`), and `nothing == Nothing` is `false`. So no dimension was inflated and a lower-dimensional array reached `offset_data`, where `ntuple(Val(ndims - length(grid_size)))` went negative.

Fix: test for both the type and the instance — `loc === Nothing || loc === nothing`.

## Test

Adds a regression test reading reduced fields (averaged over x, (x,y), and (y,z)) back as a `FieldTimeSeries`, asserting location, times, sizes, and values round-trip. This path was previously uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)