### PR TITLE
Revert "Fix NCCL send/recv for Bool fields (ImmersedBoundaryGrid mask)"

### DIFF
--- a/ext/OceananigansNCCLExt/nccl_distributed.jl
+++ b/ext/OceananigansNCCLExt/nccl_distributed.jl
@@ -161,10 +161,8 @@ nccl_corner_send_recv!(nccl_comm, corner_rank, ::Nothing) = nothing
 nccl_corner_send_recv!(nccl_comm, ::Nothing, ::Nothing) = nothing
 
 function nccl_corner_send_recv!(nccl_comm, corner_rank, buffers)
-    send_buf = eltype(buffers.send) === Bool ? reinterpret(UInt8, buffers.send) : buffers.send
-    recv_buf = eltype(buffers.recv) === Bool ? reinterpret(UInt8, buffers.recv) : buffers.recv
-    NCCL.Send(send_buf, nccl_comm; dest=corner_rank)
-    NCCL.Recv!(recv_buf, nccl_comm; source=corner_rank)
+    NCCL.Send(buffers.send, nccl_comm; dest=corner_rank)
+    NCCL.Recv!(buffers.recv, nccl_comm; source=corner_rank)
     return nothing
 end
 
@@ -174,11 +172,8 @@ end
 
 function _nccl_send_recv_pair!(buf, bc, nccl_comm; stream_kw...)
     isnothing(buf) && return nothing
-    # NCCL has no Bool dtype; reinterpret as UInt8 (same size)
-    send_buf = eltype(buf.send) === Bool ? reinterpret(UInt8, buf.send) : buf.send
-    recv_buf = eltype(buf.recv) === Bool ? reinterpret(UInt8, buf.recv) : buf.recv
-    NCCL.Send(send_buf, nccl_comm; dest=bc.condition.to, stream_kw...)
-    NCCL.Recv!(recv_buf, nccl_comm; source=bc.condition.to, stream_kw...)
+    NCCL.Send(buf.send, nccl_comm; dest=bc.condition.to, stream_kw...)
+    NCCL.Recv!(buf.recv, nccl_comm; source=bc.condition.to, stream_kw...)
     return nothing
 end
 


### PR DESCRIPTION
This PR [likely causes a segfault](https://github.com/CliMA/Oceananigans.jl/pull/5765#issuecomment-5003649002).  Note that [the distributed tests never ran on the original PR](https://buildkite.com/clima/oceananigans-distributed/builds?branch=aklocker%2Ffix-nccl-bool-dtype).

Reverts CliMA/Oceananigans.jl#5765