### PR TITLE
Density-weighted (mass-flux) adaptive implicit vertical advection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.6"
+version = "0.110.7"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/Advection/implicit_vertical_advection.jl
+++ b/src/Advection/implicit_vertical_advection.jl
@@ -78,7 +78,7 @@ end
 # Upper diagonal: coefficient of q_{k+1} in the tridiagonal system
 @inline function implicit_advection_upper_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, density=nothing)
     scheme = vertical_scheme(advection)
-    td     = TimeSteppers.time_discretization(scheme)
+    td  = TimeSteppers.time_discretization(scheme)
     wⁱ  = implicit_vertical_velocity(ℓx, ℓy, i, j, k+1, grid, scheme, td, w)
     Azᵢ = Az(i, j, k+1, grid, ℓx, ℓy, Face())
     ϖᶠ  = densityᶜᶜᶠ(i, j, k+1, grid, density)

--- a/src/Advection/implicit_vertical_advection.jl
+++ b/src/Advection/implicit_vertical_advection.jl
@@ -1,5 +1,5 @@
-using Oceananigans.Operators: Az, volume, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
 using Oceananigans.Grids: peripheral_node, Center, Face
+using Oceananigans.Operators: Az, volume, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
 
 @inline vertical_scheme(advection) = advection
 @inline vertical_scheme(advection::VectorInvariant) = advection.vertical_advection_scheme

--- a/src/Advection/implicit_vertical_advection.jl
+++ b/src/Advection/implicit_vertical_advection.jl
@@ -91,7 +91,7 @@ end
 # Uses k′ = k-1 indexing convention (LinearAlgebra.Tridiagonal convention, matching ivd_lower_diagonal)
 @inline function implicit_advection_lower_diagonal(i, j, k′, grid, advection::AIVA, w, Δt, ℓx, ℓy, density=nothing)
     scheme = vertical_scheme(advection)
-    td     = TimeSteppers.time_discretization(scheme)
+    td  = TimeSteppers.time_discretization(scheme)
     k   = k′ + 1
     wⁱ  = implicit_vertical_velocity(ℓx, ℓy, i, j, k, grid, scheme, td, w)
     Azᵢ = Az(i, j, k, grid, ℓx, ℓy, Face())

--- a/src/Advection/implicit_vertical_advection.jl
+++ b/src/Advection/implicit_vertical_advection.jl
@@ -60,15 +60,15 @@ end
 #####
 ##### Tridiagonal coefficients for implicit first-order upwind advection (for fields at cell Centers in z).
 #####
-##### The upwind flux at face k+1 (top of cell k), weighted by the face density ϖᶠ:
-#####   F_{k+1} = Az_{k+1} ϖᶠ_{k+1} * [max(wⁱ_{k+1}, 0) * c_k + min(wⁱ_{k+1}, 0) * c_{k+1}],   c = q / ρ
+##### The upwind flux at face k+1 (top of cell k), weighted by the face density ρᶠ:
+#####   F_{k+1} = Az_{k+1} ρᶠ_{k+1} * [max(wⁱ_{k+1}, 0) * c_k + min(wⁱ_{k+1}, 0) * c_{k+1}],   c = q / ρ
 #####
-##### The implicit system (I - Δt * L) qⁿ⁺¹ = q★ gives (with ϖᶜ the cell density of the reconstructed value):
+##### The implicit system (I - Δt * L) qⁿ⁺¹ = q★ gives (with ρᶜ the cell density of the reconstructed value):
 #####
-##### Upper diagonal (coeff of q_{k+1}):   Δt / V_k * Az_{k+1} ϖᶠ_{k+1} / ϖᶜ_{k+1} * min(wⁱ_{k+1}, 0)
-##### Lower diagonal (coeff of q_{k-1}): - Δt / V_k * Az_k     ϖᶠ_k     / ϖᶜ_{k-1} * max(wⁱ_k, 0)
+##### Upper diagonal (coeff of q_{k+1}):   Δt / V_k * Az_{k+1} ρᶠ_{k+1} / ρᶜ_{k+1} * min(wⁱ_{k+1}, 0)
+##### Lower diagonal (coeff of q_{k-1}): - Δt / V_k * Az_k     ρᶠ_k     / ρᶜ_{k-1} * max(wⁱ_k, 0)
 #####
