### PR TITLE
Add `nothing` defaults to distributed `LatitudeLongitudeGrid`

### DIFF
--- a/src/DistributedComputations/distributed_grids.jl
+++ b/src/DistributedComputations/distributed_grids.jl
@@ -127,9 +127,9 @@ function LatitudeLongitudeGrid(arch::Distributed,
                                FT::DataType = Oceananigans.defaults.FloatType;
                                precompute_metrics = true,
                                size,
-                               latitude,
-                               longitude,
-                               z,
+                               latitude = nothing,
+                               longitude = nothing,
+                               z = nothing,
                                topology = nothing,
                                radius = Oceananigans.defaults.planet_radius,
                                halo = nothing)


### PR DESCRIPTION
If now we build a distributed `LatitudeLongitudeGrid` with a z-flat direction, we are still forced to pass `z = nothing` because, contrarily to a serial grid, the distributed version requires passing all the coordinates as it does not have defaults.
This PR adds defaults to the constructor to match how we do the distributed `RectilinearGrid`