### PR TITLE
Fix instabilities in the `launch!` function

### DIFF
--- a/ext/OceananigansReactantExt/OceananigansReactantExt.jl
+++ b/ext/OceananigansReactantExt/OceananigansReactantExt.jl
@@ -119,13 +119,13 @@ end
 
 # https://github.com/CliMA/Oceananigans.jl/blob/d9b3b142d8252e8e11382d1b3118ac2a092b38a2/src/Grids/orthogonal_spherical_shell_grid.jl#L14
 Base.@nospecializeinfer function Reactant.traced_type_inner(
-    @nospecialize(OA::Type{Oceananigans.Grids.OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, rFT, Sz}}),
+    @nospecialize(OA::Type{Oceananigans.Grids.OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, rFT, SZ}}),
     seen,
     mode::Reactant.TraceMode,
     @nospecialize(track_numbers::Type),
     @nospecialize(sharding),
     @nospecialize(runtime)
-) where {FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, rFT, Sz}
+) where {FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, rFT, SZ}
     FT2 = Reactant.traced_type_inner(FT, seen, mode, track_numbers, sharding, runtime)
     TX2 = Reactant.traced_type_inner(TX, seen, mode, track_numbers, sharding, runtime)
     TY2 = Reactant.traced_type_inner(TY, seen, mode, track_numbers, sharding, runtime)
@@ -143,7 +143,7 @@ Base.@nospecializeinfer function Reactant.traced_type_inner(
         FT2 = Reactant.promote_traced_type(FT2, eltype(NF))
     end
     rFT2 = Reactant.traced_type_inner(rFT, seen, mode, track_numbers, sharding, runtime)
-    return Oceananigans.Grids.OrthogonalSphericalShellGrid{FT2, TX2, TY2, TZ2, Z2, Map2, CC2, FC2, CF2, FF2, Arch, rFT2, Sz}
+    return Oceananigans.Grids.OrthogonalSphericalShellGrid{FT2, TX2, TY2, TZ2, Z2, Map2, CC2, FC2, CF2, FF2, Arch, rFT2, SZ}
 end
 
 @inline Reactant.make_tracer(
@@ -191,13 +191,13 @@ end
 
 Base.@nospecializeinfer function Reactant.traced_type_inner(
     @nospecialize(OA::Type{LatitudeLongitudeGrid{FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, YC,
-                                                 DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I, Sz}}),
+                                                 DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I, SZ}}),
     seen,
     mode::Reactant.TraceMode,
     @nospecialize(track_numbers::Type),
     @nospecialize(sharding),
     @nospecialize(runtime)
-) where {FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, YC, DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I, Sz}
+) where {FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, YC, DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I, SZ}
     TX2 = Reactant.traced_type_inner(TX, seen, mode, track_numbers, sharding, runtime)
     TY2 = Reactant.traced_type_inner(TY, seen, mode, track_numbers, sharding, runtime)
     TZ2 = Reactant.traced_type_inner(TZ, seen, mode, track_numbers, sharding, runtime)
@@ -228,19 +228,19 @@ Base.@nospecializeinfer function Reactant.traced_type_inner(
     end
 
     res = Oceananigans.Grids.LatitudeLongitudeGrid{FT2, TX2, TY2, TZ2, Z2, DXF2, DXC2, XF2, XC2, DYF2, DYC2, YF2, YC2,
-                                                   DXCC2, DXFC2, DXCF2, DXFF2, DYFC2, DYCF2, Arch, I2, Sz}
+                                                   DXCC2, DXFC2, DXCF2, DXFF2, DYFC2, DYCF2, Arch, I2, SZ}
 
     return res
 end
 
 Base.@nospecializeinfer function Reactant.traced_type_inner(
-        @nospecialize(OA::Type{RectilinearGrid{FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, Sz}}),
+        @nospecialize(OA::Type{RectilinearGrid{FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, SZ}}),
         seen,
         mode::Reactant.TraceMode,
         @nospecialize(track_numbers::Type),
         @nospecialize(sharding),
         @nospecialize(runtime)
-    ) where {FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, Sz}
+    ) where {FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, SZ}
 
     TX2 = Reactant.traced_type_inner(TX, seen, mode, track_numbers, sharding, runtime)
     TY2 = Reactant.traced_type_inner(TY, seen, mode, track_numbers, sharding, runtime)
@@ -267,7 +267,7 @@ Base.@nospecializeinfer function Reactant.traced_type_inner(
         end
     end
 
-    res = Oceananigans.Grids.RectilinearGrid{FT2, TX2, TY2, TZ2, CZ2, FX2, FY2, VX2, VY2, Arch, Sz}
+    res = Oceananigans.Grids.RectilinearGrid{FT2, TX2, TY2, TZ2, CZ2, FX2, FY2, VX2, VY2, Arch, SZ}
 
     return res
 end

--- a/ext/OceananigansReactantExt/OceananigansReactantExt.jl
+++ b/ext/OceananigansReactantExt/OceananigansReactantExt.jl
@@ -119,13 +119,13 @@ end
 
 # https://github.com/CliMA/Oceananigans.jl/blob/d9b3b142d8252e8e11382d1b3118ac2a092b38a2/src/Grids/orthogonal_spherical_shell_grid.jl#L14
 Base.@nospecializeinfer function Reactant.traced_type_inner(
-    @nospecialize(OA::Type{Oceananigans.Grids.OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, rFT}}),
+    @nospecialize(OA::Type{Oceananigans.Grids.OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, rFT, Sz}}),
     seen,
     mode::Reactant.TraceMode,
     @nospecialize(track_numbers::Type),
     @nospecialize(sharding),
     @nospecialize(runtime)
-) where {FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, rFT}
+) where {FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, rFT, Sz}
     FT2 = Reactant.traced_type_inner(FT, seen, mode, track_numbers, sharding, runtime)
     TX2 = Reactant.traced_type_inner(TX, seen, mode, track_numbers, sharding, runtime)
     TY2 = Reactant.traced_type_inner(TY, seen, mode, track_numbers, sharding, runtime)
@@ -143,7 +143,7 @@ Base.@nospecializeinfer function Reactant.traced_type_inner(
         FT2 = Reactant.promote_traced_type(FT2, eltype(NF))
     end
     rFT2 = Reactant.traced_type_inner(rFT, seen, mode, track_numbers, sharding, runtime)
-    return Oceananigans.Grids.OrthogonalSphericalShellGrid{FT2, TX2, TY2, TZ2, Z2, Map2, CC2, FC2, CF2, FF2, Arch, rFT2}
+    return Oceananigans.Grids.OrthogonalSphericalShellGrid{FT2, TX2, TY2, TZ2, Z2, Map2, CC2, FC2, CF2, FF2, Arch, rFT2, Sz}
 end
 
 @inline Reactant.make_tracer(
@@ -191,13 +191,13 @@ end
 
 Base.@nospecializeinfer function Reactant.traced_type_inner(
     @nospecialize(OA::Type{LatitudeLongitudeGrid{FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, YC,
-                                                 DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I}}),
+                                                 DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I, Sz}}),
     seen,
     mode::Reactant.TraceMode,
     @nospecialize(track_numbers::Type),
     @nospecialize(sharding),
     @nospecialize(runtime)
-) where {FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, YC, DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I}
+) where {FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, YC, DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I, Sz}
     TX2 = Reactant.traced_type_inner(TX, seen, mode, track_numbers, sharding, runtime)
     TY2 = Reactant.traced_type_inner(TY, seen, mode, track_numbers, sharding, runtime)
     TZ2 = Reactant.traced_type_inner(TZ, seen, mode, track_numbers, sharding, runtime)
@@ -228,19 +228,19 @@ Base.@nospecializeinfer function Reactant.traced_type_inner(
     end
 
     res = Oceananigans.Grids.LatitudeLongitudeGrid{FT2, TX2, TY2, TZ2, Z2, DXF2, DXC2, XF2, XC2, DYF2, DYC2, YF2, YC2,
-                                                   DXCC2, DXFC2, DXCF2, DXFF2, DYFC2, DYCF2, Arch, I2}
+                                                   DXCC2, DXFC2, DXCF2, DXFF2, DYFC2, DYCF2, Arch, I2, Sz}
 
     return res
 end
 
 Base.@nospecializeinfer function Reactant.traced_type_inner(
-        @nospecialize(OA::Type{RectilinearGrid{FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch}}),
+        @nospecialize(OA::Type{RectilinearGrid{FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, Sz}}),
         seen,
         mode::Reactant.TraceMode,
         @nospecialize(track_numbers::Type),
         @nospecialize(sharding),
         @nospecialize(runtime)
-    ) where {FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch}
+    ) where {FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, Sz}
 
     TX2 = Reactant.traced_type_inner(TX, seen, mode, track_numbers, sharding, runtime)
     TY2 = Reactant.traced_type_inner(TY, seen, mode, track_numbers, sharding, runtime)
