### PR TITLE
Add `EquatorialLatitudeLongitudeGrid`

### DIFF
--- a/PR_info.md
+++ b/PR_info.md
@@ -1,0 +1,242 @@
+# EquatorialLatitudeLongitudeGrid (Work in Progress)
+
+## Motivation
+
+The standard `LatitudeLongitudeGrid` contains coordinate singularities at the
+geographic North and South poles.
+
+While these singularities are acceptable for many applications, they complicate
+regional simulations in the Arctic Ocean because grid metrics become highly
+anisotropic near the pole.
+
+The goal of `EquatorialLatitudeLongitudeGrid` is to relocate the coordinate
+singularity away from the polar regions while preserving an orthogonal spherical
+coordinate system and maintaining compatibility with Oceananigans'
+finite-volume operators.
+
+This work is currently focused on geometry construction and tracer-advection
+validation.
+
+## Current Status
+
+### Completed
+
+- [x] Construct `EquatorialLatitudeLongitudeGrid`
+- [x] Verify grid metrics and geometry
+- [x] Validate passive tracer initialization
+- [x] Validate uniform x-advection
+- [x] Validate uniform y-advection
+- [x] Validate combined x-y advection
+- [x] Perform resolution studies (64², 128², 256²)
+- [x] Compare tracer centroid trajectories
+- [x] Compare normalized displacements
+
+## Coordinate Transformations
+
+### LatitudeLongitudeGrid
+
+Let
+
+- $\lambda$ denote longitude,
+- $\phi$ denote latitude,
+- $R$ denote the planetary radius.
+
+The mapping from spherical coordinates to Cartesian coordinates is
+
+$$
+x = R \cos\phi \cos\lambda,
+$$
+
+$$
+y = R \cos\phi \sin\lambda,
+$$
+
+$$
+z = R \sin\phi.
+$$
+
+The resulting metric is
+
+$$
+ds^2
+=
+R^2 \cos^2 \phi \, d\lambda^2
++
+R^2 d\phi^2.
+$$
+
+The corresponding physical velocity components are
+
+$$
+u = R \cos\phi \frac{d\lambda}{dt},
+$$
+
+$$
+v = R \frac{d\phi}{dt}.
+$$
+
+For constant angular motion,
+
+$$
+\frac{d\lambda}{dt}
+=
+\Omega,
+$$
+
+the zonal velocity must therefore satisfy
+
+$$
+u = R \cos\phi \, \Omega.
+$$
+
+This metric correction was used in the validation experiments described below.
+
+### EquatorialLatitudeLongitudeGrid
+
+The EquatorialLatitudeLongitudeGrid is obtained by rotating the pole of the
+latitude-longitude coordinate system onto the geographic equator.
+
+The coordinate transformation is
+
+$$
+x = R \sin\phi_e,
+$$
+
+$$
+y = R \cos\phi_e \cos\lambda_e,
+$$
+
+$$
+z = R \cos\phi_e \sin\lambda_e.
+$$
+
+The resulting metric is
+
+$$
+ds^2
+=
+R^2 d\phi_e^2
++
+R^2 \cos^2\phi_e\, d\lambda_e^2.
+$$
+
+The corresponding physical velocity components satisfy
+
+$$
+u_e = R \frac{d\phi_e}{dt},
+$$
+
+$$
+v_e = R \cos\phi_e \frac{d\lambda_e}{dt}.
+$$
+
+### Key Findings
+
+- ELLC reproduces tracer transport in both coordinate directions.
+- Normalized tracer displacement is independent of grid resolution.
+- ELLC exhibits minimal tracer deformation in the current test suite.
+- ELLC permits nearly uniform transport using spatially constant velocities.
+- The current LLC comparison requires a latitude-dependent zonal velocity correction,
+  u = U₀ cos(φ), to achieve uniform angular transport.
+
+## Validation
+
+Validation currently focuses on passive tracer transport.
+
+A Gaussian tracer was initialized at the center of the computational domain and
+advected using prescribed background velocities.
+
+Three configurations were examined:
+
+### Uniform x-advection
+
+A velocity field corresponding to uniform angular transport in the x-direction.
+
+Result:
+- matching centroid trajectories;
+- matching normalized displacement;
+- comparable tracer evolution.
+
+### Uniform y-advection
+
+A velocity field corresponding to transport in the y-direction.
+
+Result:
+- comparable centroid trajectories;
+- empirical ELLC velocity scaling currently required.
+
+### Combined x-y advection
+
+Simultaneous transport in both coordinate directions.
+
+Result:
+- matching x-displacement;
+- similar y-displacement;
+- successful proof-of-concept demonstration of transport on ELLC.
+
+### Key Findings
+
+- ELLC reproduces tracer transport in both coordinate directions.
+- Normalized tracer displacement is independent of grid resolution.
+- ELLC exhibits minimal tracer deformation in the current test suite.
+- ELLC permits nearly uniform transport using spatially constant velocities.
+- The current LLC comparison requires a latitude-dependent zonal velocity correction,
+  u = U₀ cos(φ), to achieve uniform angular transport.
+
+## Resolution Study
+
+The following resolution study demonstrates that the tracer trajectories
+and normalized displacement are essentially independent of grid resolution.
+
+### Peak tracer magnitude
+
+| Grid | N | Peak |
+|------|---:|------:|
+| LLC  | 64  | 1.164 |
+| LLC  | 128 | 1.168 |
+| LLC  | 256 | 1.169 |
+| ELLC | 64  | 0.997 |
+| ELLC | 128 | 1.000 |
+| ELLC | 256 | 1.000 |
+
+### Normalized displacement
+
+### Normalized displacement
+
+| Grid | N | Δi/N | Δj/N |
+|------|---:|------:|------:|
+| LLC  | 64  | 0.1295 | 0.1307 |
+| LLC  | 128 | 0.1295 | 0.1307 |
+| LLC  | 256 | 0.1295 | 0.1307 |
+| ELLC | 64  | 0.1295 | 0.1228 |
+| ELLC | 128 | 0.1295 | 0.1228 |
+| ELLC | 256 | 0.1295 | 0.1228 |
+
+## Future Work
+
+### Geometry
+
+- [ ] Verify ELLC coordinate transformation against implementation
+- [ ] Derive inverse transformation
+
+### Physics
+
+- [ ] Coriolis operator
+- [ ] Momentum equations
+- [ ] Pressure-gradient terms
+- [ ] Geostrophic balance tests
+- [ ] Barotropic test cases
+
+### Validation
+
+- [ ] GPU validation
+- [ ] Solid-body rotation
+- [ ] Passive tracer vortex tests
+- [ ] Long-time integrations
+- [ ] Convergence studies
+
+### Applications
+
+- [ ] Arctic regional domains
+- [ ] Polar cap simulations
+- [ ] Comparison with LatitudeLongitudeGrid

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -27,6 +27,8 @@ export column_depthᶜᶜᵃ, column_depthᶠᶜᵃ, column_depthᶜᶠᵃ, colu
 export offset_data, new_data
 export on_architecture
 
+export EquatorialLatitudeLongitudeGrid
+
 using Adapt: Adapt, adapt
 using DocStringExtensions: FIELDS, TYPEDSIGNATURES
 using GPUArraysCore: @allowscalar
@@ -187,5 +189,6 @@ include("rectilinear_grid.jl")
 include("orthogonal_spherical_shell_grid.jl")
 include("latitude_longitude_grid.jl")
 include("coordinate_transformations.jl")
+include("equatorial_latitude_longitude_grid.jl")
 
 end # module

--- a/src/Grids/equatorial_latitude_longitude_grid.jl
+++ b/src/Grids/equatorial_latitude_longitude_grid.jl
@@ -253,40 +253,41 @@ EquatorialLatitudeLongitudeGrid(FT::DataType; kwargs...) = EquatorialLatitudeLon
 
 """ Return a reproduction of `grid` with precomputed metric terms. """
 function with_precomputed_metrics(grid::EquatorialLatitudeLongitudeGrid)
-        Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ = allocate_metrics(grid)
 
-    # Compute Δx spacings and Az areas
-    arch = grid.architecture
-    dev = Architectures.device(arch)
-    workgroup, worksize  = metric_workgroup(grid), metric_worksize(grid)
-    loop! = compute_Δx_Az!(dev, workgroup, worksize)
-    loop!(grid, Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ)
+    Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
+    Δyᶠᶜᵃ, Δyᶜᶠᵃ,
+    Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ = allocate_metrics(grid)
 
-    # Compute Δy spacings if needed
-    # force Δy computation for this grid
-    loop! = compute_Δy!(dev, (16,16), (length(grid.λᶜᵃᵃ), length(grid.φᵃᶜᵃ) - 1))
-    loop!(grid, Δyᶠᶜᵃ, Δyᶜᶠᵃ)
-    #if !(grid isa YRegularLLG)
-    #    loop! = compute_Δy!(dev, 16, length(grid.Δφᵃᶜᵃ) - 1)
-    #    loop!(grid, Δyᶠᶜᵃ, Δyᶜᶠᵃ)
-    #end
+    arch = architecture(grid)
+    dev  = Architectures.device(arch)
+
+    # Δx and Az
+    workgroup, worksize = metric_workgroup(grid), metric_worksize(grid)
+    compute_Δx_Az!(dev, workgroup, worksize)(
+        grid, Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
+              Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ
+    )
+
+    # Δy (always 2D for this grid)
+    compute_Δy!(dev, (16, 16), (length(grid.λᶜᵃᵃ), length(grid.φᵃᶜᵃ) - 1))(grid, Δyᶠᶜᵃ, Δyᶜᶠᵃ)
 
     Nλ, Nφ, Nz = size(grid)
     Hλ, Hφ, Hz = halo_size(grid)
     TX, TY, TZ = topology(grid)
 
-    println("Δx size:", size(Δxᶠᶜᵃ))
-    println("worksize:", metric_worksize(grid))
-
-    return EquatorialLatitudeLongitudeGrid{TX, TY, TZ}(architecture(grid),
-                                             Nλ, Nφ, Nz,
-                                             Hλ, Hφ, Hz,
-                                             grid.Lx, grid.Ly, grid.Lz,
-                                             grid.Δλᶠᵃᵃ, grid.Δλᶜᵃᵃ, grid.λᶠᵃᵃ, grid.λᶜᵃᵃ,
-                                             grid.Δφᵃᶠᵃ, grid.Δφᵃᶜᵃ, grid.φᵃᶠᵃ, grid.φᵃᶜᵃ,
-                                             grid.z,
-                                             Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ,
-                                             Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, grid.radius)
+    return EquatorialLatitudeLongitudeGrid{TX, TY, TZ}(
+        arch,
+        Nλ, Nφ, Nz,
+        Hλ, Hφ, Hz,
+        grid.Lx, grid.Ly, grid.Lz,
+        grid.Δλᶠᵃᵃ, grid.Δλᶜᵃᵃ, grid.λᶠᵃᵃ, grid.λᶜᵃᵃ,
+        grid.Δφᵃᶠᵃ, grid.Δφᵃᶜᵃ, grid.φᵃᶠᵃ, grid.φᵃᶜᵃ,
+        grid.z,
+        Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
+        Δyᶠᶜᵃ, Δyᶜᶠᵃ,
+        Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ,
+        grid.radius
+    )
 end
 
 function validate_equ_lat_lon_grid_args(topology, size, halo, FT, latitude, longitude, z, precompute_metrics)
@@ -771,3 +772,5 @@ function EquatorialLatitudeLongitudeGrid(rectilinear_grid::RectilinearGrid;
                                  longitude = λᶠ,
                                  latitude = φᶠ)
 end
+
+is_lat_lon_grid(::EquatorialLatitudeLongitudeGrid) = true

--- a/src/Grids/equatorial_latitude_longitude_grid.jl
+++ b/src/Grids/equatorial_latitude_longitude_grid.jl
@@ -1,8 +1,14 @@
 using KernelAbstractions: @kernel, @index
 using OrderedCollections: OrderedDict
 
-struct EquatorialLatitudeLongitudeGrid{FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, YC,
-                             DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I} <: AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Z, Arch}
+struct EquatorialLatitudeLongitudeGrid{FT, TX, TY, TZ, Z,
+    DXF, DXC, XF, XC,
+    DYF, DYC, YF, YC,
+    DX1, DX2, DX3, DX4,
+    DYFC, DYCF,
+    AZCC, AZFC, AZCF, AZFF,
+    Arch, I} <: AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Z, Arch}
+
     architecture :: Arch
     Nx :: I
     Ny :: I