-##### With `density === nothing`, ϖᶠ = ϖᶜ = 1 and these reduce to the volume-conserving coefficients.
+##### With `density === nothing`, ρᶠ = ρᶜ = 1 and these reduce to the volume-conserving coefficients.
 #####
 
 @inline implicit_vertical_velocity(::Center, ::Center, args...) = implicit_vertical_velocityᶜᶜᶠ(args...)
@@ -81,10 +81,10 @@ end
     td  = TimeSteppers.time_discretization(scheme)
     wⁱ  = implicit_vertical_velocity(ℓx, ℓy, i, j, k+1, grid, scheme, td, w)
     Azᵢ = Az(i, j, k+1, grid, ℓx, ℓy, Face())
-    ϖᶠ  = densityᶜᶜᶠ(i, j, k+1, grid, density)
-    ϖᶜ  = densityᶜᶜᶜ(i, j, k+1, grid, density)
+    ρᶠ  = densityᶜᶜᶠ(i, j, k+1, grid, density)
+    ρᶜ  = densityᶜᶜᶜ(i, j, k+1, grid, density)
     V⁻¹ = 1 / volume(i, j, k, grid, ℓx, ℓy, Center())
-    return Δt * V⁻¹ * Azᵢ * ϖᶠ / ϖᶜ * min(wⁱ, zero(wⁱ)) * !peripheral_node(i, j, k+1, grid, ℓx, ℓy, Face())
+    return Δt * V⁻¹ * Azᵢ * ρᶠ / ρᶜ * min(wⁱ, zero(wⁱ)) * !peripheral_node(i, j, k+1, grid, ℓx, ℓy, Face())
 end
 
 # Lower diagonal: coefficient of q_{k-1} in the tridiagonal system
@@ -95,10 +95,10 @@ end
     k   = k′ + 1
     wⁱ  = implicit_vertical_velocity(ℓx, ℓy, i, j, k, grid, scheme, td, w)
     Azᵢ = Az(i, j, k, grid, ℓx, ℓy, Face())
-    ϖᶠ  = densityᶜᶜᶠ(i, j, k, grid, density)
-    ϖᶜ  = densityᶜᶜᶜ(i, j, k-1, grid, density)
+    ρᶠ  = densityᶜᶜᶠ(i, j, k, grid, density)
+    ρᶜ  = densityᶜᶜᶜ(i, j, k-1, grid, density)
     V⁻¹ = 1 / volume(i, j, k, grid, ℓx, ℓy, Center())
-    return - Δt * V⁻¹ * Azᵢ * ϖᶠ / ϖᶜ * max(wⁱ, zero(wⁱ)) * !peripheral_node(i, j, k′, grid, ℓx, ℓy, Center())
+    return - Δt * V⁻¹ * Azᵢ * ρᶠ / ρᶜ * max(wⁱ, zero(wⁱ)) * !peripheral_node(i, j, k′, grid, ℓx, ℓy, Center())
 end
 
 @inline function implicit_advection_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, density=nothing)
@@ -110,15 +110,15 @@ end
     Az⁺ = Az(i, j, k+1, grid, ℓx, ℓy, Face())
     Az⁻ = Az(i, j, k,   grid, ℓx, ℓy, Face())
 
-    ϖᶠ⁺ = densityᶜᶜᶠ(i, j, k+1, grid, density)
-    ϖᶠ⁻ = densityᶜᶜᶠ(i, j, k,   grid, density)
-    ϖᶜ  = densityᶜᶜᶜ(i, j, k,   grid, density)   # reconstructed value at cell k
+    ρᶠ⁺ = densityᶜᶜᶠ(i, j, k+1, grid, density)
+    ρᶠ⁻ = densityᶜᶜᶠ(i, j, k,   grid, density)
+    ρᶜ  = densityᶜᶜᶜ(i, j, k,   grid, density)   # reconstructed value at cell k
 
     active⁺ = !peripheral_node(i, j, k+1, grid, ℓx, ℓy, Face())
     active⁻ = !peripheral_node(i, j, k,   grid, ℓx, ℓy, Face())
 
     V⁻¹ = 1 / volume(i, j, k, grid, ℓx, ℓy, Center())
 
-    return Δt * V⁻¹ / ϖᶜ * (Az⁺ * ϖᶠ⁺ * max(wⁱ⁺, zero(wⁱ⁺)) * active⁺ -
-                            Az⁻ * ϖᶠ⁻ * min(wⁱ⁻, zero(wⁱ⁻)) * active⁻)
+    return Δt * V⁻¹ / ρᶜ * (Az⁺ * ρᶠ⁺ * max(wⁱ⁺, zero(wⁱ⁺)) * active⁺ -
+                            Az⁻ * ρᶠ⁻ * min(wⁱ⁻, zero(wⁱ⁻)) * active⁻)
 end

