### PR TITLE
Add interpolate(f, …): map source values through f before blending

### DIFF
--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -328,6 +328,53 @@ end
 
 # interpolator, _interpolate, and ϕ₁-ϕ₈ are imported from Oceananigans.Utils
 
+#####
+##### Interpolation of a mapped field: `interpolate(f, …)`
+#####
+
+# Like `mean(f, itr)` / `sum(f, itr)`, a leading function `f` is applied to each source value
+# *before* the weighted blend; the result stays in `f`-space (no inverse is applied). With `f = log`
+# this blends log-values, so `exp(interpolate(log, …))` is a positivity-preserving, geometric-mean
+# interpolation — accurate for exponentially-varying fields (pressure, density). `f = identity`
+# reproduces the plain `interpolate` exactly. `f` is routed through the shared low-level blend
+# `_interpolate` (via a lazy mapped array) so `Field`s and `FieldTimeSeries` share one code path.
+
+"""
+    MappedData(f, data)
+
+Lazily apply `f` elementwise to `data`: a read returns `f(data[I...])`. This lets the existing
+`_interpolate` blend `f`-mapped values without copying. GPU-safe when `f` is (`log`/`exp` are).
+"""
+struct MappedData{T, N, F, A} <: AbstractArray{T, N}
+    f    :: F
+    data :: A
+end
+
+@inline MappedData(f::F, data::A) where {F, A} =
+    MappedData{eltype(A), ndims(A), F, A}(f, data)
+
+@inline Base.size(m::MappedData) = size(m.data)
+@inline Base.axes(m::MappedData) = axes(m.data)
+@inline Base.getindex(m::MappedData, I::Vararg{Int}) = m.f(@inbounds m.data[I...])
+
+Adapt.adapt_structure(to, m::MappedData) = MappedData(m.f, adapt(to, m.data))
+
+"""
+$(TYPEDSIGNATURES)
+
+Interpolate `from_field` `at_node` after mapping each source value through `f`, in the spirit of
+`mean(f, itr)`: `f` is applied to each value before the weighted blend and the result is returned in
+`f`-space (no inverse). With `f = log`, `exp(interpolate(log, …))` is a geometric-mean interpolation.
+`f = identity` reproduces `interpolate(at_node, from_field, …)`.
+"""
+@inline function interpolate(f::Base.Callable, at_node, from_field, from_loc, from_grid)
+    fidx = FractionalIndices(at_node, from_grid, from_loc...)
+    ix = interpolator(fidx.i)
+    iy = interpolator(fidx.j)
+    iz = interpolator(fidx.k)
+    return _interpolate(MappedData(f, from_field), ix, iy, iz)
+end
+
 """
 $(TYPEDSIGNATURES)
 

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -367,7 +367,9 @@ Interpolate `from_field` `at_node` after mapping each source value through `func
 in `func`-space (no inverse). With `func = log`, `exp(interpolate(log, …))` is a geometric-mean
 interpolation. `func = identity` reproduces `interpolate(at_node, from_field, …)`.
 """
