### PR TITLE
Fix stale `materialize_immersed_boundary` docstring

### DIFF
--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -68,6 +68,14 @@ function set_bottom_height!(bottom_field, bottom_height::OffsetArray)
 end
 
 bottom_height_field(bottom_data, grid) = Field{Center, Center, Nothing}(grid; data=bottom_data)
+
+"""
+$(TYPEDSIGNATURES)
+
+Return a `Field` at `(Center, Center, Nothing)` that wraps the bottom height of `grid`, which is
+stored on `grid.immersed_boundary` as a bare `OffsetArray`. The returned `Field` shares its data
+with `grid`, so mutating it mutates the bottom height of `grid`.
+"""
 bottom_height_field(grid::IBG) = bottom_height_field(grid.immersed_boundary.bottom_height, grid.underlying_grid)
 
 function Base.summary(ib::GridFittedBottom)
@@ -104,7 +112,7 @@ $(TYPEDSIGNATURES)
 Returns a new `ib` that holds the numerical `immersed_boundary`.
 If `ib` is an `AbstractGridFittedBottom`, `ib.bottom_height` is an `OffsetArray` holding the
 z-coordinate of the top-most interface of the last ``immersed`` cell in the column (wrap it as a
-`Field` with `bottom_height_field`). If `ib` is a `GridFittedBoundary`, `ib.mask` is a `Field` of
+`Field` with [`bottom_height_field`](@ref)). If `ib` is a `GridFittedBoundary`, `ib.mask` is a `Field` of
 booleans that indicates whether a cell is immersed or not.
 """
 function materialize_immersed_boundary(grid, ib::GridFittedBottom)

--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -101,10 +101,11 @@ Adapt.adapt_structure(to, ib::GridFittedBottom) = GridFittedBottom(adapt(to, ib.
 """
 $(TYPEDSIGNATURES)
 
-Returns a new `ib` wrapped around a Field that holds the numerical `immersed_boundary`.
-If `ib` is an `AbstractGridFittedBottom`, `ib.bottom_height` is the z-coordinate of
-top-most interface of the last ``immersed`` cell in the column. If `ib` is a `GridFittedBoundary`,
-`ib.mask` is a field of booleans that indicates whether a cell is immersed or not.
+Returns a new `ib` that holds the numerical `immersed_boundary`.
+If `ib` is an `AbstractGridFittedBottom`, `ib.bottom_height` is an `OffsetArray` holding the
+z-coordinate of the top-most interface of the last ``immersed`` cell in the column (wrap it as a
+`Field` with `bottom_height_field`). If `ib` is a `GridFittedBoundary`, `ib.mask` is a `Field` of
+booleans that indicates whether a cell is immersed or not.
 """
 function materialize_immersed_boundary(grid, ib::GridFittedBottom)
     bottom_field = Field{Center, Center, Nothing}(grid)


### PR DESCRIPTION
Since #5737, `materialize_immersed_boundary` for `GridFittedBottom` returns an `ib` wrapping a plain `OffsetArray` (`bottom_field.data`), not a `Field` — but the docstring still says "wrapped around a Field". The mismatch silently broke some downstream code that accessed `immersed_boundary.bottom_height` as a `Field`. This fixes the docstring and points to `bottom_height_field` as the way to obtain a `Field`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
