### PR TITLE
Allow Flat-z (2D) TripolarGrid via z = nothing

### DIFF
--- a/src/OrthogonalSphericalShellGrids/tripolar_grid.jl
+++ b/src/OrthogonalSphericalShellGrids/tripolar_grid.jl
@@ -62,15 +62,19 @@ Positional Arguments
 Keyword Arguments
 =================
 
-- `size`: The number of cells in the (longitude, latitude, vertical) dimensions.
+- `size`: The number of cells in the (longitude, latitude, vertical) dimensions. The vertical
+          entry is optional when `z = nothing` (a 2D grid); then a 2-tuple `(Nx, Ny)` suffices.
 - `southernmost_latitude`: The southernmost `Center` latitude of the grid. Default: -80.
 - `halo`: The halo size in the (longitude, latitude, vertical) dimensions. Default: (4, 4, 4).
+          As with `size`, the vertical entry is optional when `z = nothing`.
 - `radius`: The radius of the spherical shell. Default: `Oceananigans.defaults.planet_radius`.
 - `z`: The vertical ``z``-coordinate range of the grid. Could either be:
        (i) 2-tuple that specifies the end points of the coordinate,
        (ii) an array with the ``z`` interfaces, or
        (iii) a function of `k` index that returns the locations of cell interfaces
-             in ``z``-direction. Default: (0, 1).
+             in ``z``-direction, or
+       (iv) `nothing`, which builds a purely horizontal (2D) grid with a `Flat` vertical
+            (e.g. for surface forcing). Default: (0, 1).
 - `first_pole_longitude`: The longitude of the first "north" singularity.
                           The second singularity is located at `first_pole_longitude + 180ᵒ`.
                           Default: 70.

--- a/src/OrthogonalSphericalShellGrids/tripolar_grid.jl
+++ b/src/OrthogonalSphericalShellGrids/tripolar_grid.jl
@@ -162,8 +162,10 @@ function TripolarGrid(arch = CPU(), FT::DataType = Oceananigans.defaults.FloatTy
                       first_pole_longitude = 70, # second pole is at longitude `first_pole_longitude + 180ᵒ`
                       fold_topology = RightCenterFolded)
 
-    # Set the topology
-    topology = (Periodic, fold_topology, Bounded)
+    # Set the topology: passing `z = nothing` builds a purely horizontal (2D) tripolar grid with a
+    # `Flat` vertical (e.g. for surface forcing); otherwise the vertical is `Bounded`.
+    TZ = isnothing(z) ? Flat : Bounded
+    topology = (Periodic, fold_topology, TZ)
 
     # TODO: Change a couple of allocations here and there to be able
     # to construct the grid on the GPU. This is not a huge problem as
