### PR TITLE
Support writing windowed fields to NetCDF (fixes #5717)

### DIFF
--- a/ext/OceananigansNCDatasetsExt/OceananigansNCDatasetsExt.jl
+++ b/ext/OceananigansNCDatasetsExt/OceananigansNCDatasetsExt.jl
@@ -90,7 +90,6 @@ import Oceananigans.OutputWriters:
     reconstruct_grid,
     trilocation_dim_name,
     add_grid_suffix,
-    dimension_name_generator_free_surface,
     vertical_coordinate_name
 
 const c = Center()

--- a/ext/OceananigansNCDatasetsExt/dimensions.jl
+++ b/ext/OceananigansNCDatasetsExt/dimensions.jl
@@ -59,8 +59,12 @@ end
 # from the canonical full-extent dimension already in the dataset. Resolve the base name to
 # itself when it is unused or its values already match, otherwise to the first free
 # `name_2`, `name_3`, … whose values match (deduping fields that share the same window).
-function resolve_windowed_dim_name(ds, base_name, data, dimension_type)
-    (base_name == "" || data === nothing) && return base_name
+#
+# This only applies to axes the field actually windows (a non-`Colon` index). Axes with the
+# default `Colon` index keep the strict create-or-validate in `create_spatial_dimensions!`,
+# so a dimension pre-created with mismatched values still errors rather than being aliased.
+function resolve_windowed_dim_name(ds, base_name, index, data, dimension_type)
+    (base_name == "" || data === nothing || index === Colon()) && return base_name
     target = collect(dimension_type.(data))
     candidate = base_name
     n = 1
@@ -81,8 +85,8 @@ function create_field_coord_variables!(ds, fd, grid, spatial_dim_names, dim_name
     dimension_attributes = default_dimension_attributes(grid, dim_name_generator; grid_index)
     spatial_dim_data = nodes(fd; with_halos)
 
-    resolved_dim_names = map(spatial_dim_names, spatial_dim_data) do name, data
-        resolve_windowed_dim_name(ds, name, data, dimension_type)
+    resolved_dim_names = map(spatial_dim_names, indices(fd), spatial_dim_data) do name, index, data
+        resolve_windowed_dim_name(ds, name, index, data, dimension_type)
     end
 
     # A renamed windowed axis inherits the attributes of the base coordinate it derives from.

--- a/ext/OceananigansNCDatasetsExt/dimensions.jl
+++ b/ext/OceananigansNCDatasetsExt/dimensions.jl
@@ -36,10 +36,13 @@ function create_field_dimensions!(ds, fd::AbstractField, dimension_name_generato
     # Nothing location or the grid axis is Flat. The "effective" dim names are what
     # actually go into the variable's NetCDF signature.
     spatial_dim_names = field_dimensions(fd, dimension_name_generator; grid_index)
-    effective_dim_names = tuple(filter(!isempty, spatial_dim_names)...)
 
-    create_field_coord_variables!(ds, fd, grid(fd), spatial_dim_names, dimension_name_generator;
-                                  with_halos, dimension_type, grid_index)
+    # `create_field_coord_variables!` may rename windowed axes (see `resolve_windowed_dim_name`),
+    # so the variable's signature must use the resolved names it returns.
+    resolved_dim_names = create_field_coord_variables!(ds, fd, grid(fd), spatial_dim_names, dimension_name_generator;
+                                                       with_halos, dimension_type, grid_index)
+
+    effective_dim_names = tuple(filter(!isempty, resolved_dim_names)...)
 
     if time_dependent
         "time" ∉ keys(ds.dim) && create_time_dimension!(ds, dimension_type=dimension_type)
@@ -49,17 +52,51 @@ function create_field_dimensions!(ds, fd::AbstractField, dimension_name_generato
     end
 end
 
+# A "windowed" field (e.g. the free-surface displacement, or a user `view` that pins an axis
+# to a sub-range) shares a location with full-extent fields but covers only part of the
+# corresponding axis. Because a NetCDF coordinate variable maps a dimension name to a single
+# set of values, such a field needs its own dimension whenever its coordinate values differ
+# from the canonical full-extent dimension already in the dataset. Resolve the base name to
+# itself when it is unused or its values already match, otherwise to the first free
+# `name_2`, `name_3`, … whose values match (deduping fields that share the same window).
+function resolve_windowed_dim_name(ds, base_name, data, dimension_type)
+    (base_name == "" || data === nothing) && return base_name
+    target = collect(dimension_type.(data))
+    candidate = base_name
+    n = 1
+    while candidate ∈ keys(ds)
+        collect(ds[candidate]) == target && return candidate
+        n += 1
+        candidate = string(base_name, "_", n)
+    end
+    return candidate
+end
+
 # Default (1D-coordinate) path — RectilinearGrid and LatitudeLongitudeGrid: zip the
-# field's NetCDF dim names with the field's `nodes(fd)` 1D arrays and pass them through
-# `create_spatial_dimensions!`, which creates missing coord vars or validates existing
-# ones against the field's nodes (catching mismatched dim sizes early as ArgumentError).
+# field's (windowing-resolved) NetCDF dim names with the field's `nodes(fd)` 1D arrays and
+# pass them through `create_spatial_dimensions!`, which creates missing coord vars or
+# validates existing ones against the field's nodes. Returns the resolved dim names.
 function create_field_coord_variables!(ds, fd, grid, spatial_dim_names, dim_name_generator;
                                         with_halos, dimension_type, grid_index)
     dimension_attributes = default_dimension_attributes(grid, dim_name_generator; grid_index)
     spatial_dim_data = nodes(fd; with_halos)
+
+    resolved_dim_names = map(spatial_dim_names, spatial_dim_data) do name, data
+        resolve_windowed_dim_name(ds, name, data, dimension_type)
+    end
+
+    # A renamed windowed axis inherits the attributes of the base coordinate it derives from.
+    for (base, resolved) in zip(spatial_dim_names, resolved_dim_names)
+        if resolved != base && haskey(dimension_attributes, base) && !haskey(dimension_attributes, resolved)
+            dimension_attributes[resolved] = dimension_attributes[base]
+        end
+    end
+
     spatial_dim_names_dict = OrderedDict(name => data
-                                         for (name, data) in zip(spatial_dim_names, spatial_dim_data))
+                                         for (name, data) in zip(resolved_dim_names, spatial_dim_data))
     create_spatial_dimensions!(ds, spatial_dim_names_dict, dimension_attributes; dimension_type)
+
+    return resolved_dim_names
 end
 
 # OrthogonalSphericalShellGrid path: dimensions are 1D bare `i_*`/`j_*` indices plus the
@@ -78,7 +115,7 @@ function create_field_coord_variables!(ds, fd, grid::OrthogonalSphericalShellGri
         dname ∈ keys(ds.dim) && continue
         defDim(ds, dname, dsize)
     end
-    return nothing
+    return spatial_dim_names
 end
 
 # Defer through ImmersedBoundaryGrid to the underlying grid's dispatch.

--- a/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
+++ b/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
@@ -401,13 +401,9 @@ function define_output_variable!(model, dataset, output::AbstractField, output_n
                                  time_dependent, with_halos, grid_index=nothing,
                                  dimensions, filepath, dimension_type=Float64)
 
-    # If the output is the free surface, we need to handle it differently since it will be writen as a 3D array with a singleton dimension for the z-coordinate
-    if output_name == "displacement" && hasfield(typeof(model), :free_surface)
-        if output == view(model.free_surface.displacement, output.indices...)
-            local default_dimension_name_generator = dimension_name_generator
-            dimension_name_generator = (var_name, grid, LX, LY, LZ, dim) -> dimension_name_generator_free_surface(default_dimension_name_generator, var_name, grid, LX, LY, LZ, dim)
-        end
-    end
+    # Windowed fields (e.g. the free-surface displacement) are handled generically: their
+    # windowed axes get a distinct dimension in `create_field_dimensions!` (see
+    # `resolve_windowed_dim_name`), so no special-casing is needed here.
     defVar(dataset, output_name, output; array_type, time_dependent, with_halos, dimension_name_generator, deflatelevel, attrib, dimension_type, grid_index, write_data=false)
     return nothing
 end

--- a/src/OutputWriters/netcdf_writer.jl
+++ b/src/OutputWriters/netcdf_writer.jl
@@ -90,9 +90,6 @@ trilocation_dim_name(var_name, grid, LX, LY, LZ, dim) =
 
 trilocation_dim_name(var_name, grid::ImmersedBoundaryGrid, args...) = trilocation_dim_name(var_name, grid.underlying_grid, args...)
 
-dimension_name_generator_free_surface(dimension_name_generator, var_name, grid, LX, LY, LZ, dim) = dimension_name_generator(var_name, grid, LX, LY, LZ, dim)
-dimension_name_generator_free_surface(dimension_name_generator, var_name, grid, LX, LY, LZ, dim::Val{:z}) = dimension_name_generator(var_name, grid, LX, LY, LZ, dim) * "_displacement"
-
 add_grid_suffix(name, grid_index) = isempty(name) ? name : name * "_grid$(grid_index)"
 add_grid_suffix(name, ::Nothing) = name
 

--- a/test/test_netcdf_writer.jl
+++ b/test/test_netcdf_writer.jl
@@ -2571,7 +2571,7 @@ function test_netcdf_hydrostatic_free_surface_only_output(arch; immersed=false, 
     ds_h = NCDataset(filepath_with_halos)
 
     @test haskey(ds_h, "displacement")
-    @test dimsize(ds_h["displacement"]) == (λ_caa=Nλ + 2Hλ, φ_aca=Nφ + 2Hφ, z_aaf_displacement=1, time=Nt + 1)
+    @test dimsize(ds_h["displacement"]) == (λ_caa=Nλ + 2Hλ, φ_aca=Nφ + 2Hφ, z_aaf_2=1, time=Nt + 1)
 
     close(ds_h)
     rm(filepath_with_halos)
@@ -2579,7 +2579,7 @@ function test_netcdf_hydrostatic_free_surface_only_output(arch; immersed=false, 
     ds_n = NCDataset(filepath_no_halos)
 
     @test haskey(ds_n, "displacement")
-    @test dimsize(ds_n["displacement"]) == (λ_caa=Nλ, φ_aca=Nφ, z_aaf_displacement=1, time=Nt + 1)
+    @test dimsize(ds_n["displacement"]) == (λ_caa=Nλ, φ_aca=Nφ, z_aaf_2=1, time=Nt + 1)
 
     close(ds_n)
     rm(filepath_no_halos)
@@ -2643,7 +2643,7 @@ function test_netcdf_hydrostatic_free_surface_mixed_output(arch; immersed=false,
     ds_h = NCDataset(filepath_with_halos)
 
     @test haskey(ds_h, "displacement")
-    @test dimsize(ds_h["displacement"]) == (λ_caa=Nλ + 2Hλ, φ_aca=Nφ + 2Hφ, z_aaf_displacement=1, time=Nt + 1)
+    @test dimsize(ds_h["displacement"]) == (λ_caa=Nλ + 2Hλ, φ_aca=Nφ + 2Hφ, z_aaf_2=1, time=Nt + 1)
 
     @test dimsize(ds_h[:u]) == (λ_faa=Nλ + 2Hλ + 1, φ_aca=Nφ + 2Hφ,     z_aac=Nz + 2Hz,     time=Nt + 1)
     @test dimsize(ds_h[:v]) == (λ_caa=Nλ + 2Hλ,     φ_afa=Nφ + 2Hφ + 1, z_aac=Nz + 2Hz,     time=Nt + 1)
@@ -2657,7 +2657,7 @@ function test_netcdf_hydrostatic_free_surface_mixed_output(arch; immersed=false,
     ds_n = NCDataset(filepath_no_halos)
 
     @test haskey(ds_n, "displacement")
-    @test dimsize(ds_n["displacement"]) == (λ_caa=Nλ, φ_aca=Nφ, z_aaf_displacement=1, time=Nt + 1)
+    @test dimsize(ds_n["displacement"]) == (λ_caa=Nλ, φ_aca=Nφ, z_aaf_2=1, time=Nt + 1)
 
     @test dimsize(ds_n[:u]) == (λ_faa=Nλ + 1, φ_aca=Nφ,     z_aac=Nz,     time=Nt + 1)
     @test dimsize(ds_n[:v]) == (λ_caa=Nλ,     φ_afa=Nφ + 1, z_aac=Nz,     time=Nt + 1)
@@ -2723,13 +2723,13 @@ function test_netcdf_nonhydrostatic_free_surface_only_output(arch; immersed=fals
 
     ds_h = NCDataset(filepath_with_halos)
     @test haskey(ds_h, "displacement")
-    @test dimsize(ds_h["displacement"]) == (x_caa=Nx + 2Hx, y_aca=Ny + 2Hy, z_aaf_displacement=1, time=Nt + 1)
+    @test dimsize(ds_h["displacement"]) == (x_caa=Nx + 2Hx, y_aca=Ny + 2Hy, z_aaf_2=1, time=Nt + 1)
     close(ds_h)
     rm(filepath_with_halos)
 
     ds_n = NCDataset(filepath_no_halos)
     @test haskey(ds_n, "displacement")
-    @test dimsize(ds_n["displacement"]) == (x_caa=Nx, y_aca=Ny, z_aaf_displacement=1, time=Nt + 1)
+    @test dimsize(ds_n["displacement"]) == (x_caa=Nx, y_aca=Ny, z_aaf_2=1, time=Nt + 1)
     close(ds_n)
     rm(filepath_no_halos)
 
@@ -2792,7 +2792,7 @@ function test_netcdf_nonhydrostatic_free_surface_mixed_output(arch; immersed=fal
     ds_h = NCDataset(filepath_with_halos)
 
     @test haskey(ds_h, "displacement")
-    @test dimsize(ds_h["displacement"]) == (x_caa=Nx + 2Hx, y_aca=Ny + 2Hy, z_aaf_displacement=1, time=Nt + 1)
+    @test dimsize(ds_h["displacement"]) == (x_caa=Nx + 2Hx, y_aca=Ny + 2Hy, z_aaf_2=1, time=Nt + 1)
 
     @test dimsize(ds_h[:u]) == (x_faa=Nx + 2Hx + 1, y_aca=Ny + 2Hy,     z_aac=Nz + 2Hz,     time=Nt + 1)
     @test dimsize(ds_h[:v]) == (x_caa=Nx + 2Hx,     y_afa=Ny + 2Hy + 1, z_aac=Nz + 2Hz,     time=Nt + 1)
@@ -2806,7 +2806,7 @@ function test_netcdf_nonhydrostatic_free_surface_mixed_output(arch; immersed=fal
     ds_n = NCDataset(filepath_no_halos)
 
     @test haskey(ds_n, "displacement")
-    @test dimsize(ds_n["displacement"]) == (x_caa=Nx, y_aca=Ny, z_aaf_displacement=1, time=Nt + 1)
+    @test dimsize(ds_n["displacement"]) == (x_caa=Nx, y_aca=Ny, z_aaf_2=1, time=Nt + 1)
 
     @test dimsize(ds_n[:u]) == (x_faa=Nx + 1, y_aca=Ny,     z_aac=Nz,     time=Nt + 1)
     @test dimsize(ds_n[:v]) == (x_caa=Nx,     y_afa=Ny + 1, z_aac=Nz,     time=Nt + 1)
@@ -3134,6 +3134,131 @@ function test_singleton_dimension_behavior(arch)
     @test !haskey(ds_slice, "y_afa")  # y dimension should not exist (Flat)
     close(ds_slice)
     rm(filepath_slice)
+
+    return nothing
+end
+
+# Regression tests for https://github.com/CliMA/Oceananigans.jl/issues/5717:
+# writing "windowed" fields (fields whose `indices` pin an axis to a sub-range, such as
+# the free-surface displacement or a user `view`) to NetCDF. A windowed axis shares a
+# location with full-extent fields but covers only part of that axis, so it needs its own
+# NetCDF dimension whenever its coordinate values differ from the canonical full-extent one.
+function test_netcdf_windowed_field_output(arch)
+    Nx, Ny, Nz = 6, 6, 4
+    Hx, Hy, Hz = 2, 2, 2
+
+    grid = RectilinearGrid(arch;
+                           topology = (Bounded, Bounded, Bounded),
+                           size = (Nx, Ny, Nz),
+                           halo = (Hx, Hy, Hz),
+                           x = (-1, 1),
+                           y = (-1, 1),
+                           z = (-100, 0))
+
+    model = HydrostaticFreeSurfaceModel(grid; tracers = :T)
+    set!(model, T = (x, y, z) -> 3z)
+
+    displacement = model.free_surface.displacement
+    T = model.tracers.T
+
+    # A center field windowed to the top center, and a face field windowed to an interior face.
+    T_top = view(T, :, :, Nz:Nz)
+    w_mid = view(ZFaceField(grid), :, :, 2:2)
+
+    Arch = typeof(arch)
+
+    #####
+    ##### A single windowed field alongside the full field at the same location
+    #####
+
+    fp_coexist = "test_windowed_coexist_$Arch.nc"
+    isfile(fp_coexist) && rm(fp_coexist)
+
+    writer = NetCDFWriter(model, (; T, T_top, w_mid);
+                          filename = fp_coexist,
+                          schedule = IterationInterval(1),
+                          array_type = Array{Float64},
+                          include_grid_metrics = false,
+                          overwrite_existing = true)
+
+    Oceananigans.write_output!(writer, model)
+    Oceananigans.write_output!(writer, model)
+
+    ds = NCDataset(fp_coexist)
+
+    # The full tracer keeps the canonical `z_aac`; the windowed tracer gets a distinct dim.
+    @test dimsize(ds[:T])     == (x_caa=Nx, y_aca=Ny, z_aac=Nz,   time=2)
+    @test dimsize(ds[:T_top]) == (x_caa=Nx, y_aca=Ny, z_aac_2=1,  time=2)
+    @test dimsize(ds[:w_mid]) == (x_caa=Nx, y_aca=Ny, z_aaf_2=1,  time=2)
+
+    @test haskey(ds, "z_aac")
+    @test haskey(ds, "z_aac_2")
+    @test haskey(ds, "z_aaf_2")
+
+    # The windowed dimension holds the right single coordinate value...
+    z_centers = znodes(grid, Center())
+    z_faces   = znodes(grid, Face())
+    @test collect(ds["z_aac_2"]) ≈ [z_centers[Nz]]
+    @test collect(ds["z_aaf_2"]) ≈ [z_faces[2]]
+
+    # ...and inherits the descriptive attributes of the base coordinate it derives from.
+    @test ds["z_aac_2"].attrib["units"] == ds["z_aac"].attrib["units"]
+    @test ds["z_aac_2"].attrib["long_name"] == ds["z_aac"].attrib["long_name"]
+
+    # Windowed data round-trips correctly.
+    @test Array(ds["T_top"][:, :, 1, 1]) ≈ Array(interior(T))[:, :, Nz]
+
+    close(ds)
+    rm(fp_coexist)
+
+    #####
+    ##### Free-surface displacement under a non-conventional output name
+    #####
+
+    fp_eta = "test_windowed_eta_$Arch.nc"
+    isfile(fp_eta) && rm(fp_eta)
+
+    # Named "η" rather than "displacement": the windowed-field handling is name-agnostic,
+    # so it writes with its own windowed z-dimension instead of colliding with `z_aaf`
+    # (issue #5717 test 1, which failed when the output was not named "displacement").
+    eta_writer = NetCDFWriter(model, Dict("η" => displacement);
+                              filename = fp_eta,
+                              schedule = IterationInterval(1),
+                              array_type = Array{Float64},
+                              include_grid_metrics = false,
+                              overwrite_existing = true)
+
+    Oceananigans.write_output!(eta_writer, model)
+
+    ds = NCDataset(fp_eta)
+    @test haskey(ds, "η")
+    @test dimsize(ds["η"]) == (x_caa=Nx, y_aca=Ny, z_aaf_2=1, time=1)
+    close(ds)
+    rm(fp_eta)
+
+    #####
+    ##### Windowed displacement combined with writer `indices` (issue #5717 test 4)
+    #####
+
+    fp_sliced = "test_windowed_sliced_$Arch.nc"
+    isfile(fp_sliced) && rm(fp_sliced)
+
+    i_range, j_range = 2:4, 3:5
+    sliced_writer = NetCDFWriter(model, Dict("η" => displacement);
+                                 filename = fp_sliced,
+                                 indices = (i_range, j_range, :),
+                                 schedule = IterationInterval(1),
+                                 array_type = Array{Float64},
+                                 include_grid_metrics = false,
+                                 overwrite_existing = true)
+
+    Oceananigans.write_output!(sliced_writer, model)
+
+    ds = NCDataset(fp_sliced)
+    @test haskey(ds, "η")
+    @test dimsize(ds["η"]) == (x_caa=length(i_range), y_aca=length(j_range), z_aaf_2=1, time=1)
+    close(ds)
+    rm(fp_sliced)
 
     return nothing
 end
@@ -3851,6 +3976,11 @@ end
         @testset "Singleton dimension behavior [$A]" begin
             @info "  Testing singleton dimension behavior [$A]..."
             test_singleton_dimension_behavior(arch)
+        end
+
+        @testset "Windowed field output [$A]" begin
+            @info "  Testing windowed field output [$A]..."
+            test_netcdf_windowed_field_output(arch)
         end
 
         @testset "Reduced FieldTimeSeries round-trip [$A]" begin


### PR DESCRIPTION
## Summary

Fixes #5717. Writing a **windowed field** to NetCDF — a field whose `indices` pin an axis to a sub-range — failed with `ArgumentError: Variable 'z_aaf' already exists in dataset but its values differ from expected`.

The canonical example is the free-surface displacement (`model.free_surface.displacement`), a `ZFaceField` windowed to the top face `(:, :, N+1:N+1)`. But the bug affects any windowed field, e.g. `view(T, :, :, Nz:Nz)` or a manually windowed `ZFaceField`.

### Root cause

NetCDF dimensions are file-global, and a *coordinate variable* maps one dimension name to one set of coordinate values. At file initialization `gather_dimensions` pre-creates the canonical full-extent coordinates (`z_aaf`, `z_aac`, …) from the grid. A windowed field covers only part of an axis, so its `nodes` give coordinate values that differ from the canonical dimension — and the writer tried to reuse the same dimension name, triggering the collision.

The previous code handled **only** the free-surface displacement, via a special case gated on `output_name == "displacement"` plus a `_displacement` dimension-name suffix. Naming the output anything else (the issue reporter used `"η"`) bypassed it entirely, and no other windowed field was supported.

### Fix

A single general mechanism, `resolve_windowed_dim_name`, replaces the special-casing. For each field axis it compares the field's coordinate values against what already exists in the dataset:

- **reuse** the canonical dimension when values match (full fields, and writer-sliced fields whose values match the canonical sliced coordinate), or
- **allocate** the next free `name_2`, `name_3`, … when values differ (any windowed field), deduping fields that share the same window.

Renamed dimensions inherit the base coordinate's attributes (units/long_name). The free-surface displacement is now just one instance of this — the `output_name == "displacement"` special case and the `dimension_name_generator_free_surface` helper are removed. Detection is name-agnostic and grid-agnostic.

## Behavior change

The free-surface displacement's z-dimension is now named `z_aaf_2` (generic windowed naming) instead of `z_aaf_displacement`. Existing free-surface test assertions are updated accordingly.

## Tests

Adds `test_netcdf_windowed_field_output` covering:
- a windowed center field and a windowed face field written alongside the full field at the same location (`z_aac`/`z_aac_2`, `z_aaf`/`z_aaf_2` coexist);
- correctness of the windowed coordinate values, inherited attributes, and round-tripped data;
- the free surface output under a non-conventional name (`"η"`);
- windowing combined with writer `indices` (issue #5717 test 4).

Verified locally: the new test passes, the existing free-surface tests (all immersed × stretched variants) pass with the updated `z_aaf_2` name, and the singleton/Flat/reduced-field tests are unaffected.

## Not included (separate issue)

Issue tests 3 and 5 (`Integral(disp; dims=3)` combined with writer `indices` or an x/y `view`) fail with a `DimensionMismatch` *inside the reduction computation* — the operand keeps full x/y while the reduction output Field is built with sliced indices. That lives in the generic `Reduction`/`construct_output` machinery rather than NetCDF dimension naming, so it's left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)