### PR TITLE
Fast interpolate! from a LambertConformalConicGrid source

### DIFF
--- a/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
+++ b/src/OrthogonalSphericalShellGrids/OrthogonalSphericalShellGrids.jl
@@ -26,6 +26,7 @@ include("tripolar_field_extensions.jl")
 include("right_face_folded_kernel_parameters.jl")
 include("rotated_latitude_longitude_grid.jl")
 include("lambert_conformal_conic_grid.jl")
+include("lambert_conformal_conic_interpolation.jl")
 include("conformal_cubed_sphere_panel.jl")
 
 # Distributed computations on a tripolar grid

--- a/src/OrthogonalSphericalShellGrids/lambert_conformal_conic_interpolation.jl
+++ b/src/OrthogonalSphericalShellGrids/lambert_conformal_conic_interpolation.jl
@@ -1,0 +1,36 @@
+using Oceananigans.Fields: FractionalIndices, fractional_z_index
+import Oceananigans.Fields: _fractional_indices
+
+# A LambertConformalConicGrid is exactly uniform in its projected (x, y) meters
+# plane, so the fractional index is a closed-form O(1) lookup: forward-project the
+# target (λ, φ) to projected meters and divide by the (constant) projected spacing.
+# The horizontal index is *joint* in (λ, φ) — unlike the separable LatitudeLongitude
+# axes — because each projected coordinate depends on both λ and φ, so the shortcut
+# installs at the `_fractional_indices` layer where the full horizontal node is in scope.
+
+const CenterOrFace = Union{Center, Face}
+
+@inline function lcc_fractional_indices(λ, φ, grid::LambertConformalConicGrid, ℓx, ℓy)
+    map  = grid.conformal_mapping
+    x, y = lcc_forward(map, λ, φ)
+    x₀   = lcc_xnode(1, ℓx, map)
+    y₀   = lcc_ynode(1, ℓy, map)
+    ii   = (x - x₀) / map.Δx + 1
+    jj   = (y - y₀) / map.Δy + 1
+    return ii, jj
+end
+
+@inline function _fractional_indices((λ, φ, z)::NTuple{3, Any},
+                                     grid::LambertConformalConicGrid,
+                                     ℓx::CenterOrFace, ℓy::CenterOrFace, ℓz::CenterOrFace)
+    ii, jj = lcc_fractional_indices(λ, φ, grid, ℓx, ℓy)
+    kk     = fractional_z_index(z, (ℓx, ℓy, ℓz), grid)
+    return FractionalIndices(ii, jj, kk)
+end
+
+@inline function _fractional_indices((λ, φ)::NTuple{2, Any},
+                                     grid::LambertConformalConicGrid,
+                                     ℓx::CenterOrFace, ℓy::CenterOrFace, ::Nothing)
+    ii, jj = lcc_fractional_indices(λ, φ, grid, ℓx, ℓy)
+    return FractionalIndices(ii, jj, nothing)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ CUDA.allowscalar() do
             include("test_boundary_conditions.jl")
             include("test_field.jl")
             include("test_set_field_interpolation.jl")
+            include("test_lcc_interpolation.jl")
             include("test_regrid.jl")
             include("test_field_scans.jl")
             include("test_halo_regions.jl")