--- a/src/Advection/implicit_vertical_advection.jl
+++ b/src/Advection/implicit_vertical_advection.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Operators: Az, volume, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
+using Oceananigans.Operators: Az, volume, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
 using Oceananigans.Grids: peripheral_node, Center, Face
 
 @inline vertical_scheme(advection) = advection
@@ -40,44 +40,68 @@ end
 end
 
 #####
+##### Optional density weighting for mass-flux (anelastic / compressible) models.
+#####
+##### Boussinesq models advect the tracer `c` with a volume-conserving flux, so the default
+##### `density === nothing` reproduces the volume-conserving coefficients exactly. Mass-flux models
+##### evolve `q = ρ c` with the flux `Az ρ w · upwind(c)`, `c = q / ρ`: pass the (reference or
+##### prognostic) density `ρ` and the coefficients are weighted by the density interpolated to the
+##### advecting face and divided by the density at the reconstructed cell centre. `ρ` is evaluated at
+##### the advected field's location, so this is intended for tracers (Center, Center, Center).
+#####
+
+# Density at the tracer cell centre (ᶜᶜᶜ) and the vertical interface (ᶜᶜᶠ). `nothing` ⇒ unit weight,
+# which recovers the volume-conserving (Boussinesq) coefficients.
+@inline densityᶜᶜᶜ(i, j, k, grid, ρ) = @inbounds ρ[i, j, k]
+@inline densityᶜᶜᶠ(i, j, k, grid, ρ) = ℑzᵃᵃᶠ(i, j, k, grid, ρ)
+@inline densityᶜᶜᶜ(i, j, k, grid, ::Nothing) = one(grid)
+@inline densityᶜᶜᶠ(i, j, k, grid, ::Nothing) = one(grid)
+
+#####
 ##### Tridiagonal coefficients for implicit first-order upwind advection (for fields at cell Centers in z).
 #####
-##### The upwind flux at face k+1 (top of cell k):
-#####   F_{k+1} = Az_{k+1} * [max(wⁱ_{k+1}, 0) * c_k + min(wⁱ_{k+1}, 0) * c_{k+1}]
+##### The upwind flux at face k+1 (top of cell k), weighted by the face density ϖᶠ:
+#####   F_{k+1} = Az_{k+1} ϖᶠ_{k+1} * [max(wⁱ_{k+1}, 0) * c_k + min(wⁱ_{k+1}, 0) * c_{k+1}],   c = q / ρ
 #####
-##### The implicit system (I - Δt * L) cⁿ⁺¹ = c★ gives:
+##### The implicit system (I - Δt * L) qⁿ⁺¹ = q★ gives (with ϖᶜ the cell density of the reconstructed value):
 #####
-##### Upper diagonal (coeff of c_{k+1}):   Δt / V_k * Az_{k+1} * min(wⁱ_{k+1}, 0)
-##### Lower diagonal (coeff of c_{k-1}): - Δt / V_k * Az_k * max(wⁱ_k, 0)
+##### Upper diagonal (coeff of q_{k+1}):   Δt / V_k * Az_{k+1} ϖᶠ_{k+1} / ϖᶜ_{k+1} * min(wⁱ_{k+1}, 0)
+##### Lower diagonal (coeff of q_{k-1}): - Δt / V_k * Az_k     ϖᶠ_k     / ϖᶜ_{k-1} * max(wⁱ_k, 0)
+#####
+##### With `density === nothing`, ϖᶠ = ϖᶜ = 1 and these reduce to the volume-conserving coefficients.
 #####
 
 @inline implicit_vertical_velocity(::Center, ::Center, args...) = implicit_vertical_velocityᶜᶜᶠ(args...)
 @inline implicit_vertical_velocity(::Face,   ::Center, args...) = implicit_vertical_velocityᶠᶜᶠ(args...)
 @inline implicit_vertical_velocity(::Center, ::Face,   args...) = implicit_vertical_velocityᶜᶠᶠ(args...)
 
