### PR TITLE
Remove type instability from the `extract_field_time_series` function

### DIFF
--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -1,6 +1,6 @@
 using Oceananigans.AbstractOperations: AbstractOperation
 using Oceananigans.BoundaryConditions: DiscreteBoundaryFunction, ContinuousBoundaryFunction
-using Oceananigans.Fields: flattened_unique_values, Field
+using Oceananigans.Fields: Field
 using Oceananigans.Grids: AbstractGrid
 
 #####

--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -14,7 +14,8 @@ function type_contains_field_time_series(T, seen)
                           type_contains_field_time_series(T.b, seen)
     T <: FieldTimeSeries && return true
     T <: GPUAdaptedFieldTimeSeries && return true
-    (T <: Number || T <: AbstractArray || T <: AbstractGrid) && return false
+    (T <: Number || T <: AbstractGrid) && return false
+    (T <: AbstractArray && !(T <: AbstractField)) && return false
     isconcretetype(T) || return true # abstract / unresolved: assume an FTS may hide inside
     return any(ft -> type_contains_field_time_series(ft, seen), fieldtypes(T))
 end

--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -51,7 +51,6 @@ for T in CannotPossiblyContainFTS
     @eval extract_field_time_series(::$T) = ()
 end
 
-# Special recursion rules for `AbstractOperation`, `Tuple` and `NamedTuple`
 extract_field_time_series(t::AbstractOperation) =
     has_field_time_series(typeof(t)) ?
         concatenate_extracted(map(p -> extract_field_time_series(getproperty(t, p)), propertynames(t))) : ()

--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -45,7 +45,6 @@ end
 extract_field_time_series(f::FieldTimeSeries) = (f,)
 extract_field_time_series(f::TimeSeriesInterpolation) = (f.time_series,)
 
-# Types that cannot contain a `FieldTimeSeries` halt the recursion with an empty tuple.
 CannotPossiblyContainFTS = (:Number, :AbstractArray, :AbstractGrid, :AbstractField, :Returns, :Nothing)
 
 for T in CannotPossiblyContainFTS