@@ -267,7 +267,7 @@ Base.@nospecializeinfer function Reactant.traced_type_inner(
         end
     end
 
-    res = Oceananigans.Grids.RectilinearGrid{FT2, TX2, TY2, TZ2, CZ2, FX2, FY2, VX2, VY2, Arch}
+    res = Oceananigans.Grids.RectilinearGrid{FT2, TX2, TY2, TZ2, CZ2, FX2, FY2, VX2, VY2, Arch, Sz}
 
     return res
 end

--- a/src/DistributedComputations/distributed_kernel_launching.jl
+++ b/src/DistributedComputations/distributed_kernel_launching.jl
@@ -1,6 +1,6 @@
 import Oceananigans.Utils: _launch!
 
-function _launch!(arch::Distributed, args...; kwargs...)
+@inline function _launch!(arch::Distributed, args...; kwargs...)
     child_arch = child_architecture(arch)
     return _launch!(child_arch, args...; kwargs...)
 end

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -28,7 +28,7 @@ export column_depthᶜᶜᵃ, column_depthᶠᶜᵃ, column_depthᶜᶠᵃ, colu
 export offset_data, new_data
 export on_architecture
 
-using Adapt: Adapt, adapt
+using Adapt: Adapt
 using DocStringExtensions: FIELDS, TYPEDSIGNATURES
 using GPUArraysCore: @allowscalar
 using OffsetArrays: OffsetArray

--- a/src/Grids/abstract_grid.jl
+++ b/src/Grids/abstract_grid.jl
@@ -1,36 +1,38 @@
 """
-    AbstractGrid{FT, TX, TY, TZ, Arch}
+    AbstractGrid{FT, TX, TY, TZ, Arch, SZ}
 
 Abstract supertype for grids with elements of type `FT`, topology `{TX, TY, TZ}`,
-and `Arch`itecture.
+`Arch`itecture, and static size descriptor `SZ`. `SZ` is either `Nothing` (the interior
+and halo sizes are read from the `grid`'s fields at runtime) or a [`GridSize`](@ref),
 """
-abstract type AbstractGrid{FT, TX, TY, TZ, Arch} end
+abstract type AbstractGrid{FT, TX, TY, TZ, Arch, SZ} end
 
 grid(g::AbstractGrid) = g
 
 """
-    AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch}
+    AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch, SZ}
 
 Abstract supertype for "primary" grids (as opposed to grids with immersed boundaries)
-with elements of type `FT`, topology `{TX, TY, TZ}`, vertical coordinate `CZ`, and `Arch`itecture.
+with elements of type `FT`, topology `{TX, TY, TZ}`, vertical coordinate `CZ`, `Arch`itecture,
+and static size descriptor `SZ`.
 """
-abstract type AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch} <: AbstractGrid{FT, TX, TY, TZ, Arch} end
+abstract type AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch, SZ} <: AbstractGrid{FT, TX, TY, TZ, Arch, SZ} end
 
 """
-    AbstractCurvilinearGrid{FT, TX, TY, TZ, CZ, Arch}
+    AbstractCurvilinearGrid{FT, TX, TY, TZ, CZ, Arch, SZ}
 
 Abstract supertype for curvilinear grids with elements of type `FT`,
-topology `{TX, TY, TZ}`, vertical coordinate `CZ`, and `Arch`itecture.
+topology `{TX, TY, TZ}`, vertical coordinate `CZ`, `Arch`itecture, and static size descriptor `SZ`.
 """
-abstract type AbstractCurvilinearGrid{FT, TX, TY, TZ, CZ, Arch} <: AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch} end
+abstract type AbstractCurvilinearGrid{FT, TX, TY, TZ, CZ, Arch, SZ} <: AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch, SZ} end
 
 """
-    AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, CZ, Arch}
+    AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, CZ, Arch, SZ}
 
 Abstract supertype for horizontally-curvilinear grids with elements of type `FT`,
-topology `{TX, TY, TZ}`, vertical coordinate `CZ`, and `Arch`itecture.
+topology `{TX, TY, TZ}`, vertical coordinate `CZ`, `Arch`itecture, and static size descriptor `SZ`.
 """
-abstract type AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, CZ, Arch} <: AbstractCurvilinearGrid{FT, TX, TY, TZ, CZ, Arch} end
+abstract type AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, CZ, Arch, SZ} <: AbstractCurvilinearGrid{FT, TX, TY, TZ, CZ, Arch, SZ} end
 
 const XFlatGrid = AbstractGrid{<:Any, Flat}
 const YFlatGrid = AbstractGrid{<:Any, <:Any, Flat}
@@ -69,12 +71,26 @@ Return the architecture that the `grid` lives on.
 @inline Architectures.architecture(grid::AbstractGrid) = grid.architecture
 
 """
+    GridSize{Nx, Ny, Nz, Hx, Hy, Hz}
+
+Singleton type encoding a grid's interior size `(Nx, Ny, Nz)` and halo size `(Hx, Hy, Hz)` as type parameters.
+Carrying it as the trailing grid type parameter makes both `size(grid)` and `halo_size(grid)` compile-time constants.
+"""
+struct GridSize{Nx, Ny, Nz, Hx, Hy, Hz}
+    function GridSize(Nx, Ny, Nz, Hx, Hy, Hz)
+        return new{Int(Nx), Int(Ny), Int(Nz), Int(Hx), Int(Hy), Int(Hz)}()
+    end
+end
+
+"""
 $(TYPEDSIGNATURES)
 
 Return a 3-tuple of the number of "center" cells on a grid in (x, y, z).
 Center cells have the location (Center, Center, Center).
 """
-@inline Base.size(grid::AbstractGrid) = map(Int, (grid.Nx, grid.Ny, grid.Nz))
+@inline Base.size(grid::AbstractGrid{<:Any, <:Any, <:Any, <:Any, <:Any, Nothing}) = map(Int, (grid.Nx, grid.Ny, grid.Nz))
+@inline Base.size(grid::AbstractGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:GridSize{Nx, Ny, Nz}}) where {Nx, Ny, Nz} = (Nx, Ny, Nz)
+
 Base.eltype(::AbstractGrid{FT}) where FT = FT
 Base.eltype(::Type{<:AbstractGrid{FT}}) where FT = FT
 Base.eps(::AbstractGrid{FT}) where FT = eps(FT)
@@ -97,20 +113,10 @@ $(TYPEDSIGNATURES)
 Return a 3-tuple with the number of halo cells on either side of the
 domain in (x, y, z).
 """
-halo_size(grid) = map(Int, (grid.Hx, grid.Hy, grid.Hz))
+@inline halo_size(grid::AbstractGrid{<:Any, <:Any, <:Any, <:Any, <:Any, Nothing}) = map(Int, (grid.Hx, grid.Hy, grid.Hz))
+@inline halo_size(grid::AbstractGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:GridSize{Nx, Ny, Nz, Hx, Hy, Hz}}) where {Nx, Ny, Nz, Hx, Hy, Hz} = (Hx, Hy, Hz)
+
 halo_size(grid, d) = halo_size(grid)[d]
-
-"""
-    GridSize{Nx, Ny, Nz, Hx, Hy, Hz}
-
-Singleton type encoding a grid's interior size `(Nx, Ny, Nz)` and halo size `(Hx, Hy, Hz)` as type parameters.
-Carrying it as the trailing grid type parameter makes both `size(grid)` and `halo_size(grid)` compile-time constants.
-"""
-struct GridSize{Nx, Ny, Nz, Hx, Hy, Hz}
-    function GridSize(Nx, Ny, Nz, Hx, Hy, Hz)
-        return new{Int(Nx), Int(Ny), Int(Nz), Int(Hx), Int(Hy), Int(Hz)}()
-    end
-end
 
 @inline Base.size(grid::AbstractGrid, d::Int) = size(grid)[d]
 

--- a/src/Grids/abstract_grid.jl
+++ b/src/Grids/abstract_grid.jl
@@ -103,9 +103,8 @@ halo_size(grid, d) = halo_size(grid)[d]
 """
     GridSize{Nx, Ny, Nz, Hx, Hy, Hz}
 
-Singleton type encoding a grid's interior size `(Nx, Ny, Nz)` and halo size `(Hx, Hy, Hz)` as type
-parameters. Carrying it as the trailing grid type parameter makes both `size(grid)` and `halo_size(grid)`
-compile-time constants, which in turn lets `KernelParameters` built from halo-aware ranges infer concretely.
+Singleton type encoding a grid's interior size `(Nx, Ny, Nz)` and halo size `(Hx, Hy, Hz)` as type parameters. 
+Carrying it as the trailing grid type parameter makes both `size(grid)` and `halo_size(grid)` compile-time constants.
 """
 struct GridSize{Nx, Ny, Nz, Hx, Hy, Hz}
     function GridSize(Nx, Ny, Nz, Hx, Hy, Hz)

--- a/src/Grids/abstract_grid.jl
+++ b/src/Grids/abstract_grid.jl
@@ -103,7 +103,7 @@ halo_size(grid, d) = halo_size(grid)[d]
 """
     GridSize{Nx, Ny, Nz, Hx, Hy, Hz}
 
