### PR TITLE
Update input_validation.jl

### DIFF
--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -156,7 +156,7 @@ end
 
 function validate_dimension_specification(T, ξ::ExponentialDiscretization, dir, N, FT)
     if !(length(ξ.faces)) == N+1
-        throw(ArgumentError("Coordinate $(summary(ξ) has length $(length(ξ.faces)) while direction $(dir) requires a coordinate of length $(N+1)"))
+        throw(ArgumentError("Coordinate $(summary(ξ)) has length $(length(ξ.faces)) while direction $(dir) requires a coordinate of length $(N+1)"))
     end
     return ξ
 end

--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -155,7 +155,7 @@ function validate_dimension_specification(T, ξ::Union{Function, CallableDiscret
 end
 
 function validate_dimension_specification(T, ξ::ExponentialDiscretization, dir, N, FT)
-    if !(length(ξ.faces)) == N+1
+    if !(length(ξ.faces) == N+1)
         throw(ArgumentError("Coordinate $(summary(ξ)) has length $(length(ξ.faces)) while direction $(dir) requires a coordinate of length $(N+1)"))
     end
     return ξ

--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -154,6 +154,13 @@ function validate_dimension_specification(T, ξ::Union{Function, CallableDiscret
     return ξ
 end
 
+function validate_dimension_specification(T, ξ::ExponentialDiscretization, dir, N, FT)
+    if !(length(ξ.faces)) == N+1
+        throw(ArgumentError("Coordinate $(summary(ξ) has length $(length(ξ.faces)) while direction $(dir) requires a coordinate of length $(N+1)"))
+    end
+    return ξ
+end
+
 function validate_dimension_specification(::Type{Flat}, ξ::AbstractVector, dir, N, FT)
     # Convert to CPU array if needed to avoid scalar indexing errors on GPU arrays
     ξ_cpu = ξ isa Array ? ξ : Array(ξ)

--- a/src/Grids/input_validation.jl
+++ b/src/Grids/input_validation.jl
@@ -156,7 +156,7 @@ end
 
 function validate_dimension_specification(T, ξ::ExponentialDiscretization, dir, N, FT)
     if !(length(ξ.faces) == N+1)
-        throw(ArgumentError("Coordinate $(summary(ξ)) has length $(length(ξ.faces)) while direction $(dir) requires a coordinate of length $(N+1)"))
+        throw(ArgumentError("Coordinate $(summary(ξ)) has length $(length(ξ.faces)-1) while direction $(dir) requires a coordinate of length $(N)"))
     end
     return ξ
 end


### PR DESCRIPTION
Adding in validation checks for ExponentialDiscretization types passed as grid dimensions. 

**Current behaviour**
```
using Oceananigans
using Oceananigans.Units

arch=CPU()

Nx, Ny, Nz = 24, 24, 16

Lx = 100kilometers
Ly = 100kilometers
depth=1000meters
z = ExponentialDiscretization(Nz, -depth, 0; scale = depth/4, mutable = true)

grid = RectilinearGrid(arch; size = (Nx, Ny, 1),
                       x = (0, Lx),
                       y = (-Ly/2, Ly/2),
                       z)
```
 Produces no error, despite Nz=1 being passed to RectilinearGrid, returning:

> 24×24×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×1 halo
> ├── Periodic x ∈ [0.0, 100000.0)     regularly spaced with Δx=4166.67
> ├── Periodic y ∈ [-50000.0, 50000.0) regularly spaced with Δy=4166.67
> └── Bounded  z ∈ [-1000.0, -774.674] variably and mutably spaced with min(Δr)=225.326, max(Δr)=225.326

**New Behaviour**
The same RecitlinearGrid call now returns
> ERROR: ArgumentError: Coordinate ExponentialDiscretization has length 16 while direction z requires a coordinate of length 1
