### PR TITLE
(0.110.10) Fix substeps alignment in `SplitExplicitFreeSurface`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.9"
+version = "0.110.10"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
@@ -329,7 +329,6 @@ function FixedTimeStepSize(grid;
 end
 
 @inline function weights_from_substeps(FT, substeps, averaging_kernel)
-    M  = substeps ÷ 2
     τᶠ = range(FT(0), FT(2), length = substeps+1)
     Δτ = τᶠ[2] - τᶠ[1]
 
@@ -339,7 +338,12 @@ end
 
     trimmed_weights = averaging_weights[1:M★]
     trimmed_weights ./= sum(trimmed_weights)
-    transport_weights = [sum(trimmed_weights[i:M★]) for i in 1:M★] ./ M
+
+    # Rescale the substep size so the trimmed weights' first moment lands exactly on the baroclinic step
+    barycenter = sum(trimmed_weights .* (1:M★)) * Δτ
+    Δτ = Δτ / barycenter
+
+    transport_weights = [sum(trimmed_weights[i:M★]) for i in 1:M★] .* Δτ
 
     return FT(Δτ), map(FT, tuple(trimmed_weights...)), map(FT, tuple(transport_weights...))
 end

--- a/test/data_dependencies.jl
+++ b/test/data_dependencies.jl
@@ -13,9 +13,11 @@ DataDeps.register(dd)
 datadep"cubed_sphere_32_grid"
 
 # Downloading the regression fields
-path = "https://github.com/simone-silvestri/OceananigansArtifacts.jl/raw/refs/heads/ss/new-data-for-regression-2/data_for_regression_tests"
+path = "https://github.com/simone-silvestri/OceananigansArtifacts.jl/raw/refs/heads/ss/new-data-for-regression-2/data_for_regression_tests/"
 
-dh = DataDep("regression_truth_data",
+# DataDeps caches by name and never re-downloads while the cache directory exists. CI agents keep a
+# persistent depot, so the version suffix must be bumped whenever the reference data is regenerated.
+dh = DataDep("regression_truth_data_v2",
     "Data for Regression tests",
     [path * "hydrostatic_free_turbulence_regression_Periodic_ImplicitFreeSurface.jld2",
      path * "hydrostatic_free_turbulence_regression_Periodic_ExplicitFreeSurface.jld2",
@@ -46,32 +48,4 @@ dh = DataDep("regression_truth_data",
 
 DataDeps.register(dh)
 
-# Invalidate stale DataDeps cache when any expected reference file is missing
-# or has an unexpected size. Persistent CI caches (e.g. buildkite agents)
-# may hold reference data from previous artifact uploads; expected sizes are
-# the authoritative way to detect that.
-#
-# Sizes refer to the current files in glwagner/OceananigansArtifacts.jl
-# (data_for_regression_tests/). When regenerating reference data, update
-# these alongside the new upload.
-const _expected_reference_sizes = Dict(
-    "ocean_large_eddy_simulation_DynamicSmagorinsky_directional_iteration10000.jld2" => 713110,
-    "ocean_large_eddy_simulation_DynamicSmagorinsky_directional_iteration10010.jld2" => 713110,
-    "ocean_large_eddy_simulation_DynamicSmagorinsky_lagrangian_iteration10000.jld2"  => 1244676,
-    "ocean_large_eddy_simulation_DynamicSmagorinsky_lagrangian_iteration10010.jld2"  => 1244676,
-)
-
-dd_path = try; datadep"regression_truth_data"; catch; nothing; end
-if dd_path !== nothing
-    cache_stale = any(_expected_reference_sizes) do (filename, expected_size)
-        path = joinpath(dd_path, filename)
-        !isfile(path) || filesize(path) != expected_size
-    end
-    if cache_stale
-        @info "Regression truth data cache is stale, re-downloading..."
-        rm(dd_path; recursive=true)
-        datadep"regression_truth_data"
-    end
-else
-    datadep"regression_truth_data"
-end
+datadep"regression_truth_data_v2"

--- a/test/data_dependencies.jl
+++ b/test/data_dependencies.jl
@@ -13,7 +13,7 @@ DataDeps.register(dd)
 datadep"cubed_sphere_32_grid"
 
 # Downloading the regression fields
-path = "https://github.com/glwagner/OceananigansArtifacts.jl/raw/main/data_for_regression_tests/"
+path = "https://github.com/simone-silvestri/OceananigansArtifacts.jl/raw/refs/heads/ss/new-data-for-regression-2/data_for_regression_tests"
 
 dh = DataDep("regression_truth_data",
     "Data for Regression tests",

--- a/test/data_dependencies.jl
+++ b/test/data_dependencies.jl
@@ -48,4 +48,13 @@ dh = DataDep("regression_truth_data_v2",
 
 DataDeps.register(dh)
 
+# A download that fails partway leaves the cache poisoned
+reference_filenames = basename.(dh.remotepath)
+datadep_path = DataDeps.try_determine_load_path("regression_truth_data_v2", pwd())
+
+if datadep_path !== nothing && !(isdir(datadep_path) && all(f -> isfile(joinpath(datadep_path, f)), reference_filenames))
+    @info "Discarding incomplete regression truth data at $datadep_path"
+    rm(datadep_path; force=true, recursive=true)
+end
+
 datadep"regression_truth_data_v2"

--- a/test/regression_tests/hydrostatic_free_turbulence_regression_test.jl
+++ b/test/regression_tests/hydrostatic_free_turbulence_regression_test.jl
@@ -116,7 +116,7 @@ function run_hydrostatic_free_turbulence_regression_test(grid, free_surface; reg
     )
 
     if !regenerate_data
-        datadep_path = "regression_truth_data/" * output_filename
+        datadep_path = "regression_truth_data_v2/" * output_filename
         regression_data_path = @datadep_str datadep_path
         file = jldopen(regression_data_path)
 

--- a/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
+++ b/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
@@ -106,7 +106,7 @@ function run_ocean_large_eddy_simulation_regression_test(arch, grid_type, closur
     #### Regression test
     ####
 
-    datadep_path = "regression_truth_data/" * name * "_iteration$spinup_steps.jld2"
+    datadep_path = "regression_truth_data_v2/" * name * "_iteration$spinup_steps.jld2"
     initial_filename = @datadep_str datadep_path
 
     solution₀, Gⁿ₀, G⁻₀, closure₀, pNHS₀ = get_fields_from_checkpoint(initial_filename)
@@ -191,7 +191,7 @@ function run_ocean_large_eddy_simulation_regression_test(arch, grid_type, closur
         time_step!(model, Δt, euler=false)
     end
 
-    datadep_path = "regression_truth_data/" * name * "_iteration$(spinup_steps+test_steps).jld2"
+    datadep_path = "regression_truth_data_v2/" * name * "_iteration$(spinup_steps+test_steps).jld2"
     final_filename = @datadep_str datadep_path
 
     solution₁, Gⁿ₁, G⁻₁, _, _ = get_fields_from_checkpoint(final_filename)

--- a/test/regression_tests/rayleigh_benard_regression_test.jl
+++ b/test/regression_tests/rayleigh_benard_regression_test.jl
@@ -101,7 +101,7 @@ function run_rayleigh_benard_regression_test(arch, grid_type)
     #####
 
     # Load initial state
-    datadep_path = "regression_truth_data/" * prefix * "_iteration$spinup_steps.jld2"
+    datadep_path = "regression_truth_data_v2/" * prefix * "_iteration$spinup_steps.jld2"
     initial_filename = @datadep_str datadep_path
 
     solution₀, Gⁿ₀, G⁻₀, _, _ = get_fields_from_checkpoint(initial_filename)
@@ -153,7 +153,7 @@ function run_rayleigh_benard_regression_test(arch, grid_type)
         time_step!(model, Δt, euler=false)
     end
 
-    datadep_path = "regression_truth_data/" * prefix * "_iteration$(spinup_steps+test_steps).jld2"
+    datadep_path = "regression_truth_data_v2/" * prefix * "_iteration$(spinup_steps+test_steps).jld2"
     final_filename = @datadep_str datadep_path
 
     solution₁, Gⁿ₁, G⁻₁, _, _ = get_fields_from_checkpoint(final_filename)

--- a/test/regression_tests/thermal_bubble_regression_test.jl
+++ b/test/regression_tests/thermal_bubble_regression_test.jl
@@ -34,7 +34,7 @@ function run_thermal_bubble_regression_test(arch, grid_type)
     k1, k2 = round(Int, Nz/4), round(Int, 3Nz/4)
     view(model.tracers.T, i1:i2, j1:j2, k1:k2) .+= 0.01
 
-    datadep_path = "regression_truth_data/thermal_bubble_regression.nc"
+    datadep_path = "regression_truth_data_v2/thermal_bubble_regression.nc"
     regression_data_filepath = @datadep_str datadep_path
 
     ####


### PR DESCRIPTION
the substeps were not perfectly aligned with the baroclinic steps. This produces a (rather) small time delay on the barotropic mode. However, when introducing a forcing, this delay also destroys freshwater conservation.
This PR fixes it.

MWE:
```julia
grid = RectilinearGrid(size = (1, 1, 1), x = (0, 100), y = (0, 100), z = MutableVerticalDiscretization((-100, 0)))
model = HydrostaticFreeSurfaceModel(grid; free_surface=SplitExplicitFreeSurface(grid; substeps=10), forcing=(; η = (args...) -> 1e-2))
time_step!(model, 10)
```
The free surface should increase by 10 cm given the forcing is 1e-2 m/s

on main
```julia
julia> model.free_surface.displacement
1×1×1 Field{Center, Center, Face} on RectilinearGrid on CPU
├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
├── boundary conditions: FieldBoundaryConditions
│   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: Nothing, top: Nothing, immersed: Nothing
├── indices: (:, :, 2:2)
└── data: 3×3×1 OffsetArray(::Array{Float64, 3}, 0:2, 0:2, 2:2) with eltype Float64 with indices 0:2×0:2×2:2
    └── max=0.100909, min=0.100909, mean=0.100909
```

on this PR
```julia
julia> model.free_surface.displacement
1×1×1 Field{Center, Center, Face} on RectilinearGrid on CPU
├── grid: 1×1×1 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×1 halo
├── boundary conditions: FieldBoundaryConditions
│   └── west: Periodic, east: Periodic, south: Periodic, north: Periodic, bottom: Nothing, top: Nothing, immersed: Nothing
├── indices: (:, :, 2:2)
└── data: 3×3×1 OffsetArray(::Array{Float64, 3}, 0:2, 0:2, 2:2) with eltype Float64 with indices 0:2×0:2×2:2
    └── max=0.1, min=0.1, mean=0.1
```