### PR TITLE
Bump project version from 0.110.4 to 0.110.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.4"
+version = "0.110.5"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]


### PR DESCRIPTION
Patch release capturing everything merged to `main` since 0.110.4 (#5708, 2026-06-19).

## PRs included

**User-facing changes**
- #5713 — Remove `convert` type piracy from Reactant extension
- #5711 — Add Reactant `==` for `LatitudeLongitudeGrid`
- #5375 — Update `on_architecture` for MetalGPU to target `StepRangeLen{FT, Float64, Float64}`
- #5709 — Better `show` for `RotatedLatitudeLongitudeGrid` and `LambertConformalConicGrid`

**CI / tests (no effect on released package)**
- #5679 — Add tracer budget closure test
- #5710 — Upload docs build directory as a CI artifact
- #5674 — Bump codecov/codecov-action from 6 to 7

All changes are non-breaking and SemVer-patch-appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)