### PR TITLE
Fix typos and normalize text to US spelling

### DIFF
--- a/docs/src/models/boundary_conditions.md
+++ b/docs/src/models/boundary_conditions.md
@@ -366,7 +366,7 @@ When running on the GPU, `Q` must be converted to a `CuArray`.
 ### 10. Open boundary condition with matching scheme
 
 As discussed in [the numerical description of open boundary conditions](@ref numerical_bcs) it is often necessary to specify a matching scheme
-on open boundaries to approximate the behaviour of the boundary nodes given the interior state
+on open boundaries to approximate the behavior of the boundary nodes given the interior state
 and specified external conditions. For example if we want to specify an outflowing boundary
 with a mean velocity ``U=1`` and damp the exiting flow to this speed we can setup a
 [`PerturbationAdvection`](@ref) open boundary:

--- a/examples/internal_tide.jl
+++ b/examples/internal_tide.jl
@@ -78,7 +78,7 @@ fig
 # ```
 #
 # We prescribe the excursion parameter which, in turn, implies a tidal velocity ``U_{\mathrm{tidal}}``
-# which then allows us to determing the tidal forcing amplitude ``F_0``. For the last step, we
+# which then allows us to determine the tidal forcing amplitude ``F_0``. For the last step, we
 # use Fourier decomposition on the inviscid, linearized momentum equations to determine the
 # flow response for a given tidal forcing. Doing so we get that for the sinusoidal forcing above,
 # the tidal velocity and tidal forcing amplitudes are related via:

