### PR TITLE
Fix NCCL send/recv for Bool fields (ImmersedBoundaryGrid mask)

### DIFF
--- a/ext/OceananigansNCCLExt/nccl_distributed.jl
+++ b/ext/OceananigansNCCLExt/nccl_distributed.jl
@@ -161,8 +161,10 @@ nccl_corner_send_recv!(nccl_comm, corner_rank, ::Nothing) = nothing
 nccl_corner_send_recv!(nccl_comm, ::Nothing, ::Nothing) = nothing
 
 function nccl_corner_send_recv!(nccl_comm, corner_rank, buffers)
-    NCCL.Send(buffers.send, nccl_comm; dest=corner_rank)
-    NCCL.Recv!(buffers.recv, nccl_comm; source=corner_rank)
+    send_buf = eltype(buffers.send) === Bool ? reinterpret(UInt8, buffers.send) : buffers.send
+    recv_buf = eltype(buffers.recv) === Bool ? reinterpret(UInt8, buffers.recv) : buffers.recv
+    NCCL.Send(send_buf, nccl_comm; dest=corner_rank)
+    NCCL.Recv!(recv_buf, nccl_comm; source=corner_rank)
     return nothing
 end
 
@@ -172,8 +174,11 @@ end
 
 function _nccl_send_recv_pair!(buf, bc, nccl_comm; stream_kw...)
     isnothing(buf) && return nothing
-    NCCL.Send(buf.send, nccl_comm; dest=bc.condition.to, stream_kw...)
-    NCCL.Recv!(buf.recv, nccl_comm; source=bc.condition.to, stream_kw...)
+    # NCCL has no Bool dtype; reinterpret as UInt8 (same size)
+    send_buf = eltype(buf.send) === Bool ? reinterpret(UInt8, buf.send) : buf.send
+    recv_buf = eltype(buf.recv) === Bool ? reinterpret(UInt8, buf.recv) : buf.recv
+    NCCL.Send(send_buf, nccl_comm; dest=bc.condition.to, stream_kw...)
+    NCCL.Recv!(recv_buf, nccl_comm; source=bc.condition.to, stream_kw...)
     return nothing
 end
 


### PR DESCRIPTION
## Summary

`NCCLDistributed` crashes when communicating `Bool` arrays across ranks.
This happens during `ImmersedBoundaryGrid` construction: `compute_mask`
calls `fill_halo_regions!` on the mask field (`CuArray{Bool, 3}`), which
routes through the NCCL send/recv path and hits:

```
MethodError: no method matching NCCL.LibNCCL.ncclDataType_t(::Type{Bool})
```

NCCL supports `UInt8`, `UInt32`, `Float16`, `Float32`, `Float64`, etc.,
but has no data type for `Bool`. Since `Bool` is 1 byte (same as `UInt8`),
the fix is to reinterpret `Bool` buffers as `UInt8` before calling
`NCCL.Send`/`NCCL.Recv!`, then the receiver naturally reinterprets back.

## Root cause

`_nccl_send_recv_pair!` and `nccl_corner_send_recv!` pass `buf.send`/
`buf.recv` directly to NCCL without checking the element type. Any field
whose backing array has `eltype == Bool` will fail.

## Fix

Check `eltype(buf) === Bool` at the call site and reinterpret to `UInt8`:

```julia
send_buf = eltype(buf.send) === Bool ? reinterpret(UInt8, buf.send) : buf.send
recv_buf = eltype(buf.recv) === Bool ? reinterpret(UInt8, buf.recv) : buf.recv
```

Applied to both `_nccl_send_recv_pair!` (edge halos) and
`nccl_corner_send_recv!` (corner halos).

## Test plan

- [ ] Confirmed working on 2-GPU `NCCLDistributed` on GH200 aarch64: model
      with `ImmersedBoundaryGrid(grid, GridFittedBoundary(...))` now
      constructs and runs past the first time step without error
- [ ] Plain `RectilinearGrid` (no immersed boundary) unaffected: no Bool
      fields are communicated in that case


