### PR TITLE
Compute fts[Time(t)] pointwise through TimeSeriesInterpolation

### DIFF
--- a/src/OutputReaders/field_time_series.jl
+++ b/src/OutputReaders/field_time_series.jl
@@ -464,7 +464,7 @@ fts[Time(0.3)]
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── boundary conditions: FieldBoundaryConditions
 │   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: ZeroFlux, top: ZeroFlux, immersed: Nothing
-├── operand: BinaryOperation at (Center, Center, Center)
+├── operand: TimeSeriesInterpolation at (Center, Center, Center)
 ├── status: Oceananigans.Fields.FixedTime{Float64}
 └── data: 10×10×10 OffsetArray(::Array{Float64, 3}, -2:7, -2:7, -2:7) with eltype Float64 with indices -2:7×-2:7×-2:7
     └── max=0.0, min=0.0, mean=0.0

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -13,6 +13,7 @@ using Adapt
 import Oceananigans.Fields: interpolate
 
 using Oceananigans.Utils: period_to_seconds, seconds_to_nanosecond, time_difference_seconds
+using Oceananigans.TimeSteppers: Clock
 
 @inline interp_time(t₁, t₂, θ) = t₂ * θ + t₁ * (1 - θ)
 
@@ -245,8 +246,8 @@ function Base.getindex(fts::FieldTimeSeries, time_index::Time)
         return fts[n₁]
     end
 
-    # Otherwise, make a Field representing a linear interpolation in time
-    # Make sure both n₁ and n₂ are in memory by first retrieving n₂ and then n₁
+    # Otherwise, make a Field representing a linear interpolation in time.
+    # Ensure both n₁ and n₂ are in memory simultaneously,
     update_field_time_series!(fts, n₁, n₂)
 
     t₂ = @allowscalar fts.times[n₂]
@@ -254,9 +255,9 @@ function Base.getindex(fts::FieldTimeSeries, time_index::Time)
     t = interp_time(t₁, t₂, ñ)
     status = FixedTime(t)
 
-    ψ₂ = fts[n₂]
-    ψ₁ = fts[n₁]
-    ψ̃  = Field(ψ₂ * ñ + ψ₁ * (1 - ñ); status)
+    # then interpolate pointwise, via `fts[i, j, k, Time(t)]` inside the
+    # compute kernel — no intermediate slice Fields or operation trees.
+    ψ̃ = Field(TimeSeriesInterpolation(fts, fts.grid; clock=Clock(time=time_index.time)); status)
 
     # Compute the field and return it
     return compute!(ψ̃)

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -255,8 +255,7 @@ function Base.getindex(fts::FieldTimeSeries, time_index::Time)
     t = interp_time(t₁, t₂, ñ)
     status = FixedTime(t)
 
-    # then interpolate pointwise, via `fts[i, j, k, Time(t)]` inside the
-    # compute kernel — no intermediate slice Fields or operation trees.
+    # then interpolate pointwise, via `fts[i, j, k, Time(t)]` inside the compute kernel.
     ψ̃ = Field(TimeSeriesInterpolation(fts, fts.grid; clock=Clock(time=time_index.time)); status)
 
     # Compute the field and return it

--- a/src/OutputReaders/time_series_interpolated_field.jl
+++ b/src/OutputReaders/time_series_interpolated_field.jl
@@ -93,6 +93,8 @@ end
 ##### Show method
 #####
 
