### PR TITLE
node returns the physical znode (not the reference rnode) on mutable vertical grids

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.5"
+version = "0.110.6"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/Grids/nodes_and_spacings.jl
+++ b/src/Grids/nodes_and_spacings.jl
@@ -31,19 +31,22 @@ _node_names(grid, ::Nothing, ::Nothing, ℓz) = tuple(rname(grid))
 
 _node_names(grid, ::Nothing, ::Nothing, ::Nothing) = tuple()
 
-# Interface for grids to opt-in to `node`: ξnode, ηnode, rnode
+# Interface for grids to opt-in to `node`: ξnode, ηnode, and znode (which defaults to rnode).
+# We use znode (the physical vertical position) rather than rnode (the reference coordinate)
+# so that `node` reports the deformed height on a mutable vertical grid; on static grids
+# znode === rnode, so this is identical there.
 @inline _node(i, j, k, grid, ℓx, ℓy, ℓz) = (ξnode(i, j, k, grid, ℓx, ℓy, ℓz),
                                             ηnode(i, j, k, grid, ℓx, ℓy, ℓz),
-                                            rnode(i, j, k, grid, ℓx, ℓy, ℓz))
+                                            znode(i, j, k, grid, ℓx, ℓy, ℓz))
 
 # Omission of Nothing locations
-@inline _node(i, j, k, grid, ℓx::Nothing, ℓy, ℓz) = (ηnode(i, j, k, grid, ℓx, ℓy, ℓz), rnode(i, j, k, grid, ℓx, ℓy, ℓz))
-@inline _node(i, j, k, grid, ℓx, ℓy::Nothing, ℓz) = (ξnode(i, j, k, grid, ℓx, ℓy, ℓz), rnode(i, j, k, grid, ℓx, ℓy, ℓz))
+@inline _node(i, j, k, grid, ℓx::Nothing, ℓy, ℓz) = (ηnode(i, j, k, grid, ℓx, ℓy, ℓz), znode(i, j, k, grid, ℓx, ℓy, ℓz))
+@inline _node(i, j, k, grid, ℓx, ℓy::Nothing, ℓz) = (ξnode(i, j, k, grid, ℓx, ℓy, ℓz), znode(i, j, k, grid, ℓx, ℓy, ℓz))
 @inline _node(i, j, k, grid, ℓx, ℓy, ℓz::Nothing) = (ξnode(i, j, k, grid, ℓx, ℓy, ℓz), ηnode(i, j, k, grid, ℓx, ℓy, ℓz))
 
 @inline _node(i, j, k, grid, ℓx, ℓy::Nothing, ℓz::Nothing) = tuple(ξnode(i, j, k, grid, ℓx, ℓy, ℓz))
 @inline _node(i, j, k, grid, ℓx::Nothing, ℓy, ℓz::Nothing) = tuple(ηnode(i, j, k, grid, ℓx, ℓy, ℓz))
-@inline _node(i, j, k, grid, ℓx::Nothing, ℓy::Nothing, ℓz) = tuple(rnode(i, j, k, grid, ℓx, ℓy, ℓz))
+@inline _node(i, j, k, grid, ℓx::Nothing, ℓy::Nothing, ℓz) = tuple(znode(i, j, k, grid, ℓx, ℓy, ℓz))
 
 @inline _node(i, j, k, grid, ::Nothing, ::Nothing, ::Nothing) = tuple()
 

--- a/src/Grids/nodes_and_spacings.jl
+++ b/src/Grids/nodes_and_spacings.jl
@@ -32,9 +32,6 @@ _node_names(grid, ::Nothing, ::Nothing, ℓz) = tuple(rname(grid))
 _node_names(grid, ::Nothing, ::Nothing, ::Nothing) = tuple()
 
 # Interface for grids to opt-in to `node`: ξnode, ηnode, and znode (which defaults to rnode).