-# Upper diagonal: coefficient of c_{k+1} in the tridiagonal system
-@inline function implicit_advection_upper_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy)
+# Upper diagonal: coefficient of q_{k+1} in the tridiagonal system
+@inline function implicit_advection_upper_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, density=nothing)
     scheme = vertical_scheme(advection)
     td     = TimeSteppers.time_discretization(scheme)
     wⁱ  = implicit_vertical_velocity(ℓx, ℓy, i, j, k+1, grid, scheme, td, w)
     Azᵢ = Az(i, j, k+1, grid, ℓx, ℓy, Face())
+    ϖᶠ  = densityᶜᶜᶠ(i, j, k+1, grid, density)
+    ϖᶜ  = densityᶜᶜᶜ(i, j, k+1, grid, density)
     V⁻¹ = 1 / volume(i, j, k, grid, ℓx, ℓy, Center())
-    return Δt * V⁻¹ * Azᵢ * min(wⁱ, zero(wⁱ)) * !peripheral_node(i, j, k+1, grid, ℓx, ℓy, Face())
+    return Δt * V⁻¹ * Azᵢ * ϖᶠ / ϖᶜ * min(wⁱ, zero(wⁱ)) * !peripheral_node(i, j, k+1, grid, ℓx, ℓy, Face())
 end
 
-# Lower diagonal: coefficient of c_{k-1} in the tridiagonal system
+# Lower diagonal: coefficient of q_{k-1} in the tridiagonal system
 # Uses k′ = k-1 indexing convention (LinearAlgebra.Tridiagonal convention, matching ivd_lower_diagonal)
-@inline function implicit_advection_lower_diagonal(i, j, k′, grid, advection::AIVA, w, Δt, ℓx, ℓy)
+@inline function implicit_advection_lower_diagonal(i, j, k′, grid, advection::AIVA, w, Δt, ℓx, ℓy, density=nothing)
     scheme = vertical_scheme(advection)
     td     = TimeSteppers.time_discretization(scheme)
     k   = k′ + 1
     wⁱ  = implicit_vertical_velocity(ℓx, ℓy, i, j, k, grid, scheme, td, w)
     Azᵢ = Az(i, j, k, grid, ℓx, ℓy, Face())
+    ϖᶠ  = densityᶜᶜᶠ(i, j, k, grid, density)
+    ϖᶜ  = densityᶜᶜᶜ(i, j, k-1, grid, density)
     V⁻¹ = 1 / volume(i, j, k, grid, ℓx, ℓy, Center())
-    return - Δt * V⁻¹ * Azᵢ * max(wⁱ, zero(wⁱ)) * !peripheral_node(i, j, k′, grid, ℓx, ℓy, Center())
+    return - Δt * V⁻¹ * Azᵢ * ϖᶠ / ϖᶜ * max(wⁱ, zero(wⁱ)) * !peripheral_node(i, j, k′, grid, ℓx, ℓy, Center())
 end
 
-@inline function implicit_advection_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy)
+@inline function implicit_advection_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, density=nothing)
     scheme = vertical_scheme(advection)
     td     = TimeSteppers.time_discretization(scheme)
     wⁱ⁺ = implicit_vertical_velocity(ℓx, ℓy, i, j, k+1, grid, scheme, td, w)
@@ -86,11 +110,15 @@ end
     Az⁺ = Az(i, j, k+1, grid, ℓx, ℓy, Face())
     Az⁻ = Az(i, j, k,   grid, ℓx, ℓy, Face())
 
+    ϖᶠ⁺ = densityᶜᶜᶠ(i, j, k+1, grid, density)
+    ϖᶠ⁻ = densityᶜᶜᶠ(i, j, k,   grid, density)
+    ϖᶜ  = densityᶜᶜᶜ(i, j, k,   grid, density)   # reconstructed value at cell k
+
     active⁺ = !peripheral_node(i, j, k+1, grid, ℓx, ℓy, Face())
     active⁻ = !peripheral_node(i, j, k,   grid, ℓx, ℓy, Face())
 
     V⁻¹ = 1 / volume(i, j, k, grid, ℓx, ℓy, Center())
 
-    return Δt * V⁻¹ * (Az⁺ * max(wⁱ⁺, zero(wⁱ⁺)) * active⁺ -
-                       Az⁻ * min(wⁱ⁻, zero(wⁱ⁻)) * active⁻)
+    return Δt * V⁻¹ / ϖᶜ * (Az⁺ * ϖᶠ⁺ * max(wⁱ⁺, zero(wⁱ⁺)) * active⁺ -
+                            Az⁻ * ϖᶠ⁻ * min(wⁱ⁻, zero(wⁱ⁻)) * active⁻)
 end

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -237,53 +237,57 @@ end
 
 const AIVA = AdaptiveImplicitVerticalAdvection
 