-Singleton type encoding a grid's interior size `(Nx, Ny, Nz)` and halo size `(Hx, Hy, Hz)` as type parameters. 
+Singleton type encoding a grid's interior size `(Nx, Ny, Nz)` and halo size `(Hx, Hy, Hz)` as type parameters.
 Carrying it as the trailing grid type parameter makes both `size(grid)` and `halo_size(grid)` compile-time constants.
 """
 struct GridSize{Nx, Ny, Nz, Hx, Hy, Hz}

--- a/src/Grids/abstract_grid.jl
+++ b/src/Grids/abstract_grid.jl
@@ -100,6 +100,19 @@ domain in (x, y, z).
 halo_size(grid) = map(Int, (grid.Hx, grid.Hy, grid.Hz))
 halo_size(grid, d) = halo_size(grid)[d]
 
+"""
+    GridSize{Nx, Ny, Nz, Hx, Hy, Hz}
+
+Singleton type encoding a grid's interior size `(Nx, Ny, Nz)` and halo size `(Hx, Hy, Hz)` as type
+parameters. Carrying it as the trailing grid type parameter makes both `size(grid)` and `halo_size(grid)`
+compile-time constants, which in turn lets `KernelParameters` built from halo-aware ranges infer concretely.
+"""
+struct GridSize{Nx, Ny, Nz, Hx, Hy, Hz}
+    function GridSize(Nx, Ny, Nz, Hx, Hy, Hz)
+        return new{Int(Nx), Int(Ny), Int(Nz), Int(Hx), Int(Hy), Int(Hz)}()
+    end
+end
+
 @inline Base.size(grid::AbstractGrid, d::Int) = size(grid)[d]
 
 grid_name(grid::AbstractGrid) = typeof(grid).name.wrapper

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -574,10 +574,9 @@ end
 ##### Extensions for kernel launching
 #####
 
-function Utils.periphery_offset(loc, grid::AbstractGrid, side::Int)
-    T = topology(grid, side)
-    N = size(grid, side)
-
+function Utils.periphery_offset(loc, grid::AbstractGrid, ::Val{side}) where side
+    T = @inbounds topology(grid)[side]
+    N = @inbounds size(grid)[side]
     return Utils.periphery_offset(loc, T(), N)
 end
 

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -2,7 +2,7 @@ using KernelAbstractions: @kernel, @index
 using OrderedCollections: OrderedDict
 
 struct LatitudeLongitudeGrid{FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, YC,
-                             DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I, Sz} <: AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Z, Arch}
+                             DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I, SZ} <: AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Z, Arch, SZ}
     architecture :: Arch
     Nx :: I
     Ny :: I
@@ -73,20 +73,6 @@ function LatitudeLongitudeGrid{TX, TY, TZ, SZ}(architecture::Arch,
                                                           Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
                                                           Δyᶠᶜᵃ, Δyᶜᶠᵃ,
                                                           Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, radius)
-end
-
-@generated function Base.size(grid::LatitudeLongitudeGrid)
-    Sz = grid.parameters[end]
-    Sz === Nothing && return :(map(Int, (grid.Nx, grid.Ny, grid.Nz)))
-    sz = Sz.parameters
-    return :(($(sz[1]), $(sz[2]), $(sz[3])))
-end
-
-@generated function halo_size(grid::LatitudeLongitudeGrid)
-    Sz = grid.parameters[end]
-    Sz === Nothing && return :(map(Int, (grid.Hx, grid.Hy, grid.Hz)))
-    sz = Sz.parameters
-    return :(($(sz[4]), $(sz[5]), $(sz[6])))
 end
 
 const LLG = LatitudeLongitudeGrid

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -74,7 +74,6 @@ function LatitudeLongitudeGrid{TX, TY, TZ}(architecture::Arch,
                                                           Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, radius)
 end
 
-# Read size and halo from the trailing `GridSize` type parameter so both are compile-time constants.
 @generated function Base.size(grid::LatitudeLongitudeGrid)
     sz = grid.parameters[end].parameters
     return :(($(sz[1]), $(sz[2]), $(sz[3])))

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -39,26 +39,27 @@ struct LatitudeLongitudeGrid{FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, 
     radius :: FT
 end
 
-function LatitudeLongitudeGrid{TX, TY, TZ}(architecture::Arch,
-                                           Nλ::I, Nφ::I, Nz::I, Hλ::I, Hφ::I, Hz::I,
-                                           Lλ :: FT, Lφ :: FT, Lz :: FT,
-                                           Δλᶠᵃᵃ :: DXF, Δλᶜᵃᵃ :: DXC,
-                                            λᶠᵃᵃ :: XF,   λᶜᵃᵃ :: XC,
-                                           Δφᵃᶠᵃ :: DYF, Δφᵃᶜᵃ :: DYC,
-                                            φᵃᶠᵃ :: YF,   φᵃᶜᵃ :: YC, z :: Z,
-                                           Δxᶜᶜᵃ :: DXCC, Δxᶠᶜᵃ :: DXFC,
-                                           Δxᶜᶠᵃ :: DXCF, Δxᶠᶠᵃ :: DXFF,
-                                           Δyᶠᶜᵃ :: DYFC, Δyᶜᶠᵃ :: DYCF,
-                                           Azᶜᶜᵃ :: DXCC, Azᶠᶜᵃ :: DXFC,
-                                           Azᶜᶠᵃ :: DXCF, Azᶠᶠᵃ :: DXFF,
-                                           radius :: FT) where {Arch, FT, TX, TY, TZ, Z,
-                                                                DXF, DXC, XF, XC,
-                                                                DYF, DYC, YF, YC,
-                                                                DXFC, DXCF,
-                                                                DXFF, DXCC,
-                                                                DYFC, DYCF, I}
-    size = GridSize(Nλ, Nφ, Nz, Hλ, Hφ, Hz)
-    SZ   = typeof(size)
+LatitudeLongitudeGrid{TX, TY, TZ}(arch, Nλ, Nφ, Nz, Hλ, Hφ, Hz, args...) where {TX, TY, TZ} =
+    LatitudeLongitudeGrid{TX, TY, TZ, typeof(GridSize(Nλ, Nφ, Nz, Hλ, Hφ, Hz))}(arch, Nλ, Nφ, Nz, Hλ, Hφ, Hz, args...)
+
+function LatitudeLongitudeGrid{TX, TY, TZ, SZ}(architecture::Arch,
+                                               Nλ::I, Nφ::I, Nz::I, Hλ::I, Hφ::I, Hz::I,
+                                               Lλ :: FT, Lφ :: FT, Lz :: FT,
+                                               Δλᶠᵃᵃ :: DXF, Δλᶜᵃᵃ :: DXC,
+                                                λᶠᵃᵃ :: XF,   λᶜᵃᵃ :: XC,
+                                               Δφᵃᶠᵃ :: DYF, Δφᵃᶜᵃ :: DYC,
+                                                φᵃᶠᵃ :: YF,   φᵃᶜᵃ :: YC, z :: Z,
+                                               Δxᶜᶜᵃ :: DXCC, Δxᶠᶜᵃ :: DXFC,
+                                               Δxᶜᶠᵃ :: DXCF, Δxᶠᶠᵃ :: DXFF,
+                                               Δyᶠᶜᵃ :: DYFC, Δyᶜᶠᵃ :: DYCF,
+                                               Azᶜᶜᵃ :: DXCC, Azᶠᶜᵃ :: DXFC,
+                                               Azᶜᶠᵃ :: DXCF, Azᶠᶠᵃ :: DXFF,
+                                               radius :: FT) where {SZ, Arch, FT, TX, TY, TZ, Z,
+                                                                    DXF, DXC, XF, XC,
+                                                                    DYF, DYC, YF, YC,
+                                                                    DXFC, DXCF,
+                                                                    DXFF, DXCC,
+                                                                    DYFC, DYCF, I}
     return LatitudeLongitudeGrid{FT, TX, TY, TZ, Z,
                                  DXF, DXC, XF, XC,
                                  DYF, DYC, YF, YC,
@@ -75,12 +76,16 @@ function LatitudeLongitudeGrid{TX, TY, TZ}(architecture::Arch,
 end
 
 @generated function Base.size(grid::LatitudeLongitudeGrid)
-    sz = grid.parameters[end].parameters
+    Sz = grid.parameters[end]
+    Sz === Nothing && return :(map(Int, (grid.Nx, grid.Ny, grid.Nz)))
+    sz = Sz.parameters
     return :(($(sz[1]), $(sz[2]), $(sz[3])))
 end
 
 @generated function halo_size(grid::LatitudeLongitudeGrid)
-    sz = grid.parameters[end].parameters
+    Sz = grid.parameters[end]
+    Sz === Nothing && return :(map(Int, (grid.Hx, grid.Hy, grid.Hz)))
+    sz = Sz.parameters
     return :(($(sz[4]), $(sz[5]), $(sz[6])))
 end
 
@@ -452,32 +457,32 @@ end
 
 function Adapt.adapt_structure(to, grid::LatitudeLongitudeGrid)
     TX, TY, TZ = topology(grid)
-    return LatitudeLongitudeGrid{TX, TY, TZ}(nothing,
-                                             grid.Nx, grid.Ny, grid.Nz,
-                                             grid.Hx, grid.Hy, grid.Hz,
-                                             Adapt.adapt(to, grid.Lx),
-                                             Adapt.adapt(to, grid.Ly),
-                                             Adapt.adapt(to, grid.Lz),
-                                             Adapt.adapt(to, grid.Δλᶠᵃᵃ),
-                                             Adapt.adapt(to, grid.Δλᶜᵃᵃ),
-                                             Adapt.adapt(to, grid.λᶠᵃᵃ),
-                                             Adapt.adapt(to, grid.λᶜᵃᵃ),
-                                             Adapt.adapt(to, grid.Δφᵃᶠᵃ),
-                                             Adapt.adapt(to, grid.Δφᵃᶜᵃ),
-                                             Adapt.adapt(to, grid.φᵃᶠᵃ),
-                                             Adapt.adapt(to, grid.φᵃᶜᵃ),
-                                             Adapt.adapt(to, grid.z),
-                                             Adapt.adapt(to, grid.Δxᶜᶜᵃ),
-                                             Adapt.adapt(to, grid.Δxᶠᶜᵃ),
-                                             Adapt.adapt(to, grid.Δxᶜᶠᵃ),
-                                             Adapt.adapt(to, grid.Δxᶠᶠᵃ),
-                                             Adapt.adapt(to, grid.Δyᶠᶜᵃ),
-                                             Adapt.adapt(to, grid.Δyᶜᶠᵃ),
-                                             Adapt.adapt(to, grid.Azᶜᶜᵃ),
-                                             Adapt.adapt(to, grid.Azᶠᶜᵃ),
-                                             Adapt.adapt(to, grid.Azᶜᶠᵃ),
-                                             Adapt.adapt(to, grid.Azᶠᶠᵃ),
-                                             Adapt.adapt(to, grid.radius))
+    return LatitudeLongitudeGrid{TX, TY, TZ, Nothing}(nothing,
+                                                      grid.Nx, grid.Ny, grid.Nz,
+                                                      grid.Hx, grid.Hy, grid.Hz,
+                                                      Adapt.adapt(to, grid.Lx),
+                                                      Adapt.adapt(to, grid.Ly),
+                                                      Adapt.adapt(to, grid.Lz),
+                                                      Adapt.adapt(to, grid.Δλᶠᵃᵃ),
+                                                      Adapt.adapt(to, grid.Δλᶜᵃᵃ),
+                                                      Adapt.adapt(to, grid.λᶠᵃᵃ),
+                                                      Adapt.adapt(to, grid.λᶜᵃᵃ),
+                                                      Adapt.adapt(to, grid.Δφᵃᶠᵃ),
+                                                      Adapt.adapt(to, grid.Δφᵃᶜᵃ),
+                                                      Adapt.adapt(to, grid.φᵃᶠᵃ),
+                                                      Adapt.adapt(to, grid.φᵃᶜᵃ),
+                                                      Adapt.adapt(to, grid.z),
+                                                      Adapt.adapt(to, grid.Δxᶜᶜᵃ),
+                                                      Adapt.adapt(to, grid.Δxᶠᶜᵃ),
+                                                      Adapt.adapt(to, grid.Δxᶜᶠᵃ),
+                                                      Adapt.adapt(to, grid.Δxᶠᶠᵃ),
+                                                      Adapt.adapt(to, grid.Δyᶠᶜᵃ),
+                                                      Adapt.adapt(to, grid.Δyᶜᶠᵃ),
+                                                      Adapt.adapt(to, grid.Azᶜᶜᵃ),
+                                                      Adapt.adapt(to, grid.Azᶠᶜᵃ),
+                                                      Adapt.adapt(to, grid.Azᶜᶠᵃ),
+                                                      Adapt.adapt(to, grid.Azᶠᶠᵃ),
+                                                      Adapt.adapt(to, grid.radius))
 end
 
 #####

--- a/src/Grids/latitude_longitude_grid.jl
+++ b/src/Grids/latitude_longitude_grid.jl
@@ -2,7 +2,7 @@ using KernelAbstractions: @kernel, @index
 using OrderedCollections: OrderedDict
 
 struct LatitudeLongitudeGrid{FT, TX, TY, TZ, Z, DXF, DXC, XF, XC, DYF, DYC, YF, YC,
-                             DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I} <: AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Z, Arch}
+                             DXCC, DXFC, DXCF, DXFF, DYFC, DYCF, Arch, I, Sz} <: AbstractHorizontallyCurvilinearGrid{FT, TX, TY, TZ, Z, Arch}
     architecture :: Arch
     Nx :: I
     Ny :: I
@@ -57,20 +57,32 @@ function LatitudeLongitudeGrid{TX, TY, TZ}(architecture::Arch,
                                                                 DXFC, DXCF,
                                                                 DXFF, DXCC,
                                                                 DYFC, DYCF, I}
-
+    size = GridSize(Nλ, Nφ, Nz, Hλ, Hφ, Hz)
+    SZ   = typeof(size)
     return LatitudeLongitudeGrid{FT, TX, TY, TZ, Z,
                                  DXF, DXC, XF, XC,
                                  DYF, DYC, YF, YC,
                                  DXCC, DXFC, DXCF, DXFF,
-                                 DYFC, DYCF, Arch, I}(architecture,
-                                                      Nλ, Nφ, Nz,
-                                                      Hλ, Hφ, Hz,
-                                                      Lλ, Lφ, Lz,
-                                                      Δλᶠᵃᵃ, Δλᶜᵃᵃ, λᶠᵃᵃ, λᶜᵃᵃ,
-                                                      Δφᵃᶠᵃ, Δφᵃᶜᵃ, φᵃᶠᵃ, φᵃᶜᵃ, z,
-                                                      Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
-                                                      Δyᶠᶜᵃ, Δyᶜᶠᵃ,
-                                                      Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, radius)
+                                 DYFC, DYCF, Arch, I, SZ}(architecture,
+                                                          Nλ, Nφ, Nz,
+                                                          Hλ, Hφ, Hz,
+                                                          Lλ, Lφ, Lz,
+                                                          Δλᶠᵃᵃ, Δλᶜᵃᵃ, λᶠᵃᵃ, λᶜᵃᵃ,
+                                                          Δφᵃᶠᵃ, Δφᵃᶜᵃ, φᵃᶠᵃ, φᵃᶜᵃ, z,
+                                                          Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
+                                                          Δyᶠᶜᵃ, Δyᶜᶠᵃ,
+                                                          Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ, radius)
+end
+
+# Read size and halo from the trailing `GridSize` type parameter so both are compile-time constants.
+@generated function Base.size(grid::LatitudeLongitudeGrid)
+    sz = grid.parameters[end].parameters
+    return :(($(sz[1]), $(sz[2]), $(sz[3])))
+end
+
+@generated function halo_size(grid::LatitudeLongitudeGrid)
+    sz = grid.parameters[end].parameters
+    return :(($(sz[4]), $(sz[5]), $(sz[6])))
 end
 
 const LLG = LatitudeLongitudeGrid

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -1,6 +1,6 @@
 const AHCG = AbstractHorizontallyCurvilinearGrid
 
-struct OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, FT2} <: AHCG{FT, TX, TY, TZ, Z, Arch}
+struct OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, FT2, Sz} <: AHCG{FT, TX, TY, TZ, Z, Arch}
     architecture :: Arch
        Nx :: Int
        Ny :: Int
@@ -47,17 +47,31 @@ function OrthogonalSphericalShellGrid{FT, TX, TY, TZ}(architecture::Arch,
                                                   radius :: FT2,
                                                   conformal_mapping :: Map) where {TX, TY, TZ, FT, Z, Map,
                                                                                    CC, FC, CF, FF, Arch, FT2}
-    return OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, FT2}(architecture,
-                                                  Nx, Ny, Nz,
-                                                  Hx, Hy, Hz,
-                                                  Lz,
-                                                   λᶜᶜᵃ,  λᶠᶜᵃ,  λᶜᶠᵃ,  λᶠᶠᵃ,
-                                                   φᶜᶜᵃ,  φᶠᶜᵃ,  φᶜᶠᵃ,  φᶠᶠᵃ, z,
-                                                  Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
-                                                  Δyᶜᶜᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Δyᶠᶠᵃ,
-                                                  Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ,
-                                                  radius,
-                                                  conformal_mapping)
+    size = GridSize(Nx, Ny, Nz, Hx, Hy, Hz)
+    SZ   = typeof(size)
+
+    return OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, FT2, SZ}(architecture,
+                                                                                               Nx, Ny, Nz,
+                                                                                               Hx, Hy, Hz,
+                                                                                               Lz,
+                                                                                                λᶜᶜᵃ,  λᶠᶜᵃ,  λᶜᶠᵃ,  λᶠᶠᵃ,
+                                                                                                φᶜᶜᵃ,  φᶠᶜᵃ,  φᶜᶠᵃ,  φᶠᶠᵃ, z,
+                                                                                               Δxᶜᶜᵃ, Δxᶠᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
+                                                                                               Δyᶜᶜᵃ, Δyᶠᶜᵃ, Δyᶜᶠᵃ, Δyᶠᶠᵃ,
+                                                                                               Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ,
+                                                                                               radius,
+                                                                                               conformal_mapping)
+end
+
+# Read size and halo from the trailing `GridSize` type parameter so both are compile-time constants.
+@generated function Base.size(grid::OrthogonalSphericalShellGrid)
+    sz = grid.parameters[end].parameters
+    return :(($(sz[1]), $(sz[2]), $(sz[3])))
+end
+
+@generated function halo_size(grid::OrthogonalSphericalShellGrid)
+    sz = grid.parameters[end].parameters
+    return :(($(sz[4]), $(sz[5]), $(sz[6])))
 end
 
 function OrthogonalSphericalShellGrid{TX, TY, TZ}(architecture::Arch,

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -63,7 +63,6 @@ function OrthogonalSphericalShellGrid{FT, TX, TY, TZ}(architecture::Arch,
                                                                                                conformal_mapping)
 end
 
-# Read size and halo from the trailing `GridSize` type parameter so both are compile-time constants.
 @generated function Base.size(grid::OrthogonalSphericalShellGrid)
     sz = grid.parameters[end].parameters
     return :(($(sz[1]), $(sz[2]), $(sz[3])))

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -1,6 +1,6 @@
 const AHCG = AbstractHorizontallyCurvilinearGrid
 
-struct OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, FT2, Sz} <: AHCG{FT, TX, TY, TZ, Z, Arch}
+struct OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, FT2, SZ} <: AHCG{FT, TX, TY, TZ, Z, Arch, SZ}
     architecture :: Arch
        Nx :: Int
        Ny :: Int
@@ -60,20 +60,6 @@ function OrthogonalSphericalShellGrid{FT, TX, TY, TZ, SZ}(architecture::Arch,
                                                                                                Azᶜᶜᵃ, Azᶠᶜᵃ, Azᶜᶠᵃ, Azᶠᶠᵃ,
                                                                                                radius,
                                                                                                conformal_mapping)
-end
-
-@generated function Base.size(grid::OrthogonalSphericalShellGrid)
-    Sz = grid.parameters[end]
-    Sz === Nothing && return :(map(Int, (grid.Nx, grid.Ny, grid.Nz)))
-    sz = Sz.parameters
-    return :(($(sz[1]), $(sz[2]), $(sz[3])))
-end
-
-@generated function halo_size(grid::OrthogonalSphericalShellGrid)
-    Sz = grid.parameters[end]
-    Sz === Nothing && return :(map(Int, (grid.Hx, grid.Hy, grid.Hz)))
-    sz = Sz.parameters
-    return :(($(sz[4]), $(sz[5]), $(sz[6])))
 end
 
 function OrthogonalSphericalShellGrid{TX, TY, TZ}(architecture::Arch,

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -34,22 +34,21 @@ struct OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch
     conformal_mapping :: Map
 end
 
+OrthogonalSphericalShellGrid{FT, TX, TY, TZ}(arch, Nx, Ny, Nz, Hx, Hy, Hz, args...) where {FT, TX, TY, TZ} =
+    OrthogonalSphericalShellGrid{FT, TX, TY, TZ, typeof(GridSize(Nx, Ny, Nz, Hx, Hy, Hz))}(arch, Nx, Ny, Nz, Hx, Hy, Hz, args...)
 
-function OrthogonalSphericalShellGrid{FT, TX, TY, TZ}(architecture::Arch,
-                                                  Nx, Ny, Nz,
-                                                  Hx, Hy, Hz,
-                                                  Lz :: FT2,
-                                                   λᶜᶜᵃ :: CC,  λᶠᶜᵃ :: FC,  λᶜᶠᵃ :: CF,  λᶠᶠᵃ :: FF,
-                                                   φᶜᶜᵃ :: CC,  φᶠᶜᵃ :: FC,  φᶜᶠᵃ :: CF,  φᶠᶠᵃ :: FF, z :: Z,
-                                                  Δxᶜᶜᵃ :: CC, Δxᶠᶜᵃ :: FC, Δxᶜᶠᵃ :: CF, Δxᶠᶠᵃ :: FF,
-                                                  Δyᶜᶜᵃ :: CC, Δyᶠᶜᵃ :: FC, Δyᶜᶠᵃ :: CF, Δyᶠᶠᵃ :: FF,
-                                                  Azᶜᶜᵃ :: CC, Azᶠᶜᵃ :: FC, Azᶜᶠᵃ :: CF, Azᶠᶠᵃ :: FF,
-                                                  radius :: FT2,
-                                                  conformal_mapping :: Map) where {TX, TY, TZ, FT, Z, Map,
-                                                                                   CC, FC, CF, FF, Arch, FT2}
-    size = GridSize(Nx, Ny, Nz, Hx, Hy, Hz)
-    SZ   = typeof(size)
-
+function OrthogonalSphericalShellGrid{FT, TX, TY, TZ, SZ}(architecture::Arch,
+                                                          Nx, Ny, Nz,
+                                                          Hx, Hy, Hz,
+                                                          Lz :: FT2,
+                                                           λᶜᶜᵃ :: CC,  λᶠᶜᵃ :: FC,  λᶜᶠᵃ :: CF,  λᶠᶠᵃ :: FF,
+                                                           φᶜᶜᵃ :: CC,  φᶠᶜᵃ :: FC,  φᶜᶠᵃ :: CF,  φᶠᶠᵃ :: FF, z :: Z,
+                                                          Δxᶜᶜᵃ :: CC, Δxᶠᶜᵃ :: FC, Δxᶜᶠᵃ :: CF, Δxᶠᶠᵃ :: FF,
+                                                          Δyᶜᶜᵃ :: CC, Δyᶠᶜᵃ :: FC, Δyᶜᶠᵃ :: CF, Δyᶠᶠᵃ :: FF,
+                                                          Azᶜᶜᵃ :: CC, Azᶠᶜᵃ :: FC, Azᶜᶠᵃ :: CF, Azᶠᶠᵃ :: FF,
+                                                          radius :: FT2,
+                                                          conformal_mapping :: Map) where {SZ, TX, TY, TZ, FT, Z, Map,
+                                                                                           CC, FC, CF, FF, Arch, FT2}
     return OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Z, Map, CC, FC, CF, FF, Arch, FT2, SZ}(architecture,
                                                                                                Nx, Ny, Nz,
                                                                                                Hx, Hy, Hz,
@@ -64,12 +63,16 @@ function OrthogonalSphericalShellGrid{FT, TX, TY, TZ}(architecture::Arch,
 end
 
 @generated function Base.size(grid::OrthogonalSphericalShellGrid)
-    sz = grid.parameters[end].parameters
+    Sz = grid.parameters[end]
+    Sz === Nothing && return :(map(Int, (grid.Nx, grid.Ny, grid.Nz)))
+    sz = Sz.parameters
     return :(($(sz[1]), $(sz[2]), $(sz[3])))
 end
 
 @generated function halo_size(grid::OrthogonalSphericalShellGrid)
-    sz = grid.parameters[end].parameters
+    Sz = grid.parameters[end]
+    Sz === Nothing && return :(map(Int, (grid.Hx, grid.Hy, grid.Hz)))
+    sz = Sz.parameters
     return :(($(sz[4]), $(sz[5]), $(sz[6])))
 end
 
@@ -312,20 +315,19 @@ function Architectures.on_architecture(arch::AbstractSerialArchitecture, grid::O
     return new_grid
 end
 
-function Adapt.adapt_structure(to, grid::OrthogonalSphericalShellGrid)
-    TX, TY, TZ = topology(grid)
-
-    return OrthogonalSphericalShellGrid{TX, TY, TZ}(
-        nothing,
-        grid.Nx, grid.Ny, grid.Nz,
-        grid.Hx, grid.Hy, grid.Hz,
-        adapt(to, grid.Lz),
-        adapt(to,  grid.λᶜᶜᵃ), adapt(to,  grid.λᶠᶜᵃ), adapt(to,  grid.λᶜᶠᵃ), adapt(to,  grid.λᶠᶠᵃ),
-        adapt(to,  grid.φᶜᶜᵃ), adapt(to,  grid.φᶠᶜᵃ), adapt(to,  grid.φᶜᶠᵃ), adapt(to,  grid.φᶠᶠᵃ), adapt(to, grid.z),
-        adapt(to, grid.Δxᶜᶜᵃ), adapt(to, grid.Δxᶠᶜᵃ), adapt(to, grid.Δxᶜᶠᵃ), adapt(to, grid.Δxᶠᶠᵃ),
-        adapt(to, grid.Δyᶜᶜᵃ), adapt(to, grid.Δyᶠᶜᵃ), adapt(to, grid.Δyᶜᶠᵃ), adapt(to, grid.Δyᶠᶠᵃ),
-        adapt(to, grid.Azᶜᶜᵃ), adapt(to, grid.Azᶠᶜᵃ), adapt(to, grid.Azᶜᶠᵃ), adapt(to, grid.Azᶠᶠᵃ),
-        adapt(to, grid.radius), adapt(to, grid.conformal_mapping))
+function Adapt.adapt_structure(to, grid::OrthogonalSphericalShellGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
+    return OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Nothing}(nothing,
+           grid.Nx, grid.Ny, grid.Nz,
+           grid.Hx, grid.Hy, grid.Hz,
+           Adapt.adapt(to, grid.Lz),
+           Adapt.adapt(to, grid.λᶜᶜᵃ), Adapt.adapt(to, grid.λᶠᶜᵃ), Adapt.adapt(to, grid.λᶜᶠᵃ), Adapt.adapt(to, grid.λᶠᶠᵃ),
+           Adapt.adapt(to, grid.φᶜᶜᵃ), Adapt.adapt(to, grid.φᶠᶜᵃ), Adapt.adapt(to, grid.φᶜᶠᵃ), Adapt.adapt(to, grid.φᶠᶠᵃ),
+           Adapt.adapt(to, grid.z),
+           Adapt.adapt(to, grid.Δxᶜᶜᵃ), Adapt.adapt(to, grid.Δxᶠᶜᵃ), Adapt.adapt(to, grid.Δxᶜᶠᵃ), Adapt.adapt(to, grid.Δxᶠᶠᵃ),
+           Adapt.adapt(to, grid.Δyᶜᶜᵃ), Adapt.adapt(to, grid.Δyᶠᶜᵃ), Adapt.adapt(to, grid.Δyᶜᶠᵃ), Adapt.adapt(to, grid.Δyᶠᶠᵃ),
+           Adapt.adapt(to, grid.Azᶜᶜᵃ), Adapt.adapt(to, grid.Azᶠᶜᵃ), Adapt.adapt(to, grid.Azᶜᶠᵃ), Adapt.adapt(to, grid.Azᶠᶠᵃ),
+           Adapt.adapt(to, grid.radius),
+           Adapt.adapt(to, grid.conformal_mapping))
 end
 
 function Base.summary(grid::OrthogonalSphericalShellGrid)

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -1,6 +1,6 @@
 using OrderedCollections: OrderedDict
 
-struct RectilinearGrid{FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, Sz} <: AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch}
+struct RectilinearGrid{FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, SZ} <: AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch, SZ}
     architecture :: Arch
     Nx :: Int
     Ny :: Int
@@ -40,20 +40,6 @@ function RectilinearGrid{TX, TY, TZ, SZ}(arch::Arch, Nx, Ny, Nz, Hx, Hy, Hz,
                                                                          Hx, Hy, Hz, Lx, Ly, Lz,
                                                                          Δxᶠᵃᵃ, Δxᶜᵃᵃ, xᶠᵃᵃ, xᶜᵃᵃ,
                                                                          Δyᵃᶠᵃ, Δyᵃᶜᵃ, yᵃᶠᵃ, yᵃᶜᵃ, z)
-end
-
-@generated function Base.size(grid::RectilinearGrid)
-    Sz = grid.parameters[end]
-    Sz === Nothing && return :(map(Int, (grid.Nx, grid.Ny, grid.Nz)))
-    sz = Sz.parameters
-    return :(($(sz[1]), $(sz[2]), $(sz[3])))
-end
-
-@generated function halo_size(grid::RectilinearGrid)
-    Sz = grid.parameters[end]
-    Sz === Nothing && return :(map(Int, (grid.Hx, grid.Hy, grid.Hz)))
-    sz = Sz.parameters
-    return :(($(sz[4]), $(sz[5]), $(sz[6])))
 end
 
 const RG = RectilinearGrid

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -43,7 +43,6 @@ function RectilinearGrid{TX, TY, TZ}(arch::Arch, Nx, Ny, Nz, Hx, Hy, Hz,
                                                          Δyᵃᶠᵃ, Δyᵃᶜᵃ, yᵃᶠᵃ, yᵃᶜᵃ, z)
 end
 
-# Read size and halo from the trailing `GridSize` type parameter so both are compile-time constants.
 @generated function Base.size(grid::RectilinearGrid)
     sz = grid.parameters[end].parameters
     return :(($(sz[1]), $(sz[2]), $(sz[3])))

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -1,6 +1,6 @@
 using OrderedCollections: OrderedDict
 
-struct RectilinearGrid{FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch} <: AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch}
+struct RectilinearGrid{FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, Sz} <: AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch}
     architecture :: Arch
     Nx :: Int
     Ny :: Int
@@ -33,11 +33,25 @@ function RectilinearGrid{TX, TY, TZ}(arch::Arch, Nx, Ny, Nz, Hx, Hy, Hz,
                                       z    :: CZ) where {Arch, FT, TX, TY, TZ,
                                                          FX, VX, FY, VY, CZ}
 
+    size = GridSize(Nx, Ny, Nz, Hx, Hy, Hz)
+    SZ   = typeof(size)
+
     return RectilinearGrid{FT, TX, TY, TZ,
-                           CZ, FX, FY, VX, VY, Arch}(arch, Nx, Ny, Nz,
-                                                     Hx, Hy, Hz, Lx, Ly, Lz,
-                                                     Δxᶠᵃᵃ, Δxᶜᵃᵃ, xᶠᵃᵃ, xᶜᵃᵃ,
-                                                     Δyᵃᶠᵃ, Δyᵃᶜᵃ, yᵃᶠᵃ, yᵃᶜᵃ, z)
+                           CZ, FX, FY, VX, VY, Arch, SZ}(arch, Nx, Ny, Nz,
+                                                         Hx, Hy, Hz, Lx, Ly, Lz,
+                                                         Δxᶠᵃᵃ, Δxᶜᵃᵃ, xᶠᵃᵃ, xᶜᵃᵃ,
+                                                         Δyᵃᶠᵃ, Δyᵃᶜᵃ, yᵃᶠᵃ, yᵃᶜᵃ, z)
+end
+
+# Read size and halo from the trailing `GridSize` type parameter so both are compile-time constants.
+@generated function Base.size(grid::RectilinearGrid)
+    sz = grid.parameters[end].parameters
+    return :(($(sz[1]), $(sz[2]), $(sz[3])))
+end
+
+@generated function halo_size(grid::RectilinearGrid)
+    sz = grid.parameters[end].parameters
+    return :(($(sz[4]), $(sz[5]), $(sz[6])))
 end
 
 const RG = RectilinearGrid

--- a/src/Grids/rectilinear_grid.jl
+++ b/src/Grids/rectilinear_grid.jl
@@ -24,32 +24,35 @@ struct RectilinearGrid{FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, Sz} <: Abstract
     z     :: CZ
 end
 
-function RectilinearGrid{TX, TY, TZ}(arch::Arch, Nx, Ny, Nz, Hx, Hy, Hz,
-                                     Lx :: FT, Ly :: FT, Lz :: FT,
-                                     Δxᶠᵃᵃ :: FX, Δxᶜᵃᵃ :: FX,
-                                      xᶠᵃᵃ :: VX,  xᶜᵃᵃ :: VX,
-                                     Δyᵃᶠᵃ :: FY, Δyᵃᶜᵃ :: FY,
-                                      yᵃᶠᵃ :: VY,  yᵃᶜᵃ :: VY,
-                                      z    :: CZ) where {Arch, FT, TX, TY, TZ,
-                                                         FX, VX, FY, VY, CZ}
+RectilinearGrid{TX, TY, TZ}(arch, Nx, Ny, Nz, Hx, Hy, Hz, args...) where {TX, TY, TZ} =
+    RectilinearGrid{TX, TY, TZ, typeof(GridSize(Nx, Ny, Nz, Hx, Hy, Hz))}(arch, Nx, Ny, Nz, Hx, Hy, Hz, args...)
 
-    size = GridSize(Nx, Ny, Nz, Hx, Hy, Hz)
-    SZ   = typeof(size)
+function RectilinearGrid{TX, TY, TZ, SZ}(arch::Arch, Nx, Ny, Nz, Hx, Hy, Hz,
+                                         Lx :: FT, Ly :: FT, Lz :: FT,
+                                         Δxᶠᵃᵃ :: FX, Δxᶜᵃᵃ :: FX,
+                                          xᶠᵃᵃ :: VX,  xᶜᵃᵃ :: VX,
+                                         Δyᵃᶠᵃ :: FY, Δyᵃᶜᵃ :: FY,
+                                          yᵃᶠᵃ :: VY,  yᵃᶜᵃ :: VY,
+                                          z    :: CZ) where {SZ, Arch, FT, TX, TY, TZ,
+                                                             FX, VX, FY, VY, CZ}
 
-    return RectilinearGrid{FT, TX, TY, TZ,
-                           CZ, FX, FY, VX, VY, Arch, SZ}(arch, Nx, Ny, Nz,
-                                                         Hx, Hy, Hz, Lx, Ly, Lz,
-                                                         Δxᶠᵃᵃ, Δxᶜᵃᵃ, xᶠᵃᵃ, xᶜᵃᵃ,
-                                                         Δyᵃᶠᵃ, Δyᵃᶜᵃ, yᵃᶠᵃ, yᵃᶜᵃ, z)
+    return RectilinearGrid{FT, TX, TY, TZ, CZ, FX, FY, VX, VY, Arch, SZ}(arch, Nx, Ny, Nz,
+                                                                         Hx, Hy, Hz, Lx, Ly, Lz,
+                                                                         Δxᶠᵃᵃ, Δxᶜᵃᵃ, xᶠᵃᵃ, xᶜᵃᵃ,
+                                                                         Δyᵃᶠᵃ, Δyᵃᶜᵃ, yᵃᶠᵃ, yᵃᶜᵃ, z)
 end
 
 @generated function Base.size(grid::RectilinearGrid)
-    sz = grid.parameters[end].parameters
+    Sz = grid.parameters[end]
+    Sz === Nothing && return :(map(Int, (grid.Nx, grid.Ny, grid.Nz)))
+    sz = Sz.parameters
     return :(($(sz[1]), $(sz[2]), $(sz[3])))
 end
 
 @generated function halo_size(grid::RectilinearGrid)
-    sz = grid.parameters[end].parameters
+    Sz = grid.parameters[end]
+    Sz === Nothing && return :(map(Int, (grid.Hx, grid.Hy, grid.Hz)))
+    sz = Sz.parameters
     return :(($(sz[4]), $(sz[5]), $(sz[6])))
 end
 
@@ -380,7 +383,7 @@ validate_halo(TX, TY, TZ, size, e::ColumnEnsembleSize) = tuple(0, 0, e.Hz)
 
 function Adapt.adapt_structure(to, grid::RectilinearGrid)
     TX, TY, TZ = topology(grid)
-    return RectilinearGrid{TX, TY, TZ}(nothing,
+    return RectilinearGrid{TX, TY, TZ, Nothing}(nothing,
                                        grid.Nx, grid.Ny, grid.Nz,
                                        grid.Hx, grid.Hy, grid.Hz,
                                        grid.Lx, grid.Ly, grid.Lz,

--- a/src/ImmersedBoundaries/immersed_boundary_grid.jl
+++ b/src/ImmersedBoundaries/immersed_boundary_grid.jl
@@ -7,7 +7,7 @@ Abstract supertype for immersed boundary grids.
 """
 abstract type AbstractImmersedBoundary end
 