--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -41,7 +41,6 @@ extract_field_time_series(t1, tn...) = extract_field_time_series(tuple(t1, tn...
     return concatenate_extracted(ntuple(i -> extract_field_time_series(getfield(t, i)), Val(N)))
 end
 
-# Terminations: a `FieldTimeSeries` (or the series underlying a `TimeSeriesInterpolation`) is collected.
 extract_field_time_series(f::FieldTimeSeries) = (f,)
 extract_field_time_series(f::TimeSeriesInterpolation) = (f.time_series,)
 

--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -4,40 +4,61 @@ using Oceananigans.Fields: flattened_unique_values, Field
 using Oceananigans.Grids: AbstractGrid
 
 #####
+##### Compile-time predicate: does a type (recursively) contain a `FieldTimeSeries`?
+#####
+
+function type_contains_field_time_series(T, seen)
+    (T === Union{} || T in seen) && return false
+    push!(seen, T)
+    T isa Union && return type_contains_field_time_series(T.a, seen) ||
+                          type_contains_field_time_series(T.b, seen)
+    T <: FieldTimeSeries && return true
+    T <: GPUAdaptedFieldTimeSeries && return true
+    (T <: Number || T <: AbstractArray || T <: AbstractGrid) && return false
+    isconcretetype(T) || return true # abstract / unresolved: assume an FTS may hide inside
+    return any(ft -> type_contains_field_time_series(ft, seen), fieldtypes(T))
+end
+
+@generated function has_field_time_series(::Type{T}) where T
+    return type_contains_field_time_series(T, Base.IdSet{Any}()) ? :true : :false
+end
+
+#####
 ##### Utility for "extracting" FieldTimeSeries from large nested objects (eg models)
 #####
 
 extract_field_time_series(t1, tn...) = extract_field_time_series(tuple(t1, tn...))
 
-# Utility used to extract field time series from a type through recursion
-function extract_field_time_series(t)
-    prop = propertynames(t)
-    if isempty(prop)
-        return nothing
-    end
+@inline concatenate_extracted(::Tuple{}) = ()
+@inline concatenate_extracted(t::Tuple) = (first(t)..., concatenate_extracted(Base.tail(t))...)
 
-    extracted = Tuple(extract_field_time_series(getproperty(t, p)) for p in prop)
-    flattened = flattened_unique_values(extracted)
-
-    return flattened
+# Utility used to extract field time series from a type through recursion over its fields.
+@inline function extract_field_time_series(t)
+    has_field_time_series(typeof(t)) || return ()
+    N = fieldcount(typeof(t))
+    N === 0 && return ()
+    return concatenate_extracted(ntuple(i -> extract_field_time_series(getfield(t, i)), Val(N)))
 end
 
-# Termination (move all here when we switch the code up)
-extract_field_time_series(f::FieldTimeSeries) = f
+# Terminations: a `FieldTimeSeries` (or the series underlying a `TimeSeriesInterpolation`) is collected.
+extract_field_time_series(f::FieldTimeSeries) = (f,)
+extract_field_time_series(f::TimeSeriesInterpolation) = (f.time_series,)
 
-# Extract the underlying FieldTimeSeries from TimeSeriesInterpolation
-extract_field_time_series(f::TimeSeriesInterpolation) = f.time_series
-
-# For types that do not contain `FieldTimeSeries`, halt the recursion
-CannotPossiblyContainFTS = (:Number, :AbstractArray, :AbstractGrid, :AbstractField, :Returns)
+# Types that cannot contain a `FieldTimeSeries` halt the recursion with an empty tuple.
+CannotPossiblyContainFTS = (:Number, :AbstractArray, :AbstractGrid, :AbstractField, :Returns, :Nothing)
 
 for T in CannotPossiblyContainFTS
-    @eval extract_field_time_series(::$T) = nothing
+    @eval extract_field_time_series(::$T) = ()
 end
 
-# Special recursion rules for `Tuple` and `Field` types
-extract_field_time_series(t::AbstractOperation) = Tuple(extract_field_time_series(getproperty(t, p)) for p in propertynames(t))
-extract_field_time_series(t::Union{Tuple, NamedTuple}) = map(extract_field_time_series, t)
+# Special recursion rules for `AbstractOperation`, `Tuple` and `NamedTuple`
+extract_field_time_series(t::AbstractOperation) =
+    has_field_time_series(typeof(t)) ?
+        concatenate_extracted(map(p -> extract_field_time_series(getproperty(t, p)), propertynames(t))) : ()
+
+extract_field_time_series(t::Union{Tuple, NamedTuple}) =
+    has_field_time_series(typeof(t)) ?
+        concatenate_extracted(map(extract_field_time_series, values(t))) : ()
 
 const CPUFTSBC = BoundaryCondition{<:Any, <:FieldTimeSeries}
 const GPUFTSBC = BoundaryCondition{<:Any, <:GPUAdaptedFieldTimeSeries}
@@ -58,13 +79,15 @@ const FieldFTS = Field{LX, LY, LZ, O, G, I, D, T, <:FieldBCsFTS} where {LX, LY, 
 
 extract_field_time_series(f::FieldFTS) = extract_field_time_series(f.boundary_conditions)
 
-extract_field_time_series(bcs::FieldBoundaryConditions) = (extract_field_time_series(bcs.west),
-                                                           extract_field_time_series(bcs.east),
-                                                           extract_field_time_series(bcs.south),
-                                                           extract_field_time_series(bcs.north),
-                                                           extract_field_time_series(bcs.bottom),
-                                                           extract_field_time_series(bcs.top),
-                                                           extract_field_time_series(bcs.immersed))
+extract_field_time_series(bcs::FieldBoundaryConditions) =
+    has_field_time_series(typeof(bcs)) ?
+        concatenate_extracted((extract_field_time_series(bcs.west),
+                               extract_field_time_series(bcs.east),
+                               extract_field_time_series(bcs.south),
+                               extract_field_time_series(bcs.north),
+                               extract_field_time_series(bcs.bottom),
+                               extract_field_time_series(bcs.top),
+                               extract_field_time_series(bcs.immersed))) : ()
 
 extract_field_time_series(bc::BoundaryCondition) = extract_field_time_series(bc.condition)
 extract_field_time_series(bc::DiscreteBoundaryFunction) = extract_field_time_series(bc.parameters)


### PR DESCRIPTION
`extract_field_time_series` is highly type-unstable and it runs also if the model does not have any FTS! This PR fixes all the type instabilities associated with this method (pending fixes also for the `flatten_unique_tuple` method).

I will add here briefly a practical example of the fix vs the allocations on main

MWE:
```julia
using Oceananigans
using Oceananigans.Units: Time
using Oceananigans.OutputReaders: extract_field_time_series
using Oceananigans.Fields: flattened_unique_values
using Oceananigans.Models: possible_field_time_series, update_model_field_time_series!

grid = RectilinearGrid(CPU(), size=(4, 4, 4), extent=(1, 1, 1))
fts(name) = FieldTimeSeries{Center, Center, Nothing}(grid, [0.0, 1.0, 2.0]; name)
Tt, St, bt = fts("T"), fts("S"), fts("b")
@inline ϕ(i, j, grid, clock, fields, p) = @inbounds p[i, j, 1, Time(clock.time)]

bcs = (T = FieldBoundaryConditions(top    = ValueBoundaryCondition(Tt)),
       S = FieldBoundaryConditions(top    = ValueBoundaryCondition(ϕ; discrete_form=true, parameters=St)),
       b = FieldBoundaryConditions(bottom = FluxBoundaryCondition(bt)))
model = NonhydrostaticModel(grid; tracers=(:T, :S, :b), boundary_conditions=bcs)
pfts  = possible_field_time_series(model)

collected = flattened_unique_values(extract_field_time_series(pfts))   # warm up
update_model_field_time_series!(model, model.clock)

@show @allocated update_model_field_time_series!(model, model.clock)
N = 10_000; t = @elapsed for _ in 1:N; update_model_field_time_series!(model, model.clock); end
@show round(1e9 * t / N, digits=1)  # ns/call
```
On main
```julia
julia> @show @allocated update_model_field_time_series!(model, model.clock)
#= REPL[17]:1 =# @allocated(update_model_field_time_series!(model, model.clock)) = 4032
4032

julia> N = 10_000; t = @elapsed for _ in 1:N; update_model_field_time_series!(model, model.clock); end
0.091572334

julia> @show round(1e9 * t / N, digits=1)  # ns/call
round((1.0e9t) / N, digits = 1) = 9157.2
9157.2
```
On this PR:
```julia
julia> @show @allocated update_model_field_time_series!(model, model.clock)
#= REPL[15]:1 =# @allocated(update_model_field_time_series!(model, model.clock)) = 1072
1072

julia> N = 10_000; t = @elapsed for _ in 1:N; update_model_field_time_series!(model, model.clock); end
0.025518625

julia> @show round(1e9 * t / N, digits=1)  # ns/call
round((1.0e9t) / N, digits = 1) = 2551.9
2551.9
```
