### PR TITLE
Misc fixes for better type-generic support

### DIFF
--- a/src/Solvers/discrete_transforms.jl
+++ b/src/Solvers/discrete_transforms.jl
@@ -59,8 +59,11 @@ function twiddle_factors(arch::GPU, grid, dims)
     inds⁺ = reshape(0:N-1, reshaped_size(N, dim)...)
     inds⁻ = reshape(0:-1:-(N-1), reshaped_size(N, dim)...)
 
-    ω_4N⁺ = ω.(4N, inds⁺)
-    ω_4N⁻ = ω.(4N, inds⁻)
+    # Match the grid's precision: not all backends can store ComplexF64 (e.g. Metal),
+    # and mixed-precision broadcasts would promote the transformed array anyway.
+    C = complex(eltype(grid))
+    ω_4N⁺ = C.(ω.(4N, inds⁺))
+    ω_4N⁻ = C.(ω.(4N, inds⁻))
 
     # The zeroth coefficient of the IDCT (DCT-III or FFTW.REDFT01)
     # is not multiplied by 2.

--- a/src/Solvers/index_permutations.jl
+++ b/src/Solvers/index_permutations.jl
@@ -1,6 +1,6 @@
-# For why we use Base.unsafe_trunc instead of floor below see:
-# https://github.com/CliMA/Oceananigans.jl/issues/828
-# https://github.com/CliMA/Oceananigans.jl/pull/997
+# These kernels run on GPUs, some of which (e.g. Metal) cannot compile Float64
+# arithmetic, so index computations must stay in integer arithmetic throughout:
+# i ÷ 2 == trunc(i/2) and (N + 1) ÷ 2 == ceil(N/2) for the i, N ≥ 0 used here.
 
 """
 $(TYPEDSIGNATURES)
@@ -16,8 +16,8 @@ for `N=8` and `N=9` respectively.
 See equation (20) of [Makhoul80](@citet).
 """
 @inline permute_index(i, N)::Int = ifelse(isodd(i),
-                                          Base.unsafe_trunc(Int, i/2) + 1,
-                                          N - Base.unsafe_trunc(Int, (i-1)/2))
+                                          i ÷ 2 + 1,
+                                          N - (i - 1) ÷ 2)
 
 """
 $(TYPEDSIGNATURES)
@@ -33,7 +33,7 @@ for `N=8` and `N=9` respectively.
 
 See equation (20) of [Makhoul80](@citet).
 """
-@inline unpermute_index(i, N) = ifelse(i <= ceil(N/2), 2i-1, 2(N-i+1))
+@inline unpermute_index(i, N) = ifelse(i <= (N + 1) ÷ 2, 2i-1, 2(N-i+1))
 
 @kernel function permute_x_indices!(dst, src, grid)
     i, j, k = @index(Global, NTuple)

--- a/test/dependencies_for_poisson_solvers.jl
+++ b/test/dependencies_for_poisson_solvers.jl
@@ -23,10 +23,11 @@ function random_divergent_source_term(grid)
     U = (u=Ru, v=Rv, w=Rw)
 
     Nx, Ny, Nz = size(grid)
+    FT = eltype(grid)
 
-    set!(Ru, rand(size(Ru)...))
-    set!(Rv, rand(size(Rv)...))
-    set!(Rw, rand(size(Rw)...))
+    set!(Ru, rand(FT, size(Ru)...))
+    set!(Rv, rand(FT, size(Rv)...))
+    set!(Rw, rand(FT, size(Rw)...))
 
     fill_halo_regions!(Ru)
     fill_halo_regions!(Rv)
@@ -34,7 +35,7 @@ function random_divergent_source_term(grid)
 
     # Compute the right hand side R = ∇⋅U
     ArrayType = array_type(arch)
-    R = zeros(Nx, Ny, Nz) |> ArrayType
+    R = zeros(FT, Nx, Ny, Nz) |> ArrayType
     launch!(arch, grid, :xyz, divergence!, grid, U.u.data, U.v.data, U.w.data, R)
 
     return R, U
@@ -51,9 +52,11 @@ function random_divergent_source_term(grid::ImmersedBoundaryGrid)
 
     U = (u=Ru, v=Rv, w=Rw)
 
-    set!(Ru, rand(size(Ru)...))
-    set!(Rv, rand(size(Rv)...))
-    set!(Rw, rand(size(Rw)...))
+    FT = eltype(grid)
+
+    set!(Ru, rand(FT, size(Ru)...))
+    set!(Rv, rand(FT, size(Rv)...))
+    set!(Rw, rand(FT, size(Rw)...))
 
     mask_immersed_field!(Ru)
     mask_immersed_field!(Rv)
@@ -83,10 +86,11 @@ function random_divergence_free_source_term(grid)
     U = (u=Ru, v=Rv, w=Rw)
 
     Nx, Ny, Nz = size(grid)
+    FT = eltype(grid)
 
-    set!(Ru, rand(size(Ru)...))
-    set!(Rv, rand(size(Rv)...))
-    set!(Rw, rand(size(Rw)...))
+    set!(Ru, rand(FT, size(Ru)...))
+    set!(Rv, rand(FT, size(Rv)...))
+    set!(Rw, rand(FT, size(Rw)...))
 
     fill_halo_regions!(Ru)
     fill_halo_regions!(Rv)
@@ -98,7 +102,7 @@ function random_divergence_free_source_term(grid)
 
     # Compute the right hand side R = ∇⋅U
     ArrayType = array_type(arch)
-    R = zeros(Nx, Ny, Nz) |> ArrayType
+    R = zeros(FT, Nx, Ny, Nz) |> ArrayType
     launch!(arch, grid, :xyz, divergence!, grid, Ru.data, Rv.data, Rw.data, R)
 
     return R


### PR DESCRIPTION
* build DCT twiddle factors in the grid's precision: Metal cannot store ComplexF64, and this also avoids mixed-precision broadcasts on Float32 CUDA/AMDGPU grids
* use integer arithmetic in the DCT index permutations: integer / produces Float64, which Metal kernels cannot compile; i ÷ 2 == trunc(i/2) and (N + 1) ÷ 2 == ceil(N/2) exactly, and this retires the unsafe_trunc workaround from #997
* make the Poisson test helpers allocate in eltype(grid) and test the FFT and Fourier-tridiagonal solvers on Metal

Changes in preparation for Metal support for FFT-based Poisson solvers.  Taken out of #5782 because these changes are generic fixes, although strictly needed only for Metal GPUs, and can be reviewed separately from adding support for Poisson solvers.