-struct ImmersedBoundaryGrid{FT, TX, TY, TZ, G, I, M, S, Arch} <: AbstractGrid{FT, TX, TY, TZ, Arch}
+struct ImmersedBoundaryGrid{FT, TX, TY, TZ, G, I, M, S, Arch} <: AbstractGrid{FT, TX, TY, TZ, Arch, Nothing}
     architecture :: Arch
     underlying_grid :: G
     immersed_boundary :: I

--- a/src/ImmersedBoundaries/immersed_boundary_grid.jl
+++ b/src/ImmersedBoundaries/immersed_boundary_grid.jl
@@ -89,6 +89,9 @@ const IBG = ImmersedBoundaryGrid
 
 @inline architecture(ibg::IBG) = architecture(ibg.underlying_grid)
 
+@inline Base.size(ibg::IBG) = size(ibg.underlying_grid)
+@inline Grids.halo_size(ibg::IBG) = halo_size(ibg.underlying_grid)
+
 @inline x_domain(ibg::IBG) = x_domain(ibg.underlying_grid)
 @inline y_domain(ibg::IBG) = y_domain(ibg.underlying_grid)
 @inline z_domain(ibg::IBG) = z_domain(ibg.underlying_grid)

--- a/src/MultiRegion/MultiRegion.jl
+++ b/src/MultiRegion/MultiRegion.jl
@@ -21,7 +21,7 @@ using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 using Oceananigans.Utils: KernelParameters, Iterate, MultiRegionObject, Reference, Utils,
     @apply_regionally, apply_regionally!, construct_regionally, isregional, getregion, _getregion, regions
 