@@ -13,8 +19,7 @@ struct EquatorialLatitudeLongitudeGrid{FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF,
     Lx :: FT
     Ly :: FT
     Lz :: FT
-    # All directions can be either regular (FX, FY, FZ) <: Number
-    # or stretched (FX, FY, FZ) <: AbstractVector
+
     Δλᶠᵃᵃ :: DXF
     Δλᶜᵃᵃ :: DXC
     λᶠᵃᵃ  :: XF
@@ -23,19 +28,21 @@ struct EquatorialLatitudeLongitudeGrid{FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF,
     Δφᵃᶜᵃ :: DYC
     φᵃᶠᵃ  :: YF
     φᵃᶜᵃ  :: YC
-    z     :: Z
-    # Precomputed metrics M <: Nothing means metrics will be computed on the fly
-    Δxᶜᶜᵃ :: DXCC
-    Δxᶠᶜᵃ :: DXFC
-    Δxᶜᶠᵃ :: DXCF
-    Δxᶠᶠᵃ :: DXFF
+    z :: Z
+
+    Δxᶜᶜᵃ :: DX1
+    Δxᶠᶜᵃ :: DX2
+    Δxᶜᶠᵃ :: DX3
+    Δxᶠᶠᵃ :: DX4
+
     Δyᶠᶜᵃ :: DYFC
     Δyᶜᶠᵃ :: DYCF
-    Azᶜᶜᵃ :: DXCC
-    Azᶠᶜᵃ :: DXFC
-    Azᶜᶠᵃ :: DXCF
-    Azᶠᶠᵃ :: DXFF
-    # Spherical radius
+
+    Azᶜᶜᵃ :: AZCC
+    Azᶠᶜᵃ :: AZFC
+    Azᶜᶠᵃ :: AZCF
+    Azᶠᶠᵃ :: AZFF
+
     radius :: FT
 end
 
@@ -46,31 +53,35 @@ function EquatorialLatitudeLongitudeGrid{TX, TY, TZ}(architecture::Arch,
                                             λᶠᵃᵃ :: XF,   λᶜᵃᵃ :: XC,
                                            Δφᵃᶠᵃ :: DYF, Δφᵃᶜᵃ :: DYC,
                                             φᵃᶠᵃ :: YF,   φᵃᶜᵃ :: YC, z :: Z,
-                                           Δxᶜᶜᵃ :: DXCC, Δxᶠᶜᵃ :: DXFC,
-                                           Δxᶜᶠᵃ :: DXCF, Δxᶠᶠᵃ :: DXFF,
+                                           Δxᶜᶜᵃ :: DX1, Δxᶠᶜᵃ :: DX2,
+                                           Δxᶜᶠᵃ :: DX3, Δxᶠᶠᵃ :: DX4,
                                            Δyᶠᶜᵃ :: DYFC, Δyᶜᶠᵃ :: DYCF,
-                                           Azᶜᶜᵃ :: DXCC, Azᶠᶜᵃ :: DXFC,
-                                           Azᶜᶠᵃ :: DXCF, Azᶠᶠᵃ :: DXFF,
+                                           Azᶜᶜᵃ :: AZCC, Azᶠᶜᵃ :: AZFC,
+                                           Azᶜᶠᵃ :: AZCF, Azᶠᶠᵃ :: AZFF,
                                            radius :: FT) where {Arch, FT, TX, TY, TZ, Z,
                                                                 DXF, DXC, XF, XC,
                                                                 DYF, DYC, YF, YC,
-                                                                DXFC, DXCF,
-                                                                DXFF, DXCC,
-                                                                DYFC, DYCF, I}
+                                                                DX1, DX2, DX3, DX4,
+                                                                DYFC, DYCF,
+                                                                AZCC, AZFC, AZCF, AZFF,
+                                                                I}
 
     return EquatorialLatitudeLongitudeGrid{FT, TX, TY, TZ, Z,
-                                 DXF, DXC, XF, XC,
-                                 DYF, DYC, YF, YC,
-                                 DXCC, DXFC, DXCF, DXFF,
-                                 DYFC, DYCF, Arch, I}(architecture,
-                                                      Nλ, Nφ, Nz,
-                                                      Hλ, Hφ, Hz,
-                                                      Lλ, Lφ, Lz,
-                                                      Δλᶠᵃᵃ, Δλᶜᵃᵃ, λᶠᵃᵃ, λᶜᵃᵃ,
-                                                      Δφᵃᶠᵃ, Δφᵃᶜᵃ, φᵃᶠᵃ, φᵃᶜᵃ, z,
-                                                      Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
-                                                      Δyᶠᶜᵃ, Δyᶜᶠᵃ,
-                                                      Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, radius)
+        DXF, DXC, XF, XC,
+        DYF, DYC, YF, YC,
+        DX1, DX2, DX3, DX4,
+        DYFC, DYCF,
+        AZCC, AZFC, AZCF, AZFF,
+        Arch, I}(architecture,
+                 Nλ, Nφ, Nz,
+                 Hλ, Hφ, Hz,
+                 Lλ, Lφ, Lz,
+                 Δλᶠᵃᵃ, Δλᶜᵃᵃ, λᶠᵃᵃ, λᶜᵃᵃ,
+                 Δφᵃᶠᵃ, Δφᵃᶜᵃ, φᵃᶠᵃ, φᵃᶜᵃ, z,
+                 Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
+                 Δyᶠᶜᵃ, Δyᶜᶠᵃ,
+                 Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ,
+                 radius)
 end
 
 const ELLG = EquatorialLatitudeLongitudeGrid
@@ -241,8 +252,8 @@ end
 EquatorialLatitudeLongitudeGrid(FT::DataType; kwargs...) = EquatorialLatitudeLongitudeGrid(CPU(), FT; kwargs...)
 
 """ Return a reproduction of `grid` with precomputed metric terms. """
-function with_precomputed_metrics(grid)
-    Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ = allocate_metrics(grid)
+function with_precomputed_metrics(grid::EquatorialLatitudeLongitudeGrid)
+        Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ = allocate_metrics(grid)
 
     # Compute Δx spacings and Az areas
     arch = grid.architecture
@@ -252,14 +263,20 @@ function with_precomputed_metrics(grid)
     loop!(grid, Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ)
 
     # Compute Δy spacings if needed
-    if !(grid isa YRegularLLG)
-        loop! = compute_Δy!(dev, 16, length(grid.Δφᵃᶜᵃ) - 1)
-        loop!(grid, Δyᶠᶜᵃ, Δyᶜᶠᵃ)
-    end
+    # force Δy computation for this grid
+    loop! = compute_Δy!(dev, (16,16), (length(grid.λᶜᵃᵃ), length(grid.φᵃᶜᵃ) - 1))
+    loop!(grid, Δyᶠᶜᵃ, Δyᶜᶠᵃ)
+    #if !(grid isa YRegularLLG)
+    #    loop! = compute_Δy!(dev, 16, length(grid.Δφᵃᶜᵃ) - 1)
+    #    loop!(grid, Δyᶠᶜᵃ, Δyᶜᶠᵃ)
+    #end
 
     Nλ, Nφ, Nz = size(grid)
     Hλ, Hφ, Hz = halo_size(grid)
     TX, TY, TZ = topology(grid)