-@inline function interpolate(func::Base.Callable, at_node, from_field, from_loc, from_grid)
+# `at_node::Tuple` (it is always a coordinate tuple here) keeps this disjoint from the
+# `FieldTimeSeries` method `interpolate(to_node, ::Time, fts, …)`, whose second argument is a `Time`.
+@inline function interpolate(func::Base.Callable, at_node::Tuple, from_field, from_loc, from_grid)
     fidx = FractionalIndices(at_node, from_grid, from_loc...)
     return interpolate(func, fidx, from_field, from_loc, from_grid)
 end

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -314,65 +314,69 @@ where `at_node` is a tuple of coordinates and and `from_loc = (ℓx, ℓy, ℓz)
 
 Note that this is a lower-level `interpolate` method defined for use in CPU/GPU kernels.
 """
-@inline function interpolate(at_node, from_field, from_loc, from_grid)
-    fractional_indices = FractionalIndices(at_node, from_grid, from_loc...)
-    return interpolate(fractional_indices, from_field, from_loc, from_grid)
-end
+@inline interpolate(at_node, from_field, from_loc, from_grid) =
+    interpolate(identity, at_node, from_field, from_loc, from_grid)
 
-@inline function interpolate(fidx::FractionalIndices, from_field, from_loc, from_grid)
-    ix = interpolator(fidx.i)
-    iy = interpolator(fidx.j)
-    iz = interpolator(fidx.k)
-    return _interpolate(from_field, ix, iy, iz)
-end
+@inline interpolate(fidx::FractionalIndices, from_field, from_loc, from_grid) =
+    interpolate(identity, fidx, from_field, from_loc, from_grid)
 
 # interpolator, _interpolate, and ϕ₁-ϕ₈ are imported from Oceananigans.Utils
 
 #####
-##### Interpolation of a mapped field: `interpolate(f, …)`
+##### Interpolation of a mapped field: `interpolate(func, …)`
 #####
 
-# Like `mean(f, itr)` / `sum(f, itr)`, a leading function `f` is applied to each source value
-# *before* the weighted blend; the result stays in `f`-space (no inverse is applied). With `f = log`
-# this blends log-values, so `exp(interpolate(log, …))` is a positivity-preserving, geometric-mean
-# interpolation — accurate for exponentially-varying fields (pressure, density). `f = identity`
-# reproduces the plain `interpolate` exactly. `f` is routed through the shared low-level blend
-# `_interpolate` (via a lazy mapped array) so `Field`s and `FieldTimeSeries` share one code path.
+# Like `mean(func, itr)` / `sum(func, itr)`, a leading function `func` is applied to each source value
+# *before* the weighted blend; the result stays in `func`-space (no inverse is applied). With
+# `func = log` this blends log-values, so `exp(interpolate(log, …))` is a positivity-preserving,
+# geometric-mean interpolation — accurate for exponentially-varying fields (pressure, density).
+# `func = identity` reproduces the plain `interpolate` exactly. `func` is routed through the shared
+# low-level blend `_interpolate` (via a lazy mapped array) so `Field`s and `FieldTimeSeries` share
+# one code path.
 
 """
-    MappedData(f, data)
+    MappedData(func, data)
 
-Lazily apply `f` elementwise to `data`: a read returns `f(data[I...])`. This lets the existing
-`_interpolate` blend `f`-mapped values without copying. GPU-safe when `f` is (`log`/`exp` are).
+Lazily apply `func` elementwise to `data`: a read returns `func(data[I...])`. This lets the existing
+`_interpolate` blend `func`-mapped values without copying. GPU-safe when `func` is (`log`/`exp` are).
 """
 struct MappedData{T, N, F, A} <: AbstractArray{T, N}
-    f    :: F
+    func :: F
     data :: A
 end
 
-@inline MappedData(f::F, data::A) where {F, A} =
-    MappedData{eltype(A), ndims(A), F, A}(f, data)
+@inline MappedData(func::F, data::A) where {F, A} =
+    MappedData{eltype(A), ndims(A), F, A}(func, data)
 
 @inline Base.size(m::MappedData) = size(m.data)
 @inline Base.axes(m::MappedData) = axes(m.data)
-@inline Base.getindex(m::MappedData, I::Vararg{Int}) = m.f(@inbounds m.data[I...])
+@inline Base.getindex(m::MappedData, I::Vararg{Int}) = m.func(@inbounds m.data[I...])
 
-Adapt.adapt_structure(to, m::MappedData) = MappedData(m.f, adapt(to, m.data))
+Adapt.adapt_structure(to, m::MappedData) = MappedData(m.func, adapt(to, m.data))
+
+# `func = identity` returns `data` unchanged, so the identity path is byte-identical to plain
+# `interpolate` and pays no wrapper overhead.
+@inline mapped_data(func, data) = MappedData(func, data)
+@inline mapped_data(::typeof(identity), data) = data
 
 """
 $(TYPEDSIGNATURES)
 
-Interpolate `from_field` `at_node` after mapping each source value through `f`, in the spirit of
-`mean(f, itr)`: `f` is applied to each value before the weighted blend and the result is returned in
-`f`-space (no inverse). With `f = log`, `exp(interpolate(log, …))` is a geometric-mean interpolation.
-`f = identity` reproduces `interpolate(at_node, from_field, …)`.
+Interpolate `from_field` `at_node` after mapping each source value through `func`, in the spirit of
+`mean(func, itr)`: `func` is applied to each value before the weighted blend and the result is returned
+in `func`-space (no inverse). With `func = log`, `exp(interpolate(log, …))` is a geometric-mean
+interpolation. `func = identity` reproduces `interpolate(at_node, from_field, …)`.
 """
-@inline function interpolate(f::Base.Callable, at_node, from_field, from_loc, from_grid)
+@inline function interpolate(func::Base.Callable, at_node, from_field, from_loc, from_grid)
     fidx = FractionalIndices(at_node, from_grid, from_loc...)
+    return interpolate(func, fidx, from_field, from_loc, from_grid)
+end
+
+@inline function interpolate(func::Base.Callable, fidx::FractionalIndices, from_field, from_loc, from_grid)
     ix = interpolator(fidx.i)
     iy = interpolator(fidx.j)
     iz = interpolator(fidx.k)
-    return _interpolate(MappedData(f, from_field), ix, iy, iz)
+    return _interpolate(mapped_data(func, from_field), ix, iy, iz)
 end
 
 """

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -3,7 +3,8 @@ import Dates
 using Dates: AbstractTime
 
 using Oceananigans.Grids: _node
-using Oceananigans.Fields: interpolator, _interpolate, FractionalIndices, instantiated_location, flatten_node, FixedTime
+using Oceananigans.Fields: interpolator, _interpolate, FractionalIndices, instantiated_location, flatten_node, FixedTime,
+                           MappedData
 using Oceananigans.Architectures: architecture
 using Oceananigans.DistributedComputations: child_architecture, Distributed
 using GPUArraysCore: @allowscalar
@@ -271,6 +272,43 @@ end
     backend = from_fts.backend
     time_indexing = from_fts.time_indexing
     return interpolate(to_node, to_time_index, data, from_loc, from_grid, times, backend, time_indexing)
+end
+
+# Space+time interpolation of a `FieldTimeSeries` with each source value mapped through `f`
+# (in the spirit of `mean(f, itr)`). Mirrors the unmapped method above: `f` is applied per source
+# value in both time slots, blended linearly in time, and the result is returned in `f`-space (no
+# inverse). See `Oceananigans.Fields.interpolate(f, …)`.
+@inline function interpolate(f::Base.Callable, to_node, to_time_index::Time,
+                             from_fts::FlavorOfFTS, from_loc, from_grid)
+    data          = from_fts.data
+    times         = from_fts.times
+    backend       = from_fts.backend
+    time_indexing = from_fts.time_indexing
+
+    interp = TimeInterpolator(time_indexing, times, to_time_index.time)
+    node   = flatten_node(to_node...)
+
+    fi = topology(from_grid) === (Flat, Flat, Flat) ?
+         FractionalIndices(nothing, nothing, nothing) :
+         FractionalIndices(node, from_grid, from_loc...)
+
+    ix = interpolator(fi.i)
+    iy = interpolator(fi.j)
+    iz = interpolator(fi.k)
+
+    ñ  = interp.fractional_index
+    n₁ = convert(Int, interp.first_index)
+    n₂ = convert(Int, interp.second_index)
+    Nt = convert(Int, interp.length)
+    m₁ = memory_index(backend, time_indexing, Nt, n₁)
+    m₂ = memory_index(backend, time_indexing, Nt, n₂)
+
+    mapped = MappedData(f, data)
+    ψ₁ = _interpolate(mapped, ix, iy, iz, m₁)
+    ψ₂ = _interpolate(mapped, ix, iy, iz, m₂)
+    ψ̃  = ψ₂ * ñ + ψ₁ * (1 - ñ)
+
+    return ifelse(n₁ == n₂, ψ₁, ψ̃)
 end
 
 @inline function interpolate(to_node, to_time_index::Time, data::OffsetArray,

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -4,7 +4,7 @@ using Dates: AbstractTime
 
 using Oceananigans.Grids: _node
 using Oceananigans.Fields: interpolator, _interpolate, FractionalIndices, instantiated_location, flatten_node, FixedTime,
-                           MappedData
+                           mapped_data
 using Oceananigans.Architectures: architecture
 using Oceananigans.DistributedComputations: child_architecture, Distributed
 using GPUArraysCore: @allowscalar
@@ -266,52 +266,22 @@ end
 ##### Linear time- and space-interpolation of a FTS
 #####
 
-@inline function interpolate(to_node, to_time_index::Time, from_fts::FlavorOfFTS, from_loc, from_grid)
-    data = from_fts.data
-    times = from_fts.times
-    backend = from_fts.backend
+@inline interpolate(to_node, to_time_index::Time, from_fts::FlavorOfFTS, from_loc, from_grid) =
+    interpolate(identity, to_node, to_time_index, from_fts, from_loc, from_grid)
+
+# Space+time interpolation of a `FieldTimeSeries` with each source value mapped through `func`
+# (in the spirit of `mean(func, itr)`). `func = identity` reproduces the unmapped interpolation
+# exactly, since `mapped_data(identity, data)` is `data`. See `Oceananigans.Fields.interpolate(func, …)`.
+@inline function interpolate(func::Base.Callable, to_node, to_time_index::Time,
+                             from_fts::FlavorOfFTS, from_loc, from_grid)
+    data          = mapped_data(func, from_fts.data)
+    times         = from_fts.times
+    backend       = from_fts.backend
     time_indexing = from_fts.time_indexing
     return interpolate(to_node, to_time_index, data, from_loc, from_grid, times, backend, time_indexing)
 end
 
-# Space+time interpolation of a `FieldTimeSeries` with each source value mapped through `f`
-# (in the spirit of `mean(f, itr)`). Mirrors the unmapped method above: `f` is applied per source
-# value in both time slots, blended linearly in time, and the result is returned in `f`-space (no
-# inverse). See `Oceananigans.Fields.interpolate(f, …)`.
-@inline function interpolate(f::Base.Callable, to_node, to_time_index::Time,
-                             from_fts::FlavorOfFTS, from_loc, from_grid)
-    data          = from_fts.data
-    times         = from_fts.times
-    backend       = from_fts.backend
-    time_indexing = from_fts.time_indexing
-
-    interp = TimeInterpolator(time_indexing, times, to_time_index.time)
-    node   = flatten_node(to_node...)
-
-    fi = topology(from_grid) === (Flat, Flat, Flat) ?
-         FractionalIndices(nothing, nothing, nothing) :
-         FractionalIndices(node, from_grid, from_loc...)
-
-    ix = interpolator(fi.i)
-    iy = interpolator(fi.j)
-    iz = interpolator(fi.k)
-
-    ñ  = interp.fractional_index
-    n₁ = convert(Int, interp.first_index)
-    n₂ = convert(Int, interp.second_index)
-    Nt = convert(Int, interp.length)
-    m₁ = memory_index(backend, time_indexing, Nt, n₁)
-    m₂ = memory_index(backend, time_indexing, Nt, n₂)
-
-    mapped = MappedData(f, data)
-    ψ₁ = _interpolate(mapped, ix, iy, iz, m₁)
-    ψ₂ = _interpolate(mapped, ix, iy, iz, m₂)
-    ψ̃  = ψ₂ * ñ + ψ₁ * (1 - ñ)
-
-    return ifelse(n₁ == n₂, ψ₁, ψ̃)
-end
-
-@inline function interpolate(to_node, to_time_index::Time, data::OffsetArray,
+@inline function interpolate(to_node, to_time_index::Time, data::AbstractArray,
                              from_loc, from_grid, times, backend, time_indexing)
 
     to_time = to_time_index.time
@@ -319,7 +289,7 @@ end
     return interpolate(to_node, interp, data, from_loc, from_grid, backend, time_indexing)
 end
 
-@inline function interpolate(to_node, time_indices::TimeInterpolator, data::OffsetArray,
+@inline function interpolate(to_node, time_indices::TimeInterpolator, data::AbstractArray,
                              from_loc, from_grid, backend, time_indexing)
 
     # Build space interpolators
@@ -335,7 +305,7 @@ end
 end
 
 @inline function interpolate(fi::FractionalIndices, time_indices::TimeInterpolator,
-                             data::OffsetArray, backend, time_indexing)
+                             data::AbstractArray, backend, time_indexing)
 
     ñ  = time_indices.fractional_index
     n₁ = convert(Int, time_indices.first_index)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ CUDA.allowscalar() do
             include("test_boundary_conditions.jl")
             include("test_field.jl")
             include("test_set_field_interpolation.jl")
+            include("test_interpolate_transform.jl")
             include("test_regrid.jl")
             include("test_field_scans.jl")
             include("test_halo_regions.jl")

--- a/test/test_interpolate_transform.jl
+++ b/test/test_interpolate_transform.jl
@@ -1,0 +1,68 @@
+include("dependencies_for_runtests.jl")
+
+using Oceananigans.Fields: interpolate
+using Oceananigans.Units: Time
+
+# `interpolate(f, …)` applies `f` to each source value before the weighted blend, like `mean(f, itr)`:
+# the result stays in `f`-space (no inverse), so `exp(interpolate(log, …))` is geometric interpolation.
+
+@testset "Mapped interpolation interpolate(f, …)" begin
+    for arch in archs, FT in float_types
+        @info "  Testing interpolate(f, …) [$(typeof(arch)), $FT]..."
+
+        grid = RectilinearGrid(arch, FT; size=(1, 1, 8), x=(0, 1), y=(0, 1), z=(0, 1),
+                               topology=(Periodic, Periodic, Bounded))
+
+        loc = (Center(), Center(), Center())
+
+        # Strictly positive, exponentially varying in z: `log` of this is linear in z, so blending
+        # log-values is exact while a plain linear blend overestimates this convex profile.
+        profile(x, y, z) = exp(3z + 1)
+
+        c = CenterField(grid)
+        set!(c, profile)
+        fill_halo_regions!(c)
+
+        logc = Field(log(c))
+        compute!(logc)
+        fill_halo_regions!(logc)
+
+        # Interior midpoints between adjacent cell centers (strictly between nodes).
+        ztargets = [FT(k / 8) for k in 1:7]
+
+        @allowscalar for zt in ztargets
+            at_node = (FT(1//2), FT(1//2), zt)
+
+            # `identity` reproduces the unmapped interpolation exactly.
+            @test interpolate(identity, at_node, c, loc, grid) == interpolate(at_node, c, loc, grid)
+
+            # Mapping through `log` is equivalent to interpolating the lazy `log(c)` field.
+            @test interpolate(log, at_node, c, loc, grid) ≈ interpolate(at_node, logc, loc, grid)
+
+            # For an exponential profile, geometric interpolation is exact and beats the linear blend,
+            # which overestimates a convex function between nodes.
+            true_value = exp(3 * zt + 1)
+            ℑgeo = exp(interpolate(log, at_node, c, loc, grid))
+            ℑlin = interpolate(at_node, c, loc, grid)
+            @test ℑgeo ≈ true_value
+            @test ℑlin > ℑgeo
+        end
+
+        # FieldTimeSeries space + time path with a time-constant exponential profile.
+        times = range(FT(0), FT(2), length=5)
+        fts = FieldTimeSeries{Center, Center, Center}(grid, times)
+        set!(fts, (x, y, z, t) -> profile(x, y, z))
+        fill_halo_regions!(fts)
+
+        @allowscalar for zt in ztargets
+            at_node = (FT(1//2), FT(1//2), zt)
+            t = Time(FT(7//10))
+
+            # `identity` reproduces the unmapped FTS interpolation exactly.
+            @test interpolate(identity, at_node, t, fts, loc, grid) == interpolate(at_node, t, fts, loc, grid)
+
+            # Time-constant exponential: geometric interpolation recovers the profile exactly.
+            @test exp(interpolate(log, at_node, t, fts, loc, grid)) ≈ exp(3 * zt + 1)
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Adds a leading-function method `interpolate(f, …)` for both `Field`s and `FieldTimeSeries`, in the spirit of Julia's `mean(f, itr)` / `sum(f, itr)` / `mapreduce(f, op, itr)`: a leading callable `f` is applied to each source value **before** the weighted (tri)linear blend, and the result is returned in **`f`-space** (no inverse applied).

```julia
interpolate(f, at_node, from_field, from_loc, from_grid)         # field → node
interpolate(f, to_node, ::Time, from_fts, from_loc, from_grid)   # FTS → node, space + time
```

With `f = log`, `exp(interpolate(log, …))` is a positivity-preserving, geometric-mean interpolation — accurate for exponentially-varying, strictly-positive fields (pressure, density) and EOS-consistent (the ideal gas law is linear in logs, and linear interpolation commutes with it). `f = identity` reproduces the existing `interpolate` exactly (byte-identical hot path).

## Why this can't be done with `log(field)` alone

`log(field)` is a lazy `UnaryOperation <: AbstractField`, so `interpolate!(tmp, log(field))` already works **field → field**. But a `UnaryOperation` has no time axis and is not a `FlavorOfFTS`, so it cannot reach the `FieldTimeSeries` space + time path. Routing `f` through the shared low-level blend `_interpolate` — via a small lazy `MappedData` array whose `getindex` returns `f(data[I...])` — gives both `Field`s and `FieldTimeSeries` one implementation.

## Design notes

- **`mean(f, …)` convention, no inverse.** The result stays in `f`-space; the caller applies the inverse (e.g. `exp`) when physical units are wanted. This keeps the API minimal and idiomatic — no inverse registry to maintain — and still solves the FTS problem, which was the whole motivation.
- **GPU.** `MappedData` is `Adapt`-friendly (it adapts `data`; `f` is a function singleton), and `log`/`exp` are device-safe. With `f = identity` the wrapper inlines away → zero overhead on the common path.

## Tests

`test/test_interpolate_transform.jl` (added to the `unit` group):
- `interpolate(identity, …) == interpolate(…)` exactly (field and FTS).
- `interpolate(log, X, c, …) ≈ interpolate(X, Field(log(c)), …)`.
- Geometric interpolation of an exponential profile is exact and beats the (overestimating) linear blend.
- Time-constant FTS log-space matches the analytic profile; identity-FTS matches stock.

Verified on CPU for `Float32` and `Float64` (84 assertions). GPU validation left to CI — the local Julia depot is out of disk, so the CUDA test environment couldn't be instantiated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)