### PR TITLE
Remove looping over tuple of fields

### DIFF
--- a/src/BoundaryConditions/fill_halo_regions.jl
+++ b/src/BoundaryConditions/fill_halo_regions.jl
@@ -19,15 +19,16 @@ fill_halo_regions!(c::OffsetArray, ::Nothing, args...; kwargs...) = nothing
 
 "Fill halo regions in ``x``, ``y``, and ``z`` for a given field's data."
 function fill_halo_regions!(c::OffsetArray, boundary_conditions, indices, loc, grid, args...; kwargs...)
-
     kernels!, bcs = get_boundary_kernels(boundary_conditions, c, grid, loc, indices)
-    number_of_tasks = length(kernels!)
+    fill_halo_events!(c, values(kernels!), values(bcs), loc, grid, args...; kwargs...)
+    return nothing
+end
 
-    # Fill halo in the three permuted directions (1, 2, and 3), making sure dependencies are fulfilled
-    for task = 1:number_of_tasks
-        @inbounds fill_halo_event!(c, kernels![task], bcs[task], loc, grid, args...; kwargs...)
-    end
+@inline fill_halo_events!(c, ::Tuple{}, ::Tuple{}, loc, grid, args...; kwargs...) = nothing
 
+@inline function fill_halo_events!(c, kernels!::Tuple, bcs::Tuple, loc, grid, args...; kwargs...)
+    fill_halo_event!(c, first(kernels!), first(bcs), loc, grid, args...; kwargs...)
+    fill_halo_events!(c, Base.tail(kernels!), Base.tail(bcs), loc, grid, args...; kwargs...)
     return nothing
 end
 

--- a/src/BoundaryConditions/update_boundary_conditions.jl
+++ b/src/BoundaryConditions/update_boundary_conditions.jl
@@ -14,13 +14,12 @@ function update_boundary_conditions!(bcs::FieldBoundaryConditions, field, model)
     return nothing
 end
 
-update_boundary_conditions!(fields::NamedTuple, model) = update_boundary_conditions!(values(fields), model)
+@inline update_boundary_conditions!(fields::NamedTuple, model) = update_boundary_conditions!(values(fields), model)
+@inline update_boundary_conditions!(::Tuple{},          model) = nothing
 
-function update_boundary_conditions!(fields::Tuple, model)
-    for field in fields
-        bcs = boundary_conditions(field)
-        update_boundary_conditions!(bcs, field, model)
-    end
-
+@inline function update_boundary_conditions!(fields::Tuple, model)
+    field = first(fields)
+    update_boundary_conditions!(boundary_conditions(field), field, model)
+    update_boundary_conditions!(Base.tail(fields), model)
     return nothing
 end

--- a/src/DistributedComputations/distributed_fields.jl
+++ b/src/DistributedComputations/distributed_fields.jl
@@ -75,9 +75,16 @@ synchronize_communication!(::AbstractField) = nothing
 synchronize_communication!(::AbstractArray) = nothing
 synchronize_communication!(::Number)        = nothing
 synchronize_communication!(::Nothing)       = nothing
+synchronize_communication!(::Tuple{})       = nothing
 
 # Distribute synchronize_communication! over tuples and named tuples
-synchronize_communication!(t::Union{NamedTuple, Tuple}) = foreach(synchronize_communication!, t)
+synchronize_communication!(nt::NamedTuple) = synchronize_communication!(values(nt))
+
+function synchronize_communication!(t::Tuple)
+    synchronize_communication!(first(t))
+    synchronize_communication!(Base.tail(t))
+    return nothing
+end
 
 """
 $(TYPEDSIGNATURES)

--- a/src/DistributedComputations/halo_communication.jl
+++ b/src/DistributedComputations/halo_communication.jl
@@ -89,12 +89,9 @@ function fill_halo_regions!(c::OffsetArray, boundary_conditions, indices, loc, g
     arch = architecture(grid)
     kernels!, bcs = get_boundary_kernels(boundary_conditions, c, grid, loc, indices)
 
-    number_of_tasks  = length(kernels!)
     outstanding_requests = length(arch.mpi_requests)
 
-    for task = 1:number_of_tasks
-        @inbounds distributed_fill_halo_event!(c, kernels![task], bcs[task], loc, grid, args...; kwargs...)
-    end
+    distributed_fill_halo_events!(c, values(kernels!), values(bcs), loc, grid, args...; kwargs...)
 
     fill_corners!(c, arch.connectivity, indices, loc, arch, grid, args...; kwargs...)
 
@@ -105,6 +102,14 @@ function fill_halo_regions!(c::OffsetArray, boundary_conditions, indices, loc, g
         arch.mpi_tag[] += 1
     end
 
+    return nothing
+end
+
+@inline distributed_fill_halo_events!(c, ::Tuple{}, ::Tuple{}, loc, grid, args...; kwargs...) = nothing
+
+@inline function distributed_fill_halo_events!(c, kernels!::Tuple, bcs::Tuple, loc, grid, args...; kwargs...)
+    distributed_fill_halo_event!(c, first(kernels!), first(bcs), loc, grid, args...; kwargs...)
+    distributed_fill_halo_events!(c, Base.tail(kernels!), Base.tail(bcs), loc, grid, args...; kwargs...)
     return nothing
 end
 

--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -64,12 +64,13 @@ Fill halo regions for all `fields`. The algorithm:
   4. In every direction, the halo regions in each of the remaining `Field` tuple
      are filled simultaneously.
 """
