### PR TITLE
Fix type instability in interpolating_time_indices(::Clamp, …)

### DIFF
--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -76,8 +76,8 @@ end
 @inline function interpolating_time_indices(::Clamp, times, t)
     ñ, n₁, n₂ = find_time_index(times, t)
 
-    beyond_indices    = (0, n₂, n₂) # Beyond the last time:  return n₂
-    before_indices    = (0, n₁, n₁) # Before the first time: return n₁
+    beyond_indices    = (zero(ñ), n₂, n₂) # Beyond the last time:  return n₂
+    before_indices    = (zero(ñ), n₁, n₁) # Before the first time: return n₁
     unclamped_indices = (ñ, n₁, n₂) # Business as usual
 
     Nt = length(times)


### PR DESCRIPTION
## Summary

Fixes #5731.

`interpolating_time_indices(::Clamp, times, t)` built its clamped index tuples with a literal `0` for the fractional time index, while the in-range tuple used the `Float64` value `ñ`:

```julia
beyond_indices    = (0, n₂, n₂)
before_indices    = (0, n₁, n₁)
unclamped_indices = (ñ, n₁, n₂)
```

The `ifelse` over these tuples then inferred as `Union{Tuple{Int,Int,Int}, Tuple{Float64,Int,Int}}` — a type instability.

This also produces a Reactant compile warning on every compile (*"`ifelse` with different element-types in Reactant works by promoting the element-type to the common type"*), since Reactant maps `ifelse` element-wise over tuples. Because `Clamp()` is the default time-indexing mode for `FieldTimeSeries`, this fired for essentially any Reactant-compiled model interpolating time series data.

## Fix

Replace the literal `0` with `zero(ñ)` so all branches share an element type, matching the pattern already used in the sibling `find_time_index` function:

```julia
beyond_indices    = (zero(ñ), n₂, n₂)
before_indices    = (zero(ñ), n₁, n₁)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)