### PR TITLE
Unwrap FT in adapt_structure for OrthogonalSphericalShellGrid

### DIFF
--- a/ext/OceananigansReactantExt/Architectures.jl
+++ b/ext/OceananigansReactantExt/Architectures.jl
@@ -93,6 +93,7 @@ function Oceananigans.Distributed(arch::ReactantState; devices=nothing,
                                              mesh, nothing, nothing, Ref(0), devices)
 end
 
+Oceananigans.Grids.unwrapped_eltype(T::Type{<:Reactant.TracedRNumber}) = Reactant.unwrapped_eltype(T)
 Oceananigans.Grids.unwrapped_eltype(T::Type{<:Reactant.ConcretePJRTNumber}) = Reactant.unwrapped_eltype(T)
 Oceananigans.Grids.unwrapped_eltype(T::Type{<:Reactant.ConcreteIFRTNumber}) = Reactant.unwrapped_eltype(T)
 

--- a/src/Grids/orthogonal_spherical_shell_grid.jl
+++ b/src/Grids/orthogonal_spherical_shell_grid.jl
@@ -302,7 +302,7 @@ function Architectures.on_architecture(arch::AbstractSerialArchitecture, grid::O
 end
 
 function Adapt.adapt_structure(to, grid::OrthogonalSphericalShellGrid{FT, TX, TY, TZ}) where {FT, TX, TY, TZ}
-    return OrthogonalSphericalShellGrid{FT, TX, TY, TZ, Nothing}(nothing,
+    return OrthogonalSphericalShellGrid{unwrapped_eltype(FT), TX, TY, TZ, Nothing}(nothing,
            grid.Nx, grid.Ny, grid.Nz,
            grid.Hx, grid.Hy, grid.Hz,
            Adapt.adapt(to, grid.Lz),


### PR DESCRIPTION
goes from TracedRNumber{Float64} to Float64.
