### PR TITLE
Remove type instability in `flattened_unique_values`

### DIFF
--- a/ext/OceananigansEnzymeExt.jl
+++ b/ext/OceananigansEnzymeExt.jl
@@ -348,12 +348,10 @@ function EnzymeCore.EnzymeRules.augmented_primal(config,
     possible_fts = Oceananigans.Models.possible_field_time_series(model.val)
 
     time_series_tuple = Oceananigans.OutputReaders.extract_field_time_series(possible_fts)
-    time_series_tuple = Oceananigans.Models.flattened_unique_values(time_series_tuple)
 
     fulltape = if EnzymeCore.EnzymeRules.width(config) == 1
         dpossible_fts = Oceananigans.Models.possible_field_time_series(model.dval)
         dtime_series_tuple = Oceananigans.OutputReaders.extract_field_time_series(possible_fts)
-        dtime_series_tuple = Oceananigans.Models.flattened_unique_values(dtime_series_tuple)
 
         tapes = []
         for (fts, dfts) in zip(time_series_tuple, dtime_series_tuple)
@@ -368,7 +366,6 @@ function EnzymeCore.EnzymeRules.augmented_primal(config,
             Base.@_inline_meta
             dpossible_fts = Oceananigans.Models.possible_field_time_series(model.dval[i])
             dtime_series_tuple = Oceananigans.OutputReaders.extract_field_time_series(possible_fts)
-            dtime_series_tuple = Oceananigans.Models.flattened_unique_values(dtime_series_tuple)
 
             tapes = []
             for (fts, dfts) in zip(time_series_tuple, dtime_series_tuple)
@@ -396,12 +393,10 @@ function EnzymeCore.EnzymeRules.reverse(config,
     possible_fts = Oceananigans.Models.possible_field_time_series(model.val)
 
     time_series_tuple = Oceananigans.OutputReaders.extract_field_time_series(possible_fts)
-    time_series_tuple = Oceananigans.Models.flattened_unique_values(time_series_tuple)
 
     if EnzymeCore.EnzymeRules.width(config) == 1
         dpossible_fts = Oceananigans.Models.possible_field_time_series(model.dval)
         dtime_series_tuple = Oceananigans.OutputReaders.extract_field_time_series(dpossible_fts)
-        dtime_series_tuple = Oceananigans.Models.flattened_unique_values(dtime_series_tuple)
 
         tapes = fulltape
         i = 1
@@ -418,7 +413,6 @@ function EnzymeCore.EnzymeRules.reverse(config,
             tapes = fulltape[i]
             dpossible_fts = Oceananigans.Models.possible_field_time_series(model.dval[i])
             dtime_series_tuple = Oceananigans.OutputReaders.extract_field_time_series(dpossible_fts)
-            dtime_series_tuple = Oceananigans.Models.flattened_unique_values(dtime_series_tuple)
 
             i += 1
             for (fts, dfts) in zip(time_series_tuple, dtime_series_tuple)

--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -24,18 +24,26 @@ Return values of the (possibly nested) `NamedTuple` `a`,
 flattened into a single tuple, with duplicate entries removed.
 """
 @inline function flattened_unique_values(a::Union{NamedTuple, Tuple})
-    tupled = Tuple(tuplify(ai) for ai in a)
-    flattened = flatten_tuple(tupled)
-
-    # Alternative implementation of `unique` for tuples that uses === comparison, rather than ==
-    seen = []
-    return Tuple(last(push!(seen, f)) for f in flattened if !any(f === s for s in seen))
+    flattened = flatten_tuple(map(tuplify, values(a)))
+    return collect_unique_values(flattened, ())
 end
+
+@inline collect_unique_values(::Tuple{}, accumulated::Tuple) = accumulated
+
+@inline function collect_unique_values(remaining::Tuple, accumulated::Tuple)
+    head = first(remaining)
+    rest = Base.tail(remaining)
+    accumulated = is_contained(head, accumulated) ? accumulated : (accumulated..., head)
+    return collect_unique_values(rest, accumulated)
+end
+
+@inline is_contained(value, ::Tuple{}) = false
+@inline is_contained(value, accumulated::Tuple) = value === first(accumulated) || is_contained(value, Base.tail(accumulated))
 
 const FullField = Field{<:Any, <:Any, <:Any, <:Any, <:Any, <:Tuple{<:Colon, <:Colon, <:Colon}}
 
 # Utility for extracting values from nested NamedTuples
-@inline tuplify(a::NamedTuple) = Tuple(tuplify(ai) for ai in a)
+@inline tuplify(a::NamedTuple) = map(tuplify, values(a))
 @inline tuplify(a) = a
 
 # Outer-inner form

--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -38,6 +38,7 @@ end
 end
 
 @inline is_contained(value, ::Tuple{}) = false
+# `is_contained` verifies if an object is duplicated in the tuple, thus needing the equality `===` operator.
 @inline is_contained(value, accumulated::Tuple) = value === first(accumulated) || is_contained(value, Base.tail(accumulated))
 
 const FullField = Field{<:Any, <:Any, <:Any, <:Any, <:Any, <:Tuple{<:Colon, <:Colon, <:Colon}}

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
@@ -356,7 +356,7 @@ Base.show(io::IO, sefs::SplitExplicitFreeSurface) = print(io, "$(summary(sefs))\
 #####
 
 # Extending halos is not allowed with variable time-stepping
-function maybe_extend_halos(TX, TY, grid, ::FixedTimeStepSize) = grid
+maybe_extend_halos(TX, TY, grid, ::FixedTimeStepSize) = grid
 
 function maybe_extend_halos(TX, TY, grid, substepping::FixedSubstepNumber)
     old_halos = halo_size(grid)

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
@@ -3,7 +3,7 @@ using Oceananigans.Grids: Grids, Flat, LeftConnected, RightConnected, FullyConne
     RightCenterFolded, RightFaceFolded,
     halo_size, on_architecture, minimum_xspacing, minimum_yspacing, with_halo
 using Oceananigans.Fields: TracerFields, XFaceField, YFaceField
-using Oceananigans.Utils: prettytime
+using Oceananigans.Utils: prettytime, worksize, KernelParameters
 using Adapt: Adapt
 
 import Oceananigans: prognostic_state, restore_prognostic_state!
@@ -269,7 +269,8 @@ function materialize_free_surface(free_surface::SplitExplicitFreeSurface{extend_
     kernel_parameters = if extend_halos
         maybe_augmented_kernel_parameters(TX, TY, maybe_extended_grid, substepping)
     else
-        :xy
+        Wx, Wy, _ = worksize(grid)
+        KernelParameters((Wx, Wy), (0, 0)) # concretely typed parameters
     end
 
     gravitational_acceleration = convert(eltype(grid), free_surface.gravitational_acceleration)
@@ -355,7 +356,7 @@ Base.show(io::IO, sefs::SplitExplicitFreeSurface) = print(io, "$(summary(sefs))\
 #####
 
 # Extending halos is not allowed with variable time-stepping
-maybe_extend_halos(TX, TY, grid, ::FixedTimeStepSize) = grid
+function maybe_extend_halos(TX, TY, grid, ::FixedTimeStepSize) = grid
 
 function maybe_extend_halos(TX, TY, grid, substepping::FixedSubstepNumber)
     old_halos = halo_size(grid)
@@ -387,7 +388,10 @@ function maybe_extend_halos(TX, TY, grid, substepping::FixedSubstepNumber)
     end
 end
 
-maybe_augmented_kernel_parameters(TX, TY, grid, ::FixedTimeStepSize) = :xy
+function maybe_augmented_kernel_parameters(TX, TY, grid, ::FixedTimeStepSize)
+    Wx, Wy, _ = worksize(grid)
+    return KernelParameters((Wx, Wy), (0, 0))
+end
 
 function maybe_augmented_kernel_parameters(TX, TY, grid, ::FixedSubstepNumber)
     Nx, Ny, _ = size(grid)
@@ -398,19 +402,19 @@ function maybe_augmented_kernel_parameters(TX, TY, grid, ::FixedSubstepNumber)
     return KernelParameters(kernel_sizes...)
 end
 
-split_explicit_kernel_size(topo, N, H)                   =    1:N
-split_explicit_kernel_size(::Type{FullyConnected}, N, H) = -H+2:N+H-1
-split_explicit_kernel_size(::Type{RightConnected}, N, H) =    1:N+H-1
-split_explicit_kernel_size(::Type{LeftConnected},  N, H) = -H+2:N
+@inline split_explicit_kernel_size(topo, N, H)                   =    1:N
+@inline split_explicit_kernel_size(::Type{FullyConnected}, N, H) = -H+2:N+H-1
+@inline split_explicit_kernel_size(::Type{RightConnected}, N, H) =    1:N+H-1
+@inline split_explicit_kernel_size(::Type{LeftConnected},  N, H) = -H+2:N
 
-split_explicit_kernel_size(::Type{RightCenterFolded}, N, H) = 1:N+H-1
-split_explicit_kernel_size(::Type{RightFaceFolded}, N, H)   = 1:N+H-1
+@inline split_explicit_kernel_size(::Type{RightCenterFolded}, N, H) = 1:N+H-1
+@inline split_explicit_kernel_size(::Type{RightFaceFolded}, N, H)   = 1:N+H-1
 
 # Distributed fold topologies: connected on both sides (left=MPI, right=fold/zipper)
-split_explicit_kernel_size(::Type{LeftConnectedRightCenterFolded},    N, H) = -H+2:N+H-1
-split_explicit_kernel_size(::Type{LeftConnectedRightFaceFolded},      N, H) = -H+2:N+H-1
-split_explicit_kernel_size(::Type{LeftConnectedRightCenterConnected}, N, H) = -H+2:N+H-1
-split_explicit_kernel_size(::Type{LeftConnectedRightFaceConnected},   N, H) = -H+2:N+H-1
+@inline split_explicit_kernel_size(::Type{LeftConnectedRightCenterFolded},    N, H) = -H+2:N+H-1
+@inline split_explicit_kernel_size(::Type{LeftConnectedRightFaceFolded},      N, H) = -H+2:N+H-1
+@inline split_explicit_kernel_size(::Type{LeftConnectedRightCenterConnected}, N, H) = -H+2:N+H-1
+@inline split_explicit_kernel_size(::Type{LeftConnectedRightFaceConnected},   N, H) = -H+2:N+H-1
 
 # Adapt
 Adapt.adapt_structure(to, free_surface::SplitExplicitFreeSurface{extend_halos}) where {extend_halos} =

--- a/src/Models/HydrostaticFreeSurfaceModels/cache_hydrostatic_free_surface_tendencies.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/cache_hydrostatic_free_surface_tendencies.jl
@@ -98,23 +98,22 @@ properly handle mutable vertical coordinates (z-star). Velocities and free surfa
 are cached directly without modification.
 """
 function cache_current_fields!(model::HydrostaticFreeSurfaceModel)
-    previous_fields = model.timestepper.Ψ⁻
-    model_fields = prognostic_fields(model)
-    cache_current_fields!(previous_fields, model_fields, model, Val(keys(model_fields)))
+    cache_current_fields!(model, Val(keys(prognostic_fields(model))))
     return nothing
 end
 
-@inline cache_current_fields!(previous_fields, model_fields, model, ::Val{()}) = nothing
+@inline cache_current_fields!(model, ::Val{()}) = nothing
 
-@inline function cache_current_fields!(previous_fields, model_fields, model, ::Val{names}) where names
-    name = first(names)
-    cache_current_field!(previous_fields[name], model_fields[name], Val(name), model)
-    cache_current_fields!(previous_fields, model_fields, model, Val(Base.tail(names)))
+@inline function cache_current_fields!(model, ::Val{names}) where names
+    cache_current_field!(model, Val(first(names)))
+    cache_current_fields!(model, Val(Base.tail(names)))
     return nothing
 end
 
-@inline function cache_current_field!(Ψ⁻, Ψⁿ, ::Val{name}, model) where name
+@inline function cache_current_field!(model, ::Val{name}) where name
     grid = model.grid
+    Ψ⁻ = model.timestepper.Ψ⁻[name]
+    Ψⁿ = prognostic_fields(model)[name]
     if name ∈ keys(model.tracers) # Tracers are stored with the grid scaling
         launch!(architecture(grid), grid, :xyz, _cache_tracer_fields!, Ψ⁻, grid, Ψⁿ)
     else # Velocities and free surface are stored without the grid scaling

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -19,7 +19,7 @@ using DocStringExtensions: TYPEDSIGNATURES
 using Oceananigans: AbstractModel, fields, prognostic_fields
 using Oceananigans.AbstractOperations: AbstractOperation
 using Oceananigans.Advection: AbstractAdvectionScheme, Centered
-using Oceananigans.Fields: Field, flattened_unique_values
+using Oceananigans.Fields: Field
 using Oceananigans.Grids: halo_size, inflate_halo_size
 using Oceananigans.OutputReaders: update_field_time_series!, extract_field_time_series
 using Oceananigans.TimeSteppers: Clock
@@ -159,16 +159,14 @@ function possible_field_time_series(model::OceananigansModels)
     return tuple(model_fields, forcing)
 end
 
-# Update _all_ `FieldTimeSeries`es in an `OceananigansModel`.
-# Extract `FieldTimeSeries` from all property names that might contain a `FieldTimeSeries`
-# Flatten the resulting tuple by extracting unique values and set! them to the
-# correct time range by looping over them
+# Update _all_ `FieldTimeSeries`es in an `OceananigansModel` to the correct time range.
+# `extract_field_time_series` already returns a flat, type-stable tuple of every FieldTimeSeries;
+# a series reachable through more than one path is updated more than once, which is a harmless no-op.
 function update_model_field_time_series!(model::OceananigansModels, clock::Clock)
     time = Time(clock.time)
 
     possible_fts = possible_field_time_series(model)
     time_series_tuple = extract_field_time_series(possible_fts)
-    time_series_tuple = flattened_unique_values(time_series_tuple)
 
     for fts in time_series_tuple
         update_field_time_series!(fts, time)

--- a/src/Models/NonhydrostaticModels/update_nonhydrostatic_model_state.jl
+++ b/src/Models/NonhydrostaticModels/update_nonhydrostatic_model_state.jl
@@ -21,9 +21,7 @@ they are called in the end.
 function update_state!(model::NonhydrostaticModel, callbacks=[])
 
     # Mask immersed tracers
-    foreach(model.tracers) do tracer
-        mask_immersed_field!(tracer)
-    end
+    mask_immersed_field!(model.tracers)
 
     # Update all FieldTimeSeries used in the model
     update_model_field_time_series!(model, model.clock)

--- a/src/Models/interleave_communication_and_computation.jl
+++ b/src/Models/interleave_communication_and_computation.jl
@@ -24,7 +24,7 @@ complete_communication_and_compute_buffer!(model, grid, arch) = nothing
 compute_buffer_tendencies!(model) = nothing
 
 """ Kernel parameters for computing interior tendencies. """
-interior_tendency_kernel_parameters(arch, grid) = :xyz # fallback
+@inline interior_tendency_kernel_parameters(arch, grid) = KernelParameters(worksize(grid), map(zero, worksize(grid))) # fallback
 
 function interior_tendency_kernel_parameters(arch::AsynchronousDistributed, grid)
     Rx, Ry, _ = arch.ranks

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -22,6 +22,16 @@ hydrostatic_allocation_model(grid) = HydrostaticFreeSurfaceModel(grid;
                                                                  free_surface       = SplitExplicitFreeSurface(grid; substeps=8),
                                                                  tracers            = (:T, :S))
 
+hydrostatic_split_rk3_allocation_model(grid) = HydrostaticFreeSurfaceModel(grid;
+                                                                           momentum_advection = WENOVectorInvariant(),
+                                                                           tracer_advection   = WENO(),
+                                                                           buoyancy           = SeawaterBuoyancy(),
+                                                                           coriolis           = FPlane(f=1e-4),
+                                                                           closure            = CATKEVerticalDiffusivity(),
+                                                                           free_surface       = SplitExplicitFreeSurface(grid; substeps=8),
+                                                                           tracers            = (:T, :S),
+                                                                           timestepper        = :SplitRungeKutta3)
+
 nonhydrostatic_allocation_model(grid) = NonhydrostaticModel(grid;
                                                             advection = WENO(),
                                                             coriolis = FPlane(f=1e-4),
@@ -148,5 +158,18 @@ end
                 end
             end
         end
+    end
+end
+
+# The `SplitRungeKutta3` timestepper takes 3 substeps per time step, so we allow 3× the single-step hydrostatic bound.
+@testset "SplitRungeKutta3 hydrostatic memory allocations [CPU]" begin
+    arch = CPU()
+    for immersed in (:flat, :immersed, :active_immersed)
+        grid  = allocation_grid(arch; immersed_mode=immersed, size=(48, 48, 8))
+        model = hydrostatic_split_rk3_allocation_model(grid)
+        allocations = time_step_allocations(model, 1.0)
+        bound = ceil(Int, 1.1 * 3 * serial_memory_cpu[(:hydrostatic, immersed)])
+        @info "  hydrostatic_split_rk3 | $(summary(arch)) | $immersed : $(pretty_filesize(allocations)) (≤ $(pretty_filesize(bound)))"
+        @test allocations ≤ bound
     end
 end

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -111,7 +111,7 @@ archs = nonhydrostatic_regression_test_architectures()
     # identity when entries share a type, so this case is intentionally not `@inferred` (see the
     # type-stable, no-dedup `extract_field_time_series` used by `update_model_field_time_series!`).
     @test flattened_unique_values((u = u, v = c, w = u)) === (u, c)
-    @test flattened_unique_values((u = u, v = c, w = u, d = deepcopy(u))) === (u, c, u)
+    @test flattened_unique_values((u = u, v = c, w = u, d = deepcopy(u))) == (u, c, u)
 end
 
 @testset "extract_field_time_series: tuple convention, inference" begin

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -111,6 +111,7 @@ archs = nonhydrostatic_regression_test_architectures()
     # identity when entries share a type, so this case is intentionally not `@inferred` (see the
     # type-stable, no-dedup `extract_field_time_series` used by `update_model_field_time_series!`).
     @test flattened_unique_values((u = u, v = c, w = u)) === (u, c)
+    @test flattened_unique_values((u = u, v = c, w = u, d = deepcopy(u))) === (u, c, u)
 end
 
 @testset "extract_field_time_series: tuple convention, inference" begin

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -4,6 +4,8 @@ using Oceananigans
 using Oceananigans.TurbulenceClosures: CATKEVerticalDiffusivity
 using Oceananigans.DistributedComputations: @handshake
 using Oceananigans.Utils: pretty_filesize
+using Oceananigans.Fields: flattened_unique_values
+using Oceananigans.OutputReaders: extract_field_time_series, FieldTimeSeries
 
 function allocation_grid(arch, FT=Float64; immersed_mode, size, extent=(1, 1, 1), halo=(7, 7, 7), topology=(Periodic, Periodic, Bounded))
     grid = RectilinearGrid(arch, FT; size, extent, halo, topology)
@@ -80,6 +82,46 @@ const distributed_memory_gpu = Dict(
 
 # For distributed this includes only (4, 1), (1, 4) and (2, 2)
 archs = nonhydrostatic_regression_test_architectures()
+
+@testset "flattened_unique_values: correctness, inference, allocations" begin
+    grid = RectilinearGrid(CPU(), size=(4, 4, 4), extent=(1, 1, 1))
+    u = XFaceField(grid)
+    c = CenterField(grid)
+
+    nt = (velocities = (u = u, v = c), tracers = (T = c, extra = u))
+    result = flattened_unique_values(nt)
+
+    @test result isa Tuple
+    @test length(result) == 2
+    @test any(f -> f === u, result)
+    @test any(f -> f === c, result)
+
+    @test @inferred(flattened_unique_values(())) === ()
+    @test @inferred(flattened_unique_values((u = u, v = c))) === (u, c)
+
+    # De-duplication by identity: a repeated entry is dropped. The result length depends on runtime
+    # identity when entries share a type, so this case is intentionally not `@inferred` (see the
+    # type-stable, no-dedup `extract_field_time_series` used by `update_model_field_time_series!`).
+    @test flattened_unique_values((u = u, v = c, w = u)) === (u, c)
+end
+
+@testset "extract_field_time_series: tuple convention, inference" begin
+    grid = RectilinearGrid(CPU(), size=(4, 4, 4), extent=(1, 1, 1))
+
+    plain = (a = 1, b = (2.0, "x"), c = grid)
+    @test extract_field_time_series(plain) === ()
+    @test @inferred(extract_field_time_series(plain)) === ()
+    @test extract_field_time_series(3.0) === ()
+    @test extract_field_time_series(nothing) === ()
+
+    times = 0:0.5:2
+    fts = FieldTimeSeries{Center, Center, Center}(grid, times)
+    @test extract_field_time_series(fts) === (fts,)
+
+    nested = (u = 1, deep = (grid = grid, series = fts, tag = "t"))
+    got = extract_field_time_series(nested)
+    @test got == (fts,)
+end
 
 @testset "Memory allocation regression tests" begin
     for arch in archs

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -163,14 +163,20 @@ end
 end
 
 # The `SplitRungeKutta3` timestepper takes 3 substeps per time step, so we allow 3× the single-step hydrostatic bound.
-@testset "SplitRungeKutta3 hydrostatic memory allocations [CPU]" begin
-    arch = CPU()
-    for immersed in (:flat, :immersed, :active_immersed)
-        grid  = allocation_grid(arch; immersed_mode=immersed, size=(48, 48, 8))
-        model = hydrostatic_split_rk3_allocation_model(grid)
-        allocations = time_step_allocations(model, 1.0)
-        bound = ceil(Int, 1.1 * 3 * serial_memory_cpu[(:hydrostatic, immersed)])
-        @info "  hydrostatic_split_rk3 | $(summary(arch)) | $immersed : $(pretty_filesize(allocations)) (≤ $(pretty_filesize(bound)))"
-        @test allocations ≤ bound
+# This is a serial check; skip it under MPI, where the distributed pipeline would replicate the same serial run on
+# every rank (no distributed coverage) and stall on the immersed cases.
+if !mpi_test
+    @testset "SplitRungeKutta3 hydrostatic memory allocations" begin
+        for arch in archs
+            baseline = arch isa GPU ? serial_memory_gpu : serial_memory_cpu
+            for immersed in (:flat, :immersed, :active_immersed)
+                grid  = allocation_grid(arch; immersed_mode=immersed, size=(48, 48, 8))
+                model = hydrostatic_split_rk3_allocation_model(grid)
+                allocations = time_step_allocations(model, 1.0)
+                bound = ceil(Int, 1.1 * 3 * baseline[(:hydrostatic, immersed)])
+                @info "  hydrostatic_split_rk3 | $(summary(arch)) | $immersed : $(pretty_filesize(allocations)) (≤ $(pretty_filesize(bound)))"
+                @test allocations ≤ bound
+            end
+        end
     end
 end

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -163,8 +163,6 @@ end
 end
 
 # The `SplitRungeKutta3` timestepper takes 3 substeps per time step, so we allow 3× the single-step hydrostatic bound.
-# This is a serial check; skip it under MPI, where the distributed pipeline would replicate the same serial run on
-# every rank (no distributed coverage) and stall on the immersed cases.
 if !mpi_test
     @testset "SplitRungeKutta3 hydrostatic memory allocations" begin
         for arch in archs

--- a/test/test_memory_allocation.jl
+++ b/test/test_memory_allocation.jl
@@ -43,9 +43,9 @@ function time_step_allocations(model, Δt; samples=10)
 end
 
 const serial_memory_cpu = Dict(
-    (:hydrostatic,    :flat)            => 4.4e5,
-    (:hydrostatic,    :immersed)        => 4.6e5,
-    (:hydrostatic,    :active_immersed) => 5.0e3,
+    (:hydrostatic,    :flat)            => 560,
+    (:hydrostatic,    :immersed)        => 592,
+    (:hydrostatic,    :active_immersed) => 640,
     (:nonhydrostatic, :flat)            => 8.6e5,
     (:nonhydrostatic, :immersed)        => 8.9e5,
     (:nonhydrostatic, :active_immersed) => 6.9e5,


### PR DESCRIPTION
This is actually not 100% possible because when we have exactly the same variable repeated it will lead to instability. However we remove the instability in all other cases and remove `flatten_unique_values` from the `update_model_field_time_series!` hot path given that `extract_field_time_series!` now already flattens the extracted field time series and update_model_field_time_series! is idempotent