### PR TITLE
Fix AIVA stage-zero restart handling

### DIFF
--- a/src/Advection/adaptive_implicit_vertical_advection.jl
+++ b/src/Advection/adaptive_implicit_vertical_advection.jl
@@ -97,6 +97,11 @@ end
 @inline function update_advection_timestep!(a::AdaptiveImplicitVerticalAdvection, timestepper::SplitRungeKuttaTimeStepper, clock)
     td      = TimeSteppers.time_discretization(a)
     stage   = clock.stage
+    if stage <= 0
+        td.Δt[] = clock.last_Δt / timestepper.β[1]
+        return nothing
+    end
+
     Δt      = clock.last_stage_Δt * timestepper.β[stage]
     nstage  = ifelse(stage < timestepper.Nstages, stage + 1, 1)
     td.Δt[] = Δt / timestepper.β[nstage]
@@ -110,6 +115,11 @@ end
 @inline function update_advection_timestep!(a::AdaptiveImplicitVerticalAdvection, timestepper::RungeKutta3TimeStepper, clock)
     td      = TimeSteppers.time_discretization(a)
     stage   = clock.stage
+    if stage <= 0
+        td.Δt[] = clock.last_Δt * timestepper.γ¹
+        return nothing
+    end
+
     nstage  = stage == 3 ? 1 : stage + 1
     Δt      = clock.last_stage_Δt / sum_rk3_coefficients(timestepper, Val(stage))
     td.Δt[] = Δt * sum_rk3_coefficients(timestepper, Val(nstage))

--- a/test/test_adaptive_implicit_vertical_advection.jl
+++ b/test/test_adaptive_implicit_vertical_advection.jl
@@ -7,6 +7,9 @@ using Oceananigans.TimeSteppers: AdaptiveVerticallyImplicitDiscretization,
                                  ExplicitTimeDiscretization,
                                  time_discretization,
                                  reset!
+using Oceananigans.OutputWriters: Checkpointer
+using Glob: glob
+import Oceananigans.Simulations: initialize!
 
 @testset "AdaptiveVerticallyImplicitDiscretization construction" begin
     td = AdaptiveVerticallyImplicitDiscretization(cfl=0.3)
@@ -112,23 +115,59 @@ end
     @test all(isfinite, parent(model.velocities.v))
 end
 
-@testset "AIVA can be re-run after reset!" begin
-    grid = RectilinearGrid(CPU(), size=(8, 8, 8), x=(0, 1), y=(0, 1), z=(0, 1),
-                           halo=(6, 6, 4), topology=(Periodic, Periodic, Bounded))
+const aiva_test_grid = RectilinearGrid(CPU(), size=(8, 8, 8), x=(0, 1), y=(0, 1), z=(0, 1),
+                                          halo=(6, 6, 4), topology=(Periodic, Periodic, Bounded))
 
+aiva_test_model(; timestepper=:SplitRungeKutta3) = begin
     momentum_advection = WENOVectorInvariant(; time_discretization=AdaptiveVerticallyImplicitDiscretization(cfl=0.5))
-    model = HydrostaticFreeSurfaceModel(grid; momentum_advection, tracer_advection=Centered(),
-                                        timestepper=:SplitRungeKutta3)
+    HydrostaticFreeSurfaceModel(aiva_test_grid; momentum_advection, tracer_advection=Centered(), timestepper)
+end
 
-    time_step!(model, 1e-3)
-    time_step!(model, 1e-3)
+@testset "AIVA handles stage-zero pre-step state" begin
+    for timestepper in (:SplitRungeKutta3, :RungeKutta3)
+        model = aiva_test_model(; timestepper)
 
-    reset!(model.clock)
-    @test model.clock.stage == 1
+        time_step!(model, 1e-3)
+        time_step!(model, 1e-3)
 
-    time_step!(model, 1e-3)
+        reset!(model.clock)
+        @test model.clock.stage == 0
 
-    @test model.clock.iteration == 1
-    @test all(isfinite, parent(model.velocities.u))
-    @test all(isfinite, parent(model.velocities.v))
+        @test_nowarn update_state!(model)
+        @test_nowarn time_step!(model, 1e-3)
+
+        @test model.clock.iteration == 1
+        @test all(isfinite, parent(model.velocities.u))
+        @test all(isfinite, parent(model.velocities.v))
+    end
+end
+
+@testset "AIVA initializes safely from checkpoint with stage zero" begin
+    for timestepper in (:SplitRungeKutta3, :RungeKutta3)
+        prefix = "aiva_stage_zero_$(timestepper)"
+
+        simulation = Simulation(aiva_test_model(; timestepper), Δt=1e-3, stop_iteration=2, verbose=false)
+        simulation.output_writers[:checkpointer] = Checkpointer(simulation.model;
+                                                                schedule=IterationInterval(2),
+                                                                prefix=prefix)
+        @test_nowarn run!(simulation)
+
+        pickup = Simulation(aiva_test_model(; timestepper), Δt=1e-3, stop_iteration=3, verbose=false)
+        pickup.output_writers[:checkpointer] = Checkpointer(pickup.model;
+                                                            schedule=IterationInterval(2),
+                                                            prefix=prefix)
+
+        @test_nowarn set!(pickup; checkpoint=:latest)
+        pickup.model.clock.stage = 0
+
+        @test pickup.model.clock.iteration == 2
+        @test pickup.model.clock.stage == 0
+        @test_nowarn initialize!(pickup)
+        @test_nowarn run!(pickup)
+        @test pickup.model.clock.iteration == 3
+        @test all(isfinite, parent(pickup.model.velocities.u))
+        @test all(isfinite, parent(pickup.model.velocities.v))
+
+        rm.(glob("$(prefix)_iteration*.jld2"), force=true)
+    end
 end


### PR DESCRIPTION
## Summary

This PR fixes adaptive implicit vertical advection (AIVA) when `clock.stage == 0` and adds regression coverage for the pre-step restart state.

## What changed

- guard AIVA timestep updates for `SplitRungeKuttaTimeStepper` when `clock.stage <= 0`
- guard AIVA timestep updates for `RungeKutta3TimeStepper` when `clock.stage <= 0`
- add regression tests for:
  - `reset!` / pre-step `stage == 0`
  - checkpoint restore followed by initialization from `stage == 0`

## Root cause

AIVA assumed the clock was already inside a timestep stage and indexed stage-specific coefficients directly. After `reset!`, and in restart-like pre-step states, Oceananigans represents the clock with `stage == 0`. That allowed AIVA to reach invalid coefficient lookups such as `β[0]`.

## Impact

Models using AIVA are now robust to true pre-step restart states instead of requiring `stage >= 1` before `update_state!` or initialization paths run.

## Validation

- added targeted regression coverage in `test/test_adaptive_implicit_vertical_advection.jl`
- local tests not run here