+Base.summary(op::TimeSeriesInterpolation) = string("TimeSeriesInterpolation at ", show_location(op))
+
 function Base.show(io::IO, op::TimeSeriesInterpolation)
     print(io, "TimeSeriesInterpolation located at ", show_location(op), "\n",
           "├── time_series: $(summary(op.time_series))", "\n",

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -711,6 +711,20 @@ function test_interpolation_with_in_memory_backends(filepath_sine)
         @test fts_clp[Time(t)][1, 1, 1] ≈ fts_clp[end][1, 1, 1]
     end
 
+
+    # Global Time-indexing of a reduced-location series returns a computed Field
+    # with FixedTime status (interpolation computes pointwise in a single kernel)
+    grid2 = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
+    times2 = 0:1.0:3
+    s = FieldTimeSeries{Center, Center, Nothing}(grid2, times2)
+    for n in 1:length(times2)
+        set!(s[n], (x, y) -> n * y)
+    end
+    fs = s[Time(1.5)]
+    @test location(fs) == (Center, Center, Nothing)
+    @test fs.status.time == 1.5
+    @test CUDA.@allowscalar fs[1, 2, 1] ≈ 2.5 * 1.5 / 4
+
     return nothing
 end
 

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -711,19 +711,31 @@ function test_interpolation_with_in_memory_backends(filepath_sine)
         @test fts_clp[Time(t)][1, 1, 1] ≈ fts_clp[end][1, 1, 1]
     end
 
+    # Same identity with decreasing t, which slides the in-memory window backward
+    for time in reverse(0:0.3:last(fts.times))
+        tidx = findfirst(fts.times .> time)
+        if !isnothing(tidx)
+            t⁻ = fts.times[tidx - 1]
+            t⁺ = fts.times[tidx]
+            Δt⁺ = (time - t⁻) / (t⁺ - t⁻)
+            @test fts_lin[Time(time)][1, 1, 1] ≈ (sinf(t⁻) * (1 - Δt⁺) + sinf(t⁺) * Δt⁺)
+        end
+    end
 
     # Global Time-indexing of a reduced-location series returns a computed Field
     # with FixedTime status (interpolation computes pointwise in a single kernel)
-    grid2 = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
-    times2 = 0:1.0:3
-    s = FieldTimeSeries{Center, Center, Nothing}(grid2, times2)
-    for n in 1:length(times2)
-        set!(s[n], (x, y) -> n * y)
+    for arch in archs
+        grid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1))
+        times = 0:1.0:3
+        s = FieldTimeSeries{Center, Center, Nothing}(grid, times)
+        for n in 1:length(times)
+            set!(s[n], (x, y) -> n * y)
+        end
+        fs = s[Time(1.5)]
+        @test location(fs) == (Center, Center, Nothing)
+        @test fs.status.time == 1.5
+        @test Array(interior(fs))[1, 2, 1] ≈ 2.5 * 1.5 / 4
     end
-    fs = s[Time(1.5)]
-    @test location(fs) == (Center, Center, Nothing)
-    @test fs.status.time == 1.5
-    @test CUDA.@allowscalar fs[1, 2, 1] ≈ 2.5 * 1.5 / 4
 
     return nothing
 end


### PR DESCRIPTION
Follow-up to the [pointwise-indexing discussion on #5761](https://github.com/CliMA/Oceananigans.jl/pull/5761#discussion_r3516630048): an audit of the existing code for places that build intermediate slice `Field`s and operation trees where pointwise 4-D indexing does the job.

## The one real avenue found: `getindex(fts, ::Time)`

`fts[Time(t)]` currently materializes two slice `Field`s, builds the lazy tree `ψ₂ * ñ + ψ₁ * (1 - ñ)`, wraps it in a `Field`, and computes it. But the pointwise time-interpolation machinery already exists — `fts[i, j, k, Time(t)]` via `interpolating_getindex` — and `TimeSeriesInterpolation` is precisely its 3-D lazy view at fixed time. So the interpolation now computes in a single kernel:

```julia
ψ̃ = Field(TimeSeriesInterpolation(fts, fts.grid; clock=Clock(time=time_index.time)); status)
compute!(ψ̃)
```

No intermediate slice `Field`s, no operation tree; one lightweight operation instead of four objects. Semantics are identical (same bracketing, same blend, `FixedTime` status preserved), and the `n₁ == n₂` node shortcut and joint window update are unchanged.

## Audit notes (nothing else changed)

- The space+time `interpolate(...)` path and forcing/boundary-condition sampling already index pointwise — these are the good patterns the rest was measured against.
- `field_time_series_reductions.jl` loops accumulate whole slices (`interior(fts[n])`) — bulk array operations per time index, not per point, which is appropriate.
- `set_field_time_series.jl` per-slice loops are I/O, not indexing.

## Tests

Verified against manual blends: spatially-varying interpolation between nodes, node exactness, `FixedTime` status, reduced-location series, `Cyclical` wrap, and windowed on-disk series across window slides in both directions. The existing `fts[Time(t)]` coverage in `test/test_output_readers.jl` exercises the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
