### PR TITLE
(0.110.11) Restores `update_state!` ordering for nonhydrostatic model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.10"
+version = "0.110.11"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/Models/NonhydrostaticModels/update_nonhydrostatic_model_state.jl
+++ b/src/Models/NonhydrostaticModels/update_nonhydrostatic_model_state.jl
@@ -55,8 +55,8 @@ function update_state!(model::NonhydrostaticModel, callbacks=[])
     end
 
     update_advection_timestep!(model.advection, model.timestepper, model.clock)
-    compute_tendencies!(model, callbacks)
     update_biogeochemical_state!(model.biogeochemistry, model)
+    compute_tendencies!(model, callbacks)
 
     return nothing
 end


### PR DESCRIPTION
This PR fixes the ordering of `update_biogeochemical_state!` and `compute_tendencies!` in the `update_state!` method for the nonhydrostatic model. The change in ordering crept in in https://github.com/CliMA/Oceananigans.jl/pull/4811