--- a/test/test_lcc_interpolation.jl
+++ b/test/test_lcc_interpolation.jl
@@ -1,0 +1,74 @@
+include("dependencies_for_runtests.jl")
+
+using Oceananigans.OrthogonalSphericalShellGrids: LambertConformalConicGrid, lcc_forward,
+    lcc_fractional_indices
+using Oceananigans.Fields: interpolate!, interior
+using Oceananigans.Grids: Center, Face, λnodes, φnodes
+
+# Bilinear interpolation of a field that is linear in the projected (x, y)
+# coordinates is exact, so the interpolant must reproduce a·x + b·y to round-off.
+linear_in_projection(map, a, b) = (λ, φ, z) -> begin
+    x, y = lcc_forward(map, λ, φ)
+    a * x + b * y
+end
+
+@testset "LambertConformalConic source interpolation" begin
+    for arch in archs, FT in float_types
+        @info "  Testing LCC source interpolation [$(typeof(arch)), $FT]..."
+
+        source_grid = LambertConformalConicGrid(arch, FT;
+                                                size = (40, 30, 2),
+                                                center = (-95, 38),
+                                                spacing = 20000,
+                                                standard_parallels = (25, 25),
+                                                z = (-1, 0),
+                                                warn = false)
+
+        map = source_grid.conformal_mapping
+
+        # LatitudeLongitude target strictly inside the projected LCC rectangle.
+        target_grid = LatitudeLongitudeGrid(arch, FT;
+                                            size = (12, 10, 2),
+                                            longitude = (-98, -92),
+                                            latitude = (36, 40),
+                                            z = (-1, 0))
+
+        # Test 1 — constant field interpolates to the same constant (exact).
+        source_constant = CenterField(source_grid)
+        set!(source_constant, (λ, φ, z) -> convert(FT, 3.5))
+        target_constant = CenterField(target_grid)
+        interpolate!(target_constant, source_constant)
+        @test maximum(abs.(Array(interior(target_constant)) .- FT(3.5))) < 10 * eps(FT)
+
+        # Tests 2 & 3 — linear-in-projection field, at Center and at Face (u-like).
+        a, b = convert(FT, 1e-6), convert(FT, -1e-6)
+        f = linear_in_projection(map, a, b)
+        tolerance = FT == Float64 ? 1e-9 : 1e-2
+
+        for (TargetField, ℓx, ℓy) in ((CenterField, Center(), Center()),
+                                      (XFaceField,  Face(),   Center()))
+            source_field = TargetField(source_grid)
+            set!(source_field, f)
+            target_field = TargetField(target_grid)
+            interpolate!(target_field, source_field)
+
+            λt = Array(λnodes(target_grid, ℓx, ℓy, Center()))
+            φt = Array(φnodes(target_grid, ℓx, ℓy, Center()))
+            Nx, Ny = length(λt), length(φt)
+            expected = [a * lcc_forward(map, λt[i], φt[j])[1] +
+                        b * lcc_forward(map, λt[i], φt[j])[2]
+                        for i in 1:Nx, j in 1:Ny, k in 1:2]
+
+            @test maximum(abs.(Array(interior(target_field)) .- expected)) < tolerance
+        end
+
+        # Type stability and (on CPU) allocation-freedom of the fractional-index helper.
+        λ₀, φ₀ = FT(-95), FT(38)
+        @test @inferred(lcc_fractional_indices(λ₀, φ₀, source_grid, Center(), Center())) isa Tuple{FT, FT}
+
+        if arch isa CPU
+            lcc_fractional_indices(λ₀, φ₀, source_grid, Center(), Center())
+            @test (@allocated lcc_fractional_indices(λ₀, φ₀, source_grid, Center(), Center())) == 0
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Makes `Oceananigans.Fields.interpolate!(to_field, from_field)` work — and work *fast* — when `from_field` lives on a `LambertConformalConicGrid` (LCC). Previously this threw `MethodError: no method matching fractional_x_index(…, ::OrthogonalSphericalShellGrid…)`, because fractional-index methods existed only for `RectilinearGrid` and `LatitudeLongitudeGrid`.

This unblocks ingesting projected GRIB datasets (e.g. NOAA RAP) through the existing `interpolate!` path with **no KD-tree and no scattered search** — a closed-form O(1) fractional-index lookup analogous to the regular-`LatitudeLongitudeGrid` shortcut.

## How

The LCC grid is exactly uniform in its projected `(x, y)` meters plane, and the closed-form forward map `lcc_forward(map, λ, φ) → (x, y)` already exists (`@inline`, allocation-free). So the fractional index is exact:

```julia
x, y = lcc_forward(map, λ, φ)
ii = (x - lcc_xnode(1, ℓx, map)) / map.Δx + 1
jj = (y - lcc_ynode(1, ℓy, map)) / map.Δy + 1
```

The one structural subtlety: LLG shortcuts are per-axis (`fractional_x_index(λ)`, `fractional_y_index(φ)`) because lat-lon axes are separable. **LCC axes are not** — each projected coordinate depends on both λ and φ. So the shortcut installs one level up, as a joint specialization of `_fractional_indices` (where the full horizontal node is in scope), following the existing `XFlatGrid`/`XYFlatGrid`/… precedent.

## Notes

- **Module placement.** Methods live in `OrthogonalSphericalShellGrids` (loaded after `Fields`) so extending `Oceananigans.Fields._fractional_indices` introduces no import cycle.
- **No new ambiguities.** Locations are constrained to `Union{Center, Face}`, keeping the new methods disjoint from the existing `Nothing`-location methods. `detect_ambiguities` on the module stays at 0 (the module is in the strict no-ambiguities list).
- **Staggering** is exact via the location-aware `lcc_xnode(1, ℓx, map)` / `lcc_ynode(1, ℓy, map)` origin (Center vs Face).
- **Out-of-domain** targets clamp identically to the LLG path — same `interpolator`/`_interpolate` machinery, the fractional index just feeds into it.
- **GPU-safe**: the `lcc_*` helpers are already `@inline` and allocation-free; the new code adds only arithmetic.

## Tests

New `test/test_lcc_interpolation.jl` (registered in `runtests.jl`), over `archs × float_types`:

1. **Constant field** → same constant, exact to round-off.
2. **Linear-in-projected-coords field** → bilinear interpolation of a function linear in `(x, y)` is exact, so the target reproduces `a·x + b·y` to round-off. Validates origin, Δ, 1-based offset.
3. **Face-located field** (u-like, `ℓx = Face`) → same, checks staggering.
4. **Type stability** (`@inferred` → `Tuple{FT, FT}`) and **allocation-freedom** (`@allocated == 0` on CPU) of the fractional-index helper.

Verified passing: **CPU 10/10** and **GPU (H100) 8/8** (the two allocation assertions are CPU-only by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)