+
+    println("Δx size:", size(Δxᶠᶜᵃ))
+    println("worksize:", metric_worksize(grid))
 
     return EquatorialLatitudeLongitudeGrid{TX, TY, TZ}(architecture(grid),
                                              Nλ, Nφ, Nz,
@@ -444,9 +461,6 @@ end
 ##### On-the-fly computation of LatitudeLongitudeGrid metrics
 #####
 
-@inline hack_cosd(φ) = cos(π * φ / 180)
-@inline hack_sind(φ) = sin(π * φ / 180)
-
 @inline Δxᶠᶜᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
 @inline Δxᶜᶠᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
 @inline Δxᶠᶠᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
@@ -458,16 +472,16 @@ end
 @inline Azᶠᶠᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
 @inline Azᶜᶜᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
 
-@inline Δxᶠᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
-@inline Δxᶜᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
-@inline Δxᶠᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
-@inline Δxᶜᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
-@inline Δyᶜᶠᵃ(i, j, k, grid::YRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δλᶜᵃᵃ) * hack_cosd(grid.φᵃᶠᵃ[j])
-@inline Δyᶠᶜᵃ(i, j, k, grid::YRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δλᶠᵃᵃ) * hack_cosd(grid.φᵃᶜᵃ[j])
-@inline Azᶠᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
-@inline Azᶜᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶠᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶜᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+#@inline Δxᶠᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
+#@inline Δxᶜᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
+#@inline Δxᶠᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
+#@inline Δxᶜᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
+#@inline Δyᶜᶠᵃ(i, j, k, grid::YRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δλᶜᵃᵃ[i]) * hack_cosd(grid.φᵃᶠᵃ[j])
+#@inline Δyᶠᶜᵃ(i, j, k, grid::YRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δλᶠᵃᵃ[i]) * hack_cosd(grid.φᵃᶜᵃ[j])
+#@inline Azᶠᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+#@inline Azᶜᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
+#@inline Azᶠᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
+#@inline Azᶜᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
 
 #####
 ##### Utilities to precompute metrics
@@ -477,17 +491,19 @@ end
 ##### Kernels that precompute the z- and x-metric
 #####
 
-@inline metric_worksize(grid::EquatorialLatitudeLongitudeGrid)  = (length(grid.Δλᶜᵃᵃ), length(grid.φᵃᶠᵃ) - 2)
+@inline metric_worksize(grid::EquatorialLatitudeLongitudeGrid) = (length(grid.λᶜᵃᵃ), length(grid.φᵃᶠᵃ) - 2)
 @inline metric_workgroup(grid::EquatorialLatitudeLongitudeGrid) = (16, 16)
 
-@inline metric_worksize(grid::XRegularELLG)  = length(grid.φᵃᶠᵃ) - 2
-@inline metric_workgroup(grid::XRegularELLG) = 16
+#@inline metric_worksize(grid::XRegularELLG) = (1, length(grid.φᵃᶠᵃ) - 2)
+#@inline metric_workgroup(grid::XRegularELLG) = 16
 
-@kernel function compute_Δx_Az!(grid::EquatorialLatitudeLongitudeGrid, Δxᶜᶜ, Δxᶠᶜ, Δxᶜᶠ, Δxᶠᶠ, Azᶜᶜ, Azᶠᶜ, Azᶜᶠ, Azᶠᶠ)
+@kernel function compute_Δx_Az!(grid::EquatorialLatitudeLongitudeGrid,
+                               Δxᶜᶜ, Δxᶠᶜ, Δxᶜᶠ, Δxᶠᶠ,
+                               Azᶜᶜ, Azᶠᶜ, Azᶜᶠ, Azᶠᶠ)
+
     i, j = @index(Global, NTuple)
 
-    # Manually offset x- and y-index
-    i′ = i + grid.Δλᶜᵃᵃ.offsets[1]
+    i′ = i + grid.λᶜᵃᵃ.offsets[1]
     j′ = j + grid.φᵃᶜᵃ.offsets[1] + 1
 
     @inbounds begin
@@ -495,6 +511,7 @@ end
         Δxᶜᶠ[i′, j′] = Δxᶜᶠᵃ(i′, j′, 1, grid)
         Δxᶠᶠ[i′, j′] = Δxᶠᶠᵃ(i′, j′, 1, grid)
         Δxᶜᶜ[i′, j′] = Δxᶜᶜᵃ(i′, j′, 1, grid)
+
         Azᶠᶜ[i′, j′] = Azᶠᶜᵃ(i′, j′, 1, grid)
         Azᶜᶠ[i′, j′] = Azᶜᶠᵃ(i′, j′, 1, grid)
         Azᶠᶠ[i′, j′] = Azᶠᶠᵃ(i′, j′, 1, grid)
@@ -525,14 +542,14 @@ end
 #####
 
 @kernel function compute_Δy!(grid, Δyᶠᶜ, Δyᶜᶠ)
-    j = @index(Global, Linear)
+    i, j = @index(Global, NTuple)
 
-    # Manually offset y-index
-    j′ = j + grid.Δφᵃᶜᵃ.offsets[1] + 1
+    i′ = i + grid.λᶜᵃᵃ.offsets[1]
+    j′ = j + grid.φᵃᶜᵃ.offsets[1] + 1
 
     @inbounds begin
-        Δyᶜᶠ[j′] = Δyᶜᶠᵃ(1, j′, 1, grid)
-        Δyᶠᶜ[j′] = Δyᶠᶜᵃ(1, j′, 1, grid)
+        Δyᶜᶠ[i′, j′] = Δyᶜᶠᵃ(i′, j′, 1, grid)
+        Δyᶠᶜ[i′, j′] = Δyᶠᶜᵃ(i′, j′, 1, grid)
     end
 end
 
@@ -548,28 +565,39 @@ function allocate_metrics(grid::EquatorialLatitudeLongitudeGrid)
         offsets     = grid.φᵃᶜᵃ.offsets[1]
         metric_size = length(grid.φᵃᶜᵃ)
     else
-        offsets     = (grid.Δλᶜᵃᵃ.offsets[1], grid.φᵃᶜᵃ.offsets[1])
-        metric_size = (length(grid.Δλᶜᵃᵃ), length(grid.φᵃᶜᵃ))
+        offsets     = (grid.λᶜᵃᵃ.offsets[1], grid.φᵃᶜᵃ.offsets[1])
+        metric_size = (length(grid.λᶜᵃᵃ), length(grid.φᵃᶜᵃ))
     end
 
-    Δxᶜᶜ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
-    Δxᶠᶜ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
-    Δxᶜᶠ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
-    Δxᶠᶠ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
-    Azᶜᶜ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
-    Azᶠᶜ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
-    Azᶜᶠ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
-    Azᶠᶠ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
+    parentC = zeros(arch, FT, length(grid.φᵃᶜᵃ))
+    parentF = zeros(arch, FT, length(grid.φᵃᶜᵃ))
 
-    if grid isa YRegularELLG
-        Δyᶠᶜ = Δyᶠᶜᵃ(1, 1, 1, grid)
-        Δyᶜᶠ = Δyᶜᶠᵃ(1, 1, 1, grid)
-    else
-        parentC = zeros(arch, FT, length(grid.Δφᵃᶜᵃ))
-        parentF = zeros(arch, FT, length(grid.Δφᵃᶜᵃ))
-        Δyᶠᶜ    = OffsetArray(parentC, grid.Δφᵃᶜᵃ.offsets[1])
-        Δyᶜᶠ    = OffsetArray(parentF, grid.Δφᵃᶜᵃ.offsets[1])
-    end
+    Δxᶠᶜ = OffsetArray(parentC, grid.φᵃᶜᵃ.offsets[1])
+    Δxᶜᶠ = OffsetArray(parentF, grid.φᵃᶜᵃ.offsets[1])
+    Δxᶜᶜ = Δxᶠᶜ
+    Δxᶠᶠ = Δxᶜᶠ
+
+    offsets     = (grid.λᶜᵃᵃ.offsets[1], grid.φᵃᶜᵃ.offsets[1])
+    metric_size = (length(grid.λᶜᵃᵃ), length(grid.φᵃᶜᵃ))
+
+    parentC = zeros(arch, FT, metric_size...)
+    parentF = zeros(arch, FT, metric_size...)
+
+    Δyᶠᶜ = OffsetArray(parentC, offsets...)
+    Δyᶜᶠ = OffsetArray(parentF, offsets...)
+
+    offsets     = (grid.λᶜᵃᵃ.offsets[1], grid.φᵃᶜᵃ.offsets[1])
+    metric_size = (length(grid.λᶜᵃᵃ), length(grid.φᵃᶜᵃ))
+
+    parentAzᶜᶜ = zeros(arch, FT, metric_size...)
+    parentAzᶠᶜ = zeros(arch, FT, metric_size...)
+    parentAzᶜᶠ = zeros(arch, FT, metric_size...)
+    parentAzᶠᶠ = zeros(arch, FT, metric_size...)
+
+    Azᶜᶜ = OffsetArray(parentAzᶜᶜ, offsets...)
+    Azᶠᶜ = OffsetArray(parentAzᶠᶜ, offsets...)
+    Azᶜᶠ = OffsetArray(parentAzᶜᶠ, offsets...)
+    Azᶠᶠ = OffsetArray(parentAzᶠᶠ, offsets...)
 
     return Δxᶜᶜ, Δxᶠᶜ, Δxᶜᶠ, Δxᶠᶠ, Δyᶠᶜ, Δyᶜᶠ, Azᶜᶜ, Azᶠᶜ, Azᶜᶠ, Azᶠᶠ
 end
@@ -658,8 +686,11 @@ end
 @inline φnodes(grid::ELLG, ℓy::N; with_halos=false, indices=Colon()) = nothing
 
 # Flat topologies
-XFlatLLG = EquatorialLatitudeLongitudeGrid{<:Any, Flat}
-YFlatLLG = EquatorialLatitudeLongitudeGrid{<:Any, <:Any, Flat}
+#XFlatELLG = EquatorialLatitudeLongitudeGrid{<:Any, Flat}
+#YFlatELLG = EquatorialLatitudeLongitudeGrid{<:Any, <:Any, Flat}
+const XFlatELLG = EquatorialLatitudeLongitudeGrid{<:Any, Flat, <:Any, <:Any}
+const YFlatELLG = EquatorialLatitudeLongitudeGrid{<:Any, <:Any, Flat, <:Any}
+
 @inline λnodes(grid::XFlatELLG, ℓx::F; with_halos=false, indices=Colon()) = _property(grid.λᶜᵃᵃ, ℓx, topology(grid, 1), grid.Nx, grid.Hx, with_halos)
 @inline λnodes(grid::XFlatELLG, ℓx::C; with_halos=false, indices=Colon()) = _property(grid.λᶜᵃᵃ, ℓx, topology(grid, 1), grid.Nx, grid.Hx, with_halos)
 @inline φnodes(grid::YFlatELLG, ℓy::F; with_halos=false, indices=Colon()) = _property(grid.φᵃᶠᵃ, ℓy, topology(grid, 2), grid.Ny, grid.Hy, with_halos)

--- a/src/Grids/equatorial_latitude_longitude_grid.jl
+++ b/src/Grids/equatorial_latitude_longitude_grid.jl
@@ -82,25 +82,25 @@ const ELLGOTF{DXF, DXC, DYF, DYC} = ELLG{<:Any, <:Any, <:Any, <:Any, <:Any, DXF,
 #                                   ↑↑ DXCC,    DXFC,    DXCF,    DXFF,    DYFC,    DYCF
 
 # Metrics computed on the fly, constant x-spacing
-const XRegLLGOTF     =  ELLGOTF{<:Number, <:Number}
+const XRegELLGOTF     =  ELLGOTF{<:Number, <:Number}
 # Metrics computed on the fly, constant y-spacing
-const YRegLLGOTF     =  ELLGOTF{<:Any, <:Any, <:Number, <:Number}
+const YRegELLGOTF     =  ELLGOTF{<:Any, <:Any, <:Number, <:Number}
 
 # Identifying grids with various spacing patterns
 #                                          ↓↓ FT     TX     TY     TZ     Z  DXF  DXC  XF     XC     DYF  DYC
 const ELLGSpacing{Z, DXF, DXC, DYF, DYC} = ELLG{<:Any, <:Any, <:Any, <:Any, Z, DXF, DXC, <:Any, <:Any, DYF, DYC} where {Z, DXF, DXC, DYF, DYC}
 
-const XRegularLLG    = ELLGSpacing{<:Any, <:Number, <:Number}
-const YRegularLLG    = ELLGSpacing{<:Any, <:Any, <:Any, <:Number, <:Number}
-const HRegularLLG    = ELLGSpacing{<:Any, <:Number, <:Number, <:Number, <:Number}
-const ZRegularLLG    = ELLGSpacing{<:RegularVerticalCoordinate}
-const HNonRegularLLG = ELLGSpacing{<:Any, <:AbstractArray, <:AbstractArray, <:AbstractArray, <:AbstractArray}
-const YNonRegularLLG = ELLGSpacing{<:Any, <:Any, <:Any, <:AbstractArray, <:AbstractArray}
+const XRegularELLG    = ELLGSpacing{<:Any, <:Number, <:Number}
+const YRegularELLG    = ELLGSpacing{<:Any, <:Any, <:Any, <:Number, <:Number}
+const HRegularELLG    = ELLGSpacing{<:Any, <:Number, <:Number, <:Number, <:Number}
+const ZRegularELLG    = ELLGSpacing{<:RegularVerticalCoordinate}
+const HNonRegularELLG = ELLGSpacing{<:Any, <:AbstractArray, <:AbstractArray, <:AbstractArray, <:AbstractArray}
+const YNonRegularELLG = ELLGSpacing{<:Any, <:Any, <:Any, <:AbstractArray, <:AbstractArray}
 
-@inline metrics_precomputed(::LLGOTF) = false
-@inline metrics_precomputed(::LLG) = true
+@inline metrics_precomputed(::ELLGOTF) = false
+@inline metrics_precomputed(::ELLG) = true
 
-regular_dimensions(::ZRegularLLG) = tuple(3)
+regular_dimensions(::ZRegularELLG) = tuple(3)
 
 """
     EquatorialLatitudeLongitudeGrid([architecture = CPU(), FT = Oceananigans.defaults.FloatType];
@@ -206,7 +206,7 @@ function EquatorialLatitudeLongitudeGrid(architecture::AbstractArchitecture = CP
                                halo = nothing)
 
     topology, size, halo, latitude, longitude, z, precompute_metrics =
-        validate_lat_lon_grid_args(topology, size, halo, FT, latitude, longitude, z, precompute_metrics)
+        validate_equ_lat_lon_grid_args(topology, size, halo, FT, latitude, longitude, z, precompute_metrics)
 
     Nλ, Nφ, Nz = size
     Hλ, Hφ, Hz = halo
@@ -272,7 +272,7 @@ function with_precomputed_metrics(grid)
                                              Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, grid.radius)
 end
 
-function validate_lat_lon_grid_args(topology, size, halo, FT, latitude, longitude, z, precompute_metrics)
+function validate_equ_lat_lon_grid_args(topology, size, halo, FT, latitude, longitude, z, precompute_metrics)
     if !isnothing(topology)
         TX, TY, TZ = validate_topology(topology)
         Nλ, Nφ, Nz = size = validate_size(TX, TY, TZ, size)
@@ -314,16 +314,16 @@ function validate_lat_lon_grid_args(topology, size, halo, FT, latitude, longitud
     return topology, size, halo, latitude, longitude, z, precompute_metrics
 end
 
-function Base.summary(grid::LatitudeLongitudeGrid)
+function Base.summary(grid::EquatorialLatitudeLongitudeGrid)
     FT = eltype(grid)
     TX, TY, TZ = topology(grid)
 
     return string(size_summary(grid),
-                  " LatitudeLongitudeGrid{$FT, $TX, $TY, $TZ} on ", summary(architecture(grid)),
+                  " EquatorialLatitudeLongitudeGrid{$FT, $TX, $TY, $TZ} on ", summary(architecture(grid)),
                   " with ", size_summary(halo_size(grid)), " halo")
 end
 
-function Base.show(io::IO, grid::LatitudeLongitudeGrid, withsummary=true)
+function Base.show(io::IO, grid::EquatorialLatitudeLongitudeGrid, withsummary=true)
     TX, TY, TZ = topology(grid)
 
     Ωλ = domain(TX(), size(grid, 1), grid.λᶠᵃᵃ)
@@ -349,11 +349,11 @@ function Base.show(io::IO, grid::LatitudeLongitudeGrid, withsummary=true)
                      "└── ", z_summary)
 end
 
-@inline x_domain(grid::LLG) = domain(topology(grid, 1)(), grid.Nx, grid.λᶠᵃᵃ)
-@inline y_domain(grid::LLG) = domain(topology(grid, 2)(), grid.Ny, grid.φᵃᶠᵃ)
+@inline x_domain(grid::ELLG) = domain(topology(grid, 1)(), grid.Nx, grid.λᶠᵃᵃ)
+@inline y_domain(grid::ELLG) = domain(topology(grid, 2)(), grid.Ny, grid.φᵃᶠᵃ)
 
-@inline cpu_face_constructor_x(grid::XRegularLLG) = x_domain(grid)
-@inline cpu_face_constructor_y(grid::YRegularLLG) = y_domain(grid)
+@inline cpu_face_constructor_x(grid::XRegularELLG) = x_domain(grid)
+@inline cpu_face_constructor_y(grid::YRegularELLG) = y_domain(grid)
 
 function constructor_arguments(grid::EquatorialLatitudeLongitudeGrid)
     arch = architecture(grid)
@@ -447,27 +447,27 @@ end
 @inline hack_cosd(φ) = cos(π * φ / 180)
 @inline hack_sind(φ) = sin(π * φ / 180)
 
-@inline Δxᶠᶜᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶜᵃ[j]) * deg2rad(grid.Δλᶠᵃᵃ[i])
-@inline Δxᶜᶠᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶠᵃ[j]) * deg2rad(grid.Δλᶜᵃᵃ[i])
-@inline Δxᶠᶠᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶠᵃ[j]) * deg2rad(grid.Δλᶠᵃᵃ[i])
-@inline Δxᶜᶜᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶜᵃ[j]) * deg2rad(grid.Δλᶜᵃᵃ[i])
-@inline Δyᶜᶠᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
-@inline Δyᶠᶜᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
-@inline Azᶠᶜᵃ(i, j, k, grid::LLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
-@inline Azᶜᶠᵃ(i, j, k, grid::LLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶠᶠᵃ(i, j, k, grid::LLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶜᶜᵃ(i, j, k, grid::LLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+@inline Δxᶠᶜᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
+@inline Δxᶜᶠᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
+@inline Δxᶠᶠᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
+@inline Δxᶜᶜᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
+@inline Δyᶜᶠᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius * deg2rad(grid.Δλᶜᵃᵃ[i]) * hack_cosd(grid.φᵃᶠᵃ[j])
+@inline Δyᶠᶜᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius * deg2rad(grid.Δλᶠᵃᵃ[i]) * hack_cosd(grid.φᵃᶜᵃ[j])
+@inline Azᶠᶜᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+@inline Azᶜᶠᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
+@inline Azᶠᶠᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
+@inline Azᶜᶜᵃ(i, j, k, grid::ELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
 
-@inline Δxᶠᶜᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶜᵃ[j]) * deg2rad(grid.Δλᶠᵃᵃ)
-@inline Δxᶜᶠᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶠᵃ[j]) * deg2rad(grid.Δλᶜᵃᵃ)
-@inline Δxᶠᶠᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶠᵃ[j]) * deg2rad(grid.Δλᶠᵃᵃ)
-@inline Δxᶜᶜᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶜᵃ[j]) * deg2rad(grid.Δλᶜᵃᵃ)
-@inline Δyᶜᶠᵃ(i, j, k, grid::YRegularLLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ)
-@inline Δyᶠᶜᵃ(i, j, k, grid::YRegularLLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ)
-@inline Azᶠᶜᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
-@inline Azᶜᶠᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶠᶠᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
-@inline Azᶜᶜᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+@inline Δxᶠᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
+@inline Δxᶜᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
+@inline Δxᶠᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
+@inline Δxᶜᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
+@inline Δyᶜᶠᵃ(i, j, k, grid::YRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δλᶜᵃᵃ) * hack_cosd(grid.φᵃᶠᵃ[j])
+@inline Δyᶠᶜᵃ(i, j, k, grid::YRegularELLG) = @inbounds grid.radius * deg2rad(grid.Δλᶠᵃᵃ) * hack_cosd(grid.φᵃᶜᵃ[j])
+@inline Azᶠᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+@inline Azᶜᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
+@inline Azᶠᶠᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
+@inline Azᶜᶜᵃ(i, j, k, grid::XRegularELLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
 
 #####
 ##### Utilities to precompute metrics
@@ -480,8 +480,8 @@ end
 @inline metric_worksize(grid::EquatorialLatitudeLongitudeGrid)  = (length(grid.Δλᶜᵃᵃ), length(grid.φᵃᶠᵃ) - 2)
 @inline metric_workgroup(grid::EquatorialLatitudeLongitudeGrid) = (16, 16)
 
-@inline metric_worksize(grid::XRegularLLG)  = length(grid.φᵃᶠᵃ) - 2
-@inline metric_workgroup(grid::XRegularLLG) = 16
+@inline metric_worksize(grid::XRegularELLG)  = length(grid.φᵃᶠᵃ) - 2
+@inline metric_workgroup(grid::XRegularELLG) = 16
 
 @kernel function compute_Δx_Az!(grid::EquatorialLatitudeLongitudeGrid, Δxᶜᶜ, Δxᶠᶜ, Δxᶜᶠ, Δxᶠᶠ, Azᶜᶜ, Azᶠᶜ, Azᶜᶠ, Azᶠᶠ)
     i, j = @index(Global, NTuple)
@@ -561,7 +561,7 @@ function allocate_metrics(grid::EquatorialLatitudeLongitudeGrid)
     Azᶜᶠ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
     Azᶠᶠ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
 
-    if grid isa YRegularLLG
+    if grid isa YRegularELLG
         Δyᶠᶜ = Δyᶠᶜᵃ(1, 1, 1, grid)
         Δyᶜᶠ = Δyᶜᶠᵃ(1, 1, 1, grid)
     else
@@ -658,12 +658,12 @@ end
 @inline φnodes(grid::ELLG, ℓy::N; with_halos=false, indices=Colon()) = nothing
 
 # Flat topologies
-XFlatLLG = LatitudeLongitudeGrid{<:Any, Flat}
-YFlatLLG = LatitudeLongitudeGrid{<:Any, <:Any, Flat}
-@inline λnodes(grid::XFlatLLG, ℓx::F; with_halos=false, indices=Colon()) = _property(grid.λᶜᵃᵃ, ℓx, topology(grid, 1), grid.Nx, grid.Hx, with_halos)
-@inline λnodes(grid::XFlatLLG, ℓx::C; with_halos=false, indices=Colon()) = _property(grid.λᶜᵃᵃ, ℓx, topology(grid, 1), grid.Nx, grid.Hx, with_halos)
-@inline φnodes(grid::YFlatLLG, ℓy::F; with_halos=false, indices=Colon()) = _property(grid.φᵃᶠᵃ, ℓy, topology(grid, 2), grid.Ny, grid.Hy, with_halos)
-@inline φnodes(grid::YFlatLLG, ℓy::C; with_halos=false, indices=Colon()) = _property(grid.φᵃᶜᵃ, ℓy, topology(grid, 2), grid.Ny, grid.Hy, with_halos)
+XFlatLLG = EquatorialLatitudeLongitudeGrid{<:Any, Flat}
+YFlatLLG = EquatorialLatitudeLongitudeGrid{<:Any, <:Any, Flat}
+@inline λnodes(grid::XFlatELLG, ℓx::F; with_halos=false, indices=Colon()) = _property(grid.λᶜᵃᵃ, ℓx, topology(grid, 1), grid.Nx, grid.Hx, with_halos)
+@inline λnodes(grid::XFlatELLG, ℓx::C; with_halos=false, indices=Colon()) = _property(grid.λᶜᵃᵃ, ℓx, topology(grid, 1), grid.Nx, grid.Hx, with_halos)
+@inline φnodes(grid::YFlatELLG, ℓy::F; with_halos=false, indices=Colon()) = _property(grid.φᵃᶠᵃ, ℓy, topology(grid, 2), grid.Ny, grid.Hy, with_halos)
+@inline φnodes(grid::YFlatELLG, ℓy::C; with_halos=false, indices=Colon()) = _property(grid.φᵃᶜᵃ, ℓy, topology(grid, 2), grid.Ny, grid.Hy, with_halos)
 
 # Generalized coordinates
 @inline ξnodes(grid::ELLG, ℓx; kwargs...) = λnodes(grid, ℓx; kwargs...)
@@ -712,7 +712,7 @@ function EquatorialLatitudeLongitudeGrid(rectilinear_grid::RectilinearGrid;
     tx, ty, tz = TX(), TY(), TZ()
     triply_bounded = tx isa Bounded && ty isa Bounded && tz isa Bounded
     if !triply_bounded
-        msg = string("The source RectilinearGrid for constructing LatitudeLongitudeGrid ",
+        msg = string("The source RectilinearGrid for constructing EquatorialLatitudeLongitudeGrid ",
                      "must be triply-bounded, but has topology=($tx, $ty, $tz)!")
         throw(ArgumentError(msg))
     end

--- a/src/Grids/equatorial_latitude_longitude_grid.jl
+++ b/src/Grids/equatorial_latitude_longitude_grid.jl
@@ -1,0 +1,742 @@
+using KernelAbstractions: @kernel, @index
+using OrderedCollections: OrderedDict
+
+struct EquatorialLatitudeLongitudeGrid{FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, YC,
+                             DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I} <: AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Z, Arch}
+    architecture :: Arch
+    Nx :: I
+    Ny :: I
+    Nz :: I
+    Hx :: I
+    Hy :: I
+    Hz :: I
+    Lx :: FT
+    Ly :: FT
+    Lz :: FT
+    # All directions can be either regular (FX, FY, FZ) <: Number
+    # or stretched (FX, FY, FZ) <: AbstractVector
+    Δλᶠᵃᵃ :: DXF
+    Δλᶜᵃᵃ :: DXC
+    λᶠᵃᵃ  :: XF
+    λᶜᵃᵃ  :: XC
+    Δφᵃᶠᵃ :: DYF
+    Δφᵃᶜᵃ :: DYC
+    φᵃᶠᵃ  :: YF
+    φᵃᶜᵃ  :: YC
+    z     :: Z
+    # Precomputed metrics M <: Nothing means metrics will be computed on the fly
+    Δxᶜᶜᵃ :: DXCC
+    Δxᶠᶜᵃ :: DXFC
+    Δxᶜᶠᵃ :: DXCF
+    Δxᶠᶠᵃ :: DXFF
+    Δyᶠᶜᵃ :: DYFC
+    Δyᶜᶠᵃ :: DYCF
+    Azᶜᶜᵃ :: DXCC
+    Azᶠᶜᵃ :: DXFC
+    Azᶜᶠᵃ :: DXCF
+    Azᶠᶠᵃ :: DXFF
+    # Spherical radius
+    radius :: FT
+end
+
+function EquatorialLatitudeLongitudeGrid{TX, TY, TZ}(architecture::Arch,
+                                           Nλ::I, Nφ::I, Nz::I, Hλ::I, Hφ::I, Hz::I,
+                                           Lλ :: FT, Lφ :: FT, Lz :: FT,
+                                           Δλᶠᵃᵃ :: DXF, Δλᶜᵃᵃ :: DXC,
+                                            λᶠᵃᵃ :: XF,   λᶜᵃᵃ :: XC,
+                                           Δφᵃᶠᵃ :: DYF, Δφᵃᶜᵃ :: DYC,
+                                            φᵃᶠᵃ :: YF,   φᵃᶜᵃ :: YC, z :: Z,
+                                           Δxᶜᶜᵃ :: DXCC, Δxᶠᶜᵃ :: DXFC,
+                                           Δxᶜᶠᵃ :: DXCF, Δxᶠᶠᵃ :: DXFF,
+                                           Δyᶠᶜᵃ :: DYFC, Δyᶜᶠᵃ :: DYCF,
+                                           Azᶜᶜᵃ :: DXCC, Azᶠᶜᵃ :: DXFC,
+                                           Azᶜᶠᵃ :: DXCF, Azᶠᶠᵃ :: DXFF,
+                                           radius :: FT) where {Arch, FT, TX, TY, TZ, Z,
+                                                                DXF, DXC, XF, XC,
+                                                                DYF, DYC, YF, YC,
+                                                                DXFC, DXCF,
+                                                                DXFF, DXCC,
+                                                                DYFC, DYCF, I}
+
+    return EquatorialLatitudeLongitudeGrid{FT, TX, TY, TZ, Z,
+                                 DXF, DXC, XF, XC,
+                                 DYF, DYC, YF, YC,
+                                 DXCC, DXFC, DXCF, DXFF,
+                                 DYFC, DYCF, Arch, I}(architecture,
+                                                      Nλ, Nφ, Nz,
+                                                      Hλ, Hφ, Hz,
+                                                      Lλ, Lφ, Lz,
+                                                      Δλᶠᵃᵃ, Δλᶜᵃᵃ, λᶠᵃᵃ, λᶜᵃᵃ,
+                                                      Δφᵃᶠᵃ, Δφᵃᶜᵃ, φᵃᶠᵃ, φᵃᶜᵃ, z,
+                                                      Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
+                                                      Δyᶠᶜᵃ, Δyᶜᶠᵃ,
+                                                      Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, radius)
+end
+
+const ELLG = EquatorialLatitudeLongitudeGrid
+
+# Metrics computed on the fly (OTF), arbitrary xy spacing
+#                                   ↓↓ FT     TX     TY     TZ     Z      DXF  DXC  XF     XC     DYF  DYC, YF,    YC,
+const ELLGOTF{DXF, DXC, DYF, DYC} = ELLG{<:Any, <:Any, <:Any, <:Any, <:Any, DXF, DXC, <:Any, <:Any, DYF, DYC, <:Any, <:Any,
+                                       Nothing, Nothing, Nothing, Nothing, Nothing, Nothing} where {DXF, DXC, DYF, DYC}
+#                                   ↑↑ DXCC,    DXFC,    DXCF,    DXFF,    DYFC,    DYCF
+
+# Metrics computed on the fly, constant x-spacing
+const XRegLLGOTF     =  ELLGOTF{<:Number, <:Number}
+# Metrics computed on the fly, constant y-spacing
+const YRegLLGOTF     =  ELLGOTF{<:Any, <:Any, <:Number, <:Number}
+
+# Identifying grids with various spacing patterns
+#                                          ↓↓ FT     TX     TY     TZ     Z  DXF  DXC  XF     XC     DYF  DYC
+const ELLGSpacing{Z, DXF, DXC, DYF, DYC} = ELLG{<:Any, <:Any, <:Any, <:Any, Z, DXF, DXC, <:Any, <:Any, DYF, DYC} where {Z, DXF, DXC, DYF, DYC}
+
+const XRegularLLG    = ELLGSpacing{<:Any, <:Number, <:Number}
+const YRegularLLG    = ELLGSpacing{<:Any, <:Any, <:Any, <:Number, <:Number}
+const HRegularLLG    = ELLGSpacing{<:Any, <:Number, <:Number, <:Number, <:Number}
+const ZRegularLLG    = ELLGSpacing{<:RegularVerticalCoordinate}
+const HNonRegularLLG = ELLGSpacing{<:Any, <:AbstractArray, <:AbstractArray, <:AbstractArray, <:AbstractArray}
+const YNonRegularLLG = ELLGSpacing{<:Any, <:Any, <:Any, <:AbstractArray, <:AbstractArray}
+
+@inline metrics_precomputed(::LLGOTF) = false
+@inline metrics_precomputed(::LLG) = true
+
+regular_dimensions(::ZRegularLLG) = tuple(3)
+
+"""
+    EquatorialLatitudeLongitudeGrid([architecture = CPU(), FT = Oceananigans.defaults.FloatType];
+                          size,
+                          longitude,
+                          latitude,
+                          z = nothing,
+                          radius = Oceananigans.defaults.planet_radius,
+                          topology = nothing,
+                          precompute_metrics = true,
+                          halo = nothing)
+
+Creates an `EquatorialLatitudeLongitudeGrid` with coordinates `(λ, φ, z)` denoting longitude, latitude,
+and vertical coordinate respectively. Note that the North and South poles occur in the tropics in this grid.
+
+Positional arguments
+====================
+
+- `architecture`: Specifies whether arrays of coordinates and spacings are stored
+                  on the CPU or GPU. Default: `CPU()`.
+
+- `FT` : Floating point data type. Default: `Float64`.
+
+Keyword arguments
+=================
+
+- `size` (required): A 3-tuple prescribing the number of grid points each direction.
+
+- `longitude` (required), `latitude` (required), `z` (default: `nothing`):
+  Each is either a:
+  1. 2-tuple that specify the end points of the domain,
+  2. one-dimensional array specifying the cell interface locations, or
+  3. single-argument function that takes an index and returns cell interface location.
+
+  **Note**: the latitude and longitude coordinates extents are expected in degrees.
+
+- `radius`: The radius of the sphere the grid lives on. By default is equal to the radius of Earth.
+
+- `topology`: Tuple of topologies (`Flat`, `Bounded`, `Periodic`) for each direction. The vertical
+              `topology[3]` must be `Bounded`, while the latitude-longitude topologies can be
+              `Bounded`, `Periodic`, or `Flat`. If no topology is provided then, by default, the
+              topology is (`Periodic`, `Bounded`, `Bounded`) if the longitudinal extent is 360 degrees
+              or (`Bounded`, `Bounded`, `Bounded`) otherwise.
+
+- `precompute_metrics`: Boolean specifying whether to precompute horizontal spacings and areas.
+                        Default: `true`. When `false`, horizontal spacings and areas are computed
+                        on-the-fly during a simulation.
+
+- `halo`: A 3-tuple of integers specifying the size of the halo region of cells surrounding
+          the physical interior. The default is 3 halo cells in every direction.
+
+Examples
+========
+
+* A default grid with `Float64` type:
+
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = EquatorialLatitudeLongitudeGrid(size=(36, 34, 25),
+                                    longitude = (-180, 180),
+                                    latitude = (-85, 85),
+                                    z = (-1000, 0))
+36×34×25 EquatorialLatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
+├── longitude: Periodic λ ∈ [-180.0, 180.0) regularly spaced with Δλ=10.0
+├── latitude:  Bounded  φ ∈ [-85.0, 85.0]   regularly spaced with Δφ=5.0
+└── z:         Bounded  z ∈ [-1000.0, 0.0]  regularly spaced with Δz=40.0
+```
+
+* A bounded spherical sector with cell interfaces stretched hyperbolically near the top:
+
+```jldoctest
+using Oceananigans
+
+σ = 1.1 # stretching factor
+Nz = 24 # vertical resolution
+Lz = 1000 # depth (m)
+hyperbolically_spaced_faces(k) = - Lz * (1 - tanh(σ * (k - 1) / Nz) / tanh(σ))
+
+grid = EquatorialLatitudeLongitudeGrid(size=(36, 34, Nz),
+                             longitude = (-180, 180),
+                             latitude = (-20, 20),
+                             z = hyperbolically_spaced_faces,
+                             topology = (Bounded, Bounded, Bounded))
+
+# output
+
+36×34×24 EquatorialLatitudeLongitudeGrid{Float64, Bounded, Bounded, Bounded} on CPU with 3×3×3 halo
+├── longitude: Bounded  λ ∈ [-180.0, 180.0] regularly spaced with Δλ=10.0
+├── latitude:  Bounded  φ ∈ [-20.0, 20.0]   regularly spaced with Δφ=1.17647
+└── z:         Bounded  z ∈ [-1000.0, -0.0] variably spaced with min(Δz)=21.3342, max(Δz)=57.2159
+```
+"""
+function EquatorialLatitudeLongitudeGrid(architecture::AbstractArchitecture = CPU(),
+                               FT::DataType = Oceananigans.defaults.FloatType;
+                               size,
+                               longitude = nothing,
+                               latitude = nothing,
+                               z = nothing,
+                               radius = Oceananigans.defaults.planet_radius,
+                               topology = nothing,
+                               precompute_metrics = true,
+                               halo = nothing)
+
+    topology, size, halo, latitude, longitude, z, precompute_metrics =
+        validate_lat_lon_grid_args(topology, size, halo, FT, latitude, longitude, z, precompute_metrics)
+
+    Nλ, Nφ, Nz = size
+    Hλ, Hφ, Hz = halo
+
+    # Calculate all direction (which might be stretched)
+    # A direction is regular if the domain passed is a Tuple{<:Real, <:Real},
+    # it is stretched if being passed is a function or vector (as for the VerticallyStretchedRectilinearGrid)
+    TX, TY, TZ = topology
+
+    Lλ, λᶠᵃᵃ, λᶜᵃᵃ, Δλᶠᵃᵃ, Δλᶜᵃᵃ = generate_coordinate(FT, topology, size, halo, longitude, :longitude, 1, architecture)
+    Lφ, φᵃᶠᵃ, φᵃᶜᵃ, Δφᵃᶠᵃ, Δφᵃᶜᵃ = generate_coordinate(FT, topology, size, halo, latitude,  :latitude,  2, architecture)
+    Lz, z                        = generate_coordinate(FT, topology, size, halo, z,         :z,         3, architecture)
+
+    preliminary_grid = EquatorialLatitudeLongitudeGrid{TX, TY, TZ}(architecture,
+                                                         Nλ, Nφ, Nz,
+                                                         Hλ, Hφ, Hz,
+                                                         Lλ, Lφ, Lz,
+                                                         Δλᶠᵃᵃ, Δλᶜᵃᵃ, λᶠᵃᵃ, λᶜᵃᵃ,
+                                                         Δφᵃᶠᵃ, Δφᵃᶜᵃ, φᵃᶠᵃ, φᵃᶜᵃ,
+                                                         z,
+                                                         (nothing for i=1:10)..., FT(radius))
+
+    if !precompute_metrics
+        return preliminary_grid
+    else
+        return with_precomputed_metrics(preliminary_grid)
+    end
+end
+
+# architecture = CPU() default, assuming that a DataType positional arg
+# is specifying the floating point type.
+EquatorialLatitudeLongitudeGrid(FT::DataType; kwargs...) = EquatorialLatitudeLongitudeGrid(CPU(), FT; kwargs...)
+
+""" Return a reproduction of `grid` with precomputed metric terms. """
+function with_precomputed_metrics(grid)
+    Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ = allocate_metrics(grid)
+
+    # Compute Δx spacings and Az areas
+    arch = grid.architecture
+    dev = Architectures.device(arch)
+    workgroup, worksize  = metric_workgroup(grid), metric_worksize(grid)
+    loop! = compute_Δx_Az!(dev, workgroup, worksize)
+    loop!(grid, Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ)
+
+    # Compute Δy spacings if needed
+    if !(grid isa YRegularLLG)
+        loop! = compute_Δy!(dev, 16, length(grid.Δφᵃᶜᵃ) - 1)
+        loop!(grid, Δyᶠᶜᵃ, Δyᶜᶠᵃ)
+    end
+
+    Nλ, Nφ, Nz = size(grid)
+    Hλ, Hφ, Hz = halo_size(grid)
+    TX, TY, TZ = topology(grid)
+
+    return EquatorialLatitudeLongitudeGrid{TX, TY, TZ}(architecture(grid),
+                                             Nλ, Nφ, Nz,
+                                             Hλ, Hφ, Hz,
+                                             grid.Lx, grid.Ly, grid.Lz,
+                                             grid.Δλᶠᵃᵃ, grid.Δλᶜᵃᵃ, grid.λᶠᵃᵃ, grid.λᶜᵃᵃ,
+                                             grid.Δφᵃᶠᵃ, grid.Δφᵃᶜᵃ, grid.φᵃᶠᵃ, grid.φᵃᶜᵃ,
+                                             grid.z,
+                                             Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ,
+                                             Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, grid.radius)
+end
+
+function validate_lat_lon_grid_args(topology, size, halo, FT, latitude, longitude, z, precompute_metrics)
+    if !isnothing(topology)
+        TX, TY, TZ = validate_topology(topology)
+        Nλ, Nφ, Nz = size = validate_size(TX, TY, TZ, size)
+    else # Set default topology according to longitude
+        Nλ, Nφ, Nz = size # using default topology, does not support Flat
+        λ₁, λ₂ = get_domain_extent(longitude, Nλ)
+
+        Lλ = λ₂ - λ₁
+        TX = Lλ == 360 ? Periodic : Bounded
+        TY = Bounded
+        TZ = Bounded
+    end
+
+    if TY() isa Periodic
+        throw(ArgumentError("LatitudeLongitudeGrid cannot be Periodic in latitude!"))
+    end
+
+    # Validate longitude and latitude
+    λ₁, λ₂ = get_domain_extent(longitude, Nλ)
+    λ₂ - λ₁ ≤ 360 + 10 * eps(FT(360)) || throw(ArgumentError("Longitudinal extent cannot be greater than 360 degrees."))
+    λ₁ <= λ₂      || throw(ArgumentError("Longitudes must increase west to east."))
+
+    φ₁, φ₂ = get_domain_extent(latitude, Nφ)
+    -90 <= φ₁ || throw(ArgumentError("The southernmost latitude cannot be less than -90 degrees."))
+    φ₂ <= 90  || throw(ArgumentError("The northern latitude cannot be greater than 90 degrees."))
+    φ₁ <= φ₂  || throw(ArgumentError("Latitudes must increase south to north."))
+
+    if TX == Flat || TY == Flat
+        precompute_metrics = false
+    end
+
+    longitude = validate_dimension_specification(TX, longitude, :longitude, Nλ, FT)
+    latitude  = validate_dimension_specification(TY, latitude,  :latitude,  Nφ, FT)
+    z         = validate_dimension_specification(TZ, z,         :z,         Nz, FT)
+
+    halo = validate_halo(TX, TY, TZ, size, halo)
+    topology = (TX, TY, TZ)
+
+    return topology, size, halo, latitude, longitude, z, precompute_metrics
+end
+
+function Base.summary(grid::LatitudeLongitudeGrid)
+    FT = eltype(grid)
+    TX, TY, TZ = topology(grid)
+
+    return string(size_summary(grid),
+                  " LatitudeLongitudeGrid{$FT, $TX, $TY, $TZ} on ", summary(architecture(grid)),
+                  " with ", size_summary(halo_size(grid)), " halo")
+end
+
+function Base.show(io::IO, grid::LatitudeLongitudeGrid, withsummary=true)
+    TX, TY, TZ = topology(grid)
+
+    Ωλ = domain(TX(), size(grid, 1), grid.λᶠᵃᵃ)
+    Ωφ = domain(TY(), size(grid, 2), grid.φᵃᶠᵃ)
+    Ωz = domain(TZ(), size(grid, 3), grid.z.cᵃᵃᶠ)
+
+    x_summary = domain_summary(TX(), "λ", Ωλ)
+    y_summary = domain_summary(TY(), "φ", Ωφ)
+    z_summary = domain_summary(TZ(), "z", Ωz)
+
+    longest = max(length(x_summary), length(y_summary), length(z_summary))
+
+    x_summary = "longitude: " * dimension_summary(TX(), "λ", Ωλ, grid.Δλᶜᵃᵃ, longest - length(x_summary))
+    y_summary = "latitude:  " * dimension_summary(TY(), "φ", Ωφ, grid.Δφᵃᶜᵃ, longest - length(y_summary))
+    z_summary = "z:         " * dimension_summary(TZ(), "z", Ωz, grid.z,     longest - length(z_summary))
+
+    if withsummary
+        print(io, summary(grid), "\n")
+    end
+
+    return print(io, "├── ", x_summary, "\n",
+                     "├── ", y_summary, "\n",
+                     "└── ", z_summary)
+end
+
+@inline x_domain(grid::LLG) = domain(topology(grid, 1)(), grid.Nx, grid.λᶠᵃᵃ)
+@inline y_domain(grid::LLG) = domain(topology(grid, 2)(), grid.Ny, grid.φᵃᶠᵃ)
+
+@inline cpu_face_constructor_x(grid::XRegularLLG) = x_domain(grid)
+@inline cpu_face_constructor_y(grid::YRegularLLG) = y_domain(grid)
+
+function constructor_arguments(grid::EquatorialLatitudeLongitudeGrid)
+    arch = architecture(grid)
+    args = OrderedDict(:architecture => arch, :number_type => eltype(grid))
+
+    # Kwargs
+    topo = topology(grid)
+    size = (grid.Nx, grid.Ny, grid.Nz)
+    halo = (grid.Hx, grid.Hy, grid.Hz)
+    size = pop_flat_elements(size, topo)
+    halo = pop_flat_elements(halo, topo)
+
+    kwargs = Dict(:size => size,
+                  :halo => halo,
+                  :longitude => cpu_face_constructor_x(grid),
+                  :latitude => cpu_face_constructor_y(grid),
+                  :z => cpu_face_constructor_z(grid),
+                  :topology => topo,
+                  :radius => grid.radius,
+                  :precompute_metrics => metrics_precomputed(grid))
+
+    return args, kwargs
+end
+
+function Base.similar(grid::EquatorialLatitudeLongitudeGrid)
+    args, kwargs = constructor_arguments(grid)
+    arch = args[:architecture]
+    FT = args[:number_type]
+    return EquatorialLatitudeLongitudeGrid(arch, FT; kwargs...)
+end
+
+function with_number_type(FT, grid::EquatorialLatitudeLongitudeGrid)
+    args, kwargs = constructor_arguments(grid)
+    arch = args[:architecture]
+    return EquatorialLatitudeLongitudeGrid(arch, FT; kwargs...)
+end
+
+function with_halo(halo, grid::EquatorialLatitudeLongitudeGrid)
+    args, kwargs = constructor_arguments(grid)
+    halo = pop_flat_elements(halo, topology(grid))
+    kwargs[:halo] = halo
+    arch = args[:architecture]
+    FT = args[:number_type]
+    return EquatorialLatitudeLongitudeGrid(arch, FT; kwargs...)
+end
+
+function Architectures.on_architecture(arch::AbstractSerialArchitecture, grid::EquatorialLatitudeLongitudeGrid)
+    if arch == architecture(grid)
+        return grid
+    end
+
+    args, kwargs = constructor_arguments(grid)
+    FT = args[:number_type]
+    return EquatorialLatitudeLongitudeGrid(arch, FT; kwargs...)
+end
+
+function Adapt.adapt_structure(to, grid::EquatorialLatitudeLongitudeGrid)
+    TX, TY, TZ = topology(grid)
+    return EquatorialLatitudeLongitudeGrid{TX, TY, TZ}(nothing,
+                                             grid.Nx, grid.Ny, grid.Nz,
+                                             grid.Hx, grid.Hy, grid.Hz,
+                                             Adapt.adapt(to, grid.Lx),
+                                             Adapt.adapt(to, grid.Ly),
+                                             Adapt.adapt(to, grid.Lz),
+                                             Adapt.adapt(to, grid.Δλᶠᵃᵃ),
+                                             Adapt.adapt(to, grid.Δλᶜᵃᵃ),
+                                             Adapt.adapt(to, grid.λᶠᵃᵃ),
+                                             Adapt.adapt(to, grid.λᶜᵃᵃ),
+                                             Adapt.adapt(to, grid.Δφᵃᶠᵃ),
+                                             Adapt.adapt(to, grid.Δφᵃᶜᵃ),
+                                             Adapt.adapt(to, grid.φᵃᶠᵃ),
+                                             Adapt.adapt(to, grid.φᵃᶜᵃ),
+                                             Adapt.adapt(to, grid.z),
+                                             Adapt.adapt(to, grid.Δxᶜᶜᵃ),
+                                             Adapt.adapt(to, grid.Δxᶠᶜᵃ),
+                                             Adapt.adapt(to, grid.Δxᶜᶠᵃ),
+                                             Adapt.adapt(to, grid.Δxᶠᶠᵃ),
+                                             Adapt.adapt(to, grid.Δyᶠᶜᵃ),
+                                             Adapt.adapt(to, grid.Δyᶜᶠᵃ),
+                                             Adapt.adapt(to, grid.Azᶜᶜᵃ),
+                                             Adapt.adapt(to, grid.Azᶠᶜᵃ),
+                                             Adapt.adapt(to, grid.Azᶜᶠᵃ),
+                                             Adapt.adapt(to, grid.Azᶠᶠᵃ),
+                                             Adapt.adapt(to, grid.radius))
+end
+
+#####
+##### On-the-fly computation of LatitudeLongitudeGrid metrics
+#####
+
+@inline hack_cosd(φ) = cos(π * φ / 180)
+@inline hack_sind(φ) = sin(π * φ / 180)
+
+@inline Δxᶠᶜᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶜᵃ[j]) * deg2rad(grid.Δλᶠᵃᵃ[i])
+@inline Δxᶜᶠᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶠᵃ[j]) * deg2rad(grid.Δλᶜᵃᵃ[i])
+@inline Δxᶠᶠᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶠᵃ[j]) * deg2rad(grid.Δλᶠᵃᵃ[i])
+@inline Δxᶜᶜᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶜᵃ[j]) * deg2rad(grid.Δλᶜᵃᵃ[i])
+@inline Δyᶜᶠᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ[j])
+@inline Δyᶠᶜᵃ(i, j, k, grid::LLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
+@inline Azᶠᶜᵃ(i, j, k, grid::LLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+@inline Azᶜᶠᵃ(i, j, k, grid::LLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
+@inline Azᶠᶠᵃ(i, j, k, grid::LLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ[i]) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
+@inline Azᶜᶜᵃ(i, j, k, grid::LLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ[i]) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+
+@inline Δxᶠᶜᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶜᵃ[j]) * deg2rad(grid.Δλᶠᵃᵃ)
+@inline Δxᶜᶠᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶠᵃ[j]) * deg2rad(grid.Δλᶜᵃᵃ)
+@inline Δxᶠᶠᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶠᵃ[j]) * deg2rad(grid.Δλᶠᵃᵃ)
+@inline Δxᶜᶜᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius * hack_cosd(grid.φᵃᶜᵃ[j]) * deg2rad(grid.Δλᶜᵃᵃ)
+@inline Δyᶜᶠᵃ(i, j, k, grid::YRegularLLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶠᵃ)
+@inline Δyᶠᶜᵃ(i, j, k, grid::YRegularLLG) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ)
+@inline Azᶠᶜᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+@inline Azᶜᶠᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
+@inline Azᶠᶠᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶠᵃᵃ) * (hack_sind(grid.φᵃᶜᵃ[j])   - hack_sind(grid.φᵃᶜᵃ[j-1]))
+@inline Azᶜᶜᵃ(i, j, k, grid::XRegularLLG) = @inbounds grid.radius^2 * deg2rad(grid.Δλᶜᵃᵃ) * (hack_sind(grid.φᵃᶠᵃ[j+1]) - hack_sind(grid.φᵃᶠᵃ[j]))
+
+#####
+##### Utilities to precompute metrics
+#####
+
+#####
+##### Kernels that precompute the z- and x-metric
+#####
+
+@inline metric_worksize(grid::EquatorialLatitudeLongitudeGrid)  = (length(grid.Δλᶜᵃᵃ), length(grid.φᵃᶠᵃ) - 2)
+@inline metric_workgroup(grid::EquatorialLatitudeLongitudeGrid) = (16, 16)
+
+@inline metric_worksize(grid::XRegularLLG)  = length(grid.φᵃᶠᵃ) - 2
+@inline metric_workgroup(grid::XRegularLLG) = 16
+
+@kernel function compute_Δx_Az!(grid::EquatorialLatitudeLongitudeGrid, Δxᶜᶜ, Δxᶠᶜ, Δxᶜᶠ, Δxᶠᶠ, Azᶜᶜ, Azᶠᶜ, Azᶜᶠ, Azᶠᶠ)
+    i, j = @index(Global, NTuple)
+
+    # Manually offset x- and y-index
+    i′ = i + grid.Δλᶜᵃᵃ.offsets[1]
+    j′ = j + grid.φᵃᶜᵃ.offsets[1] + 1
+
+    @inbounds begin
+        Δxᶠᶜ[i′, j′] = Δxᶠᶜᵃ(i′, j′, 1, grid)
+        Δxᶜᶠ[i′, j′] = Δxᶜᶠᵃ(i′, j′, 1, grid)
+        Δxᶠᶠ[i′, j′] = Δxᶠᶠᵃ(i′, j′, 1, grid)
+        Δxᶜᶜ[i′, j′] = Δxᶜᶜᵃ(i′, j′, 1, grid)
+        Azᶠᶜ[i′, j′] = Azᶠᶜᵃ(i′, j′, 1, grid)
+        Azᶜᶠ[i′, j′] = Azᶜᶠᵃ(i′, j′, 1, grid)
+        Azᶠᶠ[i′, j′] = Azᶠᶠᵃ(i′, j′, 1, grid)
+        Azᶜᶜ[i′, j′] = Azᶜᶜᵃ(i′, j′, 1, grid)
+    end
+end
+
+@kernel function compute_Δx_Az!(grid::XRegularLLG, Δxᶜᶜ, Δxᶠᶜ, Δxᶜᶠ, Δxᶠᶠ, Azᶜᶜ, Azᶠᶜ, Azᶜᶠ, Azᶠᶠ)
+    j = @index(Global, Linear)
+
+    # Manually offset y-index
+    j′ = j + grid.φᵃᶜᵃ.offsets[1] + 1
+
+    @inbounds begin
+        Δxᶠᶜ[j′] = Δxᶠᶜᵃ(1, j′, 1, grid)
+        Δxᶜᶠ[j′] = Δxᶜᶠᵃ(1, j′, 1, grid)
+        Δxᶠᶠ[j′] = Δxᶠᶠᵃ(1, j′, 1, grid)
+        Δxᶜᶜ[j′] = Δxᶜᶜᵃ(1, j′, 1, grid)
+        Azᶠᶜ[j′] = Azᶠᶜᵃ(1, j′, 1, grid)
+        Azᶜᶠ[j′] = Azᶜᶠᵃ(1, j′, 1, grid)
+        Azᶠᶠ[j′] = Azᶠᶠᵃ(1, j′, 1, grid)
+        Azᶜᶜ[j′] = Azᶜᶜᵃ(1, j′, 1, grid)
+    end
+end
+
+#####
+##### Kernels that precompute the y-metric
+#####
+
+@kernel function compute_Δy!(grid, Δyᶠᶜ, Δyᶜᶠ)
+    j = @index(Global, Linear)
+
+    # Manually offset y-index
+    j′ = j + grid.Δφᵃᶜᵃ.offsets[1] + 1
+
+    @inbounds begin
+        Δyᶜᶠ[j′] = Δyᶜᶠᵃ(1, j′, 1, grid)
+        Δyᶠᶜ[j′] = Δyᶠᶜᵃ(1, j′, 1, grid)
+    end
+end
+
+#####
+##### Metric memory allocation
+#####
+
+function allocate_metrics(grid::EquatorialLatitudeLongitudeGrid)
+    FT = eltype(grid)
+    arch = grid.architecture
+
+    if grid isa XRegularLLG
+        offsets     = grid.φᵃᶜᵃ.offsets[1]
+        metric_size = length(grid.φᵃᶜᵃ)
+    else
+        offsets     = (grid.Δλᶜᵃᵃ.offsets[1], grid.φᵃᶜᵃ.offsets[1])
+        metric_size = (length(grid.Δλᶜᵃᵃ), length(grid.φᵃᶜᵃ))
+    end
+
+    Δxᶜᶜ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
+    Δxᶠᶜ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
+    Δxᶜᶠ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
+    Δxᶠᶠ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
+    Azᶜᶜ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
+    Azᶠᶜ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
+    Azᶜᶠ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
+    Azᶠᶠ = OffsetArray(zeros(arch, FT, metric_size...), offsets...)
+
+    if grid isa YRegularLLG
+        Δyᶠᶜ = Δyᶠᶜᵃ(1, 1, 1, grid)
+        Δyᶜᶠ = Δyᶜᶠᵃ(1, 1, 1, grid)
+    else
+        parentC = zeros(arch, FT, length(grid.Δφᵃᶜᵃ))
+        parentF = zeros(arch, FT, length(grid.Δφᵃᶜᵃ))
+        Δyᶠᶜ    = OffsetArray(parentC, grid.Δφᵃᶜᵃ.offsets[1])
+        Δyᶜᶠ    = OffsetArray(parentF, grid.Δφᵃᶜᵃ.offsets[1])
+    end
+
+    return Δxᶜᶜ, Δxᶠᶜ, Δxᶜᶠ, Δxᶠᶠ, Δyᶠᶜ, Δyᶜᶠ, Azᶜᶜ, Azᶠᶜ, Azᶜᶠ, Azᶠᶠ
+end
+
+#####
+##### Grid nodes
+#####
+
+ξname(::ELLG) = :λ
+ηname(::ELLG) = :φ
+rname(::ELLG) = :z
+
+@inline λnode(i, grid::ELLG, ::Center) = getnode(grid.λᶜᵃᵃ, i)
+@inline λnode(i, grid::ELLG, ::Face)   = getnode(grid.λᶠᵃᵃ, i)
+@inline φnode(j, grid::ELLG, ::Center) = getnode(grid.φᵃᶜᵃ, j)
+@inline φnode(j, grid::ELLG, ::Face)   = getnode(grid.φᵃᶠᵃ, j)
+
+# Definitions for node
+@inline ξnode(i, j, k, grid::ELLG, ℓx, ℓy, ℓz) = λnode(i, grid, ℓx)
+@inline ηnode(i, j, k, grid::ELLG, ℓx, ℓy, ℓz) = φnode(j, grid, ℓy)
+@inline xnode(i, j, grid::ELLG, ℓx, ℓy) = grid.radius * deg2rad(λnode(i, grid, ℓx)) * hack_cosd((φnode(j, grid, ℓy)))
+@inline ynode(j, grid::ELLG, ℓy)        = grid.radius * deg2rad(φnode(j, grid, ℓy))
+
+# Convenience definitions
+@inline λnode(i, j, k, grid::ELLG, ℓx, ℓy, ℓz) = λnode(i, grid, ℓx)
+@inline φnode(i, j, k, grid::ELLG, ℓx, ℓy, ℓz) = φnode(j, grid, ℓy)
+@inline xnode(i, j, k, grid::ELLG, ℓx, ℓy, ℓz) = xnode(i, j, grid, ℓx, ℓy)
+@inline ynode(i, j, k, grid::ELLG, ℓx, ℓy, ℓz) = ynode(j, grid, ℓy)
+
+function nodes(grid::ELLG, ℓx, ℓy, ℓz; reshape=false, with_halos=false, indices=(Colon(), Colon(), Colon()))
+    λ = λnodes(grid, ℓx, ℓy, ℓz; with_halos, indices = indices[1])
+    φ = φnodes(grid, ℓx, ℓy, ℓz; with_halos, indices = indices[2])
+    z = znodes(grid, ℓx, ℓy, ℓz; with_halos, indices = indices[3])
+
+    if reshape
+        # Here we have to deal with the fact that Flat directions may have
+        # `nothing` nodes.
+        #
+        # A better solution (and more consistent with the rest of the API?)
+        # might be to omit the `nothing` nodes in the `reshape`. In other words,
+        # if `TX === Flat`, then we should return `(x, z)`. This is for future
+        # consideration...
+        #
+        # See also `nodes` for `RectilinearGrid`.
+
+        Nλ = isnothing(λ) ? 1 : length(λ)
+        Nφ = isnothing(φ) ? 1 : length(φ)
+        Nz = isnothing(z) ? 1 : length(z)
+
+        λ = isnothing(λ) ? zeros(1, 1, 1) : Base.reshape(λ, Nλ, 1, 1)
+        φ = isnothing(φ) ? zeros(1, 1, 1) : Base.reshape(φ, 1, Nφ, 1)
+        z = isnothing(z) ? zeros(1, 1, 1) : Base.reshape(z, 1, 1, Nz)
+    end
+
+    return (λ, φ, z)
+end
+
+const F = Face
+const C = Center
+const N = Nothing
+
+@inline function xnodes(grid::ELLG, ℓx, ℓy; with_halos=false)
+    λ = λnodes(grid, ℓx; with_halos=with_halos)'
+    φ = φnodes(grid, ℓy; with_halos=with_halos)
+    R = grid.radius
+    return @. R * deg2rad(λ) * hack_cosd(φ)
+end
+
+@inline function ynodes(grid::ELLG, ℓy; with_halos=false)
+    φ = φnodes(grid, ℓy; with_halos=with_halos)
+    R = grid.radius
+    return @. R * deg2rad(φ)
+end
+
+# Convenience
+@inline λnodes(grid::ELLG, ℓx, ℓy, ℓz; with_halos=false, indices=Colon()) = λnodes(grid, ℓx; with_halos, indices)
+@inline φnodes(grid::ELLG, ℓx, ℓy, ℓz; with_halos=false, indices=Colon()) = φnodes(grid, ℓy; with_halos, indices)
+@inline xnodes(grid::ELLG, ℓx, ℓy, ℓz; with_halos=false) = xnodes(grid, ℓx, ℓy; with_halos)
+@inline ynodes(grid::ELLG, ℓx, ℓy, ℓz; with_halos=false) = ynodes(grid, ℓy; with_halos)
+
+@inline λnodes(grid::ELLG, ℓx::F; with_halos=false, indices=Colon()) = view(_property(grid.λᶠᵃᵃ, ℓx, topology(grid, 1), grid.Nx, grid.Hx, with_halos), indices)
+@inline λnodes(grid::ELLG, ℓx::C; with_halos=false, indices=Colon()) = view(_property(grid.λᶜᵃᵃ, ℓx, topology(grid, 1), grid.Nx, grid.Hx, with_halos), indices)
+@inline λnodes(grid::ELLG, ℓx::N; with_halos=false, indices=Colon()) = nothing
+@inline φnodes(grid::ELLG, ℓy::F; with_halos=false, indices=Colon()) = view(_property(grid.φᵃᶠᵃ, ℓy, topology(grid, 2), grid.Ny, grid.Hy, with_halos), indices)
+@inline φnodes(grid::ELLG, ℓy::C; with_halos=false, indices=Colon()) = view(_property(grid.φᵃᶜᵃ, ℓy, topology(grid, 2), grid.Ny, grid.Hy, with_halos), indices)
+@inline φnodes(grid::ELLG, ℓy::N; with_halos=false, indices=Colon()) = nothing
+
+# Flat topologies
+XFlatLLG = LatitudeLongitudeGrid{<:Any, Flat}
+YFlatLLG = LatitudeLongitudeGrid{<:Any, <:Any, Flat}
+@inline λnodes(grid::XFlatLLG, ℓx::F; with_halos=false, indices=Colon()) = _property(grid.λᶜᵃᵃ, ℓx, topology(grid, 1), grid.Nx, grid.Hx, with_halos)
+@inline λnodes(grid::XFlatLLG, ℓx::C; with_halos=false, indices=Colon()) = _property(grid.λᶜᵃᵃ, ℓx, topology(grid, 1), grid.Nx, grid.Hx, with_halos)
+@inline φnodes(grid::YFlatLLG, ℓy::F; with_halos=false, indices=Colon()) = _property(grid.φᵃᶠᵃ, ℓy, topology(grid, 2), grid.Ny, grid.Hy, with_halos)
+@inline φnodes(grid::YFlatLLG, ℓy::C; with_halos=false, indices=Colon()) = _property(grid.φᵃᶜᵃ, ℓy, topology(grid, 2), grid.Ny, grid.Hy, with_halos)
+
+# Generalized coordinates
+@inline ξnodes(grid::ELLG, ℓx; kwargs...) = λnodes(grid, ℓx; kwargs...)
+@inline ηnodes(grid::ELLG, ℓy; kwargs...) = φnodes(grid, ℓy; kwargs...)
+
+@inline ξnodes(grid::ELLG, ℓx, ℓy, ℓz; kwargs...) = λnodes(grid, ℓx; kwargs...)
+@inline ηnodes(grid::ELLG, ℓx, ℓy, ℓz; kwargs...) = φnodes(grid, ℓy; kwargs...)
+
+#####
+##### Grid spacings
+#####
+
+@inline xspacings(grid::ELLG, ℓx, ℓy) = xspacings(grid, ℓx, ℓy, nothing)
+@inline yspacings(grid::ELLG, ℓx, ℓy) = yspacings(grid, ℓx, ℓy, nothing)
+
+@inline λspacings(grid::ELLG, ℓx) = λspacings(grid, ℓx, nothing, nothing)
+@inline φspacings(grid::ELLG, ℓy) = φspacings(grid, nothing, ℓy, nothing)
+
+"""
+    EquatorialLatitudeLongitudeGrid(rectilinear_grid::RectilinearGrid;
+                          radius = Oceananigans.defaults.planet_radius,
+                          origin = (0, 0))
+
+Construct an `EquatorialLatitudeLongitudeGrid` from a `RectilinearGrid`. The horizontal coordinates of the
+rectilinear grid are transformed to longitude-latitude coordinates in degrees, accounting for
+spherical Earth geometry. The longitudes are computed approximately using the latitudinal origin.
+
+The vertical coordinate and architecture are inherited from the input grid.
+
+Keyword Arguments
+================
+- `radius`: The radius of the sphere, defaults to Earth's mean radius (≈ 6371 km)
+- `origin`: Tuple of (longitude, latitude) in degrees specifying the origin of the rectilinear grid
+"""
+function EquatorialLatitudeLongitudeGrid(rectilinear_grid::RectilinearGrid;
+                               radius = Oceananigans.defaults.planet_radius,
+                               origin = (0, 0))
+
+    arch = architecture(rectilinear_grid)
+    Hx, Hy, Hz = halo_size(rectilinear_grid)
+    Nx, Ny, Nz = size(rectilinear_grid)
+
+    λ₀, φ₀ = origin
+
+    TX, TY, TZ = topology(rectilinear_grid)
+    tx, ty, tz = TX(), TY(), TZ()
+    triply_bounded = tx isa Bounded && ty isa Bounded && tz isa Bounded
+    if !triply_bounded
+        msg = string("The source RectilinearGrid for constructing LatitudeLongitudeGrid ",
+                     "must be triply-bounded, but has topology=($tx, $ty, $tz)!")
+        throw(ArgumentError(msg))
+    end
+
+    # Get face coordinates from rectilinear grid
+    xᶠ = xnodes(rectilinear_grid, Face())
+    yᶠ = ynodes(rectilinear_grid, Face())
+
+    xᶠ = on_architecture(CPU(), xᶠ)
+    yᶠ = on_architecture(CPU(), yᶠ)
+
+    # Convert y coordinates to latitudes
+    R = radius
+    φᶠ = @. φ₀ + 180 / π * yᶠ / R
+
+    # Convert x to longitude, using the origin as a reference
+    λᶠ = @. λ₀ + 180 / π * xᶠ / (R * cosd(φ₀))
+
+    z = cpu_face_constructor_z(rectilinear_grid)
+
+    return EquatorialLatitudeLongitudeGrid(arch, eltype(rectilinear_grid); z, radius,
+                                 topology = (Bounded, Bounded, Bounded),
+                                 size = (Nx, Ny, Nz),
+                                 halo = (Hx, Hy, Hz),
+                                 longitude = λᶠ,
+                                 latitude = φᶠ)
+end

--- a/src/Operators/Operators.jl
+++ b/src/Operators/Operators.jl
@@ -60,6 +60,7 @@ using Oceananigans.Grids: LatitudeLongitudeGrid, LLGOTF, XRegLLGOTF, YRegLLGOTF,
     OrthogonalSphericalShellGrid, RectilinearGrid, XRegularLLG, XRegularRG, YRegularLLG,
     YRegularRG, ZRegOrthogonalSphericalShellGrid, ZRegularLLG, ZRegularRG, AbstractGrid,
     Center, Face
+using Oceananigans.Grids: EquatorialLatitudeLongitudeGrid
 using DocStringExtensions: TYPEDSIGNATURES
 
 #####

--- a/src/Operators/spacings_and_areas_and_volumes.jl
+++ b/src/Operators/spacings_and_areas_and_volumes.jl
@@ -253,6 +253,19 @@ for sym in (:Δφᵃᶜᵃ, :Δφᵃᶠᵃ)
     end
 end
 
+#####
+##### EquatorialLatitudeLongitude Grids (define both precomputed and non-precomputed metrics)
+#####
+
+### Curvilinear spacings
+
+# --- EquatorialLatitudeLongitudeGrid spacings (NON-RECURSIVE) ---
+
+@inline Δxᶠᵃᵃ(i, j, k, grid::EquatorialLatitudeLongitudeGrid) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
+@inline Δxᶜᵃᵃ(i, j, k, grid::EquatorialLatitudeLongitudeGrid) = @inbounds grid.radius * deg2rad(grid.Δφᵃᶜᵃ[j])
+@inline Δyᵃᶠᵃ(i, j, k, grid::EquatorialLatitudeLongitudeGrid) = @inbounds grid.radius * deg2rad(grid.Δλᶠᵃᵃ[i]) * cosd(grid.φᵃᶜᵃ[j])
+@inline Δyᵃᶜᵃ(i, j, k, grid::EquatorialLatitudeLongitudeGrid) = @inbounds grid.radius * deg2rad(grid.Δλᶜᵃᵃ[i]) * cosd(grid.φᵃᶜᵃ[j])
+
 ### Linear spacings
 
 ### Precomputed metrics

--- a/test_equatorial_grid.jl
+++ b/test_equatorial_grid.jl
@@ -1,0 +1,304 @@
+using Oceananigans
+using Oceananigans.Units
+using Oceananigans.Grids
+using Oceananigans.Fields
+using Oceananigans.Operators
+using Oceananigans.OutputWriters
+using CairoMakie
+using Revise
+using Statistics
+using NCDatasets
+
+# ------------------------
+# 1. Construct your grid
+# ------------------------
+
+Nx, Ny = 64, 64
+
+grid = EquatorialLatitudeLongitudeGrid(
+    size = (Nx, Ny, 1),
+    longitude = (-60, 60),
+    latitude  = (-60, 60),
+    z = (-1000, 0)
+)
+
+model = NonhydrostaticModel(grid, 
+                            tracers = :c,
+                            advection = WENO(order=3))
+
+model.velocities.u .= 1.0
+model.velocities.v .= 0.0
+
+u, v = model.velocities
+
+δ = ∂x(u) + ∂y(v)
+ω = ∂x(v) - ∂y(u)
+compute!(δ)
+compute!(ω)
+
+println("divergence extrema: = ", extrema(interior(δ)))
+println("vorticity extrema:  = ", extrema(interior(ω)))
+
+set!(model, u = 2, c = (x,y,z) -> exp(-(x^2 + y^2) / (2e2)))
+
+simulation = Simulation(model, Δt = 1hours , stop_time=50*days)
+
+function print_tracer_stats(sim)
+    c = interior(sim.model.tracers.c)[:, :, 1]
+    println("t = ", sim.model.clock.time,
+            " | min(c) = ", minimum(c),
+            " | max(c) = ", maximum(c),
+            " | mean(c) = ", mean(c))
+end
+
+simulation.callbacks[:progress] =
+    Callback(print_tracer_stats, IterationInterval(50))
+
+
+saved_c = Vector{Array{Float64,2}}()
+saved_t = Float64[]
+
+simulation.callbacks[:save_c] = Callback(sim -> begin
+    c = Array(interior(sim.model.tracers.c)[:, :, 1])
+    push!(saved_c, c)
+    push!(saved_t, sim.model.clock.time)
+end, TimeInterval(1days))
+
+run!(simulation)
+
+print(maximum(interior(model.tracers.c)), " ")
+print(minimum(interior(model.tracers.c)))
+
+λ = collect(grid.λᶜᵃᵃ)
+φ = collect(grid.φᵃᶜᵃ)
+
+c = collect(interior(model.tracers.c))[:, :, 1]
+
+fig = Figure()
+ax = Axis(fig[1,1], xlabel="φ", ylabel="λ")
+
+hm = heatmap!(ax, φ, λ, c')   # transpose for correct orientation
+Colorbar(fig[1,2], hm)
+
+display(fig)
+
+
+λ = collect(grid.λᶜᵃᵃ)
+φ = collect(grid.φᵃᶜᵃ)
+
+using NCDatasets
+using CairoMakie
+
+# ------------------------
+# 1. Load NetCDF file
+# ------------------------
+
+ds = NCDataset("tracer.nc")
+
+c_data = ds["c"]          # (φ, λ, time)
+time   = ds["time"]
+
+Ny, Nx, Nt = size(c_data)
+
+println("Loaded data size:", size(c_data))
+
+# ------------------------
+# 2. Build coordinate axes
+# ------------------------
+# (Use grid values if still in memory — otherwise reconstruct)
+
+# If grid exists:
+λ = collect(grid.λᶜᵃᵃ)
+φ = collect(grid.φᵃᶜᵃ)
+
+# If grid is NOT available, use simple indices:
+# λ = 1:Nx
+# φ = 1:Ny
+
+# ------------------------
+# 3. Plot a single frame
+# ------------------------
+
+n = 1   # first time step
+
+c = c_data[:, :, n]
+
+fig = Figure()
+ax = Axis(fig[1,1],
+    xlabel = "φ (degrees)",
+    ylabel = "λ (degrees)",
+    title = "Tracer field (t = $(round(time[n]/86400, digits=2)) days)"
+)
+
+hm = heatmap!(ax, φ, λ, c'; colorrange=(minimum(c), maximum(c)))
+Colorbar(fig[1,2], hm)
+
+display(fig)
+
+
+# ------------------------
+# 4. Animate all frames
+# ------------------------
+
+fig = Figure()
+ax = Axis(fig[1,1],
+    xlabel="φ (degrees)",
+    ylabel="λ (degrees)"
+)
+
+c0 = c_data[:, :, 1]
+
+# FIXED color range so animation is meaningful
+crange = (minimum(c_data), maximum(c_data))
+
+hm = heatmap!(ax, φ, λ, c0'; colorrange=crange)
+Colorbar(fig[1,2], hm)
+
+record(fig, "tracer_animation.mp4", 1:Nt) do n
+    c = c_data[:, :, n]
+
+    hm[3] = c'   # update heatmap
+
+    ax.title = "t = $(round(time[n]/86400, digits=2)) days"
+end
+
+close(ds)
+
+println("Animation saved as tracer_animation.mp4")
+
+
+
+#=
+println("Grid constructed successfully.")
+
+Δx = collect(grid.Δxᶜᶜᵃ)
+Δy = collect(grid.Δyᶠᶜᵃ)
+Az = collect(grid.Azᶜᶜᵃ)
+
+Δx_mat = repeat(Δx', size(Δy,1), 1)
+
+ratio = Az ./ (Δx_mat .* Δy)
+println(extrema(ratio[isfinite.(ratio)]))
+
+# ------------------------
+# 2. Extract nodes
+# ------------------------
+
+λC, φC, _ = nodes(grid, Center(), Center(), Center())
+
+println("\nφ (latitude) range:")
+println(extrema(φC))
+
+# ------------------------
+# 3. Access metrics
+# ------------------------
+
+Δx = grid.Δxᶜᶜᵃ
+Δy = grid.Δyᶠᶜᵃ
+Az = grid.Azᶜᶜᵃ
+
+println("\nMetric ranges:")
+println("Δx: ", extrema(Δx))
+println("Δy: ", extrema(Δy))
+println("Az: ", extrema(Az))
+
+# ------------------------
+# 4. Sanity checks
+# ------------------------
+
+println("\nSanity checks:")
+
+# Δx should not vary in i-direction
+println("\nCheck Δx variation along i (should be small):")
+maximum(abs, Δx .- mean(Δx))
+
+# Δy should vary with latitude (cos φ)
+println("\nCheck Δy min/max (should vary):")
+println(extrema(Δy))
+
+# Area consistency (avoid division by zero)
+println("\nCheck Az ≈ Δx * Δy:")
+
+Δx_arr = parent(grid.Δxᶜᶜᵃ)
+Δy_arr = isa(grid.Δyᶠᶜᵃ, Number) ? fill(grid.Δyᶠᶜᵃ, size(Δx_arr)) : parent(grid.Δyᶠᶜᵃ)
+Az_arr = parent(grid.Azᶜᶜᵃ)
+
+println("Δx range: ", extrema(Δx_arr))
+println("Δy range: ", extrema(Δy_arr))
+println("Az range: ", extrema(Az_arr))
+
+# Simple check (no slicing!)
+println("Check Δx variation:")
+println(maximum(abs, Δx_arr .- mean(Δx_arr; dims=1)))
+
+println("Check Δy variation:")
+println(maximum(abs, Δy_arr .- mean(Δy_arr)))
+
+Δx_vec = collect(grid.Δxᶜᶜᵃ)          # 1D
+Δy_mat = collect(grid.Δyᶠᶜᵃ)          # 2D
+Az_mat = collect(grid.Azᶜᶜᵃ)
+
+# Broadcast Δx into 2D
+Δx_mat = repeat(Δx_vec', size(Δy_mat, 1), 1)
+
+ratio = Az_mat ./ (Δx_mat .* Δy_mat)
+
+println("ratio range: ", extrema(ratio[isfinite.(ratio)]))
+
+# ------------------------
+# 5. Plot diagnostics
+# ------------------------
+
+fig = Figure(size = (1200, 400))
+
+φ = collect(grid.φᵃᶜᵃ)
+λ = collect(grid.λᶜᵃᵃ)
+
+# Δx (1D)
+ax1 = Axis(fig[1,1], title="Δx vs φ",
+           xlabel="φ (degrees)", ylabel="Δx (m)")
+
+lines!(ax1, φ, collect(grid.Δxᶜᶜᵃ))
+scatter!(ax1, φ, collect(grid.Δxᶜᶜᵃ))
+
+# Δy (2D)
+ax2 = Axis(fig[1,2], title="Δy",
+           xlabel="φ (degrees)", ylabel="λ (degrees)")
+
+hm2 = heatmap!(ax2, φ, λ, collect(grid.Δyᶠᶜᵃ)')
+Colorbar(fig[1,3], hm2)
+
+# Az (2D)
+ax3 = Axis(fig[1,4], title="Az",
+           xlabel="φ (degrees)", ylabel="λ (degrees)")
+
+hm3 = heatmap!(ax3, φ, λ, collect(grid.Azᶜᶜᵃ)')
+Colorbar(fig[1,5], hm3)
+
+display(fig)
+
+# ------------------------
+# 6. Optional: geometry in 3D
+# ------------------------
+
+λ = collect(grid.λᶜᵃᵃ)
+φ = collect(grid.φᵃᶜᵃ)
+
+Λ = reshape(λ, :, 1) .* ones(1, length(φ))
+Φ = ones(length(λ), 1) .* reshape(φ, 1, :)
+
+R = grid.radius
+
+X = R .* cosd.(Φ) .* cosd.(Λ)
+Y = R .* cosd.(Φ) .* sind.(Λ)
+Z = R .* sind.(Φ)
+
+fig2 = Figure(size = (500, 500))
+ax = Axis3(fig2[1,1])
+
+surface!(ax, X, Y, Z)
+
+display(fig2)
+
+println("\nDone.")
+=#

--- a/test_equatorial_grid.jl
+++ b/test_equatorial_grid.jl
@@ -1,17 +1,9 @@
 using Oceananigans
 using Oceananigans.Units
 using Oceananigans.Grids
-using Oceananigans.Fields
 using Oceananigans.Operators
-using Oceananigans.OutputWriters
 using CairoMakie
-using Revise
 using Statistics
-using NCDatasets
-
-# ------------------------
-# 1. Construct your grid
-# ------------------------
 
 Nx, Ny = 64, 64
 
@@ -22,10 +14,13 @@ grid = EquatorialLatitudeLongitudeGrid(
     z = (-1000, 0)
 )
 
-model = NonhydrostaticModel(grid, 
-                            tracers = :c,
-                            advection = WENO(order=3))
+model = NonhydrostaticModel(
+    grid,
+    tracers = :c,
+    advection = WENO(order=3)
+)
 
+# Constant flow
 model.velocities.u .= 1.0
 model.velocities.v .= 0.0
 
@@ -33,139 +28,78 @@ u, v = model.velocities
 
 δ = ∂x(u) + ∂y(v)
 ω = ∂x(v) - ∂y(u)
-compute!(δ)
-compute!(ω)
 
-println("divergence extrema: = ", extrema(interior(δ)))
-println("vorticity extrema:  = ", extrema(interior(ω)))
+compute!(δ); compute!(ω)
 
-set!(model, u = 2, c = (x,y,z) -> exp(-(x^2 + y^2) / (2e2)))
+println("div extremum  : ", extrema(interior(δ)))
+println("vorticity ext : ", extrema(interior(ω)))
 
-simulation = Simulation(model, Δt = 1hours , stop_time=50*days)
+set!(model, u = 2, c = (x,y,z) -> begin
+    φ = y / grid.radius
+    λ = x / (grid.radius * cos(φ))
+    exp(-(φ^2 + λ^2) / 0.1^2)
+end)
 
-function print_tracer_stats(sim)
-    c = interior(sim.model.tracers.c)[:, :, 1]
-    println("t = ", sim.model.clock.time,
-            " | min(c) = ", minimum(c),
-            " | max(c) = ", maximum(c),
-            " | mean(c) = ", mean(c))
-end
+simulation = Simulation(model, Δt = 1hours, stop_time = 50days)
 
-simulation.callbacks[:progress] =
-    Callback(print_tracer_stats, IterationInterval(50))
-
-
-saved_c = Vector{Array{Float64,2}}()
+saved_c = Matrix{Float64}[]
 saved_t = Float64[]
 
-simulation.callbacks[:save_c] = Callback(sim -> begin
-    c = Array(interior(sim.model.tracers.c)[:, :, 1])
-    push!(saved_c, c)
+simulation.callbacks[:save] = Callback(sim -> begin
+    push!(saved_c, Array(interior(sim.model.tracers.c)[:, :, 1]))
     push!(saved_t, sim.model.clock.time)
 end, TimeInterval(1days))
 
 run!(simulation)
 
-print(maximum(interior(model.tracers.c)), " ")
-print(minimum(interior(model.tracers.c)))
+println("Final min/max: ",
+    minimum(interior(model.tracers.c)), " ",
+    maximum(interior(model.tracers.c)))
 
-λ = collect(grid.λᶜᵃᵃ)
-φ = collect(grid.φᵃᶜᵃ)
+λ = collect(grid.λᶜᵃᵃ)[1:Nx]
+φ = collect(grid.φᵃᶜᵃ)[1:Ny]
 
-c = collect(interior(model.tracers.c))[:, :, 1]
+function plot_tracer(c, λ, φ; title="")
+
+    cmin, cmax = extrema(c)
+
+    if cmax - cmin < 1e-12
+        cmax = cmin + 1e-6   # avoid Makie crash
+    end
+
+    fig = Figure()
+    ax = Axis(fig[1,1],
+              xlabel="φ (deg)",
+              ylabel="λ (deg)",
+              title=title)
+
+    hm = heatmap!(ax, φ, λ, c'; colorrange=(cmin, cmax))
+    Colorbar(fig[1,2], hm)
+
+    display(fig)
+end
+
+c_final = saved_c[end]
+plot_tracer(c_final, λ, φ; title="Final tracer")
+
+Nt = length(saved_c)
+
+# Global color scale (important!)
+global_min = minimum(map(minimum, saved_c))
+global_max = maximum(map(maximum, saved_c))
 
 fig = Figure()
 ax = Axis(fig[1,1], xlabel="φ", ylabel="λ")
 
-hm = heatmap!(ax, φ, λ, c')   # transpose for correct orientation
-Colorbar(fig[1,2], hm)
+hm = heatmap!(ax, φ, λ, saved_c[1]';
+              colorrange=(global_min, global_max))
 
-display(fig)
-
-
-λ = collect(grid.λᶜᵃᵃ)
-φ = collect(grid.φᵃᶜᵃ)
-
-using NCDatasets
-using CairoMakie
-
-# ------------------------
-# 1. Load NetCDF file
-# ------------------------
-
-ds = NCDataset("tracer.nc")
-
-c_data = ds["c"]          # (φ, λ, time)
-time   = ds["time"]
-
-Ny, Nx, Nt = size(c_data)
-
-println("Loaded data size:", size(c_data))
-
-# ------------------------
-# 2. Build coordinate axes
-# ------------------------
-# (Use grid values if still in memory — otherwise reconstruct)
-
-# If grid exists:
-λ = collect(grid.λᶜᵃᵃ)
-φ = collect(grid.φᵃᶜᵃ)
-
-# If grid is NOT available, use simple indices:
-# λ = 1:Nx
-# φ = 1:Ny
-
-# ------------------------
-# 3. Plot a single frame
-# ------------------------
-
-n = 1   # first time step
-
-c = c_data[:, :, n]
-
-fig = Figure()
-ax = Axis(fig[1,1],
-    xlabel = "φ (degrees)",
-    ylabel = "λ (degrees)",
-    title = "Tracer field (t = $(round(time[n]/86400, digits=2)) days)"
-)
-
-hm = heatmap!(ax, φ, λ, c'; colorrange=(minimum(c), maximum(c)))
-Colorbar(fig[1,2], hm)
-
-display(fig)
-
-
-# ------------------------
-# 4. Animate all frames
-# ------------------------
-
-fig = Figure()
-ax = Axis(fig[1,1],
-    xlabel="φ (degrees)",
-    ylabel="λ (degrees)"
-)
-
-c0 = c_data[:, :, 1]
-
-# FIXED color range so animation is meaningful
-crange = (minimum(c_data), maximum(c_data))
-
-hm = heatmap!(ax, φ, λ, c0'; colorrange=crange)
 Colorbar(fig[1,2], hm)
 
 record(fig, "tracer_animation.mp4", 1:Nt) do n
-    c = c_data[:, :, n]
-
-    hm[3] = c'   # update heatmap
-
-    ax.title = "t = $(round(time[n]/86400, digits=2)) days"
+    hm[3] = saved_c[n]'
+    ax.title = "t = $(round(saved_t[n]/86400, digits=1)) days"
 end
-
-close(ds)
-
-println("Animation saved as tracer_animation.mp4")
-
 
 
 #=

--- a/test_llc_ellc.jl
+++ b/test_llc_ellc.jl
@@ -1,0 +1,273 @@
+using Oceananigans
+using Oceananigans.Grids
+using Oceananigans.Units
+using CairoMakie
+using Statistics
+using LinearAlgebra
+
+gaussian(λ, φ, λ₀, φ₀, σ) =
+    exp(-((λ - λ₀)^2 + (φ - φ₀)^2) / σ^2)
+
+function make_llc_model(grid;
+                        λ₀=45,
+                        φ₀=45,
+                        σ=5,
+                       U0=10,
+                       V0=10)
+
+    background_fields = (
+        u = (λ, φ, z, t) -> U0 * cosd(φ),
+        v = (λ, φ, z, t) -> V0,
+    )
+
+    model = NonhydrostaticModel(
+        grid,
+        tracers = :c,
+        advection = WENO(order=5),
+        coriolis = nothing,
+        background_fields = background_fields
+    )
+
+    set!(model,
+         c = (λ, φ, z) -> gaussian(λ, φ, λ₀, φ₀, σ))
+
+    return model
+end
+
+function make_ellc_model(grid;
+                         λ₀=45,
+                         φ₀=45,
+                         σ=5,
+                        U0=10,
+                        V0=6.1)
+
+    background_fields = (
+        u = (λ, φ, z, t) -> U0,
+        v = (λ, φ, z, t) -> V0
+    )
+
+    model = NonhydrostaticModel(
+        grid,
+        tracers = :c,
+        advection = WENO(order=5),
+        coriolis = nothing,
+        background_fields = background_fields
+    )
+
+    set!(model,
+         c = (λ, φ, z) -> gaussian(λ, φ, λ₀, φ₀, σ))
+
+    return model
+end
+
+function comparison_plot(
+    λ_llc, φ_llc, c_llc,
+    λ_ellc, φ_ellc, c_ellc;
+    title1="LLC",
+    title2="ELLC"
+)
+
+    fig = Figure(size=(800, 400))
+
+    ax1 = Axis(
+        fig[1,1],
+        title=title1,
+        xlabel="λ",
+        ylabel="φ",
+        aspect=DataAspect()
+    )
+
+    hm1 = heatmap!(ax1, λ_llc, φ_llc, c_llc)
+    Colorbar(fig[1,2], hm1)
+
+    ax2 = Axis(
+        fig[1,3],
+        title=title2,
+        xlabel="φₑ",
+        ylabel="λₑ",
+        aspect=DataAspect()
+    )
+
+    hm2 = heatmap!(ax2, φ_ellc, λ_ellc, c_ellc)
+    Colorbar(fig[1,4], hm2)
+
+    display(fig)
+
+    return fig
+end
+
+function peak_location(c, λ, φ)
+
+    i, j = Tuple(argmax(c))
+
+    return (
+        λ = λ[i],
+        φ = φ[j],
+        cmax = c[i,j]
+    )
+end
+
+function centroid(c, λ, φ)
+
+    M = sum(c)
+
+    (
+        λ = sum(c .* reshape(λ, :, 1)) / M,
+        φ = sum(c .* reshape(φ, 1, :)) / M
+    )
+end
+
+function index_centroid(c)
+
+    M = sum(c)
+
+    Nx, Ny = size(c)
+
+    i = collect(1:Nx)
+    j = collect(1:Ny)
+
+    (
+        i = sum(c .* reshape(i, :, 1)) / M,
+        j = sum(c .* reshape(j, 1, :)) / M
+    )
+end
+
+function displacement(c0, cf)
+
+    p0 = index_centroid(c0)
+    pf = index_centroid(cf)
+
+    (
+        Δi = pf.i - p0.i,
+        Δj = pf.j - p0.j
+    )
+end
+
+function report_case(
+    name,
+    c0,
+    cf,
+    λ,
+    φ
+)
+
+    p0 = peak_location(c0, λ, φ)
+    pf = peak_location(cf, λ, φ)
+
+    c0c = centroid(c0, λ, φ)
+    cfc = centroid(cf, λ, φ)
+
+    i0 = index_centroid(c0)
+    ifc = index_centroid(cf)
+
+    println("\n", "="^40)
+    println(name)
+    println("="^40)
+
+    println("Peak:")
+    println("  initial = ", p0)
+    println("  final   = ", pf)
+
+    println("Centroid:")
+    println("  initial = ", c0c)
+    println("  final   = ", cfc)
+
+    println("Index centroid:")
+    println("  initial = ", i0)
+    println("  final   = ", ifc)
+
+    println("Displacement:")
+    println("  Δi = ", ifc.i - i0.i)
+    println("  Δj = ", ifc.j - i0.j)
+
+    println("Field change:")
+    println("  max|Δc| = ",
+            maximum(abs.(cf .- c0)))
+end
+
+Nx, Ny = 256, 256
+
+grid_llc = LatitudeLongitudeGrid(
+    size = (Nx, Ny, 1),
+    longitude = (15, 75),
+    latitude  = (15, 75),
+    z = (-1000, 0)
+)
+
+grid_ellc = EquatorialLatitudeLongitudeGrid(
+    size = (Ny, Nx, 1),
+    longitude = (15, 75), 
+    latitude  = (15, 75),
+    z = (-1000, 0)
+)
+
+model_llc = make_llc_model(
+    grid_llc;
+    λ₀ = 45,
+    φ₀ = 45,
+    U0 = 10,
+    V0 = 10
+)
+
+model_ellc = make_ellc_model(
+    grid_ellc;
+    λ₀ = 45,
+    φ₀ = 45,
+    U0 = 10,
+    V0 = 6.1
+)
+
+λ_llc,  φ_llc, _  = nodes(grid_llc,  Center(), Center(), Center())
+λ_ellc, φ_ellc, _ = nodes(grid_ellc, Center(), Center(), Center())
+
+sim_llc  = Simulation(model_llc,  Δt = 10minutes, stop_time = 1days)
+sim_ellc = Simulation(model_ellc, Δt = 10minutes, stop_time = 1days)
+
+function progress(sim)
+    c = interior(sim.model.tracers.c)[:, :, 1]
+
+    println(
+        "t = ", sim.model.clock.time / days,
+        "  max(c) = ", maximum(c),
+        #"  u = ", extrema(interior(sim.model.velocities.u)),
+        #"  v = ", extrema(interior(sim.model.velocities.v))
+    )
+end
+
+sim_llc.callbacks[:progress]  = Callback(progress, IterationInterval(10))
+sim_ellc.callbacks[:progress] = Callback(progress, IterationInterval(10))
+
+c_initial_llc  = copy(Array(interior(model_llc.tracers.c))[:, :, 1])
+c_initial_ellc = copy(Array(interior(model_ellc.tracers.c))[:, :, 1])
+
+comparison_plot(
+    λ_llc,  φ_llc, c_initial_llc,
+    λ_ellc, φ_ellc, c_initial_ellc
+)
+
+run!(sim_llc)
+run!(sim_ellc)
+
+c_final_llc  = Array(interior(model_llc.tracers.c))[:, :, 1]
+c_final_ellc = Array(interior(model_ellc.tracers.c))[:, :, 1]
+
+comparison_plot(
+    λ_llc, φ_llc, c_final_llc,
+    λ_ellc, φ_ellc, c_final_ellc
+)
+
+report_case(
+    "LLC",
+    c_initial_llc,
+    c_final_llc,
+    λ_llc,
+    φ_llc
+)
+
+report_case(
+    "ELLC",
+    c_initial_ellc,
+    c_final_ellc,
+    λ_ellc,
+    φ_ellc
+)


### PR DESCRIPTION
# Summary

This PR introduces an `EquatorialLatitudeLongitudeGrid`
for Oceananigans.

The coordinate singularities are relocated to the tropics
 while preserving an orthogonal spherical coordinate system.

# Current Status

## Completed

- [x] Grid construction
- [x] Metric implementation
- [x] Tracer initialization
- [x] Uniform x-advection validation
- [x] Uniform y-advection validation
- [x] Combined x-y advection validation
- [x] Resolution studies (64², 128², 256²)

## Remaining Work

### Physics

- [ ] Coriolis operator
- [ ] Momentum equations
- [ ] Pressure-gradient terms
- [ ] Geostrophic balance

### Validation

- [ ] GPU validation
- [ ] Solid-body rotation
- [ ] Vortex transport tests

# Validation Results

| Grid | N | Peak |
|------|---:|------:|
| LLC  | 64  | 1.164 |
| LLC  | 128 | 1.168 |
| LLC  | 256 | 1.169 |
| ELLC | 64  | 0.997 |
| ELLC | 128 | 1.000 |
| ELLC | 256 | 1.000 |

### Initial Profiles
<img width="1600" height="800" alt="initial_llc_ellc" src="https://github.com/user-attachments/assets/5dc2a275-22cc-46ac-886d-2f49d1c9f2c3" />

### Final Profiles
<img width="1600" height="800" alt="final_llc_ellc" src="https://github.com/user-attachments/assets/f5d1b27d-8a80-43f4-9c18-3709e6222815" />

# Reviewer Feedback Requested

- Any of your thoughts and/or suggestions are welcome.