### PR TITLE
Remove `convert` type piracy from Reactant extension

### DIFF
--- a/ext/OceananigansReactantExt/TimeSteppers.jl
+++ b/ext/OceananigansReactantExt/TimeSteppers.jl
@@ -47,13 +47,6 @@ function Clock(grid::ReactantGrid)
     return Clock(; time=t, iteration=iter, stage, last_Δt, last_stage_Δt, kernel_time_type=FT)
 end
 
-Base.convert(::Type{T}, x::Reactant.TracedRNumber) where {T<:Reactant.ReactantPrimitive} =
-      Reactant.promote_to(Reactant.TracedRNumber{T}, x)
-
-Base.convert(::Type{T}, x::Reactant.ConcreteRNumber{T}) where {T<:AbstractFloat} = x
-Base.convert(::Type{T}, x::Reactant.ConcreteRNumber) where {T<:AbstractFloat} =
-      Reactant.ConcreteRNumber(convert(T, Reactant.to_number(x)); x.sharding)
-
 innertype(::ConcreteRNumber{T}) where T = T
 
 const ConcreteReactantClock = Clock{<:ConcreteRNumber}

--- a/ext/OceananigansReactantExt/TimeSteppers.jl
+++ b/ext/OceananigansReactantExt/TimeSteppers.jl
@@ -9,6 +9,7 @@ using Oceananigans
 using Oceananigans: AbstractModel, Distributed
 using Oceananigans.Grids: architecture
 using Oceananigans.TimeSteppers:
+    TimeSteppers as OceananigansTimeSteppers,
     update_state!,
     tick!,
     tick_stage!,
@@ -46,6 +47,17 @@ function Clock(grid::ReactantGrid)
 
     return Clock(; time=t, iteration=iter, stage, last_Δt, last_stage_Δt, kernel_time_type=FT)
 end
+
+# Extend `Oceananigans.TimeSteppers.clock_convert` not to commit type piracy on
+# `Base.convert`.  For Reactant's traced numbers we actually don't want to
+# `convert` them to the "destination" type `T` (which is in contrast with the
+# semantic of `Base.convert`).
+OceananigansTimeSteppers.clock_convert(::Type{T}, x::Reactant.TracedRNumber) where {T<:Reactant.ReactantPrimitive} =
+    Reactant.promote_to(Reactant.TracedRNumber{T}, x)
+
+OceananigansTimeSteppers.clock_convert(::Type{T}, x::Reactant.ConcreteRNumber{T}) where {T<:AbstractFloat} = x
+OceananigansTimeSteppers.clock_convert(::Type{T}, x::Reactant.ConcreteRNumber) where {T<:AbstractFloat} =
+    Reactant.ConcreteRNumber(convert(T, Reactant.to_number(x)); x.sharding)
 
 innertype(::ConcreteRNumber{T}) where T = T
 

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -172,6 +172,9 @@ function tick_stage!(clock, stage_Δt, step_Δt)
     return nothing
 end
 
+# Helper function to convert clock internal fields, so that we don't overload `Base.convert`.
+clock_convert(T, x) = convert(T, x)
+
 """
 $(TYPEDSIGNATURES)
 
@@ -181,9 +184,9 @@ function Adapt.adapt_structure(to, clock::Clock)
     KT = kernel_time_type(clock)
     DT = time_step_type(KT)
 
-    return (time          = convert(KT, clock.time),
-            last_Δt       = convert(DT, clock.last_Δt),
-            last_stage_Δt = convert(DT, clock.last_stage_Δt),
+    return (time          = clock_convert(KT, clock.time),
+            last_Δt       = clock_convert(DT, clock.last_Δt),
+            last_stage_Δt = clock_convert(DT, clock.last_stage_Δt),
             iteration     = clock.iteration,
             stage         = clock.stage)
 end


### PR DESCRIPTION
Currently we have
```julia-repl
julia> using Reactant

julia> convert(Float64, ConcretePJRTNumber(1.0))
1.0

julia> using Oceananigans

julia> convert(Float64, ConcretePJRTNumber(1.0))
ConcretePJRTNumber{Float64, 1}(1.0)
```
These methods are type piracy (behaviour of Reactant changes after you load Oceananigans) and not a good idea anyway (`convert(T, x)` should return an instance of `T`, otherwise why calling `convert` in the first place).

Ref: https://github.com/CliMA/Oceananigans.jl/pull/5570#discussion_r3461050696.