### PR TITLE
Fix tilted bottom boundary layer example

### DIFF
--- a/examples/baroclinic_adjustment.jl
+++ b/examples/baroclinic_adjustment.jl
@@ -166,6 +166,7 @@ simulation.output_writers[:zonal] = JLD2Writer(model, (; b=B, u=U, v=V);
 
 @info "Running the simulation..."
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/baroclinic_adjustment.jl
+++ b/examples/baroclinic_adjustment.jl
@@ -166,6 +166,7 @@ simulation.output_writers[:zonal] = JLD2Writer(model, (; b=B, u=U, v=V);
 
 @info "Running the simulation..."
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 @info "Simulation completed in " * prettytime(simulation.run_wall_time)

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -194,6 +194,7 @@ simulation.output_writers[:simple_output] =
 #
 # The simulation is set up. Let there be plankton:
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # Notice how the time-step is reduced at early times, when turbulence is strong,

--- a/examples/convecting_plankton.jl
+++ b/examples/convecting_plankton.jl
@@ -194,6 +194,7 @@ simulation.output_writers[:simple_output] =
 #
 # The simulation is set up. Let there be plankton:
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -155,6 +155,7 @@ nothing #hide
 
 # Ready to press the big red button:
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Load saved output, process, visualize

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -155,6 +155,7 @@ nothing #hide
 
 # Ready to press the big red button:
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/hydrostatic_lock_exchange.jl
+++ b/examples/hydrostatic_lock_exchange.jl
@@ -163,6 +163,7 @@ simulation.output_writers[:fields] = JLD2Writer(model, (; b, e, u, N²);
 
 # ## Run Simulation
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/hydrostatic_lock_exchange.jl
+++ b/examples/hydrostatic_lock_exchange.jl
@@ -163,6 +163,7 @@ simulation.output_writers[:fields] = JLD2Writer(model, (; b, e, u, N²);
 
 # ## Run Simulation
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 @info "Simulation finished. Output saved to $(filename)"

--- a/examples/internal_tide.jl
+++ b/examples/internal_tide.jl
@@ -172,6 +172,7 @@ simulation.output_writers[:fields] = JLD2Writer(model, (; u, u′, w, b, N²); f
 
 # We are ready -- let's run!
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Load output

--- a/examples/internal_tide.jl
+++ b/examples/internal_tide.jl
@@ -172,6 +172,7 @@ simulation.output_writers[:fields] = JLD2Writer(model, (; u, u′, w, b, N²); f
 
 # We are ready -- let's run!
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -127,6 +127,7 @@ simulation.output_writers[:velocities] = JLD2Writer(model, model.velocities; fil
 
 # With initial conditions set and an output writer at the ready, we run the simulation
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Animating a propagating packet

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -127,6 +127,7 @@ simulation.output_writers[:velocities] = JLD2Writer(model, model.velocities; fil
 
 # With initial conditions set and an output writer at the ready, we run the simulation
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -387,8 +387,6 @@ simulation.output_writers[:vorticity] =
 # And now we...
 
 @info "*** Running a simulation of Kelvin-Helmholtz instability..."
-## Fail the docs build if this simulation produces NaNs #hide
-Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Pretty things

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -188,6 +188,7 @@ function grow_instability!(simulation, energy)
     energy₀ = energy[1, 1, 1]
 
     ## Grow
+    Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
     run!(simulation)
 
     ## Analyze
@@ -385,6 +386,7 @@ simulation.output_writers[:vorticity] =
 # And now we...
 
 @info "*** Running a simulation of Kelvin-Helmholtz instability..."
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Pretty things

--- a/examples/kelvin_helmholtz_instability.jl
+++ b/examples/kelvin_helmholtz_instability.jl
@@ -188,6 +188,7 @@ function grow_instability!(simulation, energy)
     energy₀ = energy[1, 1, 1]
 
     ## Grow
+    ## Fail the docs build if this simulation produces NaNs #hide
     Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
     run!(simulation)
 
@@ -386,6 +387,7 @@ simulation.output_writers[:vorticity] =
 # And now we...
 
 @info "*** Running a simulation of Kelvin-Helmholtz instability..."
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -243,6 +243,7 @@ simulation.output_writers[:averages] =
 #
 # This part is easy,
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # # Making a neat movie

--- a/examples/langmuir_turbulence.jl
+++ b/examples/langmuir_turbulence.jl
@@ -243,6 +243,7 @@ simulation.output_writers[:averages] =
 #
 # This part is easy,
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -235,6 +235,7 @@ simulation.output_writers[:slices] =
 
 # We're ready:
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Turbulence visualization

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -235,6 +235,7 @@ simulation.output_writers[:slices] =
 
 # We're ready:
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -92,6 +92,7 @@ simulation = Simulation(model, Δt = 0.1 * diffusion_time_scale, stop_iteration 
 # `simulation` will run for 1000 iterations with a time-step that resolves the time-scale
 # at which our temperature field diffuses. All that's left is to
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Visualizing the results
@@ -117,6 +118,7 @@ simulation.output_writers[:temperature] =
 # We run the simulation for 10,000 more iterations,
 
 simulation.stop_iteration += 10000
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # Finally, we animate the results by opening the JLD2 file, extract the

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -92,6 +92,7 @@ simulation = Simulation(model, Δt = 0.1 * diffusion_time_scale, stop_iteration 
 # `simulation` will run for 1000 iterations with a time-step that resolves the time-scale
 # at which our temperature field diffuses. All that's left is to
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
@@ -118,6 +119,7 @@ simulation.output_writers[:temperature] =
 # We run the simulation for 10,000 more iterations,
 
 simulation.stop_iteration += 10000
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/one_dimensional_diffusion.jl
+++ b/examples/one_dimensional_diffusion.jl
@@ -119,8 +119,6 @@ simulation.output_writers[:temperature] =
 # We run the simulation for 10,000 more iterations,
 
 simulation.stop_iteration += 10000
-## Fail the docs build if this simulation produces NaNs #hide
-Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # Finally, we animate the results by opening the JLD2 file, extract the

--- a/examples/polar_vortex_crystal.jl
+++ b/examples/polar_vortex_crystal.jl
@@ -134,6 +134,7 @@ simulation.output_writers[:fields] = JLD2Writer(model, (; η, ζ, s);
                                                 schedule = TimeInterval(12hours),
                                                 overwrite_existing = true)
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/polar_vortex_crystal.jl
+++ b/examples/polar_vortex_crystal.jl
@@ -134,6 +134,7 @@ simulation.output_writers[:fields] = JLD2Writer(model, (; η, ζ, s);
                                                 schedule = TimeInterval(12hours),
                                                 overwrite_existing = true)
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Visualization

--- a/examples/shallow_water_Bickley_jet.jl
+++ b/examples/shallow_water_Bickley_jet.jl
@@ -154,6 +154,7 @@ simulation.output_writers[:growth] = NetCDFWriter(model, (; perturbation_norm),
 
 # And finally run the simulation.
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Visualize the results

--- a/examples/shallow_water_Bickley_jet.jl
+++ b/examples/shallow_water_Bickley_jet.jl
@@ -154,6 +154,7 @@ simulation.output_writers[:growth] = NetCDFWriter(model, (; perturbation_norm),
 
 # And finally run the simulation.
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/spherical_baroclinic_instability.jl
+++ b/examples/spherical_baroclinic_instability.jl
@@ -188,6 +188,7 @@ function run_baroclinic_instability(grid, name; stop_time=60days, save_interval=
     simulation.output_writers[:surface] = JLD2Writer(model, fields; indices, filename,
                                                      schedule = TimeInterval(save_interval),
                                                      overwrite_existing = true)
+    Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
     run!(simulation)
     return filename
 end

--- a/examples/spherical_baroclinic_instability.jl
+++ b/examples/spherical_baroclinic_instability.jl
@@ -188,6 +188,7 @@ function run_baroclinic_instability(grid, name; stop_time=60days, save_interval=
     simulation.output_writers[:surface] = JLD2Writer(model, fields; indices, filename,
                                                      schedule = TimeInterval(save_interval),
                                                      overwrite_existing = true)
+    ## Fail the docs build if this simulation produces NaNs #hide
     Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
     run!(simulation)
     return filename

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -207,6 +207,7 @@ simulation.output_writers[:fields] = NetCDFWriter(model, outputs;
 
 # Now we just run it!
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -162,8 +162,7 @@ set!(model, u=noise, w=noise)
 # conservatively, based on the smallest grid size of our domain and either an advective
 # or diffusive time scaling, depending on which is shorter.
 
-Δt₀ = 0.5 * minimum([Oceananigans.Advection.cell_advection_timescale(model),
-                     Oceananigans.Diagnostics.cell_diffusion_timescale(model)])
+Δt₀ = 0.5 * minimum_xspacing(grid) / V∞
 simulation = Simulation(model, Δt = Δt₀, stop_time = 1day)
 
 # We use a `TimeStepWizard` to adapt our time-step,

--- a/examples/tilted_bottom_boundary_layer.jl
+++ b/examples/tilted_bottom_boundary_layer.jl
@@ -207,6 +207,7 @@ simulation.output_writers[:fields] = NetCDFWriter(model, outputs;
 
 # Now we just run it!
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Visualize the results

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -118,6 +118,7 @@ simulation.output_writers[:fields] = JLD2Writer(model, (; ω, s),
 #
 # Pretty much just
 
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 
 # ## Visualizing the results

--- a/examples/two_dimensional_turbulence.jl
+++ b/examples/two_dimensional_turbulence.jl
@@ -118,6 +118,7 @@ simulation.output_writers[:fields] = JLD2Writer(model, (; ω, s),
 #
 # Pretty much just
 
+## Fail the docs build if this simulation produces NaNs #hide
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation) #hide
 run!(simulation)
 


### PR DESCRIPTION
Closes https://github.com/CliMA/Oceananigans.jl/issues/5722#issuecomment-4847975700

Currently this is fixing the example the simple way: by manually calculating the initial time step. With this the initial time step goes from 600 to 15 seconds.

Another possibility that I'd like to flag is to change the way that `Oceananigans.Advection.cell_advection_timescale()` works and make it take background velocities into consideration (currently it seems like it doesn't do that).

Tested locally.

cc @chyurenpo @glwagner @navidcy 