@@ -174,15 +176,19 @@ function TripolarGrid(arch = CPU(), FT::DataType = Oceananigans.defaults.FloatTy
 
     focal_distance = tand((90 - north_poles_latitude) / 2)
 
-    Nx, Ny, Nz = size
-    Hx, Hy, Hz = halo
+    # The vertical entry of `size` and `halo` is optional for a `Flat` (2D) grid.
+    Nx, Ny = size[1], size[2]
+    Hx, Hy = halo[1], halo[2]
+    Nz = TZ === Flat ? 1 : size[3]
+    Hz = TZ === Flat ? 0 : halo[3]
+    size = (Nx, Ny, Nz)
+    halo = (Hx, Hy, Hz)
 
     if isodd(Nx)
         throw(ArgumentError("The number of cells in the longitude dimension should be even!"))
     end
 
     # Generate coordinates
-    TZ = topology[3]
     z = validate_dimension_specification(TZ, z, :z, Nz, FT)
     Lz, z                        = generate_coordinate(FT, topology, size, halo, z,         :z,         3, CPU())
     Ly, φᵃᶠᵃ, φᵃᶜᵃ, Δφᶠᵃᵃ, Δφᶜᵃᵃ = generate_coordinate(FT, topology, size, halo, latitude,  :latitude,  2, CPU())

--- a/test/test_tripolar_grid.jl
+++ b/test/test_tripolar_grid.jl
@@ -91,6 +91,31 @@ end
     end
 end
 
+@testset "Flat-z (2D) construction: z = nothing builds a horizontal-only tripolar grid" begin
+    for arch in archs
+        @testset "$fold_topology fold topology" for fold_topology in fold_topologies
+            # `z = nothing` builds a purely horizontal (2D) tripolar grid with a `Flat` vertical;
+            # the vertical entry of `size`/`halo` is then optional.
+            grid_2tuple = TripolarGrid(arch; size = (4, 5),    z = nothing, halo = (3, 3),    fold_topology)
+            grid_3tuple = TripolarGrid(arch; size = (4, 5, 1), z = nothing, halo = (3, 3, 3), fold_topology)
+
+            for grid in (grid_2tuple, grid_3tuple)
+                @test grid isa TripolarGrid
+                @test topology(grid, 3) === Flat
+                @test (grid.Nx, grid.Ny, grid.Nz) == (4, 5, 1)
+            end
+
+            # The default Bounded-z grid is unchanged, and shares the same horizontal coordinates.
+            grid_bounded = TripolarGrid(arch; size = (4, 5, 1), z = (0, 1), halo = (3, 3, 3), fold_topology)
+            @test topology(grid_bounded, 3) === Bounded
+            @allowscalar begin
+                @test λnodes(grid_2tuple, Center(), Center()) ≈ λnodes(grid_bounded, Center(), Center())
+                @test φnodes(grid_2tuple, Center(), Center()) ≈ φnodes(grid_bounded, Center(), Center())
+            end
+        end
+    end
+end
+
 @testset "Model tests..." begin
     for arch in archs
         @testset "$fold_topology fold topology" for fold_topology in fold_topologies

--- a/test/test_tripolar_grid.jl
+++ b/test/test_tripolar_grid.jl
@@ -1,14 +1,14 @@
 include("dependencies_for_runtests.jl")
 
-using Statistics
+using Oceananigans.BoundaryConditions: Zipper, FPivot, UPivot
 using Oceananigans.Grids: get_cartesian_nodes_and_vertices, RightFaceFolded, RightCenterFolded
 using Oceananigans.ImmersedBoundaries: immersed_cell
-using Oceananigans.BoundaryConditions: Zipper, FPivot, UPivot
+using Oceananigans.Utils: KernelParameters, contiguousrange
+using Statistics
 
-using Oceananigans.Utils: KernelParameters
-import Oceananigans.Utils: contiguousrange
+Oceananigans.Utils.contiguousrange(::KernelParameters{spec, offset}) where {spec, offset} =
+    contiguousrange(spec, offset)
 
-contiguousrange(::KernelParameters{spec, offset}) where {spec, offset} = contiguousrange(spec, offset)
 fold_topologies = (RightCenterFolded, RightFaceFolded)
 
 @kernel function compute_nonorthogonality_angle!(angle, grid, xF, yF, zF)
@@ -96,17 +96,17 @@ end
         @testset "$fold_topology fold topology" for fold_topology in fold_topologies
             # `z = nothing` builds a purely horizontal (2D) tripolar grid with a `Flat` vertical;
             # the vertical entry of `size`/`halo` is then optional.
-            grid_2tuple = TripolarGrid(arch; size = (4, 5),    z = nothing, halo = (3, 3),    fold_topology)
-            grid_3tuple = TripolarGrid(arch; size = (4, 5, 1), z = nothing, halo = (3, 3, 3), fold_topology)
+            grid_2tuple = TripolarGrid(arch; size = (4, 15),    z = nothing, halo = (3, 3),    fold_topology, )
+            grid_3tuple = TripolarGrid(arch; size = (4, 15, 1), z = nothing, halo = (3, 3, 3), fold_topology, southernmost_latitude)
 
             for grid in (grid_2tuple, grid_3tuple)
                 @test grid isa TripolarGrid
                 @test topology(grid, 3) === Flat
-                @test (grid.Nx, grid.Ny, grid.Nz) == (4, 5, 1)
+                @test (grid.Nx, grid.Ny, grid.Nz) == (4, 15, 1)
             end
 
             # The default Bounded-z grid is unchanged, and shares the same horizontal coordinates.
-            grid_bounded = TripolarGrid(arch; size = (4, 5, 1), z = (0, 1), halo = (3, 3, 3), fold_topology)
+            grid_bounded = TripolarGrid(arch; size = (4, 15, 1), z = (0, 1), halo = (3, 3, 3), fold_topology)
             @test topology(grid_bounded, 3) === Bounded
             @allowscalar begin
                 @test λnodes(grid_2tuple, Center(), Center()) ≈ λnodes(grid_bounded, Center(), Center())

--- a/test/test_tripolar_grid.jl
+++ b/test/test_tripolar_grid.jl
@@ -96,8 +96,8 @@ end
         @testset "$fold_topology fold topology" for fold_topology in fold_topologies
             # `z = nothing` builds a purely horizontal (2D) tripolar grid with a `Flat` vertical;
             # the vertical entry of `size`/`halo` is then optional.
-            grid_2tuple = TripolarGrid(arch; size = (4, 15),    z = nothing, halo = (3, 3),    fold_topology, )
-            grid_3tuple = TripolarGrid(arch; size = (4, 15, 1), z = nothing, halo = (3, 3, 3), fold_topology, southernmost_latitude)
+            grid_2tuple = TripolarGrid(arch; size = (4, 15),    z = nothing, halo = (3, 3),    fold_topology)
+            grid_3tuple = TripolarGrid(arch; size = (4, 15, 1), z = nothing, halo = (3, 3, 3), fold_topology)
 
             for grid in (grid_2tuple, grid_3tuple)
                 @test grid isa TripolarGrid


### PR DESCRIPTION
## Motivation

`TripolarGrid` hardcoded its vertical topology to `Bounded`:

```julia
topology = (Periodic, fold_topology, Bounded)
```

so there was no way to build a purely horizontal (2D) tripolar grid. Every other grid (`RectilinearGrid`, `LatitudeLongitudeGrid`) supports a `Flat` dimension via `z = nothing`; this brings `TripolarGrid` in line.

The concrete need is downstream (NumericalEarth): a **surface / single-level prescribed atmosphere** (or any 2D coupling field) on a tripolar grid wants a 2D `(Center, Center, Nothing)` field with the north-fold zipper BC — which requires the grid's vertical to be `Flat`, not a 1-cell `Bounded` column.

## What changed

- `z = nothing` ⇒ `Flat` vertical topology; otherwise `Bounded` (unchanged default).
- The vertical entry of `size`/`halo` is now optional, so both of these work:
  ```julia
  TripolarGrid(size = (Nx, Ny),    z = nothing, halo = (Hx, Hy))      # 2-tuple
  TripolarGrid(size = (Nx, Ny, 1), z = nothing, halo = (Hx, Hy, Hz))  # 3-tuple, vertical entry ignored
  ```
- The default `z = (0, 1)` path is byte-for-byte unchanged.
- The distributed `TripolarGrid(::Distributed; …)` inherits this for free — it delegates to the serial constructor.

## Tests

Added a `Flat-z (2D) construction` testset (`test/test_tripolar_grid.jl`) over both fold topologies: builds via 2- and 3-tuple `size`, checks `topology(grid, 3) === Flat` and `Nz == 1`, and confirms the horizontal coordinates match the `Bounded`-z grid of the same horizontal size.

> Note: I couldn't precompile locally (an unrelated extension-precompile issue in my dev env), so I'm relying on CI to exercise the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)