-abstract type AbstractMultiRegionGrid{FT, TX, TY, TZ, Arch} <: AbstractGrid{FT, TX, TY, TZ, Arch} end
+abstract type AbstractMultiRegionGrid{FT, TX, TY, TZ, Arch, SZ} <: AbstractGrid{FT, TX, TY, TZ, Arch, SZ} end
 
 abstract type AbstractPartition end
 

--- a/src/MultiRegion/multi_region_grid.jl
+++ b/src/MultiRegion/multi_region_grid.jl
@@ -13,7 +13,7 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces
                                                                                   FixedTimeStepSize,
                                                                                   maybe_augmented_kernel_parameters
 
-struct MultiRegionGrid{FT, TX, TY, TZ, CZ, P, C, G, Arch} <: AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch}
+struct MultiRegionGrid{FT, TX, TY, TZ, CZ, P, C, G, Arch} <: AbstractUnderlyingGrid{FT, TX, TY, TZ, CZ, Arch, Nothing}
     architecture :: Arch
     partition :: P
     connectivity :: C

--- a/src/OrthogonalSphericalShellGrids/right_face_folded_kernel_parameters.jl
+++ b/src/OrthogonalSphericalShellGrids/right_face_folded_kernel_parameters.jl
@@ -29,4 +29,7 @@ const RFTRG = TripolarGridOfSomeKind{<:Any, <:Any, <:RightFaceFolded}
 ##### and the active cells maps which use `worksize` to find all the active indices
 #####
 