-# With AdaptiveImplicitVerticalAdvection: add advection contribution
+# With AdaptiveImplicitVerticalAdvection: add advection contribution. The optional trailing `density`
+# (default `nothing`) selects volume-conserving (Boussinesq) vs density-weighted (mass-flux) coefficients.
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionUpperDiagonal, p, ::ZDirection,
                                  clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection::AIVA, w)
+                                 advection::AIVA, w, density=nothing)
     du_diff = _ivd_upper_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
-    du_adv = implicit_advection_upper_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy)
+    du_adv = implicit_advection_upper_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, density)
     return du_diff + du_adv
 end
 
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionLowerDiagonal, p, ::ZDirection,
                                  clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection::AIVA, w)
+                                 advection::AIVA, w, density=nothing)
     dl_diff = _ivd_lower_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
-    dl_adv = implicit_advection_lower_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy)
+    dl_adv = implicit_advection_lower_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, density)
     return dl_diff + dl_adv
 end
 
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionDiagonal, p, ::ZDirection,
                                  clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection::AIVA, w)
+                                 advection::AIVA, w, density=nothing)
     d_diff = ivd_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
-    d_adv = implicit_advection_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy)
+    d_adv = implicit_advection_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, density)
     return d_diff + d_adv
 end
 
 # Fallback: non-adaptive advection schemes contribute nothing to the implicit system
 @inline get_coefficient(i, j, k, grid, d::VerticallyImplicitDiffusionUpperDiagonal, p, dir::ZDirection,
-                        clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields, advection, w) =
+                        clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields, advection, w, density=nothing) =
     _ivd_upper_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
 
 @inline get_coefficient(i, j, k, grid, d::VerticallyImplicitDiffusionLowerDiagonal, p, dir::ZDirection,
-                        clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields, advection, w) =
+                        clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields, advection, w, density=nothing) =
     _ivd_lower_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
 
 @inline get_coefficient(i, j, k, grid, d::VerticallyImplicitDiffusionDiagonal, p, dir::ZDirection,
-                        clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields, advection, w) =
+                        clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields, advection, w, density=nothing) =
     ivd_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
 
 #####
 ##### Extended implicit_step! that passes advection and vertical velocity through
+#####
+##### The trailing `density` (default `nothing`) selects density-weighted advection coefficients for
+##### mass-flux (anelastic / compressible) models; `nothing` keeps the volume-conserving Boussinesq behavior.
 #####
 
 function implicit_step!(field::Field,
                         implicit_solver::BatchedTridiagonalSolver,
                         closure, closure_fields, tracer_index,
                         clock, fields, Δt,
-                        advection, velocities)
+                        advection, velocities, density=nothing)
 
     if closure isa Tuple
         N = length(closure)
@@ -298,5 +302,5 @@ function implicit_step!(field::Field,
     return solve!(field, implicit_solver, field,
                   vi_closure, vi_closure_fields, tracer_index,
                   LX(), LY(), LZ(), Δt, clock, fields,
-                  advection, velocities.w)
+                  advection, velocities.w, density)
 end

--- a/test/test_adaptive_implicit_vertical_advection.jl
+++ b/test/test_adaptive_implicit_vertical_advection.jl
@@ -6,13 +6,10 @@ using Oceananigans.Advection: AdaptiveImplicitVerticalAdvection,
                               implicit_advection_upper_diagonal,
                               implicit_advection_lower_diagonal,
                               implicit_advection_diagonal
-using Oceananigans.TimeSteppers: AdaptiveVerticallyImplicitDiscretization,
-                                 ExplicitTimeDiscretization,
-                                 time_discretization,
-                                 implicit_step!,
-                                 reset!
 using Oceananigans.Grids: Center
 using Oceananigans.Operators: ℑzᵃᵃᶠ
+using Oceananigans.TimeSteppers: AdaptiveVerticallyImplicitDiscretization, ExplicitTimeDiscretization,
+                                 time_discretization, implicit_step!, reset!
 using Oceananigans.TurbulenceClosures: implicit_diffusion_solver, VerticallyImplicitTimeDiscretization
 
 @testset "AdaptiveVerticallyImplicitDiscretization construction" begin