-function BoundaryConditions.fill_halo_regions!(fields::Union{NamedTuple, Tuple}, args...; kwargs...)
+@inline BoundaryConditions.fill_halo_regions!(fields::NamedTuple, args...; kwargs...) = fill_halo_regions!(values(fields), args...; kwargs...)
 
-    for i in eachindex(fields)
-        @inbounds fill_halo_regions!(fields[i], args...; kwargs...)
-    end
+@inline BoundaryConditions.fill_halo_regions!(::Tuple{}, args...; kwargs...) = nothing
 
+@inline function BoundaryConditions.fill_halo_regions!(fields::Tuple, args...; kwargs...)
+    fill_halo_regions!(first(fields), args...; kwargs...)
+    fill_halo_regions!(Base.tail(fields), args...; kwargs...)
     return nothing
 end
 

--- a/src/ImmersedBoundaries/mask_immersed_field.jl
+++ b/src/ImmersedBoundaries/mask_immersed_field.jl
@@ -8,6 +8,17 @@ using Oceananigans.Fields: ConstantField, OneField, ZeroField
 instantiate(T::Type) = T()
 instantiate(t) = t
 
+# Recurse on Tuple and NamedTuples
+mask_immersed_field!(nt::NamedTuple) = mask_immersed_field!(values(nt))
+
+function mask_immersed_field!(t::Tuple)
+    mask_immersed_field!(first(t))
+    mask_immersed_field!(Base.tail(t))
+    return nothing
+end
+
+mask_immersed_field!(::Tuple{}) = nothing
+
 # No masking for constant fields, numbers or nothing
 mask_immersed_field!(::OneField, args...; kw...) = nothing
 mask_immersed_field!(::ZeroField, args...; kw...) = nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/distributed_split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/distributed_split_explicit_free_surface.jl
