### PR TITLE
Fix distributed `mean`: reduce `conditional_length` globally

### DIFF
--- a/src/DistributedComputations/distributed_fields.jl
+++ b/src/DistributedComputations/distributed_fields.jl
@@ -11,10 +11,11 @@ using Oceananigans.Fields: ReducedAbstractField,
                            reduced_dimensions,
                            reduced_location
 using Oceananigans.Fields: condition_operand, conditional_length
+using Oceananigans.ImmersedBoundaries: NotImmersed
 using LinearAlgebra: dot, norm
 using Statistics: mean
 
-import Oceananigans.Fields: Field, set!
+import Oceananigans.Fields: Field, set!, conditional_length
 import Oceananigans.BoundaryConditions: fill_halo_regions!
 import LinearAlgebra: norm, dot
 import Statistics: mean
@@ -226,6 +227,18 @@ for (reduction, all_reduce_op) in zip((:sum, :maximum, :minimum, :all, :any, :pr
         end
     end
 end
+
+# `conditional_length` normalizes `mean`. For a bare field the generic method returns
+# `length(c)`, which on a distributed grid is the per-rank local count, whereas the paired
+# `sum` is globally reduced. Reduce the length too so `mean = sum / conditional_length`
+# divides by the global count instead of the local one.
+@inline conditional_length(c::DistributedField) = all_reduce(+, length(c), architecture(c))
+
+# A field on a distributed immersed grid matches both `DistributedField` and the immersed
+# `AbstractField{…, <:ImmersedBoundaryGrid}` method; defer to the immersed definition, which
+# excludes inactive cells and is already globally reduced through the distributed `sum`.
+@inline conditional_length(c::Field{<:Any, <:Any, <:Any, <:Any, <:DistributedImmersedBoundaryGrid}) =
+    conditional_length(condition_operand(identity, c, NotImmersed(), 0))
 
 # Distributed norm
 @inline function norm(u::DistributedField; condition=nothing)

--- a/test/test_distributed_models.jl
+++ b/test/test_distributed_models.jl
@@ -604,6 +604,11 @@ end
 
             all!(cbool_reduced, cbool)
             @test @allowscalar cbool_reduced[1, 1, 1] == false
+
+            # `mean` must divide the globally-reduced `sum` by the *global* point count.
+            # The four equal rank-blocks hold 1, 2, 3, 4, so the global mean is 2.5
+            # regardless of the local block size N.
+            @test mean(c) == (1 + 2 + 3 + 4) / 4
         end
     end
 


### PR DESCRIPTION
Closes #5762.

## Problem

`mean` on a `DistributedField` returns `global_sum / local_length` — `nranks×` too large. `_mean` reduces the numerator (`sum`) across ranks, but the denominator `conditional_length(operand)` falls back to the generic `conditional_length(c::AbstractField) = length(c)` (the per-rank **local** count) for a bare field. So the two halves of the mean are reduced inconsistently.

This breaks `enforce_zero_mean_gauge!` in `ConjugateGradientPoissonSolver` on distributed grids (wrong gauge constant), and any other distributed `mean` caller.

## Fix

Two methods in `src/DistributedComputations/distributed_fields.jl`:

```julia
@inline conditional_length(c::DistributedField) = all_reduce(+, length(c), architecture(c))

@inline conditional_length(c::Field{<:Any,<:Any,<:Any,<:Any,<:DistributedImmersedBoundaryGrid}) =
    conditional_length(condition_operand(identity, c, NotImmersed(), 0))
```

The second resolves method ambiguity: a field on a distributed *immersed* grid matches both `DistributedField` and the immersed `AbstractField{…,<:ImmersedBoundaryGrid}` method. It defers to the immersed definition, which excludes inactive cells and is already globally reduced through the distributed `sum`.

The `dims` form of `_mean` likely has an analogous issue for partitioned dims (see #5762) — left as a follow-up.

## Verification

Regression test added to the "Distributed reductions" testset. Verified on 4 ranks across `Partition(1,4)`, `(2,2)`, `(4,1)`: `mean` now equals the true global mean (2.5 for rank-blocks holding 1/2/3/4), and `dot`/`norm`/`min`/`max` remain correct.

Unblocks #5757 (distributed `ConjugateGradientPoissonSolver` tests), which currently marks the `mean` case `@test_broken`.

Once this is merged all tests on https://github.com/CliMA/Oceananigans.jl/pull/5757 will pass and then https://github.com/CliMA/Oceananigans.jl/pull/5756 can be closed too. 

@aklocker42 

🤖 Generated with [Claude Code](https://claude.com/claude-code)