--- a/test/test_adaptive_implicit_vertical_advection.jl
+++ b/test/test_adaptive_implicit_vertical_advection.jl
@@ -29,7 +29,7 @@ end
         adaptive = scheme(; time_discretization = AdaptiveVerticallyImplicitDiscretization(), extra_kw...)
 
         @test !(explicit isa AdaptiveImplicitVerticalAdvection)
-        @test adaptive  isa AdaptiveImplicitVerticalAdvection
+        @test adaptive isa AdaptiveImplicitVerticalAdvection
 
         @test time_discretization(explicit) isa ExplicitTimeDiscretization
         @test time_discretization(adaptive) isa AdaptiveVerticallyImplicitDiscretization

--- a/test/test_adaptive_implicit_vertical_advection.jl
+++ b/test/test_adaptive_implicit_vertical_advection.jl
@@ -2,11 +2,18 @@ include("dependencies_for_runtests.jl")
 
 using Oceananigans.Advection: AdaptiveImplicitVerticalAdvection,
                               advective_tracer_flux_z,
-                              needs_implicit_solver
+                              needs_implicit_solver,
+                              implicit_advection_upper_diagonal,
+                              implicit_advection_lower_diagonal,
+                              implicit_advection_diagonal
 using Oceananigans.TimeSteppers: AdaptiveVerticallyImplicitDiscretization,
                                  ExplicitTimeDiscretization,
                                  time_discretization,
+                                 implicit_step!,
                                  reset!
+using Oceananigans.Grids: Center
+using Oceananigans.Operators: ℑzᵃᵃᶠ
+using Oceananigans.TurbulenceClosures: implicit_diffusion_solver, VerticallyImplicitTimeDiscretization
 
 @testset "AdaptiveVerticallyImplicitDiscretization construction" begin
     td = AdaptiveVerticallyImplicitDiscretization(cfl=0.3)
@@ -131,4 +138,70 @@ end
     @test model.clock.iteration == 1
     @test all(isfinite, parent(model.velocities.u))
     @test all(isfinite, parent(model.velocities.v))
+end
+
+@testset "Density-weighted implicit advection (mass-flux models)" begin
+    grid = RectilinearGrid(CPU(), size=(2, 2, 16), x=(0, 1), y=(0, 1), z=(0, 1000),
+                           topology=(Periodic, Periodic, Bounded))
+
+    Δt = 50.0
+    td = AdaptiveVerticallyImplicitDiscretization(cfl=0.3)
+    td.Δt[] = Δt
+    scheme = WENO(; time_discretization=td, weight_computation=Oceananigans.Utils.NormalDivision)
+
+    W = ZFaceField(grid)
+    set!(W, (x, y, z) -> 5 * sinpi(z / 500))   # exceeds the target CFL over part of the column
+    fill_halo_regions!(W)
+
+    ℓx = ℓy = Center()
+
+    @testset "ρ ≡ 1 reproduces the volume-conserving coefficients" begin
+        ρ = CenterField(grid)
+        set!(ρ, 1)
+        fill_halo_regions!(ρ)
+        for k in 2:15, j in 1:2, i in 1:2
+            @test implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ρ) ≈
+                  implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy)
+            @test implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ρ) ≈
+                  implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy)
+            @test implicit_advection_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ρ) ≈
+                  implicit_advection_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy)
+        end
+    end
+
+    @testset "off-diagonals scale with the density ratio" begin
+        ρ = CenterField(grid)
+        set!(ρ, (x, y, z) -> 1 + z / 1000)   # ρ varies smoothly from 1 to 2
+        fill_halo_regions!(ρ)
+        for k in 2:15, j in 1:2, i in 1:2
+            uw = implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ρ)
+            u0 = implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy)
+            @test uw ≈ u0 * ℑzᵃᵃᶠ(i, j, k+1, grid, ρ) / ρ[i, j, k+1]
+
+            lw = implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ρ)
+            l0 = implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy)
+            @test lw ≈ l0 * ℑzᵃᵃᶠ(i, j, k+1, grid, ρ) / ρ[i, j, k]
+        end
+    end
+
+    @testset "density-weighted implicit solve conserves column mass" begin
+        ρ = CenterField(grid)
+        set!(ρ, (x, y, z) -> 1 + z / 1000)
+        fill_halo_regions!(ρ)
+
+        solver = implicit_diffusion_solver(VerticallyImplicitTimeDiscretization(), grid)
+        clock = Clock(grid)
+
+        q = CenterField(grid)
+        set!(q, (x, y, z) -> exp(-((z - 500) / 100)^2))
+        fill_halo_regions!(q)
+        mass₀ = sum(interior(q))
+
+        # No closure ⇒ the solve is the density-weighted implicit vertical advection alone.
+        implicit_step!(q, solver, nothing, nothing, Val(1), clock, (;), Δt, scheme, (; w=W), ρ)
+
+        @test all(isfinite, interior(q))
+        # The upwind operator is flux-form, so a closed column conserves ∑ V q (uniform V here).
+        @test sum(interior(q)) ≈ mass₀ rtol=1e-10
+    end
 end


