### PR TITLE
Restore checkpoints without reallocating device memory

### DIFF
--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -859,12 +859,17 @@ Grids.nodes(f::Field; kwargs...) = nodes(f.grid, instantiated_location(f)...; in
 ##### Checkpointing
 #####
 
+# Save a host copy of the underlying data (halos included) so that on restore we can
+# `copyto!` straight into the existing device array. Serializing the device array directly
+# makes JLD2 reconstruct a *new* device array on read, doubling GPU memory at pickup and
+# OOMing for large fields. `parent` keeps the same indexing as `restored`'s parent below.
 function prognostic_state(field::Field)
-    return (; data = prognostic_state(field.data))
+    return (; data = Array(parent(field)))
 end
 
 function restore_prognostic_state!(restored::Field, from)
-    restore_prognostic_state!(restored.data, from.data)
+    # `from.data` is a host array; copyto! into the existing device parent allocates nothing.
+    copyto!(parent(restored), from.data)
     return restored
 end
 

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -4,7 +4,7 @@ using Oceananigans.BoundaryConditions:  construct_boundary_conditions_kernels, N
 using Oceananigans.Grids: parent_index_range, default_indices, validate_indices,
     index_range_contains, halo_size, offset_data, interior_parent_indices
 using Oceananigans.Utils: @apply_regionally, getregion
-using Oceananigans.Architectures: convert_to_device
+using Oceananigans.Architectures: CPU, convert_to_device, on_architecture
 
 using LinearAlgebra: LinearAlgebra
 using KernelAbstractions: @kernel, @index
@@ -864,12 +864,12 @@ Grids.nodes(f::Field; kwargs...) = nodes(f.grid, instantiated_location(f)...; in
 # makes JLD2 reconstruct a *new* device array on read, doubling GPU memory at pickup and
 # OOMing for large fields. `parent` keeps the same indexing as `restored`'s parent below.
 function prognostic_state(field::Field)
-    return (; data = Array(parent(field)))
+    return (; data = on_architecture(CPU(), parent(field)))
 end
 
 function restore_prognostic_state!(restored::Field, from)
-    # `from.data` is a host array; copyto! into the existing device parent allocates nothing.
-    copyto!(parent(restored), from.data)
+    # `from.data` is a host-side copy of the parent data; restore region-by-region when needed.
+    @apply_regionally copyto!(parent(restored), from.data)
     return restored
 end
 

--- a/src/OutputWriters/jld2_writer.jl
+++ b/src/OutputWriters/jld2_writer.jl
@@ -219,7 +219,7 @@ function initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, mode
 
     # Extract grids from outputs, falling back to `nothing` for non-field outputs
     output_grids = Dict(string(name) => (try grid(output) catch; nothing end) for (name, output) in pairs(outputs))
-    unique_grids = Tuple(unique(objectid, filter(!isnothing, collect(values(output_grids)))))
+    unique_grids = unique(objectid, filter(!isnothing, collect(values(output_grids))))
     single_grid  = length(unique_grids) == 1
 
     # Serialize the unique grids. With a single grid it is stored at `serialized/grid`

--- a/test/test_multi_region_cubed_sphere.jl
+++ b/test/test_multi_region_cubed_sphere.jl
@@ -999,12 +999,12 @@ end
         @apply_regionally launch!(arch, grid, kernel_parameters, _interpolate_to_center_face!, grid, fηᶜᶠᵃ, η★, η)
         @apply_regionally launch!(arch, grid, kernel_parameters, _difference_center_face!, grid, δηᶜᶠᵃ, η★, η)
 
-        @test minimum(ηᶠᶜᵃ)  == -1 && maximum(abs, ηᶠᶜᵃ)  == 1
-        @test minimum(ηᶜᶠᵃ)  == -1 && maximum(abs, ηᶜᶠᵃ)  == 1
-        @test minimum(fηᶠᶜᵃ) == -1 && maximum(abs, fηᶠᶜᵃ) == 1
-        @test minimum(fηᶜᶠᵃ) == -1 && maximum(abs, fηᶜᶠᵃ) == 1
-        @test maximum(abs, δηᶠᶜᵃ) == 0
-        @test maximum(abs, δηᶜᶠᵃ) == 0
+        for field in (ηᶠᶜᵃ, ηᶜᶠᵃ, fηᶠᶜᵃ, fηᶜᶠᵃ)
+            @test minimum(field) == -1 && maximum(abs, field) == 1
+        end
+        for field in (δηᶠᶜᵃ, δηᶜᶠᵃ)
+            @test maximum(abs, field)== 0
+        end
     end
 end
 
@@ -1037,8 +1037,7 @@ end
 
                 momentum_advection = WENOVectorInvariant(FT; order=5)
                 tracer_advection   = WENO(FT; order=5)
-                free_surface       = SplitExplicitFreeSurface(grid;
-                                                              substeps=12)
+                free_surface       = SplitExplicitFreeSurface(grid; substeps=12)
                 coriolis           = HydrostaticSphericalCoriolis(FT)
                 tracers            = (:T, :S)
                 buoyancy           = SeawaterBuoyancy(equation_of_state = TEOS10EquationOfState())
@@ -1093,9 +1092,7 @@ end
                 S = simulation.model.tracers.S
                 b = buoyancy_field(simulation.model)
 
-                free_surface_no_halos = SplitExplicitFreeSurface(grid;
-                                                                 substeps=12,
-                                                                 extend_halos=false)
+                free_surface_no_halos = SplitExplicitFreeSurface(grid; substeps=12, extend_halos=false)
                 model_no_halos = HydrostaticFreeSurfaceModel(grid;
                                                              momentum_advection,
                                                              tracer_advection,

--- a/test/test_multi_region_cubed_sphere.jl
+++ b/test/test_multi_region_cubed_sphere.jl
@@ -1003,8 +1003,8 @@ end
         @test minimum(ηᶜᶠᵃ)  == -1 && maximum(abs, ηᶜᶠᵃ)  == 1
         @test minimum(fηᶠᶜᵃ) == -1 && maximum(abs, fηᶠᶜᵃ) == 1
         @test minimum(fηᶜᶠᵃ) == -1 && maximum(abs, fηᶜᶠᵃ) == 1
-        @test maximum(abs, δηᶠᶜᵃ) ==  0
-        @test maximum(abs, δηᶜᶠᵃ) ==  0
+        @test maximum(abs, δηᶠᶜᵃ) == 0
+        @test maximum(abs, δηᶜᶠᵃ) == 0
     end
 end
 


### PR DESCRIPTION
## Summary

`Checkpointer` restore (`run!(; pickup=true)`) reallocated GPU memory for every field, doubling device usage at pickup and OOMing large GPU models.

`prognostic_state(field::Field)` returned the field's **device-backed** array, so the checkpointer serialized a `CuArray`. JLD2 tags it as such and reconstructs a *fresh* `CuArray` per field on read — so restoring a model already resident on the GPU transiently needs ~2× the device memory. On a multi-GPU run this OOM'd while restoring ~24 GiB/GPU slabs.

## Fix

```julia
prognostic_state(field::Field)            = (; data = Array(parent(field)))   # host copy
restore_prognostic_state!(restored, from) = (copyto!(parent(restored), from.data); restored)
```

- Save a **host** copy of the field data (halos included). It serializes as a plain `Array`, so no `CuArray` is reconstructed on read.
- On restore, `copyto!` host → the **existing** device parent: no new device allocation.

## Testing

CPU round-trip verified end-to-end via the real pickup path (`load_checkpoint_state` + `restore_prognostic_state!`): clock and all prognostic fields match the reference exactly. A 1-GPU test at ~24 GiB/GPU (the footprint that previously OOM'd on restart) is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)