### PR TITLE
Fix broken cross-references in docs overview pages

### DIFF
--- a/docs/src/models/models_overview.md
+++ b/docs/src/models/models_overview.md
@@ -17,7 +17,7 @@ The [NonhydrostaticModel](@ref) integrates the Boussinesq equations _without_ ma
 and therefore possessing a prognostic vertical momentum equation. The NonhydrostaticModel is useful for simulations
 that resolve three-dimensional turbulence, such as large eddy simulations on [RectilinearGrid](@ref) with grid
 spacings of O(1 m), as well as direct numerical simulation. The NonhydrostaticModel may also be used for
-idealized classroom problems, as in the [two-dimensional turbulence example](@ref "Two dimensional turbulence example").
+idealized classroom problems, as in the [two-dimensional turbulence example](@ref two_dimensional_turbulence).
 
 The [HydrostaticFreeSurfaceModel](@ref) integrates the hydrostatic or "primitive" Boussinesq equations
 with a free surface on its top boundary. The hydrostatic approximation allows the HydrostaticFreeSurfaceModel

--- a/docs/src/simulations/simulations_overview.md
+++ b/docs/src/simulations/simulations_overview.md
@@ -264,4 +264,4 @@ simulation.output_writers[:snapshots] = JLD2Writer(simulation.model, simulation.
 run!(simulation)
 ```
 
-For more recipes continue with the page on [schedules](@ref schedules).
+For more recipes continue with the page on [schedules](@ref callback_schedules).


### PR DESCRIPTION
## Summary

- Fixes `@ref "Two dimensional turbulence example"` → `@ref two_dimensional_turbulence` in `models_overview.md` (broken since #4843)
- Fixes `@ref schedules` → `@ref callback_schedules` in `simulations_overview.md` (broken since #4834)

Both references were already using the correct anchor elsewhere in the docs (e.g. `quick_start.md`), so this is a straightforward alignment fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)