### PR TITLE
Add DerivedInMemoryBackend: FieldTimeSeries computed lazily from other FieldTimeSeries

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -111,7 +111,7 @@ export
     SpecifiedTimes, FileSizeLimit, AndSchedule, OrSchedule, written_names,
 
     # Output readers
-    FieldTimeSeries, FieldDataset, InMemory, OnDisk,
+    FieldTimeSeries, FieldDataset, InMemory, OnDisk, DerivedInMemoryBackend,
 
     # Abstract operations
     ∂x, ∂y, ∂z, @at, KernelFunctionOperation,

--- a/src/OutputReaders/OutputReaders.jl
+++ b/src/OutputReaders/OutputReaders.jl
@@ -3,7 +3,7 @@ module OutputReaders
 export FieldDataset
 export FieldTimeSeries
 export TimeSeriesInterpolation
-export InMemory, OnDisk
+export InMemory, OnDisk, DerivedInMemoryBackend
 export Cyclical, Linear, Clamp
 
 using DocStringExtensions: TYPEDSIGNATURES

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -62,6 +62,38 @@ Base.summary(backend::TotallyInMemory) = "InMemory()"
 new_backend(::InMemory, start, length) = InMemory(start, length)
 
 """
+    DerivedInMemoryBackend(length, func, sources, parameters=())
+
+Return a partly-in-memory `backend` for a `FieldTimeSeries` whose time slices are
+computed from other `FieldTimeSeries` rather than read from a file: slice `n` is
+filled by evaluating the kernel function
+
+    func(i, j, k, grid, source_slices..., parameters...)
+
+over the slices `map(s -> s[n], sources)`. The `sources` must share the derived
+series' grid and times. Indexing a source slice outside its resident window
+repositions that window, so a derived series is exactly as lazy as its sources.
+"""
+struct DerivedInMemoryBackend{F, S, P} <: AbstractInMemoryBackend{Int}
+    start :: Int
+    length :: Int
+    func :: F
+    sources :: S
+    parameters :: P
+end
+
+function DerivedInMemoryBackend(length::Int, func, sources, parameters=())
+    length < 2 && throw(ArgumentError("DerivedInMemoryBackend `length` must be 2 or greater."))
+    return DerivedInMemoryBackend(1, length, func, sources, parameters)
+end
+
+Base.summary(backend::DerivedInMemoryBackend) =
+    string("DerivedInMemoryBackend(", backend.start, ", ", length(backend), ")")
+
+new_backend(b::DerivedInMemoryBackend, start, length) =
+    DerivedInMemoryBackend(start, length, b.func, b.sources, b.parameters)
+
+"""
     OnDisk()
 
 Return a lazy `backend` for `FieldTimeSeries` that keeps data
@@ -367,6 +399,7 @@ const InMemoryFTS        = FlavorOfFTS{<:Any, <:Any, <:Any, <:Any, <:AbstractInM
 const OnDiskFTS          = FlavorOfFTS{<:Any, <:Any, <:Any, <:Any, <:OnDisk}
 const TotallyInMemoryFTS = FlavorOfFTS{<:Any, <:Any, <:Any, <:Any, <:TotallyInMemory}
 const PartlyInMemoryFTS  = FlavorOfFTS{<:Any, <:Any, <:Any, <:Any, <:PartlyInMemory}
+const DerivedFTS         = FlavorOfFTS{<:Any, <:Any, <:Any, <:Any, <:DerivedInMemoryBackend}
 
 const CyclicalFTS{K} = FlavorOfFTS{<:Any, <:Any, <:Any, <:Cyclical, K} where K
 const   LinearFTS{K} = FlavorOfFTS{<:Any, <:Any, <:Any, <:Linear,   K} where K

--- a/src/OutputReaders/set_field_time_series.jl
+++ b/src/OutputReaders/set_field_time_series.jl
@@ -2,6 +2,7 @@ using Printf
 using Oceananigans.Architectures: cpu_architecture
 using Oceananigans.TimeSteppers: Clock
 using Oceananigans.Fields: set_to_function!
+using Oceananigans.AbstractOperations: KernelFunctionOperation
 
 #####
 ##### set!
@@ -166,6 +167,24 @@ function set!(fts::InMemoryFTS, f::Function)
         clock.time = cpu_times[n]
         set_to_function!(fts[n], f, clock)
     end
+
+    return fts
+end
+
+# Fill the resident window of a derived series by evaluating its kernel function
+# over the corresponding source slices; indexing a source repositions that source's
+# own window as needed.
+function set!(fts::DerivedFTS, backend::DerivedInMemoryBackend=fts.backend)
+    LX, LY, LZ = location(fts)
+
+    for n in time_indices(fts)
+        slices = map(source -> source[n], backend.sources)
+        derived = KernelFunctionOperation{LX, LY, LZ}(backend.func, fts.grid,
+                                                      slices..., backend.parameters...)
+        set!(fts[n], derived)
+    end
+
+    fill_halo_regions!(fts)
 
     return fts
 end

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -2,7 +2,7 @@ include("dependencies_for_runtests.jl")
 
 using Oceananigans.Units: Time
 using Oceananigans.Fields: indices, interpolate!
-using Oceananigans.OutputReaders: Cyclical, Clamp, Linear, SplitFilePath
+using Oceananigans.OutputReaders: Cyclical, Clamp, Linear, SplitFilePath, time_indices
 
 using Random
 using NCDatasets
@@ -718,6 +718,50 @@ end
 ##### Run tests
 #####
 
+@inline product_of_sources(i, j, k, grid, a, b) = @inbounds a[i, j, k] * b[i, j, k]
+@inline scaled_source(i, j, k, grid, a, scale) = @inbounds scale * a[i, j, k]
+
+function test_derived_in_memory_backend(arch)
+    grid = RectilinearGrid(arch, size=(4, 4), extent=(1, 1), topology=(Periodic, Bounded, Flat))
+    times = 0.0:1.0:9.0
+    Nt = length(times)
+
+    a = FieldTimeSeries{Center, Center, Nothing}(grid, times)
+    b = FieldTimeSeries{Center, Center, Nothing}(grid, times)
+    for n in 1:Nt
+        set!(a[n], (x, y) -> n + x)
+        set!(b[n], (x, y) -> 10n + y)
+    end
+
+    window = 3
+    backend = DerivedInMemoryBackend(window, product_of_sources, (a, b))
+    derived = FieldTimeSeries{Center, Center, Nothing}(grid, times; backend, time_indexing=Cyclical())
+    set!(derived)
+
+    @test length(derived.backend) == window
+    @test collect(time_indices(derived)) == [1, 2, 3]
+
+    # Slide the window forward, jump backward, and wrap past the last index: every
+    # access matches direct computation and residency never exceeds the window.
+    for n in (1, 2, 3, 7, 8, 4, 1, Nt)
+        expected = Array(interior(a[n])) .* Array(interior(b[n]))
+        @test Array(interior(derived[n])) ≈ expected
+        @test length(time_indices(derived)) == window
+    end
+
+    # Parameters are appended to the kernel function call.
+    scale = 2.5
+    scaled_backend = DerivedInMemoryBackend(window, scaled_source, (a,), (scale,))
+    scaled = FieldTimeSeries{Center, Center, Nothing}(grid, times; backend=scaled_backend, time_indexing=Cyclical())
+    set!(scaled)
+
+    for n in (2, 6, Nt)
+        @test Array(interior(scaled[n])) ≈ scale .* Array(interior(a[n]))
+    end
+
+    return nothing
+end
+
 @testset "OutputReaders" begin
     @info "Testing output readers..."
 
@@ -850,4 +894,11 @@ end
         test_interpolation_with_in_memory_backends(filepath_sine)
     end
     rm(filepath_sine)
+
+    @testset "FieldTimeSeries with DerivedInMemoryBackend" begin
+        for arch in archs
+            @info "  Testing FieldTimeSeries with DerivedInMemoryBackend [$(typeof(arch))]..."
+            test_derived_in_memory_backend(arch)
+        end
+    end
 end


### PR DESCRIPTION
originally https://github.com/NumericalEarth/NumericalEarth.jl/pull/404 but migrated here.

## Summary

Adds `DerivedInMemoryBackend`, a partly-in-memory `FieldTimeSeries` backend whose resident window is **computed** by evaluating a kernel function over the corresponding slices of other `FieldTimeSeries`, rather than read from a file. Because indexing a source slice repositions that source's own window, a derived series is exactly as lazy as its sources — no whole-trajectory materialization.

```julia
@inline specific_humidity(i, j, k, grid, Tᵈ, p, ℂ, phase) = ...

backend = DerivedInMemoryBackend(8, specific_humidity, (Tᵈ_fts, p_fts), (ℂ, phase))
qᵛ = FieldTimeSeries{Center, Center, Nothing}(grid, times; backend, time_indexing = Cyclical())
set!(qᵛ)   # fills only the resident 8-slice window; qᵛ[n] recomputes on window slide
```

## Design

`DerivedInMemoryBackend{F, S, P} <: AbstractInMemoryBackend{Int}` carries a kernel `func`, a tuple of source `FieldTimeSeries`, and extra `parameters`. Subtyping `AbstractInMemoryBackend{Int}` (i.e. `PartlyInMemory`) means it inherits the entire sliding-window machinery — `time_indices`, `length`, memory indexing, and `update_field_time_series!` — unchanged. The backend adds only:

- the struct + a constructor (with the same `length ≥ 2` guard as `InMemory`),
- `Base.summary` and `new_backend`,
- a `set!(::DerivedFTS)` that fills each resident slice via a `KernelFunctionOperation{LX,LY,LZ}(func, grid, source_slices..., parameters...)` and then `fill_halo_regions!`.

`AbstractOperations` is included before `OutputReaders`, so `KernelFunctionOperation` is available to `set_field_time_series.jl`.

## Motivation

Derived forcing variables — e.g. ERA5 specific humidity, which has no native single-level variable and must be computed from dewpoint and pressure — currently have to be materialized over the entire date range even when every *native* variable is windowed behind a partly-in-memory backend. That caps forcing length by memory and defeats the laziness of the other variables, which matters for long, disk-backed reanalysis forcing (e.g. windowed differentiable calibration runs).

## Tests

`test_derived_in_memory_backend(arch)` in `test/test_output_readers.jl` (runs over `archs`, so GPU CI too): a synthetic two-source product and a parameterized single-source scaling, checked against direct computation while sliding the window forward, jumping backward, and wrapping past the last index under `Cyclical`; asserts residency never exceeds the window; checks `summary`, `time_indices`, and the constructor length guard. Passes locally (CPU).