### PR TITLE
Add node and spacing inspection examples to grids tutorial

### DIFF
--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -99,7 +99,7 @@ grid = RectilinearGrid(architecture,
 The ``y``-dimension is "missing" because it's marked `Flat` in `topology = (Periodic, Flat, Bounded)`.
 So nothing varies in ``y``: `y`-derivatives are 0.
 Also, the keyword argument (or "kwarg" for short) that specifies the ``y``-domains may be omitted, and `size` has only two elements rather than 3 as in the first example.
-The stretched cell interfaces specified by `z_faces`. Because ``z`` is Bounded, the number of
+The stretched cell interfaces specified by `z_faces`. Because ``z`` is `Bounded`, the number of
 vertical cell interfaces required is `Nz + 1 = length(z_faces) = 5`, where `Nz = 4` is the number
 of cells in the vertical.
 

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -99,8 +99,8 @@ grid = RectilinearGrid(architecture,
 The ``y``-dimension is "missing" because it's marked `Flat` in `topology = (Periodic, Flat, Bounded)`.
 So nothing varies in ``y``: `y`-derivatives are 0.
 Also, the keyword argument (or "kwarg" for short) that specifies the ``y``-domains may be omitted, and `size` has only two elements rather than 3 as in the first example.
-In the stretched cell interfaces specified by `z_interfaces`, the number of
-vertical cell interfaces is `Nz + 1 = length(z_interfaces) = 5`, where `Nz = 4` is the number
+The stretched cell interfaces specified by `z_faces`. Because ``z`` is Bounded, the number of
+vertical cell interfaces required is `Nz + 1 = length(z_faces) = 5`, where `Nz = 4` is the number
 of cells in the vertical.
 
 The companion functions [`xspacings`](@ref), [`yspacings`](@ref), and [`zspacings`](@ref) return the cell widths in each direction and are most informative when the grid spacing varies.

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -108,7 +108,7 @@ To inspect the variable ``z`` spacings the grid above, we write:
 
 ```jldoctest grids_gpu
 Δz = zspacings(grid, Center(), Center(), Center())
-[Δz[1, 1, k] for k in 1:grid.Nz]
+[CUDA.@allowscalar Δz[1, 1, k] for k in 1:grid.Nz]
 
 # output
 4-element Vector{Float64}:
@@ -118,7 +118,9 @@ To inspect the variable ``z`` spacings the grid above, we write:
  4.0
 ```
 
-The ``z``-spacings increase from 1.0 to 4.0, matching the growing gaps between successive entries in `z_faces`.
+The `CUDA.@allowscalar` above is needed because scalar indexing is by default not allowed for arrays that live on the GPU.
+(For more discussion on scalar indexing on GPUs see the [Simulation tips](@ref simulation_tips) section.)
+The ``z``-spacings increase from `1.0` to `4.0`, matching the growing gaps between successive entries in `z_faces`.
 
 A bit later in this tutorial, we'll give examples that illustrate how to build a grid that's [`Distributed`](@ref) across _multiple_ CPUs and GPUs.
 

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -166,6 +166,9 @@ The main difference between the syntax for `LatitudeLongitudeGrid` versus that f
 
     To type `λ` or `φ` at the REPL, write either `\lambda` (for `λ`) or `\varphi` (for `φ`) and then press `<TAB>`.
 
+!!! note "Inspecting grids with geographical coordinates"
+    We can inspect grids with geographical coordinates `(λ, φ, z)` using  [`λnodes`](@ref), [`φnodes`](@ref) and also [`λspacings`](@ref) and [`φspacings`](@ref).
+
 If `topology` is not provided for `LatitudeLongitudeGrid`, then Oceananigans tries infer it: if the `longitude` spans 360 degrees,
 the default `x`-topology is `Periodic`; if `longitude` spans less than 360 degrees `x`-topology is `Bounded`.
 

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -104,16 +104,11 @@ vertical cell interfaces is `Nz + 1 = length(z_interfaces) = 5`, where `Nz = 4` 
 of cells in the vertical.
 
 The companion functions [`xspacings`](@ref), [`yspacings`](@ref), and [`zspacings`](@ref) return the cell widths in each direction and are most informative when the grid spacing varies.
-To inspect the variable ``z`` spacings for a CPU version of the grid above, we write:
+To inspect the variable ``z`` spacings the grid above, we write:
 
-```jldoctest grids
-z_faces = [0, 1, 3, 6, 10]
-irregular_grid = RectilinearGrid(topology = (Periodic, Flat, Bounded),
-                                 size = (10, 4),
-                                 x = (0, 20),
-                                 z = z_faces)
-Δz = zspacings(irregular_grid, Center(), Center(), Center())
-[Δz[1, 1, k] for k in 1:irregular_grid.Nz]
+```jldoctest grids_gpu
+Δz = zspacings(grid, Center(), Center(), Center())
+[Δz[1, 1, k] for k in 1:grid.Nz]
 
 # output
 4-element Vector{Float64}:
@@ -123,7 +118,7 @@ irregular_grid = RectilinearGrid(topology = (Periodic, Flat, Bounded),
  4.0
 ```
 
-The spacings increase from `1.0` to `4.0`, matching the growing gaps between successive entries in `z_faces`.
+The ``z``-spacings increase from 1.0 to 4.0, matching the growing gaps between successive entries in `z_faces`.
 
 A bit later in this tutorial, we'll give examples that illustrate how to build a grid that's [`Distributed`](@ref) across _multiple_ CPUs and GPUs.
 

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -44,6 +44,33 @@ This simple grid
 * Has cells that are all the same size, dividing the box in 512 that each has dimension ``4 \times 4 \times 2``.
   Note that length units are whatever is used to construct the grid, so it's up to the user to make sure that all inputs use consistent units.
 
+We can inspect the grid using [`xnodes`](@ref), [`ynodes`](@ref), and [`znodes`](@ref) to retrieve node positions.
+The `Center()` or `Face()` argument specifies whether to return positions at cell centers or faces.
+For the `Bounded` ``z`` direction, `znodes` returns ``N_z = 4`` center nodes and ``N_z + 1 = 5`` face nodes, since both boundary faces are included:
+
+```jldoctest grids
+znodes(grid, Center())
+
+# output
+1.0:2.0:7.0
+```
+
+```jldoctest grids
+znodes(grid, Face())
+
+# output
+0.0:2.0:8.0
+```
+
+For the `Periodic` ``x`` direction, the face at ``x = 64`` is identified with the face at ``x = 0`` and therefore not repeated, so there are only ``N_x = 16`` face nodes (not ``N_x + 1 = 17``):
+
+```jldoctest grids
+xnodes(grid, Face())
+
+# output
+0.0:4.0:60.0
+```
+
 In building our first grid, we did not specify whether it should be constructed on the [`CPU`](@ref) or [`GPU`](@ref).
 As a result, the grid was constructed by default on the CPU.
 Next we build a grid on the _GPU_ that's two-dimensional in ``x, z`` and has variably-spaced cell interfaces in the `z`-direction,
@@ -75,6 +102,28 @@ Also, the keyword argument (or "kwarg" for short) that specifies the ``y``-domai
 In the stretched cell interfaces specified by `z_interfaces`, the number of
 vertical cell interfaces is `Nz + 1 = length(z_interfaces) = 5`, where `Nz = 4` is the number
 of cells in the vertical.
+
+The companion functions [`xspacings`](@ref), [`yspacings`](@ref), and [`zspacings`](@ref) return the cell widths in each direction and are most informative when the grid spacing varies.
+To inspect the variable ``z`` spacings for a CPU version of the grid above, we write:
+
+```jldoctest grids
+z_faces = [0, 1, 3, 6, 10]
+irregular_grid = RectilinearGrid(topology = (Periodic, Flat, Bounded),
+                                 size = (10, 4),
+                                 x = (0, 20),
+                                 z = z_faces)
+Δz = zspacings(irregular_grid, Center(), Center(), Center())
+[Δz[1, 1, k] for k in 1:irregular_grid.Nz]
+
+# output
+4-element Vector{Float64}:
+ 1.0
+ 2.0
+ 3.0
+ 4.0
+```
+
+The spacings increase from `1.0` to `4.0`, matching the growing gaps between successive entries in `z_faces`.
 
 A bit later in this tutorial, we'll give examples that illustrate how to build a grid that's [`Distributed`](@ref) across _multiple_ CPUs and GPUs.
 

--- a/src/AbstractOperations/grid_metrics.jl
+++ b/src/AbstractOperations/grid_metrics.jl
@@ -95,162 +95,41 @@ end
 ##### Spacings
 #####
 
-"""
-$(TYPEDSIGNATURES)
+# Docstrings for xspacings, yspacings, λspacings, φspacings live in
+# src/Grids/nodes_and_spacings.jl and for zspacings, rspacings in
+# src/Grids/vertical_discretization.jl so that @autodocs picks them up
+# from the Oceananigans.Grids module where these functions are exported.
 
-Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
-in the ``x`` direction at location `ℓx, ℓy, ℓz`.
-
-Examples
-========
-```jldoctest
-julia> using Oceananigans
-
-julia> grid = RectilinearGrid(size=(2, 4, 8), extent=(1, 1, 1));
-
-julia> xspacings(grid, Center(), Center(), Center())
-KernelFunctionOperation at (Center, Center, Center)
-├── grid: 2×4×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
-├── kernel_function: Δx (generic function with 20 methods)
-└── arguments: ("Center", "Center", "Center")
-```
-"""
 function xspacings(grid, ℓx, ℓy, ℓz)
     LX, LY, LZ = map(typeof, (ℓx, ℓy, ℓz))
     Δx_op = KernelFunctionOperation{LX, LY, LZ}(Δx, grid, ℓx, ℓy, ℓz)
     return Δx_op
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
-in the ``y`` direction at location `ℓx, ℓy, ℓz`.
-
-Examples
-========
-```jldoctest
-julia> using Oceananigans
-
-julia> grid = RectilinearGrid(size=(2, 4, 8), extent=(1, 1, 1));
-
-julia> yspacings(grid, Center(), Face(), Center())
-KernelFunctionOperation at (Center, Face, Center)
-├── grid: 2×4×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
-├── kernel_function: Δy (generic function with 20 methods)
-└── arguments: ("Center", "Face", "Center")
-```
-"""
 function yspacings(grid, ℓx, ℓy, ℓz)
     LX, LY, LZ = map(typeof, (ℓx, ℓy, ℓz))
     Δy_op = KernelFunctionOperation{LX, LY, LZ}(Δy, grid, ℓx, ℓy, ℓz)
     return Δy_op
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
-in the ``z`` direction at location `ℓx, ℓy, ℓz`.
-
-Examples
-========
-```jldoctest
-julia> using Oceananigans
-
-julia> grid = RectilinearGrid(size=(2, 4, 8), extent=(1, 1, 1));
-
-julia> zspacings(grid, Center(), Center(), Face())
-KernelFunctionOperation at (Center, Center, Face)
-├── grid: 2×4×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
-├── kernel_function: Δz (generic function with 19 methods)
-└── arguments: ("Center", "Center", "Face")
-```
-"""
 function zspacings(grid, ℓx, ℓy, ℓz)
     LX, LY, LZ = map(typeof, (ℓx, ℓy, ℓz))
     Δz_op = KernelFunctionOperation{LX, LY, LZ}(Δz, grid, ℓx, ℓy, ℓz)
     return Δz_op
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
-in the ``r`` direction at location `ℓx, ℓy, ℓz`.
-
-Examples
-========
-```jldoctest
-julia> using Oceananigans
-
-julia> grid = RectilinearGrid(size=(2, 4, 8), extent=(1, 1, 1));
-
-julia> rspacings(grid, Center(), Center(), Face())
-KernelFunctionOperation at (Center, Center, Face)
-├── grid: 2×4×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
-├── kernel_function: Δr (generic function with 19 methods)
-└── arguments: ("Center", "Center", "Face")
-```
-"""
 function rspacings(grid, ℓx, ℓy, ℓz)
     LX, LY, LZ = map(typeof, (ℓx, ℓy, ℓz))
     Δr_op = KernelFunctionOperation{LX, LY, LZ}(Δr, grid, ℓx, ℓy, ℓz)
     return Δr_op
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
-in the ``λ`` direction at location `ℓx, ℓy, ℓz`.
-
-Examples
-========
-```jldoctest
-julia> using Oceananigans
-
-julia> grid = LatitudeLongitudeGrid(size=(36, 34, 25),
-                                    longitude = (-180, 180),
-                                    latitude = (-85, 85),
-                                    z = (-1000, 0));
-
-julia> λspacings(grid, Center(), Face(), Center())
-KernelFunctionOperation at (Center, Face, Center)
-├── grid: 36×34×25 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: Δλ (generic function with 20 methods)
-└── arguments: ("Center", "Face", "Center")
-```
-"""
 function λspacings(grid, ℓx, ℓy, ℓz)
     LX, LY, LZ = map(typeof, (ℓx, ℓy, ℓz))
     Δλ_op = KernelFunctionOperation{LX, LY, LZ}(Δλ, grid, ℓx, ℓy, ℓz)
     return Δλ_op
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
-in the ``φ`` direction at location `ℓx, ℓy, ℓz`.
-
-Examples
-========
-```jldoctest
-julia> using Oceananigans
-
-julia> grid = LatitudeLongitudeGrid(size=(36, 34, 25),
-                                    longitude = (-180, 180),
-                                    latitude = (-85, 85),
-                                    z = (-1000, 0));
-
-julia> φspacings(grid, Center(), Face(), Center())
-KernelFunctionOperation at (Center, Face, Center)
-├── grid: 36×34×25 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: Δφ (generic function with 20 methods)
-└── arguments: ("Center", "Face", "Center")
-```
-"""
 function φspacings(grid, ℓx, ℓy, ℓz)
     LX, LY, LZ = map(typeof, (ℓx, ℓy, ℓz))
     Δφ_op = KernelFunctionOperation{LX, LY, LZ}(Δφ, grid, ℓx, ℓy, ℓz)

--- a/src/Grids/nodes_and_spacings.jl
+++ b/src/Grids/nodes_and_spacings.jl
@@ -130,11 +130,98 @@ nodes(grid::AbstractGrid, (ℓx, ℓy, ℓz); reshape=false, with_halos=false) =
 ##### << Spacings >>
 #####
 
-# placeholders
-# see Oceananigans/AbstractOperations/grid_metrics.jl for definitions
+"""
+    xspacings(grid, ℓx, ℓy, ℓz)
+
+Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
+in the ``x`` direction at location `ℓx, ℓy, ℓz`.
+
+Examples
+========
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = RectilinearGrid(size=(2, 4, 8), extent=(1, 1, 1));
+
+julia> xspacings(grid, Center(), Center(), Center())
+KernelFunctionOperation at (Center, Center, Center)
+├── grid: 2×4×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
+├── kernel_function: Δx (generic function with 20 methods)
+└── arguments: ("Center", "Center", "Center")
+```
+"""
 function xspacings end
+
+"""
+    yspacings(grid, ℓx, ℓy, ℓz)
+
+Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
+in the ``y`` direction at location `ℓx, ℓy, ℓz`.
+
+Examples
+========
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = RectilinearGrid(size=(2, 4, 8), extent=(1, 1, 1));
+
+julia> yspacings(grid, Center(), Face(), Center())
+KernelFunctionOperation at (Center, Face, Center)
+├── grid: 2×4×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
+├── kernel_function: Δy (generic function with 20 methods)
+└── arguments: ("Center", "Face", "Center")
+```
+"""
 function yspacings end
+
+"""
+    λspacings(grid, ℓx, ℓy, ℓz)
+
+Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
+in the ``λ`` direction at location `ℓx, ℓy, ℓz`.
+
+Examples
+========
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = LatitudeLongitudeGrid(size=(36, 34, 25),
+                                    longitude = (-180, 180),
+                                    latitude = (-85, 85),
+                                    z = (-1000, 0));
+
+julia> λspacings(grid, Center(), Face(), Center())
+KernelFunctionOperation at (Center, Face, Center)
+├── grid: 36×34×25 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
+├── kernel_function: Δλ (generic function with 20 methods)
+└── arguments: ("Center", "Face", "Center")
+```
+"""
 function λspacings end
+
+"""
+    φspacings(grid, ℓx, ℓy, ℓz)
+
+Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
+in the ``φ`` direction at location `ℓx, ℓy, ℓz`.
+
+Examples
+========
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = LatitudeLongitudeGrid(size=(36, 34, 25),
+                                    longitude = (-180, 180),
+                                    latitude = (-85, 85),
+                                    z = (-1000, 0));
+
+julia> φspacings(grid, Center(), Face(), Center())
+KernelFunctionOperation at (Center, Face, Center)
+├── grid: 36×34×25 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
+├── kernel_function: Δφ (generic function with 20 methods)
+└── arguments: ("Center", "Face", "Center")
+```
+"""
 function φspacings end
 
 destantiate(::Face)   = Face

--- a/src/Grids/vertical_discretization.jl
+++ b/src/Grids/vertical_discretization.jl
@@ -305,6 +305,8 @@ KernelFunctionOperation at (Center, Center, Face)
 """
 function rspacings end
 
+# The 3-argument implementations of zspacings and rspacings are defined in
+# src/AbstractOperations/grid_metrics.jl, where KernelFunctionOperation is available.
 @inline rspacings(grid, ℓz) = rspacings(grid, nothing, nothing, ℓz)
 @inline zspacings(grid, ℓz) = zspacings(grid, nothing, nothing, ℓz)
 

--- a/src/Grids/vertical_discretization.jl
+++ b/src/Grids/vertical_discretization.jl
@@ -261,8 +261,49 @@ julia> z = znodes(horz_periodic_grid, Center(), Center(), Center(), with_halos=t
 @inline znodes(grid::AUG, ℓz; kwargs...) = rnodes(grid, ℓz; kwargs...)
 @inline znodes(grid::AUG, ℓx, ℓy, ℓz; kwargs...) = rnodes(grid, ℓx, ℓy, ℓz; kwargs...)
 
-function rspacings end
+"""
+    zspacings(grid, ℓx, ℓy, ℓz)
+
+Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
+in the ``z`` direction at location `ℓx, ℓy, ℓz`.
+
+Examples
+========
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = RectilinearGrid(size=(2, 4, 8), extent=(1, 1, 1));
+
+julia> zspacings(grid, Center(), Center(), Face())
+KernelFunctionOperation at (Center, Center, Face)
+├── grid: 2×4×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
+├── kernel_function: Δz (generic function with 19 methods)
+└── arguments: ("Center", "Center", "Face")
+```
+"""
 function zspacings end
+
+"""
+    rspacings(grid, ℓx, ℓy, ℓz)
+
+Return a `KernelFunctionOperation` that computes the grid spacings for `grid`
+in the ``r`` direction at location `ℓx, ℓy, ℓz`.
+
+Examples
+========
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = RectilinearGrid(size=(2, 4, 8), extent=(1, 1, 1));
+
+julia> rspacings(grid, Center(), Center(), Face())
+KernelFunctionOperation at (Center, Center, Face)
+├── grid: 2×4×8 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 2×3×3 halo
+├── kernel_function: Δr (generic function with 19 methods)
+└── arguments: ("Center", "Center", "Face")
+```
+"""
+function rspacings end
 
 @inline rspacings(grid, ℓz) = rspacings(grid, nothing, nothing, ℓz)
 @inline zspacings(grid, ℓz) = zspacings(grid, nothing, nothing, ℓz)


### PR DESCRIPTION
## Summary

- After the first grid's description, adds three `jldoctest grids` blocks demonstrating `xnodes`/`znodes` with both `Center()` and `Face()` locations, highlighting the key difference between `Periodic` (N face nodes) and `Bounded` (N+1 face nodes) directions.
- After the GPU grid's description, adds a `jldoctest grids` block that creates a CPU equivalent of the irregular-z grid and uses `zspacings` to show the varying cell widths `[1.0, 2.0, 3.0, 4.0]`.

## Test plan

- [x] Verify `jldoctest grids` blocks pass (`julia --project=docs/ docs/make.jl`)
- [x] Check rendered tutorial reads naturally end-to-end

Docs preview at https://clima.github.io/OceananigansDocumentation/previews/PR5699/grids

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Suggested by @Thefrollickingnerd; thanks heaps! 🙏🏼