### PR TITLE
Immersed boundary as a plain `OffsetArray`

### DIFF
--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -289,7 +289,7 @@ mountain_grid = ImmersedBoundaryGrid(grid, GridFittedBottom(mountain))
 ```@example grids
 using CairoMakie
 
-h = mountain_grid.immersed_boundary.bottom_height
+h = bottom_height_field(mountain_grid)
 
 fig = Figure()
 ax = Axis(fig[2, 1], xlabel="x (m)", ylabel="y (m)", aspect=1)

--- a/examples/internal_tide.jl
+++ b/examples/internal_tide.jl
@@ -48,7 +48,7 @@ grid = ImmersedBoundaryGrid(underlying_grid, PartialCellBottom(bottom))
 # Let's see how the domain with the bathymetry is.
 
 x = xnodes(grid, Center())
-bottom_boundary = interior(grid.immersed_boundary.bottom_height, :, 1, 1)
+bottom_boundary = interior(bottom_height_field(grid), :, 1, 1)
 top_boundary = 0 * x
 
 using CairoMakie

--- a/ext/OceananigansNCDatasetsExt/OceananigansNCDatasetsExt.jl
+++ b/ext/OceananigansNCDatasetsExt/OceananigansNCDatasetsExt.jl
@@ -48,7 +48,7 @@ using Oceananigans.Grids: OrthogonalSphericalShellGrid
 using OffsetArrays: OffsetArray
 using Oceananigans.ImmersedBoundaries:
     ImmersedBoundaryGrid, GridFittedBottom, GFBIBG, GridFittedBoundary, PartialCellBottom, PCBIBG,
-    CenterImmersedCondition, InterfaceImmersedCondition, underlying_grid
+    CenterImmersedCondition, InterfaceImmersedCondition, underlying_grid, bottom_height_field
 using Oceananigans.Models: LagrangianParticles
 using Oceananigans.OutputReaders:
     InMemoryFTS,

--- a/ext/OceananigansNCDatasetsExt/grid_reconstruction.jl
+++ b/ext/OceananigansNCDatasetsExt/grid_reconstruction.jl
@@ -247,7 +247,7 @@ function gather_immersed_boundary(grid::PCBorGFBIBG, indices, dim_name_generator
     op_inactive_nodes_cfc = KernelFunctionOperation{Center, Face, Center}(inactive_node, grid, Center(), Face(), Center())
     op_inactive_nodes_ccf = KernelFunctionOperation{Center, Center, Face}(inactive_node, grid, Center(), Center(), Face())
 
-    ib_vars = Dict("bottom_height" => Field(grid.immersed_boundary.bottom_height; indices),
+    ib_vars = Dict("bottom_height" => Field(bottom_height_field(grid); indices),
                    "peripheral_nodes_ccc" => Field(op_peripheral_nodes_ccc; indices),
                    "peripheral_nodes_fcc" => Field(op_peripheral_nodes_fcc; indices),
                    "peripheral_nodes_cfc" => Field(op_peripheral_nodes_cfc; indices),
@@ -323,9 +323,9 @@ end
 function write_immersed_boundary_data!(ds, grid::ImmersedBoundaryGrid, immersed_grid_args, prefix)
     group_name = "$(prefix)immersed_grid_reconstruction_args"
     if (grid.immersed_boundary isa GridFittedBottom) || (grid.immersed_boundary isa PartialCellBottom)
-        bottom_height = pop!(immersed_grid_args, :bottom_height)
+        pop!(immersed_grid_args, :bottom_height)
         ibg_group = defGroup(ds, group_name; attrib=convert_for_netcdf(immersed_grid_args))
-        defVar(ibg_group, "bottom_height", bottom_height)
+        defVar(ibg_group, "bottom_height", bottom_height_field(grid))
 
     elseif grid.immersed_boundary isa GridFittedBoundary
         mask = pop!(immersed_grid_args, :mask)

--- a/ext/OceananigansReactantExt/Models.jl
+++ b/ext/OceananigansReactantExt/Models.jl
@@ -39,8 +39,8 @@ function initialize_immersed_boundary_grid!(ibg::ReactantImmersedBoundaryGrid)
 
     if needs_initialization
         ib = ibg.immersed_boundary
-        bottom_field = ib.bottom_height
         grid = ibg.underlying_grid
+        bottom_field = Oceananigans.ImmersedBoundaries.bottom_height_field(ibg)
         Oceananigans.ImmersedBoundaries.compute_numerical_bottom_height!(bottom_field, grid, ib)
         Oceananigans.BoundaryConditions.fill_halo_regions!(bottom_field)
     end

--- a/ext/OceananigansReactantExt/Models.jl
+++ b/ext/OceananigansReactantExt/Models.jl
@@ -12,7 +12,6 @@ using Oceananigans.DistributedComputations: Distributed
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel
 
 using ..TimeSteppers: ReactantModel
-using ..Grids: ReactantGrid, ReactantImmersedBoundaryGrid
 using ..Grids: ShardedGrid, ShardedDistributed
 
 import Oceananigans.Models:
@@ -26,30 +25,7 @@ const ReactantHFSM{TS, E} = Union{
     HydrostaticFreeSurfaceModel{TS, E, <:ShardedDistributed},
 }
 
-initialize_immersed_boundary_grid!(grid) = nothing
-
-using Oceananigans.ImmersedBoundaries:
-    GridFittedBottom,
-    PartialCellBottom
-
-function initialize_immersed_boundary_grid!(ibg::ReactantImmersedBoundaryGrid)
-    # TODO This assumes that the IBG is GridFittedBottom or PartialCellBottom
-    needs_initialization = ibg.immersed_boundary isa GridFittedBottom ||
-                           ibg.immersed_boundary isa PartialCellBottom
-
-    if needs_initialization
-        ib = ibg.immersed_boundary
-        grid = ibg.underlying_grid
-        bottom_field = Oceananigans.ImmersedBoundaries.bottom_height_field(ibg)
-        Oceananigans.ImmersedBoundaries.compute_numerical_bottom_height!(bottom_field, grid, ib)
-        Oceananigans.BoundaryConditions.fill_halo_regions!(bottom_field)
-    end
-
-    return nothing
-end
-
 function initialize!(model::ReactantHFSM)
-    initialize_immersed_boundary_grid!(model.grid)
     reconcile_state!(model)
     return nothing
 end

--- a/src/DistributedComputations/distributed_immersed_boundaries.jl
+++ b/src/DistributedComputations/distributed_immersed_boundaries.jl
@@ -5,6 +5,7 @@ using Oceananigans.ImmersedBoundaries:
     GridFittedBottom,
     PartialCellBottom,
     GridFittedBoundary,
+    bottom_height_interior,
     compute_mask,
     has_active_cells_map,
     has_active_z_columns,
@@ -33,13 +34,15 @@ end
 
 function reconstruct_global_immersed_boundary(ib::GridFittedBottom, arch, grid)
     Nx, Ny, _ = size(grid)
-    global_bottom_height = construct_global_array(ib.bottom_height, arch, (Nx, Ny, 1))
+    bottom_interior = bottom_height_interior(ib.bottom_height)
+    global_bottom_height = construct_global_array(bottom_interior, arch, (Nx, Ny, 1))
     return GridFittedBottom(global_bottom_height, ib.immersed_condition)
 end
 
 function reconstruct_global_immersed_boundary(ib::PartialCellBottom, arch, grid)
     Nx, Ny, _ = size(grid)
-    global_bottom_height = construct_global_array(ib.bottom_height, arch, (Nx, Ny, 1))
+    bottom_interior = bottom_height_interior(ib.bottom_height)
+    global_bottom_height = construct_global_array(bottom_interior, arch, (Nx, Ny, 1))
     return PartialCellBottom(global_bottom_height, ib.minimum_fractional_cell_height)
 end
 
@@ -66,8 +69,9 @@ function scatter_local_grids(global_grid::ImmersedBoundaryGrid, arch::Distribute
 
     local_ug = scatter_local_grids(ug, arch, local_size)
 
-    # Kinda hacky
-    local_bottom_height = partition(ib.bottom_height, arch, local_size)
+    nx, ny, _ = local_size
+    bottom_interior = bottom_height_interior(ib.bottom_height)
+    local_bottom_height = partition(bottom_interior, arch, (nx, ny, 1))
     ImmersedBoundaryConstructor = getnamewrapper(ib)
     local_ib = ImmersedBoundaryConstructor(local_bottom_height)
 
@@ -106,19 +110,16 @@ function resize_immersed_boundary(ib::AbstractGridFittedBottom{<:OffsetArray}, g
     Nx, Ny, _ = size(grid)
     Hx, Hy, _ = halo_size(grid)
 
-    bottom_heigth_size = (Nx, Ny) .+ 2 .* (Hx, Hy)
+    bottom_height_size = (Nx, Ny, 1) .+ 2 .* (Hx, Hy, 0)
 
-    # Check that the size of a bottom field are
-    # consistent with the size of the grid
-    if any(size(ib.bottom_height) .!= bottom_heigth_size)
-        @warn "Resizing the bottom field to match the grids' halos"
+    # Check that the size of the bottom height is consistent with the grid's halos
+    if any(size(ib.bottom_height) .!= bottom_height_size)
+        @warn "Resizing the bottom height to match the grid's halos"
         bottom_field = Field{Center, Center, Nothing}(grid)
-        cpu_bottom   = on_architecture(CPU(), ib.bottom_height)[1:Nx, 1:Ny]
+        cpu_bottom   = on_architecture(CPU(), ib.bottom_height)[1:Nx, 1:Ny, :]
         set!(bottom_field, cpu_bottom)
         fill_halo_regions!(bottom_field)
-        offset_bottom_array = dropdims(bottom_field.data, dims=3)
-
-        return getnamewrapper(ib)(offset_bottom_array)
+        return getnamewrapper(ib)(bottom_field.data)
     end
 
     return ib

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -3,7 +3,6 @@ module ImmersedBoundaries
 export ImmersedBoundaryGrid, GridFittedBoundary, GridFittedBottom, PartialCellBottom, ImmersedBoundaryCondition
 
 using Printf: @sprintf
-using Statistics: mean
 
 using Oceananigans.Architectures: Architectures, on_architecture
 using Oceananigans.Grids: Center, Face, Flat, size_summary, inactive_node, peripheral_node, AbstractGrid

--- a/src/ImmersedBoundaries/ImmersedBoundaries.jl
+++ b/src/ImmersedBoundaries/ImmersedBoundaries.jl
@@ -1,6 +1,6 @@
 module ImmersedBoundaries
 
-export ImmersedBoundaryGrid, GridFittedBoundary, GridFittedBottom, PartialCellBottom, ImmersedBoundaryCondition
+export ImmersedBoundaryGrid, GridFittedBoundary, GridFittedBottom, PartialCellBottom, ImmersedBoundaryCondition, bottom_height_field
 
 using Printf: @sprintf
 

--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -1,6 +1,7 @@
 using Oceananigans.Grids: Grids, constructor_arguments, rnode
-using Oceananigans.Fields: Field, fill_halo_regions!
+using Oceananigans.Fields: Field, fill_halo_regions!, interior
 using Oceananigans.BoundaryConditions: FBC
+using OffsetArrays: OffsetArray
 
 #####
 ##### GridFittedBottom (2.5D immersed boundary with modified bottom height)
@@ -46,10 +47,27 @@ Arguments
 """
 GridFittedBottom(bottom_height) = GridFittedBottom(bottom_height, CenterImmersedCondition())
 
+@inline function bottom_height_interior(bottom_height)
+    interior_ranges = ntuple(Val(ndims(bottom_height))) do d
+        H = 1 - first(axes(bottom_height, d))      # halo width along d (0 for the z-axis)
+        1:(size(bottom_height, d) - 2H)
+    end
+    return view(bottom_height, interior_ranges...)
+end
+
+set_bottom_height!(bottom_field, bottom_height) = set!(bottom_field, bottom_height)
+
+function set_bottom_height!(bottom_field, bottom_height::OffsetArray)
+    source = on_architecture(architecture(bottom_field), bottom_height_interior(bottom_height))
+    copyto!(interior(bottom_field), source)
+    return bottom_field
+end
+
 function Base.summary(ib::GridFittedBottom)
-    zmax  = maximum(ib.bottom_height)
-    zmin  = minimum(ib.bottom_height)
-    zmean = mean(ib.bottom_height)
+    bottom_interior = bottom_height_interior(ib.bottom_height)
+    zmax  = maximum(bottom_interior)
+    zmin  = minimum(bottom_interior)
+    zmean = mean(bottom_interior)
 
     summary1 = "GridFittedBottom("
 
@@ -71,15 +89,6 @@ end
 
 Architectures.on_architecture(arch, ib::GridFittedBottom) = GridFittedBottom(on_architecture(arch, ib.bottom_height), ib.immersed_condition)
 
-function Architectures.on_architecture(arch, ib::GridFittedBottom{<:Field})
-    architecture(ib.bottom_height) == arch && return ib
-    arch_grid = on_architecture(arch, ib.bottom_height.grid)
-    new_bottom_height = Field{Center, Center, Nothing}(arch_grid)
-    set!(new_bottom_height, ib.bottom_height)
-    fill_halo_regions!(new_bottom_height)
-    return GridFittedBottom(new_bottom_height, ib.immersed_condition)
-end
-
 Adapt.adapt_structure(to, ib::GridFittedBottom) = GridFittedBottom(adapt(to, ib.bottom_height), adapt(to, ib.immersed_condition))
 
 """
@@ -92,11 +101,10 @@ top-most interface of the last ``immersed`` cell in the column. If `ib` is a `Gr
 """
 function materialize_immersed_boundary(grid, ib::GridFittedBottom)
     bottom_field = Field{Center, Center, Nothing}(grid)
-    set!(bottom_field, ib.bottom_height)
+    set_bottom_height!(bottom_field, ib.bottom_height)
     @apply_regionally compute_numerical_bottom_height!(bottom_field, grid, ib)
     fill_halo_regions!(bottom_field)
-    new_ib = GridFittedBottom(bottom_field)
-    return new_ib
+    return GridFittedBottom(bottom_field.data, ib.immersed_condition)
 end
 
 compute_numerical_bottom_height!(bottom_field, grid, ib) =

--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -105,7 +105,7 @@ top-most interface of the last ``immersed`` cell in the column. If `ib` is a `Gr
 """
 function materialize_immersed_boundary(grid, ib::GridFittedBottom)
     bottom_field = Field{Center, Center, Nothing}(grid)