-# We use znode (the physical vertical position) rather than rnode (the reference coordinate)
-# so that `node` reports the deformed height on a mutable vertical grid; on static grids
-# znode === rnode, so this is identical there.
 @inline _node(i, j, k, grid, ℓx, ℓy, ℓz) = (ξnode(i, j, k, grid, ℓx, ℓy, ℓz),
                                             ηnode(i, j, k, grid, ℓx, ℓy, ℓz),
                                             znode(i, j, k, grid, ℓx, ℓy, ℓz))

--- a/test/test_set_field_interpolation.jl
+++ b/test/test_set_field_interpolation.jl
@@ -68,3 +68,22 @@ end
         end
     end
 end
+
+@testset "node returns the physical (deformed) znode on mutable grids" begin
+    # On a mutable vertical grid the physical height is znode = rnode·σ + η, which differs
+    # from the reference rnode once η ≠ 0. `node` (and hence interpolation targets and every
+    # node-evaluated forcing / closure / boundary function) must report the physical znode.
+    z = Oceananigans.Grids.MutableVerticalDiscretization(collect(0:0.25:1))   # 5 faces ⇒ Nz = 4
+    grid = RectilinearGrid(CPU(); size=(2, 2, 4), x=(0, 1), y=(0, 1), z=z,
+                           topology=(Periodic, Periodic, Bounded))
+
+    Δη = 0.3
+    fill!(grid.z.ηⁿ, Δη)                                       # σ stays 1, η = Δη ⇒ znode = rnode + Δη
+    c = Center()
+    for k in 1:4
+        zr = Oceananigans.Grids.rnode(1, 1, k, grid, c, c, c)
+        zz = Oceananigans.Grids.znode(1, 1, k, grid, c, c, c)
+        @test zz ≈ zr + Δη                                     # deformation is actually present
+        @test Oceananigans.Grids.node(1, 1, k, grid, c, c, c)[end] == zz   # node reports znode, not rnode
+    end
+end


### PR DESCRIPTION
### Motivation

On a `MutableVerticalDiscretization` (z-star / free-surface- or terrain-following) grid the vertical has two coordinates: the fixed reference `rnode`, and the deformed physical height `znode = rnode·σ + η`. On a static grid they are identical (`znode` falls back to `rnode`).

`_node` — the accessor behind `node(i, j, k, grid, ℓx, ℓy, ℓz)`, and therefore behind every "where is this point in space" query — builds its vertical component from **`rnode`**. So on a mutable grid it returns the *reference* coordinate, ignoring the deformation. Every caller of `node` actually wants the *physical* position:

- `interpolate!` (field→field and `FieldTimeSeries`→`FieldTimeSeries`) builds the target node from `_node`, so interpolating **onto** a mutable grid samples the source at the undeformed heights — the lowest cells of a terrain-following grid land below the source's surface.
- user `Forcing`, turbulence-closure `ν`/`κ`, boundary-condition, Stokes-drift, and `FunctionField` functions are all evaluated at `node(...)` and documented as functions of physical `(x, y, z)` — they silently receive the reference coordinate on a mutable grid.

### Fix

Build `_node`'s vertical component from `znode` instead of `rnode`. Because `znode === rnode` on every static grid, this is a no-op everywhere except mutable vertical grids, where it is the correction. `rnode` keeps its role as the grid's reference primitive (spacings, the coordinate grids opt into, index lookups against the grid's own discretization).

### Test

Added a regression test: on a mutable grid with `η = 0.3` (so `znode = rnode + 0.3`), `node(...)[end]` must equal `znode`, not `rnode`. Verified locally (passes with this change; the vertical component reports `0.675 = znode`, not `0.375 = rnode`).

### Scope

- Fixes the **target** node for both interpolation kernels and all `node`-based function evaluation on mutable grids.
- Mutable **source** interpolation (fractional-index lookup into a *deformed source*) is a separate concern, out of scope here.

Patch release (bug fix): 0.110.4 → 0.110.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