@@ -10,16 +10,14 @@ function wait_free_surface_communication!(free_surface::DistributedSplitExplicit
 
     barotropic_velocities = free_surface.barotropic_velocities
 
-    for field in (barotropic_velocities.U, barotropic_velocities.V)
-        synchronize_communication!(field)
-    end
+    synchronize_communication!(barotropic_velocities.U)
+    synchronize_communication!(barotropic_velocities.V)
 
     Gᵁ = model.timestepper.Gⁿ.U
     Gⱽ = model.timestepper.Gⁿ.V
 
-    for field in (Gᵁ, Gⱽ)
-        synchronize_communication!(field)
-    end
+    synchronize_communication!(Gᵁ)
+    synchronize_communication!(Gⱽ)
 
     return nothing
 end
@@ -29,9 +27,11 @@ function synchronize_communication!(free_surface::SplitExplicitFreeSurface)
     U, V = free_surface.barotropic_velocities
     Ũ, Ṽ = free_surface.filtered_state.Ũ, free_surface.filtered_state.Ṽ
 
-    for field in (U, V, Ũ, Ṽ, η)
-        synchronize_communication!(field)
-    end
+    synchronize_communication!(U)
+    synchronize_communication!(V)
+    synchronize_communication!(Ũ)
+    synchronize_communication!(Ṽ)
+    synchronize_communication!(η)
 
     return nothing
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/initialize_split_explicit_substepping.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/initialize_split_explicit_substepping.jl
@@ -33,9 +33,11 @@ function initialize_free_surface_state!(free_surface, baroclinic_timestepper, ti
 
     initialize_free_surface_timestepper!(timestepper, η, U, V)
 
-    for field in free_surface.filtered_state
-        fill!(field, 0)
-    end
+    fill!(free_surface.filtered_state.η̅, 0)
+    fill!(free_surface.filtered_state.U̅, 0)
+    fill!(free_surface.filtered_state.V̅, 0)
+    fill!(free_surface.filtered_state.Ũ, 0)
+    fill!(free_surface.filtered_state.Ṽ, 0)
 
     return nothing
 end
@@ -57,9 +59,11 @@ function initialize_free_surface_state!(free_surface, baroclinic_ts::SplitRungeK
 
     initialize_free_surface_timestepper!(barotropic_ts, η, U, V)
 
-    for field in free_surface.filtered_state
-        fill!(field, 0)
-    end
+    fill!(free_surface.filtered_state.η̅, 0)
+    fill!(free_surface.filtered_state.U̅, 0)
+    fill!(free_surface.filtered_state.V̅, 0)
+    fill!(free_surface.filtered_state.Ũ, 0)
+    fill!(free_surface.filtered_state.Ṽ, 0)
 
     return nothing
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/cache_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/cache_hydrostatic_free_surface_tendencies.jl
@@ -49,31 +49,29 @@ If CATKE or TD closures are active, their prognostic tracers (`e`, `ϵ`) are ski
 For `ExplicitFreeSurface`, the free surface tendency is also cached.
 """
 function cache_previous_tendencies!(model::HydrostaticFreeSurfaceModel)
-    prognostic_field_names = keys(prognostic_fields(model))
-    three_dimensional_prognostic_field_names = filter(name -> name != :η, prognostic_field_names)
-
-    closure = model.closure
-    catke_in_closures = hasclosure(closure, FlavorOfCATKE)
-    td_in_closures    = hasclosure(closure, FlavorOfTD)
-
-    for field_name in three_dimensional_prognostic_field_names
-
-        if catke_in_closures && field_name == :e
-            @debug "Skipping store tendencies for e"
-        elseif td_in_closures && field_name == :ϵ
-            @debug "Skipping store tendencies for ϵ"
-        elseif td_in_closures && field_name == :e
-            @debug "Skipping store tendencies for e"
-        else
-            launch!(model.architecture, model.grid, :xyz,
-                    _cache_field_tendencies!,
-                    model.timestepper.G⁻[field_name],
-                    model.timestepper.Gⁿ[field_name])
-        end
-    end
-
+    cache_prognostic_field_tendencies!(model, Val(keys(prognostic_fields(model))))
     cache_free_surface_tendency!(model.free_surface, model)
+    return nothing
+end
 
+@inline cache_prognostic_field_tendencies!(model, ::Val{()}) = nothing
+
+@inline function cache_prognostic_field_tendencies!(model, ::Val{names}) where names
+    cache_prognostic_field_tendency!(model, Val(first(names)))
+    cache_prognostic_field_tendencies!(model, Val(Base.tail(names)))
+    return nothing
+end
+
+@inline function cache_prognostic_field_tendency!(model, ::Val{field_name}) where field_name
+    closure = model.closure
+    skip = field_name == :η ||
+           (hasclosure(closure, FlavorOfCATKE) && field_name == :e) ||
+           (hasclosure(closure, FlavorOfTD) && (field_name == :ϵ || field_name == :e))
+    skip && return nothing
+    launch!(model.architecture, model.grid, :xyz,
+            _cache_field_tendencies!,
+            model.timestepper.G⁻[field_name],
+            model.timestepper.Gⁿ[field_name])
     return nothing
 end
 
@@ -100,21 +98,27 @@ properly handle mutable vertical coordinates (z-star). Velocities and free surfa
 are cached directly without modification.
 """
 function cache_current_fields!(model::HydrostaticFreeSurfaceModel)
-
     previous_fields = model.timestepper.Ψ⁻
     model_fields = prognostic_fields(model)
+    cache_current_fields!(previous_fields, model_fields, model, Val(keys(model_fields)))
+    return nothing
+end
+
+@inline cache_current_fields!(previous_fields, model_fields, model, ::Val{()}) = nothing
+
+@inline function cache_current_fields!(previous_fields, model_fields, model, ::Val{names}) where names
+    name = first(names)
+    cache_current_field!(previous_fields[name], model_fields[name], Val(name), model)
+    cache_current_fields!(previous_fields, model_fields, model, Val(Base.tail(names)))
+    return nothing
+end
+
+@inline function cache_current_field!(Ψ⁻, Ψⁿ, ::Val{name}, model) where name
     grid = model.grid
-    arch = architecture(grid)
-
-    for name in keys(model_fields)
-        Ψ⁻ = previous_fields[name]
-        Ψⁿ = model_fields[name]
-        if name ∈ keys(model.tracers) # Tracers are stored with the grid scaling
-            launch!(arch, grid, :xyz, _cache_tracer_fields!, Ψ⁻, grid, Ψⁿ)
-        else # Velocities and free surface are stored without the grid scaling
-            parent(Ψ⁻) .= parent(Ψⁿ)
-        end
+    if name ∈ keys(model.tracers) # Tracers are stored with the grid scaling
+        launch!(architecture(grid), grid, :xyz, _cache_tracer_fields!, Ψ⁻, grid, Ψⁿ)
+    else # Velocities and free surface are stored without the grid scaling
+        parent(Ψ⁻) .= parent(Ψⁿ)
     end
-
     return nothing
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/compute_hydrostatic_flux_bcs.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/compute_hydrostatic_flux_bcs.jl
@@ -25,14 +25,16 @@ end
 end
 
 @inline function compute_tracer_flux_bcs!(model::HydrostaticFreeSurfaceModel)
-    Gⁿ   = model.timestepper.Gⁿ
-    grid = model.grid
-    arch = architecture(grid)
+    compute_tracer_flux_bcs!(model, Val(propertynames(model.tracers)))
+    return nothing
+end
+
+@inline compute_tracer_flux_bcs!(model, ::Val{()}) = nothing
+
+@inline function compute_tracer_flux_bcs!(model, ::Val{names}) where names
+    name = first(names)
     args = (model.clock, fields(model), model.closure, model.buoyancy)
-
-    for i in propertynames(model.tracers)
-        compute_flux_bcs!(Gⁿ[i], model.tracers[i], arch, args)
-    end
-
+    compute_flux_bcs!(model.timestepper.Gⁿ[name], model.tracers[name], architecture(model.grid), args)
+    compute_tracer_flux_bcs!(model, Val(Base.tail(names)))
     return nothing
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_ab2_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_ab2_step.jl
@@ -159,27 +159,29 @@ Velocities are updated as: `u += Δt * ((3/2 + χ) * Gⁿ - (1/2 + χ) * G⁻)`.
 If an implicit solver is configured, implicit vertical diffusion is applied after the explicit step.
 """
 function ab2_step_velocities!(velocities, model, Δt, χ)
+    ab2_step_velocity!(model, Δt, χ, Val(:u))
+    ab2_step_velocity!(model, Δt, χ, Val(:v))
+    return nothing
+end
 
-    for (i, name) in enumerate((:u, :v))
-        Gⁿ = model.timestepper.Gⁿ[name]
-        G⁻ = model.timestepper.G⁻[name]
-        velocity_field = model.velocities[name]
+@inline function ab2_step_velocity!(model, Δt, χ, ::Val{name}) where name
+    Gⁿ = model.timestepper.Gⁿ[name]
+    G⁻ = model.timestepper.G⁻[name]
+    velocity_field = model.velocities[name]
 
-        launch!(model.architecture, model.grid, :xyz,
-                _ab2_step_field!, velocity_field, Δt, χ, Gⁿ, G⁻; exclude_periphery=true)
+    launch!(model.architecture, model.grid, :xyz,
+            _ab2_step_field!, velocity_field, Δt, χ, Gⁿ, G⁻; exclude_periphery=true)
 
-        implicit_step!(velocity_field,
-                       model.timestepper.implicit_solver,
-                       model.closure,
-                       model.closure_fields,
-                       nothing,
-                       model.clock,
-                       fields(model),
-                       Δt,
-                       model.advection.momentum,
-                       model.velocities)
-    end
-
+    implicit_step!(velocity_field,
+                   model.timestepper.implicit_solver,
+                   model.closure,
+                   model.closure_fields,
+                   nothing,
+                   model.clock,
+                   fields(model),
+                   Δt,
+                   model.advection.momentum,
+                   model.velocities)
     return nothing
 end
 
@@ -206,43 +208,43 @@ If CATKE or TD closures are active, their prognostic tracers (`e`, `ϵ`) are ski
 as they are handled separately. Implicit vertical diffusion is applied if configured.
 """
 function ab2_step_tracers!(tracers, model, Δt, χ)
+    ab2_step_tracers!(model, Δt, χ, Val(1), Val(propertynames(tracers)))
+    return nothing
+end
 
+@inline ab2_step_tracers!(model, Δt, χ, ::Val, ::Val{()}) = nothing
+
+@inline function ab2_step_tracers!(model, Δt, χ, ::Val{tracer_index}, ::Val{names}) where {tracer_index, names}
+    ab2_step_tracer!(model, Δt, χ, Val(tracer_index), Val(first(names)))
+    ab2_step_tracers!(model, Δt, χ, Val(tracer_index + 1), Val(Base.tail(names)))
+    return nothing
+end
+
+@inline function ab2_step_tracer!(model, Δt, χ, ::Val{tracer_index}, ::Val{tracer_name}) where {tracer_index, tracer_name}
     closure = model.closure
-    catke_in_closures = hasclosure(closure, FlavorOfCATKE)
-    td_in_closures    = hasclosure(closure, FlavorOfTD)
+    skip = (hasclosure(closure, FlavorOfCATKE) && tracer_name == :e) ||
+           (hasclosure(closure, FlavorOfTD) && (tracer_name == :ϵ || tracer_name == :e))
+    skip && return nothing
 
-    # Tracer update kernels
-    for (tracer_index, tracer_name) in enumerate(propertynames(tracers))
+    Gⁿ = model.timestepper.Gⁿ[tracer_name]
+    G⁻ = model.timestepper.G⁻[tracer_name]
+    tracer_field = model.tracers[tracer_name]
+    grid = model.grid
 
-        if catke_in_closures && tracer_name == :e
-            @debug "Skipping AB2 step for e"
-        elseif td_in_closures && tracer_name == :ϵ
-            @debug "Skipping AB2 step for ϵ"
-        elseif td_in_closures && tracer_name == :e
-            @debug "Skipping AB2 step for e"
-        else
-            Gⁿ = model.timestepper.Gⁿ[tracer_name]
-            G⁻ = model.timestepper.G⁻[tracer_name]
-            tracer_field = tracers[tracer_name]
-            grid = model.grid
+    FT = eltype(grid)
+    launch!(architecture(grid), grid, :xyz, _ab2_step_tracer_field!, tracer_field, grid, convert(FT, Δt), χ, Gⁿ, G⁻)
 
-            FT = eltype(grid)
-            launch!(architecture(grid), grid, :xyz, _ab2_step_tracer_field!, tracer_field, grid, convert(FT, Δt), χ, Gⁿ, G⁻)
-
-            @inbounds c_advection = model.advection[tracer_name]
-            implicit_step!(tracer_field,
-                           model.timestepper.implicit_solver,
-                           closure,
-                           model.closure_fields,
-                           Val(tracer_index),
-                           model.clock,
-                           fields(model),
-                           Δt,
-                           c_advection,
-                           model.transport_velocities)
-        end
-    end
-
+    @inbounds c_advection = model.advection[tracer_name]
+    implicit_step!(tracer_field,
+                   model.timestepper.implicit_solver,
+                   closure,
+                   model.closure_fields,
+                   Val(tracer_index),
+                   model.clock,
+                   fields(model),
+                   Δt,
+                   c_advection,
+                   model.transport_velocities)
     return nothing
 end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk_step.jl
@@ -149,30 +149,32 @@ stored in `model.timestepper.Ψ⁻` and `Gᵤ` is the current tendency in `model
 If an implicit solver is configured, implicit vertical diffusion is applied after the explicit step.
 """
 function rk_substep_velocities!(velocities, model, Δt)
+    rk_substep_velocity!(velocities, model, Δt, Val(:u))
+    rk_substep_velocity!(velocities, model, Δt, Val(:v))
+    return nothing
+end
 
+@inline function rk_substep_velocity!(velocities, model, Δt, ::Val{name}) where name
     grid = model.grid
     FT = eltype(grid)
 
-    for name in (:u, :v)
-        Gⁿ = model.timestepper.Gⁿ[name]
-        Ψ⁻ = model.timestepper.Ψ⁻[name]
-        velocity_field = velocities[name]
+    Gⁿ = model.timestepper.Gⁿ[name]
+    Ψ⁻ = model.timestepper.Ψ⁻[name]
+    velocity_field = velocities[name]
 
-        launch!(architecture(grid), grid, :xyz,
-                _rk_substep_field!, velocity_field, convert(FT, Δt), Gⁿ, Ψ⁻; exclude_periphery=true)
+    launch!(architecture(grid), grid, :xyz,
+            _rk_substep_field!, velocity_field, convert(FT, Δt), Gⁿ, Ψ⁻; exclude_periphery=true)
 
-        implicit_step!(velocity_field,
-                       model.timestepper.implicit_solver,
-                       model.closure,
-                       model.closure_fields,
-                       nothing,
-                       model.clock,
-                       fields(model),
-                       Δt,
-                       model.advection.momentum,
-                       model.velocities)
-    end
-
+    implicit_step!(velocity_field,
+                   model.timestepper.implicit_solver,
+                   model.closure,
+                   model.closure_fields,
+                   nothing,
+                   model.clock,
+                   fields(model),
+                   Δt,
+                   model.advection.momentum,
+                   model.velocities)
     return nothing
 end
 
@@ -195,40 +197,43 @@ If CATKE closure is active, the TKE tracer `e` is skipped (handled separately).
 Implicit vertical diffusion is applied after the explicit step if configured.
 """
 function rk_substep_tracers!(tracers, model, Δt)
+    rk_substep_tracers!(model, Δt, Val(1), Val(propertynames(tracers)))
+    return nothing
+end
 
+@inline rk_substep_tracers!(model, Δt, ::Val, ::Val{()}) = nothing
+
+@inline function rk_substep_tracers!(model, Δt, ::Val{tracer_index}, ::Val{names}) where {tracer_index, names}
+    rk_substep_tracer!(model, Δt, Val(tracer_index), Val(first(names)))
+    rk_substep_tracers!(model, Δt, Val(tracer_index + 1), Val(Base.tail(names)))
+    return nothing
+end
+
+@inline function rk_substep_tracer!(model, Δt, ::Val{tracer_index}, ::Val{tracer_name}) where {tracer_index, tracer_name}
     closure = model.closure
+    (hasclosure(closure, FlavorOfCATKE) && tracer_name == :e) && return nothing
+
     grid = model.grid
     FT = eltype(grid)
 
-    catke_in_closures = hasclosure(closure, FlavorOfCATKE)
+    Gⁿ = model.timestepper.Gⁿ[tracer_name]
+    Ψ⁻ = model.timestepper.Ψ⁻[tracer_name]
+    c  = model.tracers[tracer_name]
 
-    # Tracer update kernels
-    for (tracer_index, tracer_name) in enumerate(propertynames(tracers))
+    launch!(architecture(grid), grid, :xyz,
+            _rk_substep_tracer_field!, c, grid, convert(FT, Δt), Gⁿ, Ψ⁻)
 
-        if catke_in_closures && tracer_name == :e
-            @debug "Skipping RK substep for e"
-        else
-            Gⁿ = model.timestepper.Gⁿ[tracer_name]
-            Ψ⁻ = model.timestepper.Ψ⁻[tracer_name]
-            c  = tracers[tracer_name]
-
-            launch!(architecture(grid), grid, :xyz,
-                    _rk_substep_tracer_field!, c, grid, convert(FT, Δt), Gⁿ, Ψ⁻)
-
-            @inbounds c_advection = model.advection[tracer_name]
-            implicit_step!(c,
-                           model.timestepper.implicit_solver,
-                           closure,
-                           model.closure_fields,
-                           Val(tracer_index),
-                           model.clock,
-                           fields(model),
-                           Δt,
-                           c_advection,
-                           model.transport_velocities)
-        end
-    end
-
+    @inbounds c_advection = model.advection[tracer_name]
+    implicit_step!(c,
+                   model.timestepper.implicit_solver,
+                   closure,
+                   model.closure_fields,
+                   Val(tracer_index),
+                   model.clock,
+                   fields(model),
+                   Δt,
+                   c_advection,
+                   model.transport_velocities)
     return nothing
 end
 

--- a/src/Models/HydrostaticFreeSurfaceModels/update_hydrostatic_free_surface_model_state.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/update_hydrostatic_free_surface_model_state.jl
@@ -44,7 +44,7 @@ function update_state!(model::HydrostaticFreeSurfaceModel, grid, callbacks)
     arch = architecture(grid)
 
     @apply_regionally begin
-        foreach(mask_immersed_field!, model.tracers)
+        mask_immersed_field!(model.tracers)
         update_model_field_time_series!(model, model.clock)
         update_boundary_conditions!(fields(model), model)
     end

--- a/src/Models/HydrostaticFreeSurfaceModels/z_star_coordinate.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/z_star_coordinate.jl
@@ -153,13 +153,16 @@ This function scales tendencies after they are computed so that the time-steppin
 advances `σ * c` correctly.
 """
 function scale_by_stretching_factor!(Gⁿ, tracers, grid::MutableGridOfSomeKind)
+    scale_by_stretching_factor!(Gⁿ, grid, Val(propertynames(tracers)))
+    return nothing
+end
 
-    # Multiply the Gⁿ tendencies by the grid scaling
-    for i in propertynames(tracers)
-        @inbounds G = Gⁿ[i]
-        launch!(architecture(grid), grid, :xyz, _scale_by_stretching_factor!, G, grid)
-    end
+@inline scale_by_stretching_factor!(Gⁿ, grid, ::Val{()}) = nothing
 
+@inline function scale_by_stretching_factor!(Gⁿ, grid, ::Val{names}) where names
+    name = first(names)
+    launch!(architecture(grid), grid, :xyz, _scale_by_stretching_factor!, Gⁿ[name], grid)
+    scale_by_stretching_factor!(Gⁿ, grid, Val(Base.tail(names)))
     return nothing
 end
 

--- a/src/Utils/multi_region_transformation.jl
+++ b/src/Utils/multi_region_transformation.jl
@@ -61,13 +61,9 @@ end
 @inline isregional(a)                   = false
 @inline isregional(::MultiRegionObject) = true
 
-@inline isregional(t::Tuple{}) = false
-@inline isregional(nt::NT) where NT<:NamedTuple{(), Tuple{}} = false
-
-@inline function isregional(t::Union{Tuple, NamedTuple})
-    idx = findfirst(isregional, t)
-    return !isnothing(idx)
-end
+@inline isregional(::Tuple{}) = false
+@inline isregional(t::Tuple) = isregional(first(t)) || isregional(Base.tail(t))
+@inline isregional(nt::NamedTuple) = isregional(values(nt))
 
 @inline regions(t::Union{Tuple, NamedTuple}) = regions(first(t))
 @inline regions(mo::MultiRegionObject) = 1:length(mo.regional_objects)

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -43,12 +43,12 @@ end
 #TODO: Fix allocations in the nonhydrostatic model
 
 const serial_memory = Dict(
-    (:hydrostatic,    :flat)            => 2e10,
-    (:hydrostatic,    :immersed)        => 2e10,
-    (:hydrostatic,    :active_immersed) => 2e10,
-    (:nonhydrostatic, :flat)            => 2e10,
-    (:nonhydrostatic, :immersed)        => 2e10,
-    (:nonhydrostatic, :active_immersed) => 2e10,
+    (:hydrostatic,    :flat)            => 2.6e6,
+    (:hydrostatic,    :immersed)        => 2.8e6,
+    (:hydrostatic,    :active_immersed) => 2.9e6,
+    (:nonhydrostatic, :flat)            => 1.9e6,
+    (:nonhydrostatic, :immersed)        => 2.2e6,
+    (:nonhydrostatic, :active_immersed) => 2.3e6,
 )
 
 const distributed_memory = Dict(


### PR DESCRIPTION
Looping tuple of fields is type-unstable and allocating. This PR removes the damaging pattern in favor of a type-stable pattern.

MWE:
```julia
grid = RectilinearGrid(CPU(), size=(4, 4, 4), extent=(1, 1, 1))
t = (CenterField(grid), XFaceField(grid))

function allocating_set(fields::Tuple)
    for field in fields
        set!(field, 1)
    end
end

function clean_set(fields::Tuple)
    set!(first(fields), 1)
    clean_set(Base.tail(fields))
end

clean_set(::Tuple{}) = nothing
```

If you run `@code_warntype` on these functions you'll see that `allocating_set` is type-unstable, while `clean_set` is inferrable (I am not copying here the output since it is gigantic).
With inferrability comes less allocations:
```julia
julia> @allocated allocating_set(t)
2448

julia> @allocated clean_set(t)
352
```

Another step in the #5729