-    set_bottom_height!(bottom_field, ib.bottom_height)
+    set!(bottom_field, ib.bottom_height)
     @apply_regionally compute_numerical_bottom_height!(bottom_field, grid, ib)
     fill_halo_regions!(bottom_field)
     return GridFittedBottom(bottom_field.data, ib.immersed_condition)

--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -56,6 +56,9 @@ GridFittedBottom(bottom_height) = GridFittedBottom(bottom_height, CenterImmersed
     return view(parent(bottom_height), parent_ranges...)
 end
 
+@inline bottom_heights_equal(h1, h2) = h1 == h2
+@inline bottom_heights_equal(h1::AbstractArray, h2::AbstractArray) = bottom_height_interior(h1) == bottom_height_interior(h2)
+
 set_bottom_height!(bottom_field, bottom_height) = set!(bottom_field, bottom_height)
 
 function set_bottom_height!(bottom_field, bottom_height::OffsetArray)
@@ -71,7 +74,7 @@ function Base.summary(ib::GridFittedBottom)
     bottom_interior = bottom_height_interior(ib.bottom_height)
     zmax  = maximum(bottom_interior)
     zmin  = minimum(bottom_interior)
-    zmean = mean(bottom_interior)
+    zmean = sum(bottom_interior) / length(bottom_interior)
 
     summary1 = "GridFittedBottom("
 
@@ -173,5 +176,5 @@ function Grids.constructor_arguments(grid::AGFBIBG)
 end
 
 function Base.:(==)(gfb1::GridFittedBottom, gfb2::GridFittedBottom)
-    return gfb1.bottom_height == gfb2.bottom_height && gfb1.immersed_condition == gfb2.immersed_condition
+    return bottom_heights_equal(gfb1.bottom_height, gfb2.bottom_height) && gfb1.immersed_condition == gfb2.immersed_condition
 end

--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -47,7 +47,7 @@ Arguments
 """
 GridFittedBottom(bottom_height) = GridFittedBottom(bottom_height, CenterImmersedCondition())
 
-# 1-based interior view of a bare bottom-height array. 
+# 1-based interior view of a bare bottom-height array.
 @inline function bottom_height_interior(bottom_height)
     parent_ranges = ntuple(Val(ndims(bottom_height))) do d
         H = 1 - first(axes(bottom_height, d))

--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -47,12 +47,13 @@ Arguments
 """
 GridFittedBottom(bottom_height) = GridFittedBottom(bottom_height, CenterImmersedCondition())
 
+# 1-based interior view of a bare bottom-height array. 
 @inline function bottom_height_interior(bottom_height)
-    interior_ranges = ntuple(Val(ndims(bottom_height))) do d
-        H = 1 - first(axes(bottom_height, d))      # halo width along d (0 for the z-axis)
-        1:(size(bottom_height, d) - 2H)
+    parent_ranges = ntuple(Val(ndims(bottom_height))) do d
+        H = 1 - first(axes(bottom_height, d))
+        (1 + H):(size(bottom_height, d) - H)
     end
-    return view(bottom_height, interior_ranges...)
+    return view(parent(bottom_height), parent_ranges...)
 end
 
 set_bottom_height!(bottom_field, bottom_height) = set!(bottom_field, bottom_height)
@@ -62,6 +63,9 @@ function set_bottom_height!(bottom_field, bottom_height::OffsetArray)
     copyto!(interior(bottom_field), source)
     return bottom_field
 end
+
+bottom_height_field(bottom_data, grid) = Field{Center, Center, Nothing}(grid; data=bottom_data)
+bottom_height_field(grid::IBG) = bottom_height_field(grid.immersed_boundary.bottom_height, grid.underlying_grid)
 
 function Base.summary(ib::GridFittedBottom)
     bottom_interior = bottom_height_interior(ib.bottom_height)

--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -108,7 +108,7 @@ top-most interface of the last ``immersed`` cell in the column. If `ib` is a `Gr
 """
 function materialize_immersed_boundary(grid, ib::GridFittedBottom)
     bottom_field = Field{Center, Center, Nothing}(grid)
-    set!(bottom_field, ib.bottom_height)
+    set_bottom_height!(bottom_field, ib.bottom_height)
     @apply_regionally compute_numerical_bottom_height!(bottom_field, grid, ib)
     fill_halo_regions!(bottom_field)
     return GridFittedBottom(bottom_field.data, ib.immersed_condition)

--- a/src/ImmersedBoundaries/partial_cell_bottom.jl
+++ b/src/ImmersedBoundaries/partial_cell_bottom.jl
@@ -66,7 +66,7 @@ end
 
 function materialize_immersed_boundary(grid, ib::PartialCellBottom)
     bottom_field = Field{Center, Center, Nothing}(grid)
-    set_bottom_height!(bottom_field, ib.bottom_height)
+    set!(bottom_field, ib.bottom_height)
 
     minimum_fractional_cell_height = convert(eltype(grid), ib.minimum_fractional_cell_height)
     compute_ib = PartialCellBottom(bottom_field, minimum_fractional_cell_height)

--- a/src/ImmersedBoundaries/partial_cell_bottom.jl
+++ b/src/ImmersedBoundaries/partial_cell_bottom.jl
@@ -20,7 +20,7 @@ function Base.summary(ib::PartialCellBottom)
     bottom_interior = bottom_height_interior(ib.bottom_height)
     zmax = maximum(bottom_interior)
     zmin = minimum(bottom_interior)
-    zmean = mean(bottom_interior)
+    zmean = sum(bottom_interior) / length(bottom_interior)
 
     summary1 = "PartialCellBottom("
 
@@ -212,5 +212,5 @@ function Grids.constructor_arguments(grid::PCBIBG)
 end
 
 function Base.:(==)(pcb1::PartialCellBottom, pcb2::PartialCellBottom)
-    return pcb1.bottom_height == pcb2.bottom_height && pcb1.minimum_fractional_cell_height == pcb2.minimum_fractional_cell_height
+    return bottom_heights_equal(pcb1.bottom_height, pcb2.bottom_height) && pcb1.minimum_fractional_cell_height == pcb2.minimum_fractional_cell_height
 end

--- a/src/ImmersedBoundaries/partial_cell_bottom.jl
+++ b/src/ImmersedBoundaries/partial_cell_bottom.jl
@@ -66,7 +66,7 @@ end
 
 function materialize_immersed_boundary(grid, ib::PartialCellBottom)
     bottom_field = Field{Center, Center, Nothing}(grid)
-    set!(bottom_field, ib.bottom_height)
+    set_bottom_height!(bottom_field, ib.bottom_height)
 
     minimum_fractional_cell_height = convert(eltype(grid), ib.minimum_fractional_cell_height)
     compute_ib = PartialCellBottom(bottom_field, minimum_fractional_cell_height)

--- a/src/ImmersedBoundaries/partial_cell_bottom.jl
+++ b/src/ImmersedBoundaries/partial_cell_bottom.jl
@@ -17,9 +17,10 @@ end
 const PCBIBG{FT, TX, TY, TZ} = ImmersedBoundaryGrid{FT, TX, TY, TZ, <:Any, <:PartialCellBottom} where {FT, TX, TY, TZ}
 
 function Base.summary(ib::PartialCellBottom)
-    zmax = maximum(parent(ib.bottom_height))
-    zmin = minimum(parent(ib.bottom_height))
-    zmean = mean(parent(ib.bottom_height))
+    bottom_interior = bottom_height_interior(ib.bottom_height)
+    zmax = maximum(bottom_interior)
+    zmin = minimum(bottom_interior)
+    zmean = mean(bottom_interior)
 
     summary1 = "PartialCellBottom("
 
@@ -65,15 +66,15 @@ end
 
 function materialize_immersed_boundary(grid, ib::PartialCellBottom)
     bottom_field = Field{Center, Center, Nothing}(grid)
-    set!(bottom_field, ib.bottom_height)
+    set_bottom_height!(bottom_field, ib.bottom_height)
 
     minimum_fractional_cell_height = convert(eltype(grid), ib.minimum_fractional_cell_height)
-    new_ib = PartialCellBottom(bottom_field, minimum_fractional_cell_height)
+    compute_ib = PartialCellBottom(bottom_field, minimum_fractional_cell_height)
 
-    @apply_regionally compute_numerical_bottom_height!(bottom_field, grid, new_ib)
+    @apply_regionally compute_numerical_bottom_height!(bottom_field, grid, compute_ib)
     fill_halo_regions!(bottom_field)
 
-    return new_ib
+    return PartialCellBottom(bottom_field.data, minimum_fractional_cell_height)
 end
 
 @kernel function _compute_numerical_bottom_height!(bottom_field, grid, ib::PartialCellBottom)
@@ -103,14 +104,6 @@ end
         adjusted_zb = ifelse(bottom_cell, capped_zb, adjusted_zb)
     end
     @inbounds bottom_field[i, j, 1] = adjusted_zb
-end
-
-function Architectures.on_architecture(arch, ib::PartialCellBottom{<:Field})
-    architecture(ib.bottom_height) == arch && return ib
-    arch_grid = on_architecture(arch, ib.bottom_height.grid)
-    new_bottom_height = Field{Center, Center, Nothing}(arch_grid)
-    copyto!(parent(new_bottom_height), parent(ib.bottom_height))
-    return PartialCellBottom(new_bottom_height, ib.minimum_fractional_cell_height)
 end
 
 Adapt.adapt_structure(to, ib::PartialCellBottom) = PartialCellBottom(adapt(to, ib.bottom_height),

--- a/src/MultiRegion/multi_region_grid.jl
+++ b/src/MultiRegion/multi_region_grid.jl
@@ -1,13 +1,17 @@
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions
 using Oceananigans.DistributedComputations: reconstruct_global_grid
 using Oceananigans.Grids: RectilinearGrid, LatitudeLongitudeGrid, metrics_precomputed,
-    pop_flat_elements, grid_name, new_data, halo_size, with_halo, minimum_xspacing, minimum_yspacing, minimum_zspacing
-using Oceananigans.ImmersedBoundaries: GridFittedBottom, PartialCellBottom, GridFittedBoundary, bottom_height_field
-import Oceananigans.ImmersedBoundaries: set_bottom_height!
+                          pop_flat_elements, grid_name, new_data, halo_size, with_halo,
+                          minimum_xspacing, minimum_yspacing, minimum_zspacing
+using Oceananigans.ImmersedBoundaries: GridFittedBottom, PartialCellBottom, GridFittedBoundary,
+                                       bottom_height_field, set_bottom_height!
 using Oceananigans.Models: PrescribedVelocityFields
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModels
 using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces: SplitExplicitFreeSurfaces,
-    SplitExplicitFreeSurface, FixedSubstepNumber, FixedTimeStepSize, maybe_augmented_kernel_parameters
+                                                                                  SplitExplicitFreeSurface,
+                                                                                  FixedSubstepNumber,
+                                                                                  FixedTimeStepSize,
+                                                                                  maybe_augmented_kernel_parameters
 
 struct MultiRegionGrid{FT, TX, TY, TZ, CZ, P, C, G, Arch} <: AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch}
     architecture :: Arch
@@ -189,7 +193,7 @@ reconstruct_global_immersed_boundary(g::GridFittedBoundary{<:Field}, ::MultiRegi
 
 # On a multi-region grid the stored bottom height is a `MultiRegionObject` of per-region halo-inclusive
 # `OffsetArray`s; strip each region's halos before copying (the bare-`OffsetArray` method does this per region).
-set_bottom_height!(bottom_field, bottom_height::MultiRegionObject) =
+Oceananigans.ImmersedBoundaries.set_bottom_height!(bottom_field, bottom_height::MultiRegionObject) =
     @apply_regionally set_bottom_height!(bottom_field, bottom_height)
 
 @inline  Utils.getregion(mrg::ImmersedMultiRegionGrid{FT, TX, TY, TZ}, r) where {FT, TX, TY, TZ} = ImmersedBoundaryGrid{TX, TY, TZ}(_getregion(mrg.underlying_grid, r),

--- a/src/MultiRegion/multi_region_grid.jl
+++ b/src/MultiRegion/multi_region_grid.jl
@@ -166,15 +166,27 @@ end
 
 function DistributedComputations.reconstruct_global_grid(mrg::ImmersedMultiRegionGrid)
     global_grid     = reconstruct_global_grid(mrg.underlying_grid)
-    global_immersed_boundary = reconstruct_global_immersed_boundary(mrg.immersed_boundary)
+    global_immersed_boundary = reconstruct_global_immersed_boundary(mrg.immersed_boundary, mrg.underlying_grid)
     global_immersed_boundary = on_architecture(architecture(mrg), global_immersed_boundary)
 
     return ImmersedBoundaryGrid(global_grid, global_immersed_boundary)
 end
 
-reconstruct_global_immersed_boundary(g::GridFittedBottom{<:Field})   =   GridFittedBottom(reconstruct_global_field(g.bottom_height), g.immersed_condition)
-reconstruct_global_immersed_boundary(g::PartialCellBottom{<:Field})  =  PartialCellBottom(reconstruct_global_field(g.bottom_height), g.minimum_fractional_cell_height)
-reconstruct_global_immersed_boundary(g::GridFittedBoundary{<:Field}) = GridFittedBoundary(reconstruct_global_field(g.mask))
+function reconstruct_global_immersed_boundary(ib::GridFittedBottom, mrg::MultiRegionGrids)
+    bottom_field  = bottom_height_field(ib.bottom_height, mrg)
+    global_bottom = reconstruct_global_field(bottom_field)
+    return GridFittedBottom(interior(global_bottom), ib.immersed_condition)
+end
+
+function reconstruct_global_immersed_boundary(ib::PartialCellBottom, mrg::MultiRegionGrids)
+    bottom_field  = bottom_height_field(ib.bottom_height, mrg)
+    global_bottom = reconstruct_global_field(bottom_field)
+    return PartialCellBottom(interior(global_bottom), ib.minimum_fractional_cell_height)
+end
+
+reconstruct_global_immersed_boundary(g::GridFittedBoundary{<:Field}, ::MultiRegionGrids) = GridFittedBoundary(reconstruct_global_field(g.mask))
+
+bottom_height_field(bottom_height, grid) = Field{Center, Center, Nothing}(grid; data=bottom_height)
 
 @inline  Utils.getregion(mrg::ImmersedMultiRegionGrid{FT, TX, TY, TZ}, r) where {FT, TX, TY, TZ} = ImmersedBoundaryGrid{TX, TY, TZ}(_getregion(mrg.underlying_grid, r),
                                                                                                                               _getregion(mrg.immersed_boundary, r),

--- a/src/MultiRegion/multi_region_grid.jl
+++ b/src/MultiRegion/multi_region_grid.jl
@@ -2,7 +2,8 @@ using Oceananigans.BoundaryConditions: FieldBoundaryConditions
 using Oceananigans.DistributedComputations: reconstruct_global_grid
 using Oceananigans.Grids: RectilinearGrid, LatitudeLongitudeGrid, metrics_precomputed,
     pop_flat_elements, grid_name, new_data, halo_size, with_halo, minimum_xspacing, minimum_yspacing, minimum_zspacing
-using Oceananigans.ImmersedBoundaries: GridFittedBottom, PartialCellBottom, GridFittedBoundary
+using Oceananigans.ImmersedBoundaries: GridFittedBottom, PartialCellBottom, GridFittedBoundary, bottom_height_field
+import Oceananigans.ImmersedBoundaries: set_bottom_height!
 using Oceananigans.Models: PrescribedVelocityFields
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModels
 using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces: SplitExplicitFreeSurfaces,
@@ -186,7 +187,10 @@ end
 
 reconstruct_global_immersed_boundary(g::GridFittedBoundary{<:Field}, ::MultiRegionGrids) = GridFittedBoundary(reconstruct_global_field(g.mask))
 
-bottom_height_field(bottom_height, grid) = Field{Center, Center, Nothing}(grid; data=bottom_height)
+# On a multi-region grid the stored bottom height is a `MultiRegionObject` of per-region halo-inclusive
+# `OffsetArray`s; strip each region's halos before copying (the bare-`OffsetArray` method does this per region).
+set_bottom_height!(bottom_field, bottom_height::MultiRegionObject) =
+    @apply_regionally set_bottom_height!(bottom_field, bottom_height)
 
 @inline  Utils.getregion(mrg::ImmersedMultiRegionGrid{FT, TX, TY, TZ}, r) where {FT, TX, TY, TZ} = ImmersedBoundaryGrid{TX, TY, TZ}(_getregion(mrg.underlying_grid, r),
                                                                                                                               _getregion(mrg.immersed_boundary, r),

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -29,7 +29,7 @@ export
     # Immersed boundaries
     ImmersedBoundaryGrid,
     GridFittedBoundary, GridFittedBottom, PartialCellBottom,
-    ImmersedBoundaryCondition,
+    ImmersedBoundaryCondition, bottom_height_field,
 
     # Distributed
     Distributed, Partition,

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -24,7 +24,7 @@ MPI.Init()
 using Oceananigans.BoundaryConditions: fill_halo_regions!, DCBC
 using Oceananigans.DistributedComputations: Distributed, index2rank, cpu_architecture, child_architecture, reconstruct_global_grid
 using Oceananigans.Fields: AbstractField, interior
-using Oceananigans.ImmersedBoundaries: GridFittedBottom, PartialCellBottom, GridFittedBoundary
+using Oceananigans.ImmersedBoundaries: GridFittedBottom, PartialCellBottom, GridFittedBoundary, bottom_height_interior
 using Oceananigans.Grids:
     architecture,
     halo_size,
@@ -552,7 +552,7 @@ end
 
         # GridFittedBottom: shape, type and rank-wise stitching.
         gfb = reconstruct_global_grid(ibg_gfb)
-        bh = Array(interior(gfb.immersed_boundary.bottom_height))
+        bh = Array(bottom_height_interior(gfb.immersed_boundary.bottom_height))
         @test gfb.immersed_boundary isa GridFittedBottom
         @test size(bh) == (Nx, Ny, 1)
         for r in 0:3
@@ -564,7 +564,7 @@ end
 
         pcb = reconstruct_global_grid(ibg_pcb)
         @test pcb.immersed_boundary isa PartialCellBottom
-        @test size(interior(pcb.immersed_boundary.bottom_height)) == (Nx, Ny, 1)
+        @test size(bottom_height_interior(pcb.immersed_boundary.bottom_height)) == (Nx, Ny, 1)
         @test pcb.immersed_boundary.minimum_fractional_cell_height == 0.3
 
         # GridFittedBoundary: 3-D mask path

--- a/test/test_immersed_boundary_grid.jl
+++ b/test/test_immersed_boundary_grid.jl
@@ -1,7 +1,7 @@
 include("dependencies_for_runtests.jl")
 
 using Oceananigans.Grids: total_extent, xspacings, yspacings, zspacings, rspacings, xnode, ynode, znode
-using Oceananigans.ImmersedBoundaries: GridFittedBottom, PartialCellBottom, GridFittedBoundary, immersed_cell, _immersed_cell, CenterImmersedCondition, InterfaceImmersedCondition
+using Oceananigans.ImmersedBoundaries: GridFittedBottom, PartialCellBottom, GridFittedBoundary, immersed_cell, _immersed_cell, CenterImmersedCondition, InterfaceImmersedCondition, bottom_height_interior
 
 #####
 ##### Basic immersed boundary grid construction tests
@@ -21,8 +21,9 @@ function test_immersed_boundary_grid_construction(FT, arch, boundary_type)
     @test halo_size(ibg) == halo_size(underlying_grid)
     @test topology(ibg) == topology(underlying_grid)
 
-    # Test that immersed boundary was materialized
-    @test ibg.immersed_boundary.bottom_height isa Field
+    # Test that immersed boundary was materialized as a bare array (not a Field)
+    @test ibg.immersed_boundary.bottom_height isa AbstractArray
+    @test !(ibg.immersed_boundary.bottom_height isa Field)
     @test eltype(ibg.immersed_boundary.bottom_height) === FT
 
     # Test summary function
@@ -136,7 +137,7 @@ function test_bottom_height_field_consistency(FT, arch, boundary_type)
 
     ib = boundary_type(bottom_function)
     ibg = ImmersedBoundaryGrid(underlying_grid, ib)
-    bottom_height = interior(ibg.immersed_boundary.bottom_height)
+    bottom_height = bottom_height_interior(ibg.immersed_boundary.bottom_height)
     if boundary_type === GridFittedBottom
         # For GridFittedBottom, the bottom should be snapped to grid faces
         zfaces = znodes(ibg, Face())

--- a/test/test_netcdf_writer.jl
+++ b/test/test_netcdf_writer.jl
@@ -769,7 +769,7 @@ function test_netcdf_rectilinear_grid_fitted_bottom(arch, bottom_boundary_type)
     @test dimsize(ds_n[:inactive_nodes_cfc]) == (x_caa=Nx,     y_afa=Ny + 1, z_aac=Nz)
     @test dimsize(ds_n[:inactive_nodes_ccf]) == (x_caa=Nx,     y_aca=Ny,     z_aaf=Nz + 1)
 
-    @test all(ds_n[:bottom_height][:, :] .≈ Array(interior(grid.immersed_boundary.bottom_height)))
+    @test all(ds_n[:bottom_height][:, :] .≈ Array(bottom_height_interior(grid.immersed_boundary.bottom_height)))
 
     close(ds_n)
     rm(filepath_no_halos)
@@ -798,7 +798,7 @@ function test_netcdf_rectilinear_grid_fitted_bottom(arch, bottom_boundary_type)
     @test dimsize(ds_s[:inactive_nodes_cfc]) == (x_caa=nx, y_afa=ny, z_aac=nz)
     @test dimsize(ds_s[:inactive_nodes_ccf]) == (x_caa=nx, y_aca=ny, z_aaf=nz)
 
-    @test all(ds_s[:bottom_height][:, :] .≈ Array(interior(grid.immersed_boundary.bottom_height, i_slice, j_slice)))
+    @test all(ds_s[:bottom_height][:, :] .≈ Array(bottom_height_interior(grid.immersed_boundary.bottom_height)[i_slice, j_slice, :]))
 
     close(ds_s)
     rm(filepath_sliced)
@@ -939,7 +939,7 @@ function test_netcdf_latlon_grid_fitted_bottom(arch, bottom_boundary_type)
     @test dimsize(ds_n[:inactive_nodes_cfc]) == (λ_caa=Nλ,     φ_afa=Nφ + 1, z_aac=Nz)
     @test dimsize(ds_n[:inactive_nodes_ccf]) == (λ_caa=Nλ,     φ_aca=Nφ,     z_aaf=Nz + 1)
 
-    @test all(ds_n[:bottom_height][:, :] .≈ Array(interior(grid.immersed_boundary.bottom_height)))
+    @test all(ds_n[:bottom_height][:, :] .≈ Array(bottom_height_interior(grid.immersed_boundary.bottom_height)))
 
     close(ds_n)
     rm(filepath_no_halos)
@@ -968,7 +968,7 @@ function test_netcdf_latlon_grid_fitted_bottom(arch, bottom_boundary_type)
     @test dimsize(ds_s[:inactive_nodes_cfc]) == (λ_caa=nλ, φ_afa=nφ, z_aac=nz)
     @test dimsize(ds_s[:inactive_nodes_ccf]) == (λ_caa=nλ, φ_aca=nφ, z_aaf=nz)
 
-    @test all(ds_s[:bottom_height][:, :] .≈ Array(interior(grid.immersed_boundary.bottom_height, i_slice, j_slice)))
+    @test all(ds_s[:bottom_height][:, :] .≈ Array(bottom_height_interior(grid.immersed_boundary.bottom_height)[i_slice, j_slice, :]))
 
     close(ds_s)
     rm(filepath_sliced)
@@ -3264,7 +3264,7 @@ end
 using Oceananigans.OrthogonalSphericalShellGrids: TripolarGrid, RotatedLatitudeLongitudeGrid,
                                                   ConformalCubedSpherePanelGrid
 using Oceananigans.OutputWriters: reconstruct_grid
-using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBottom
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBottom, bottom_height_interior
 
 function test_netcdf_tripolar_grid_output(arch)
     grid = TripolarGrid(arch, size=(20, 16, 4), z=(-100, 0))

--- a/test/test_tripolar_grid.jl
+++ b/test/test_tripolar_grid.jl
@@ -331,7 +331,7 @@ isrot180antisymmetric(arr) = arr == -rot180(arr)
                 grid = TripolarGrid(arch; size = (10, 10, 1), fold_topology = fold_topology)
                 bottom(x, y) = rand()
                 grid = ImmersedBoundaryGrid(grid, GridFittedBottom(bottom))
-                bottom_height = on_architecture(CPU(), grid.immersed_boundary.bottom_height.data)
+                bottom_height = on_architecture(CPU(), grid.immersed_boundary.bottom_height)
                 @test view(bottom_height, iᶜ, jᶜ, 1) == view(bottom_height, iᶜ′, jᶜ′, 1)
             end
 


### PR DESCRIPTION
we actually do not need a `Field` (the grid is the same grid the immersed boundary is attached to). So it's good to have just plain `OffsetArray`s. It also help with memory allocation issues and keeping the field descriptor of a model a bit more contained; each `Field` has a gigantic field descriptor, and on an immersed boundary we now have in main `Field(Grid(Field(Grid))` which explodes the descriptor by a factor of 2