-Utils.worksize(grid::RFTRG) = grid.Nx, grid.Ny+1, grid.Nz
+@inline function Utils.worksize(grid::RFTRG)
+    Nx, Ny, Nz = size(grid)
+    return Nx, Ny+1, Nz
+end

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -312,20 +312,24 @@ keyword arguments `kw`.
     _launch!(arch, grid, workspec, args...; kwargs...)
 
 @inline function launch!(arch, grid, workspec_tuple::Tuple, args...; kwargs...)
-    for workspec in workspec_tuple
-        _launch!(arch, grid, workspec, args...; kwargs...)
-    end
+    _launch!(arch, grid, first(workspec_tuple), args...; kwargs...)
+    launch!(arch, grid, Base.tail(workspec_tuple), args...; kwargs...)
     return nothing
 end
 
-# launching with an empty tuple has no effect
-@inline function launch!(arch, grid, workspec_tuple::Tuple{}, kernel, args...; kwargs...)
-    @warn "trying to launch kernel $kernel with workspec == (). The kernel will not be launched."
-    return nothing
-end
+@inline launch!(arch, grid, ::Tuple{}, args...; kwargs...) = nothing
 
 @inline launch!(arch, grid, workspec::Symbol, args...; kw...) = _launch!(arch, grid, Val(workspec), args...; kw...)
 @inline launch!(arch, grid, workspec::Val,    args...; kw...) = _launch!(arch, grid, workspec, args...; kw...)
