### PR TITLE
Reject FieldTimeSeries operands in AbstractOperations

### DIFF
--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -43,6 +43,17 @@ Return `abstract_operation` relocated to `loc`ation.
 """
 at(loc, f) = f # fallback
 
+"""
+$(TYPEDSIGNATURES)
+
+Validate that `a` may be an operand of an `AbstractOperation`, returning `a`.
+
+The fallback validates everything. Four-dimensional fields like `FieldTimeSeries`
+extend `validate_operand` to throw an error, since `AbstractOperation`s are
+three-dimensional and would silently drop the time dimension of their operands.
+"""
+@inline validate_operand(a) = a
+
 include("grid_validation.jl")
 include("grid_metrics.jl")
 include("metric_field_reductions.jl")

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -34,6 +34,8 @@ indices(β::BinaryOperation) = construct_regionally(intersect_indices, location(
 """Create a binary operation for `op` acting on `a` and `b` at `Lc`, where
 `a` and `b` have location `La` and `Lb`."""
 function _binary_operation(Lc::Tuple{LX, LY, LZ}, op, a, b, La, Lb, grid) where {LX<:Location, LY<:Location, LZ<:Location}
+    a = validate_operand(a)
+    b = validate_operand(b)
     ▶a = interpolation_operator(La, Lc)
     ▶b = interpolation_operator(Lb, Lc)
 

--- a/src/AbstractOperations/derivatives.jl
+++ b/src/AbstractOperations/derivatives.jl
@@ -29,6 +29,7 @@ end
 """Create a derivative operator `∂` acting on `arg` at `L∂`, followed by
 interpolation to `L` on `grid`."""
 function _derivative(L::Tuple{LX, LY, LZ}, ∂, arg, L∂, abstract_∂, grid) where {LX, LY, LZ}
+    arg = validate_operand(arg)
     ▶ = interpolation_operator(L∂, L)
     return Derivative{LX, LY, LZ}(∂, arg, ▶, abstract_∂, grid)
 end

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -58,6 +58,7 @@ end
 indices(Π::MultiaryOperation) = construct_regionally(intersect_indices, location(Π), Π.args...)
 
 function _multiary_operation(L::Tuple{LX, LY, LZ}, op, args, Largs, grid) where {LX, LY, LZ}
+    args = map(validate_operand, args)
     ▶ = Tuple(interpolation_operator(La, L) for La in Largs)
     return MultiaryOperation{LX, LY, LZ}(op, Tuple(a for a in args), ▶, grid)
 end

--- a/src/AbstractOperations/unary_operations.jl
+++ b/src/AbstractOperations/unary_operations.jl
@@ -32,6 +32,7 @@ indices(υ::UnaryOperation) = indices(υ.arg)
 """Create a unary operation for `operator` acting on `arg` which interpolates the
 result from `Larg` to `L`."""
 function _unary_operation(L::Tuple{LX, LY, LZ}, operator, arg, Larg, grid) where {LX, LY, LZ}
+    arg = validate_operand(arg)
     ▶ = interpolation_operator(Larg, L)
     return UnaryOperation{LX, LY, LZ}(operator, arg, ▶, grid)
 end

--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -384,6 +384,15 @@ time_indices(fts) = time_indices(fts.backend, fts.time_indexing, length(fts.time
     return memory_index(backend, ti, Nt, n)
 end
 
+# A FieldTimeSeries cannot be an operand of a (three-dimensional) AbstractOperation:
+# the result would silently drop the time dimension (issue #5758).
+Oceananigans.AbstractOperations.validate_operand(fts::FieldTimeSeries) =
+    throw(ArgumentError("AbstractOperations on FieldTimeSeries are not supported yet: the" *
+                        " result would be a three-dimensional operation that silently drops" *
+                        " the time dimension. To operate on a single snapshot, slice the" *
+                        " FieldTimeSeries first with `fts[n]` or `fts[Time(t)]`, or wrap it" *
+                        " in `TimeSeriesInterpolation` to interpolate to a clock time."))
+
 #####
 ##### Constructors
 #####

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -724,6 +724,33 @@ end
     Nt = 5
     Nx, Ny, Nz = 16, 10, 5
 
+    for arch in archs
+        @testset "FieldTimeSeries rejects AbstractOperations [$(typeof(arch))]" begin
+            @info "  Testing that FieldTimeSeries operands are rejected by AbstractOperations [$(typeof(arch))]..."
+            grid = RectilinearGrid(arch, size=(2, 2, 2), extent=(1, 1, 1))
+            times = 0:1.0:3
+            a = FieldTimeSeries{Center, Center, Center}(grid, times)
+            b = FieldTimeSeries{Center, Center, Center}(grid, times)
+            [set!(a[n], n) for n in 1:length(times)]
+            [set!(b[n], 2n) for n in 1:length(times)]
+
+            # Operations with FieldTimeSeries operands would silently drop
+            # the time dimension (issue #5758), so they throw instead.
+            @test_throws ArgumentError a * b
+            @test_throws ArgumentError a + b
+            @test_throws ArgumentError a * 2
+            @test_throws ArgumentError 2 * a
+            @test_throws ArgumentError sqrt(a)
+            @test_throws ArgumentError -a
+            @test_throws ArgumentError +(a, b, b)
+            @test_throws ArgumentError ∂x(a)
+
+            # Slicing a snapshot out of the series still supports operations
+            c = compute!(Field(a[2] * b[2]))
+            @test CUDA.@allowscalar c[1, 1, 1] == 8
+        end
+    end
+
     for output_writer in (JLD2Writer, NetCDFWriter)
         filepath1d, filepath2d, filepath3d, unsplit_filepath, split_filepath = generate_some_interesting_simulation_data(Nx, Ny, Nz; output_writer)
 


### PR DESCRIPTION
Closes #5758.

## Summary

`a_fts * b_fts` (and `sqrt(fts)`, `∂x(fts)`, `+(fts, b, c)`, `fts * 2`, …) currently dispatch through the `AbstractField` operator methods and silently build a **3-D** operation that reads only the **first time slice** — no error, plausible-looking numbers (MWE in #5758).

This PR makes those constructions throw an informative `ArgumentError` instead:

```
AbstractOperations on FieldTimeSeries are not supported yet: the result would be a
three-dimensional operation that silently drops the time dimension. To operate on a
single snapshot, slice the FieldTimeSeries first with `fts[n]` or `fts[Time(t)]`, or
wrap it in `TimeSeriesInterpolation` to interpolate to a clock time.
```

## Design

`AbstractOperations` is included before `OutputReaders`, so it cannot dispatch on `FieldTimeSeries` directly. Instead:

- `AbstractOperations` gains a `validate_operand(a) = a` hook, called on every operand by the four central constructors (`_unary_operation`, `_binary_operation`, `_multiary_operation`, `_derivative`) — one line each.
- `OutputReaders` extends `validate_operand(::FieldTimeSeries)` to throw.

All existing operand types pass through the inlined no-op fallback unchanged.

This is the "immediate" step from #5758; actual support for operations over `FieldTimeSeries` (same operator names, dispatching to a lazy 4-D operation) is prototyped in a companion draft PR. When that lands, the operator methods intercept FTS operands before they ever reach these constructors, and this error remains as a safety net for uncovered paths.

## Tests

New testset in `test/test_output_readers.jl` (runs over `archs`): asserts the error for binary (field–field and field–scalar), unary, multiary, and derivative constructions, and that slicing (`a[n] * b[n]`) still composes and computes correctly. Verified locally on CPU along with checks that `Field`-only operations and `fts[Time(t)]` interpolation are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