--- a/ext/OceananigansNCDatasetsExt/dimensions.jl
+++ b/ext/OceananigansNCDatasetsExt/dimensions.jl
@@ -112,7 +112,7 @@ function create_spatial_dimensions!(dataset, dims, attributes_dict; dimension_ty
     for (var_name, entry) in dims
         var_name == "" && continue # Skip empty names
 
-        # Normalise to (array, var_dims). A bare `AbstractArray` is interpreted as a 1D
+        # Normalize to (array, var_dims). A bare `AbstractArray` is interpreted as a 1D
         # coordinate variable; explicit `NamedTuple` entries are taken as-is.
         if entry isa NamedTuple
             arr = entry.array
@@ -296,7 +296,7 @@ end
 #     CF-aware tools (xarray, ncview, Panoply, CDO) pick up the right lat/lon pair.
 #
 
-# 2D analogue of `collect_dim`: take a 2D coordinate or metric array, optionally trim halos,
+# 2D analog of `collect_dim`: take a 2D coordinate or metric array, optionally trim halos,
 # and return a plain CPU `Array{T,2}`. Indices for OSSG are 2-tuples `(i_range, j_range)`.
 function collect_2d(arr, ℓx, ℓy, Tx, Ty, Nx, Ny, Hx, Hy, indices, with_halos)
     if with_halos

--- a/src/DistributedComputations/distributed_fft_tridiagonal_solver.jl
+++ b/src/DistributedComputations/distributed_fft_tridiagonal_solver.jl
@@ -26,7 +26,7 @@ struct DistributedFourierTridiagonalPoissonSolver{G, L, B, P, R, S, β}
     buffer :: β
 end
 
-# Usefull aliases for dispatch...
+# Useful aliases for dispatch...
 const XStretchedDistributedSolver = DistributedFourierTridiagonalPoissonSolver{<:Any, <:Any, <:XTridiagonalSolver}
 const YStretchedDistributedSolver = DistributedFourierTridiagonalPoissonSolver{<:Any, <:Any, <:YTridiagonalSolver}
 const ZStretchedDistributedSolver = DistributedFourierTridiagonalPoissonSolver{<:Any, <:Any, <:ZTridiagonalSolver}

--- a/src/DistributedComputations/halo_communication.jl
+++ b/src/DistributedComputations/halo_communication.jl
@@ -47,7 +47,7 @@ end
 # the MPI tag is an integer with:
 #   digit 1-2: an counter which keeps track of how many communications are live. The counter is stored in `arch.mpi_tag`
 #   digit 3-4: a unique identifier for the field's location that goes from 0 - 26 (see `loc_id`)
-#   digit 5: the side we send / recieve from
+#   digit 5: the side we send / receive from
 
 for side in sides
     side_str = string(side)

--- a/src/DistributedComputations/partition_assemble.jl
+++ b/src/DistributedComputations/partition_assemble.jl
@@ -182,7 +182,7 @@ end
 $(TYPEDSIGNATURES)
 
 Construct global array from local arrays (2D of size `(nx, ny)` or 3D of size (`nx, ny, nz`)).
-Usefull for boundary arrays, forcings and initial conditions.
+Useful for boundary arrays, forcings, and initial conditions.
 """
 construct_global_array(c_local::AbstractArray, arch, n) = c_local
 construct_global_array(c_local::Function, arch,  N)     = c_local

--- a/src/Models/LagrangianParticleTracking/drogued_dynamics.jl
+++ b/src/Models/LagrangianParticleTracking/drogued_dynamics.jl
@@ -2,9 +2,9 @@
     DroguedParticleDynamics(depths)
 
 `DroguedParticleDynamics` goes in the `dynamics` slot of `LagrangianParticles`
-and modifies their behaviour to mimic the behaviour of bouys which are
-drogued at `depths`. The particles remain at the their `z` position
-so the "measurment depth can be set", and then are advected in the `x` and `y`
+and modifies their behavior to mimic the behavior of buoys that are
+drogued at `depths`. The particles remain at their `z` position
+so the "measurement depth can be set", and then are advected in the `x` and `y`
 directions according to the velocity field at `depths`.
 
 `depths` should be an (abstract) array of length `length(particles)`.

--- a/src/OutputReaders/field_dataset.jl
+++ b/src/OutputReaders/field_dataset.jl
@@ -124,7 +124,7 @@ function FieldDataset(grid, times, fields::NTuple{N, Symbol};
 
     field_names = map(String, fields)
 
-    # Default behaviour
+    # Default behavior
     indices = merge(
         NamedTuple(field=>(:, :, :) for field in fields),
         indices

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -927,7 +927,7 @@ end
 ext(path) = splitext(path) |> last
 
 function FieldTimeSeries(path::String, args...; reader_kw = NamedTuple(), kwargs...)
-    # JLD2 is the default; don't append .jld2 to paths that already carry a recognised extension
+    # JLD2 is the default; don't append .jld2 to paths that already carry a recognized extension
     path = (endswith(path, ".nc") || endswith(path, ".zarr") || endswith(path, ".zip")) ?
            path : auto_extension(path, ".jld2")
     typed_path = if ext(path) == ".jld2"

--- a/validation/open_boundaries/targeted_flux_xy.jl
+++ b/validation/open_boundaries/targeted_flux_xy.jl
@@ -145,7 +145,7 @@ xu, yu = xnodes(u_ts), ynodes(u_ts)
 xv, yv = xnodes(v_ts), ynodes(v_ts)
 xζ, yζ = xnodes(ζ_ts), ynodes(ζ_ts)
 
-# Colour limits: maximum over all snapshots, saturated at 1.5 × U_in for u and v.
+# Color limits: maximum over all snapshots, saturated at 1.5 × U_in for u and v.
 clim_u = 1.5 * U_in
 clim_v = 1.5 * U_in
 clim_ζ = max(1e-6, maximum(

--- a/validation/open_boundaries/tracer_outflow.jl
+++ b/validation/open_boundaries/tracer_outflow.jl
@@ -98,7 +98,7 @@ end
 
 # Combined Hovmöller (x–t) of all three tracers in one figure with a shared colorbar, so
 # the panels are directly comparable across c̄. Boundary noise / pileup / wrong-branch
-# behavior shows up as vertical striations or sharp colour jumps near the domain edges —
+# behavior shows up as vertical striations or sharp color jumps near the domain edges —
 # easier to spot here than in single animation frames.
 function plot_tracer_outflow_hovmollers(filepath)
     @info "Plotting Hovmöllers from $filepath"


### PR DESCRIPTION
## What changed
This PR fixes a small set of typos in comments, docstrings, Markdown prose, and literated example text.

It also normalizes the edited text to US American spelling where applicable.

## Scope
This PR only changes human-facing text.

It does not change:
- variable names
- method names
- executable logic
- numerical behavior

## Validation
No tests were run for this PR because the changes are text-only.