+
+@inline launch_split_maps!(::Tuple{}, args...; kw...) = nothing
+
+@inline function launch_split_maps!(maps::Tuple, arch, grid, workspec, kernel!, first_kernel_arg, other_kernel_args...; exclude_periphery = false, reduced_dimensions = ())
+    cells_map = first(maps)
+    isnothing(cells_map) || _launch!(arch, grid, workspec, kernel!, first_kernel_arg, other_kernel_args...; exclude_periphery, reduced_dimensions, active_cells_map = cells_map)
+    launch_split_maps!(Base.tail(maps), arch, grid, workspec, kernel!, first_kernel_arg, other_kernel_args...; exclude_periphery, reduced_dimensions)
+    return nothing
+end
 
 # Inner interface
 @inline function _launch!(arch, grid, workspec, kernel!, first_kernel_arg, other_kernel_args...;
@@ -335,15 +339,9 @@ end
 
     active_map = possibly_load_active_cells_map(active_cells_map, grid, workspec, exclude_periphery)
 
-    # When active_cells_map is a NamedTuple (distributed grids with split maps),
-    # launch once for each non-nothing sub-map.
+    # When active_cells_map is a NamedTuple (distributed grids with split maps), launch once for each non-nothing sub-map.
     if active_map isa NamedTuple
-        for map in active_map
-            if !isnothing(map)
-                _launch!(arch, grid, workspec, kernel!, first_kernel_arg, other_kernel_args...;
-                         exclude_periphery, reduced_dimensions, active_cells_map = map)
-            end
-        end
+        launch_split_maps!(values(active_map), arch, grid, workspec, kernel!, first_kernel_arg, other_kernel_args...; exclude_periphery, reduced_dimensions)
         return nothing
     end
 

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -140,7 +140,7 @@ periphery_offset(loc, grid, side) = 0
 
 # Returns the default worksize given a particular grid
 # defaults to the size of the grid.
-worksize(grid) = size(grid)
+@inline worksize(grid) = size(grid)
 
 """
 $(TYPEDSIGNATURES)

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -152,37 +152,24 @@ dimension. The `worksize` specifies the range of the loop in each dimension.
 
 For more information, see: https://github.com/CliMA/Oceananigans.jl/pull/308
 """
-@inline function interior_work_layout(grid, workdims::Symbol, (LX, LY, LZ))
+@inline select_dims(::Val{:xyz}, x, y, z) = (x, y, z)
+@inline select_dims(::Val{:xy},  x, y, z) = (x, y)
+@inline select_dims(::Val{:xz},  x, y, z) = (x, z)
+@inline select_dims(::Val{:yz},  x, y, z) = (y, z)
+
+@inline function interior_work_layout(grid, workdims::Val, (ℓx, ℓy, ℓz))
     Fx, Fy, Fz = worksize(grid)
 
-    # just an example for :xyz
-    ℓx = instantiate(LX)
-    ℓy = instantiate(LY)
-    ℓz = instantiate(LZ)
+    ox = periphery_offset(ℓx, grid, Val(1))
+    oy = periphery_offset(ℓy, grid, Val(2))
+    oz = periphery_offset(ℓz, grid, Val(3))
 
-    # Offsets
-    ox = periphery_offset(ℓx, grid, 1)
-    oy = periphery_offset(ℓy, grid, 2)
-    oz = periphery_offset(ℓz, grid, 3)
-
-    # Worksize
     Wx, Wy, Wz = (Fx-ox, Fy-oy, Fz-oz)
-    workgroup = heuristic_workgroup(Wx, Wy, Wz)
-    workgroup = StaticSize(workgroup)
+    workgroup = StaticSize(heuristic_workgroup(Wx, Wy, Wz))
 
-    # Adapt to workdims
-    _worksize = ifelse(workdims == :xyz, (Wx, Wy, Wz),
-                ifelse(workdims == :xy,  (Wx, Wy),
-                ifelse(workdims == :xz,  (Wx, Wz), (Wy, Wz))))
+    range = contiguousrange(select_dims(workdims, Wx, Wy, Wz), select_dims(workdims, ox, oy, oz))
 
-    offsets = ifelse(workdims == :xyz, (ox, oy, oz),
-              ifelse(workdims == :xy,  (ox, oy),
-              ifelse(workdims == :xz,  (ox, oz), (oy, oz))))
-
-    range = contiguousrange(_worksize, offsets)
-    _worksize = OffsetStaticSize(range)
-
-    return workgroup, _worksize
+    return workgroup, OffsetStaticSize(range)
 end
 
 """
@@ -194,28 +181,19 @@ dimension. The `worksize` specifies the range of the loop in each dimension.
 
 For more information, see: https://github.com/CliMA/Oceananigans.jl/pull/308
 """
-@inline function work_layout(grid, workdims::Symbol, reduced_dimensions)
+@inline function work_layout(grid, workdims::Val, reduced_dimensions)
     Fx, Fy, Fz = worksize(grid)
     Wx, Wy, Wz = flatten_reduced_dimensions((Fx, Fy, Fz), reduced_dimensions) # this seems to be for halo filling
     workgroup  = heuristic_workgroup(Wx, Wy, Wz)
-
-    _worksize = ifelse(workdims == :xyz, (Wx, Wy, Wz),
-                ifelse(workdims == :xy,  (Wx, Wy),
-                ifelse(workdims == :xz,  (Wx, Wz),
-                                         (Wy, Wz))))
-
-    return StaticSize(workgroup), StaticSize(_worksize)
+    return StaticSize(workgroup), StaticSize(select_dims(workdims, Wx, Wy, Wz))
 end
+
+@inline work_layout(grid, workdims::Symbol, reduced_dimensions) = work_layout(grid, Val(workdims), reduced_dimensions)
+@inline interior_work_layout(grid, workdims::Symbol, location) = interior_work_layout(grid, Val(workdims), location)
 
 @inline function work_layout(grid, worksize::NTuple{N, Int}, reduced_dimensions) where N
     workgroup = heuristic_workgroup(worksize...)
     return StaticSize(workgroup), StaticSize(worksize)
-end
-
-@inline function work_layout(active_cells_map::AbstractArray)
-    length_map = length(active_cells_map)
-    workgroup = min(length_map, 256)
-    return StaticSize(workgroup), StaticSize(length_map)
 end
 
 @inline function offset_work_layout(grid, ::KernelParameters{spec, offsets}, reduced_dimensions) where {spec, offsets}
@@ -251,6 +229,9 @@ Keyword Arguments
                       the kernel is configured as a linear kernel with a worksize equal to the length of the active cell map. Default is `nothing`.
 - `exclude_periphery`: A boolean indicating whether to exclude the periphery, used only for interior kernels.
 """
+@inline configure_kernel(arch, grid, workspec::Symbol, kernel!; kwargs...) =
+    configure_kernel(arch, grid, Val(workspec), kernel!; kwargs...)
+
 @inline function configure_kernel(arch, grid, workspec, kernel!;
                                   active_cells_map = nothing,
                                   exclude_periphery = false,
@@ -275,7 +256,7 @@ end
 end
 
 # With a "true" exclude_periphery, we use the `interior_work_layout` function
-@inline function configure_kernel(arch, grid, workspec::Symbol, kernel!, ::Nothing, ::Val{true};
+@inline function configure_kernel(arch, grid, workspec::Val, kernel!, ::Nothing, ::Val{true};
                                   reduced_dimensions = (),
                                   location = nothing)
 
@@ -300,15 +281,13 @@ end
 # When there is an active_cells_map, we use the `mapped_kernel` function
 @inline function configure_kernel(arch, grid, workspec, kernel!, active_cells_map::AbstractArray, args...; kwargs...)
 
-    workgroup, worksize = work_layout(active_cells_map)
-
     dev  = Architectures.device(arch)
-    loop = kernel!(dev, workgroup, worksize)
+    loop = kernel!(dev, StaticSize((256,)), NDIteration.DynamicSize())
 
     # Map out the function to use active_cells_map as an index map
     loop = mapped_kernel(loop, dev, active_cells_map)
 
-    return loop, worksize::StaticSize
+    return loop, active_cells_map
 end
 
 @inline function mapped_kernel(kernel::Kernel{Dev, B, W}, dev, map) where {Dev, B, W}
@@ -345,9 +324,8 @@ end
     return nothing
 end
 
-# When dims::Val
-@inline launch!(arch, grid, ::Val{workspec}, args...; kw...) where workspec =
-    _launch!(arch, grid, workspec, args...; kw...)
+@inline launch!(arch, grid, workspec::Symbol, args...; kw...) = _launch!(arch, grid, Val(workspec), args...; kw...)
+@inline launch!(arch, grid, workspec::Val,    args...; kw...) = _launch!(arch, grid, workspec, args...; kw...)
 
 # Inner interface
 @inline function _launch!(arch, grid, workspec, kernel!, first_kernel_arg, other_kernel_args...;
@@ -369,7 +347,7 @@ end
         return nothing
     end
 
-    location = Oceananigans.location(first_kernel_arg)
+    location = Oceananigans.instantiated_location(first_kernel_arg)
 
     loop!, worksize = configure_kernel(arch, grid, workspec, kernel!, active_map, Val(exclude_periphery);
                                        location,
@@ -387,19 +365,18 @@ end
 possibly_load_active_cells_map(active_cells_map, grid, workspec, exclude_periphery) = active_cells_map
 
 # If we use standard dimensions, load the corresponding map
-@inline function possibly_load_active_cells_map(::Nothing, grid, workspec::Symbol, exclude_periphery)
-    if exclude_periphery # The active cell map includes borders
-        return nothing
-    end
-
-    if workspec == :xyz
-        return get_active_cells_map(grid, Val(:xyz))
-    elseif workspec == :xy
-        return get_active_cells_map(grid, Val(:xy))
-    else
-        return nothing
-    end
+@inline function possibly_load_active_cells_map(::Nothing, grid, ::Val{:xyz}, exclude_periphery)
+    exclude_periphery && return nothing
+    return get_active_cells_map(grid, Val(:xyz))
 end
+
+@inline function possibly_load_active_cells_map(::Nothing, grid, ::Val{:xy}, exclude_periphery)
+    exclude_periphery && return nothing
+    return get_active_cells_map(grid, Val(:xy))
+end
+
+@inline possibly_load_active_cells_map(::Nothing, grid, ::Val, exclude_periphery) = nothing
+@inline possibly_load_active_cells_map(::Nothing, grid, workspec::Symbol, exclude_periphery) = possibly_load_active_cells_map(nothing, grid, Val(workspec), exclude_periphery)
 
 #####
 ##### Extension to KA for offset indices: to remove when implemented in KA
@@ -510,9 +487,17 @@ end
 ##### Utilities for Mapped kernels
 #####
 
-struct IndexMap end
+struct IndexMap{T, N, M <: AbstractArray{T, N}} <: AbstractArray{T, N}
+    index_map :: M
+end
 
-const MappedNDRange{N, B, W} = NDRange{N, B, W, <:IndexMap, <:AbstractArray} where {N, B<:StaticSize, W<:StaticSize}
+@inline Base.size(m::IndexMap) = size(m.index_map)
+@inline Base.IndexStyle(::Type{<:IndexMap{T, N, M}}) where {T, N, M} = IndexStyle(M)
+Base.@propagate_inbounds Base.getindex(m::IndexMap, I...) = m.index_map[I...]
+
+Adapt.adapt_structure(to, m::IndexMap) = IndexMap(Adapt.adapt(to, m.index_map))
+
+const MappedNDRange{N, B, W} = NDRange{N, B, W, <:Any, <:IndexMap} where {N, B, W<:StaticSize}
 
 # TODO: maybe don't do this
 # NDRange has been modified to include an index_map in place of workitems.
@@ -552,11 +537,7 @@ function partition(kernel::MappedKernel, inrange, ingroupsize)
     groupsize = get(static_workgroupsize)
 
     blocks, groupsize, dynamic = NDIteration.partition(range, groupsize)
-
-    static_blocks = StaticSize{blocks}
-    static_workgroupsize = StaticSize{groupsize} # we might have padded workgroupsize
-
-    iterspace = NDRange{length(range), static_blocks, static_workgroupsize}(IndexMap(), index_map)
+    iterspace = NDRange{1, NDIteration.DynamicSize, static_workgroupsize}(CartesianIndices(blocks), IndexMap(index_map))
 
     return iterspace, dynamic
 end
@@ -565,7 +546,7 @@ end
 ##### Extend the valid index function to check whether the index is valid in the index map
 #####
 
-const MappedCompilerMetadata{N, C} = CompilerMetadata{N, C, <:Any, <:Any, <:MappedNDRange} where {N<:StaticSize, C}
+const MappedCompilerMetadata{N, C} = CompilerMetadata{N, C, <:Any, <:Any, <:MappedNDRange} where {N, C}
 
 Adapt.adapt_structure(to, cm::MappedCompilerMetadata{N, C}) where {N, C} =
     CompilerMetadata{N, C}(Adapt.adapt(to, cm.groupindex),

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -40,42 +40,40 @@ function time_step_allocations(model, Δt; samples=10)
     return minimum(@allocated(time_step!(model, Δt)) for _ in 1:samples)
 end
 
-#TODO: Fix allocations in the nonhydrostatic model
-
 const serial_memory_cpu = Dict(
-    (:hydrostatic,    :flat)            => 1.1e6,
-    (:hydrostatic,    :immersed)        => 1.1e6,
-    (:hydrostatic,    :active_immersed) => 1.3e6,
-    (:nonhydrostatic, :flat)            => 8.7e5,
-    (:nonhydrostatic, :immersed)        => 9.8e5,
-    (:nonhydrostatic, :active_immersed) => 1.1e6,
+    (:hydrostatic,    :flat)            => 4.4e5,
+    (:hydrostatic,    :immersed)        => 4.6e5,
+    (:hydrostatic,    :active_immersed) => 5.0e3,
+    (:nonhydrostatic, :flat)            => 8.6e5,
+    (:nonhydrostatic, :immersed)        => 8.9e5,
+    (:nonhydrostatic, :active_immersed) => 6.9e5,
 )
 
 const serial_memory_gpu = Dict(
-    (:hydrostatic,    :flat)            => 2.6e6,
-    (:hydrostatic,    :immersed)        => 2.8e6,
-    (:hydrostatic,    :active_immersed) => 2.9e6,
-    (:nonhydrostatic, :flat)            => 1.9e6,
+    (:hydrostatic,    :flat)            => 2.2e6,
+    (:hydrostatic,    :immersed)        => 2.4e6,
+    (:hydrostatic,    :active_immersed) => 2.1e6,
+    (:nonhydrostatic, :flat)            => 2.0e6,
     (:nonhydrostatic, :immersed)        => 2.2e6,
-    (:nonhydrostatic, :active_immersed) => 2.3e6,
+    (:nonhydrostatic, :active_immersed) => 2.1e6,
 )
 
 const distributed_memory_cpu = Dict(
-    (:hydrostatic,    :flat)            => 8.0e6,
-    (:hydrostatic,    :immersed)        => 9.6e6,
-    (:hydrostatic,    :active_immersed) => 1.3e7,
+    (:hydrostatic,    :flat)            => 7.5e5,
+    (:hydrostatic,    :immersed)        => 8.7e5,
+    (:hydrostatic,    :active_immersed) => 9.1e5,
     (:nonhydrostatic, :flat)            => 6.6e6,
     (:nonhydrostatic, :immersed)        => 8.0e6,
     (:nonhydrostatic, :active_immersed) => 1.0e7,
 )
 
 const distributed_memory_gpu = Dict(
-    (:hydrostatic,    :flat)            => 1.5e7,
-    (:hydrostatic,    :immersed)        => 1.7e7,
-    (:hydrostatic,    :active_immersed) => 2.2e7,
-    (:nonhydrostatic, :flat)            => 1.2e7,
-    (:nonhydrostatic, :immersed)        => 1.4e7,
-    (:nonhydrostatic, :active_immersed) => 1.7e7,
+    (:hydrostatic,    :flat)            => 8.8e6,
+    (:hydrostatic,    :immersed)        => 1.0e7,
+    (:hydrostatic,    :active_immersed) => 1.2e7,
+    (:nonhydrostatic, :flat)            => 8.4e6,
+    (:nonhydrostatic, :immersed)        => 9.5e6,
+    (:nonhydrostatic, :active_immersed) => 1.2e7,
 )
 
 # For distributed this includes only (4, 1), (1, 4) and (2, 2)
@@ -87,6 +85,15 @@ archs = nonhydrostatic_regression_test_architectures()
             for (name, (build, Δt)) in pairs(Models)
                 for immersed in (:flat, :immersed, :active_immersed)
                     grid  = allocation_grid(arch; immersed_mode=immersed, size=(48, 48, 8))
+
+                    @test try
+                        wg,  ws  = @inferred work_layout(grid, :xyz, ())
+                        wg2, ws2 = @inferred interior_work_layout(grid, :xyz, (Center(), Center(), Center()))
+                        true
+                    catch
+                        false
+                    end
+
                     model = build(grid)
                     allocations = time_step_allocations(model, Δt)
                     baseline = if arch isa Distributed{<:GPU}

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -3,7 +3,7 @@ include("dependencies_for_runtests.jl")
 using Oceananigans
 using Oceananigans.TurbulenceClosures: CATKEVerticalDiffusivity
 using Oceananigans.DistributedComputations: @handshake
-using Oceananigans.Utils: pretty_filesize
+using Oceananigans.Utils: pretty_filesize, work_layout, interior_work_layout
 
 function allocation_grid(arch, FT=Float64; immersed_mode, size, extent=(1, 1, 1), halo=(7, 7, 7), topology=(Periodic, Periodic, Bounded))
     grid = RectilinearGrid(arch, FT; size, extent, halo, topology)

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -86,13 +86,8 @@ archs = nonhydrostatic_regression_test_architectures()
                 for immersed in (:flat, :immersed, :active_immersed)
                     grid  = allocation_grid(arch; immersed_mode=immersed, size=(48, 48, 8))
 
-                    @test try
-                        wg,  ws  = @inferred work_layout(grid, :xyz, ())
-                        wg2, ws2 = @inferred interior_work_layout(grid, :xyz, (Center(), Center(), Center()))
-                        true
-                    catch
-                        false
-                    end
+                    @test (@inferred work_layout(grid, Val(:xyz), ())) isa Tuple
+                    @test (@inferred interior_work_layout(grid, Val(:xyz), (Center(), Center(), Center()))) isa Tuple
 
                     model = build(grid)
                     allocations = time_step_allocations(model, Δt)


### PR DESCRIPTION
this PR is a clean extract of the workaround in PR #5729 to make sure the `launch!` function is completely type stable.
We always derive our `StaticSize` from grid size and halo size information, which then need to be compile-time constants.
By adding a `GridSize` type parameter to the grid we can always infer the `StaticSize` of kernel and then squash the type instability.

This is not possible for kernels that launch on the active cells map, but in that case, since the kernel is always 1D and the index is computed already with `length(map)` inside the `@index` macro, we can safely use a `DynamicSize`

MWE:
```julia
using Oceananigans
using Oceananigans.Utils: work_layout, interior_work_layout, configure_kernel
using KernelAbstractions.NDIteration: StaticSize
using Test

grid = RectilinearGrid(size=(8, 6, 4), halo=(2, 2, 2), extent=(1, 1, 1))
wg,  ws  = @inferred work_layout(grid,:xyz, ())
wg2, ws2 = @inferred interior_work_layout(grid, :xyz, (Center(), Center(), Center()))
```

on main:

```julia
julia> wg,  ws  = @inferred work_layout(grid,:xyz, ())
ERROR: return type Tuple{StaticSize{(16, 16)}, StaticSize{(8, 6, 4)}} does not match inferred return type Tuple{StaticSize, StaticSize}
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:44
 [2] top-level scope
   @ REPL[15]:1

julia> wg2, ws2 = @inferred interior_work_layout(grid, :xyz, (Center(), Center(), Center()))
ERROR: return type Tuple{StaticSize{(16, 16)}, Oceananigans.Utils.OffsetStaticSize{(1:8, 1:6, 1:4)}} does not match inferred return type Tuple{StaticSize, Oceananigans.Utils.OffsetStaticSize}
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:44
 [2] top-level scope
   @ REPL[16]:1
```

on this PR

```julia
julia> wg,  ws  = @inferred work_layout(grid, Val(:xyz), ())
(StaticSize{(16, 16)}(), StaticSize{(8, 6, 4)}())

julia> wg2, ws2 = @inferred interior_work_layout(grid, Val(:xyz), (Center(), Center(), Center()))
(StaticSize{(16, 16)}(), Oceananigans.Utils.OffsetStaticSize{(1:8, 1:6, 1:4)}())
```