### PR DESCRIPTION
## Summary

Adaptive implicit vertical advection (AIVA) currently assumes a **volume-conserving (Boussinesq)** tracer flux. Anelastic and compressible models advect in **mass-flux** form, `∂t(ρc) = -∇·(ρ 𝐰 c)`, so they can't reuse the implicit coefficients and have to re-derive them downstream (with type piracy / wrappers — see context below).

This PR adds an **optional `density`** to the implicit vertical advection, as a trailing positional argument (default `nothing`) — keeping the existing positional call structure:

```julia
# Boussinesq (unchanged):
implicit_step!(field, solver, closure, closure_fields, idx, clock, fields, Δt, advection, velocities)

# mass-flux model:
implicit_step!(field, solver, closure, closure_fields, idx, clock, fields, Δt, advection, velocities, ρ)
```

When a density field is supplied, the implicit upwind coefficients are weighted by the density at the advecting interface (`densityᶜᶜᶠ`) and divided by the density at the reconstructed cell centre (`densityᶜᶜᶜ`), i.e. `c = ρc/ρ`:

```
upper_k =  Δt/V_k · Az_{k+½} · ρᶜᶜᶠ_{k+½} / ρᶜᶜᶜ_{k+1} · min(wⁱ, 0)
lower_k = −Δt/V_k · Az_{k−½} · ρᶜᶜᶠ_{k−½} / ρᶜᶜᶜ_{k−1} · max(wⁱ, 0)
```

**The default `density === nothing` reproduces the volume-conserving coefficients exactly** (`ρᶜᶜᶠ/ρᶜᶜᶜ → 1`), so existing Boussinesq behaviour is bit-for-bit unchanged.

## What changed

- `densityᶜᶜᶜ(i, j, k, grid, ρ)` / `densityᶜᶜᶠ(i, j, k, grid, ρ)` return the density at the tracer cell centre / vertical interface, and `1` for `ρ === nothing`.
- `implicit_advection_{upper,lower,diagonal}` take an optional trailing `density = nothing` and apply the `ρᶜᶜᶠ/ρᶜᶜᶜ` weighting.
- The `get_coefficient` overloads thread the same optional `density` through (default `nothing`).
- `implicit_step!` gains a trailing `density = nothing` positional argument and forwards it to `solve!`.

Intended for tracers (`Center, Center, Center`); momentum stays volume-conserving (passing `nothing`). No exported API changes; all additions are backward-compatible optional arguments.

## Tests

Extends `test/test_adaptive_implicit_vertical_advection.jl`:
- `ρ ≡ 1` reproduces the volume-conserving coefficients;
- off-diagonal coefficients scale with the density ratio `ℑz(ρ)/ρ`;
- the density-weighted implicit solve **conserves column mass** (the upwind operator is flux-form, so a closed column preserves `∑ V ρ c`).

The existing AIVA tests (incl. the `WENOVectorInvariant` + `SplitRungeKutta3` paths) also exercise the `density = nothing` path through `implicit_step!`/`get_coefficient`/the kernel, guarding the Boussinesq behaviour. Full `TEST_FILE=test_adaptive_implicit_vertical_advection.jl` run: 325 pass / 0 fail.

## Motivation / downstream

[Breeze.jl](https://github.com/NumericalEarth/Breeze.jl) (anelastic/compressible) currently reimplements the density-weighted coefficients and wires its own `breeze_implicit_step!` because there's no hook for `ρ` in the upstream signature (and extending `get_coefficient`/`implicit_step!` with all-Oceananigans argument types is type piracy). With this PR, Breeze can call `implicit_step!(…, advection, velocities, ρ)` directly and delete that machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)