### PR TITLE
Fix three synchronization bugs in OceananigansNCCLExt halo exchange

### DIFF
--- a/ext/OceananigansNCCLExt/nccl_distributed.jl
+++ b/ext/OceananigansNCCLExt/nccl_distributed.jl
@@ -120,11 +120,7 @@ end
 function synchronize_communication!(field::NCCLDistributedField)
     arch = DC.architecture(field.grid)
 
-    # Complete requests pooled by fills that took the mainline MPI path and reset
-    # the MPI tag, as the mainline method does — otherwise the tag counter grows
-    # past MPI_TAG_UB and MPI_Irecv errors. Unlike mainline, do NOT unpack
-    # `field`'s MPI buffers: the pooled requests belong to other fields, and
-    # `field`'s halos arrived via NCCL, so its MPI buffers hold stale data.
+Synchronize when using heterogeneous NCCL/MPI
     if !isempty(arch.mpi_requests)
         DC.cooperative_waitall!(arch.mpi_requests)
         arch.mpi_tag[] = 0

--- a/ext/OceananigansNCCLExt/nccl_distributed.jl
+++ b/ext/OceananigansNCCLExt/nccl_distributed.jl
@@ -57,10 +57,6 @@ function DC.NCCLDistributed(child_arch = GPU(); partition = nothing, kwargs...)
                           mpi_arch.devices)
 end
 
-# No sync_device! override here: mainline MPI halo fills and `maybe_all_reduce!`
-# need a real device sync before GPU-aware MPI reads GPU buffers. The NCCL fill
-# path below is stream-ordered and never calls it.
-
 #####
 ##### distributed_fill_halo_event! for NCCLDistributedGrid
 #####

--- a/ext/OceananigansNCCLExt/nccl_distributed.jl
+++ b/ext/OceananigansNCCLExt/nccl_distributed.jl
@@ -1,18 +1,16 @@
 using Oceananigans.BoundaryConditions: DistributedFillHalo, WestAndEast, SouthAndNorth,
                                        West, East, South, North, BottomAndTop, Bottom, Top
 
-import Oceananigans.Utils: sync_device!
 import Oceananigans.DistributedComputations: synchronize_communication!
 
 #####
 ##### NCCLCommunicator
 #####
 
-struct NCCLCommunicator{NC, MC, CS, EV}
+struct NCCLCommunicator{NC, MC, CS}
     nccl        :: NC   # NCCL.Communicator
     mpi         :: MC   # MPI.Comm
     comm_stream :: CS   # Dedicated CUDA stream for async NCCL ops
-    sync_event  :: EV   # CUDA event for cross-stream synchronization
 end
 
 # Forward MPI operations to the inner MPI comm
@@ -44,8 +42,7 @@ function DC.NCCLDistributed(child_arch = GPU(); partition = nothing, kwargs...)
     mpi_arch = Distributed(child_arch; partition, kwargs...)
     nccl_comm = create_nccl_comm_from_mpi(mpi_arch.communicator)
     comm_stream = CUDA.CuStream(; flags=CUDA.STREAM_NON_BLOCKING)
-    sync_event = CUDA.CuEvent()
-    nccl_communicator = NCCLCommunicator(nccl_comm, mpi_arch.communicator, comm_stream, sync_event)
+    nccl_communicator = NCCLCommunicator(nccl_comm, mpi_arch.communicator, comm_stream)
 
     S = mpi_arch isa DC.SynchronizedDistributed
     return Distributed{S}(mpi_arch.child_architecture,
@@ -60,8 +57,14 @@ function DC.NCCLDistributed(child_arch = GPU(); partition = nothing, kwargs...)
                           mpi_arch.devices)
 end
 
-# NCCL is stream-native; sync is handled via CUDA events on comm_stream.
-sync_device!(::NCCLDistributedArchitecture) = nothing
+# NOTE: do NOT override `sync_device!(::NCCLDistributedArchitecture) = nothing`.
+# The NCCL fill path below is stream-ordered and never calls `sync_device!`,
+# but other code paths still rely on it being a real device sync under this
+# architecture: mainline MPI halo fills (e.g. for fields on adapted,
+# architecture-stripped grids) call it between packing send buffers and
+# GPU-aware `MPI.Isend`, and `maybe_all_reduce!` calls it before MPI
+# reductions on GPU data. A no-op here lets those paths read GPU buffers
+# while the kernels producing them are still in flight.
 
 #####
 ##### distributed_fill_halo_event! for NCCLDistributedGrid
@@ -72,7 +75,7 @@ sync_device!(::NCCLDistributedArchitecture) = nothing
 #####   synchronize_communication! later waits for comm_stream and unpacks.
 #####
 
-# Storage for pending async unpacks: (data, buffers, grid, side) tuples
+# Storage for pending async unpacks: (data, buffers, grid, side, event) tuples
 const pending_unpacks = Vector{Any}()
 const pending_unpacks_lock = ReentrantLock()
 
@@ -87,26 +90,36 @@ function DC.distributed_fill_halo_event!(c, kernel!::DistributedFillHalo, bcs, l
     nccl_comm = communicator.nccl
     buffer_side = kernel!.side
 
+    # Every stream dependency below uses a fresh event, NOT one shared event
+    # stored in the communicator: a CUDA event only remembers its most recent
+    # record, so a single event re-recorded by every fill (twice per call,
+    # several fields per timestep) can leave synchronize_communication!'s
+    # wait targeting a pack record on the default stream instead of the NCCL
+    # ops on comm_stream. The unpack then races the in-flight transfer and
+    # can read a partially received halo. Timing-disabled events are cheap.
+
     # Pack send buffers, then make comm_stream wait for the pack to complete.
     DC.fill_send_buffers!(c, buffers, grid, buffer_side)
-    CUDA.record(communicator.sync_event)
-    CUDA.cuStreamWaitEvent(communicator.comm_stream, communicator.sync_event, UInt32(0))
+    pack_done = CUDA.CuEvent(CUDA.EVENT_DISABLE_TIMING)
+    CUDA.record(pack_done)
+    CUDA.cuStreamWaitEvent(communicator.comm_stream, pack_done, UInt32(0))
 
     NCCL.groupStart()
     enqueue_nccl_send_recv!(kernel!, bcs, nccl_comm, buffers; stream=communicator.comm_stream)
     NCCL.groupEnd()
 
-    CUDA.record(communicator.sync_event, communicator.comm_stream)
+    comm_done = CUDA.CuEvent(CUDA.EVENT_DISABLE_TIMING)
+    CUDA.record(comm_done, communicator.comm_stream)
 
     if async
         lock(pending_unpacks_lock) do
-            push!(pending_unpacks, (; c, buffers, grid, side=buffer_side))
+            push!(pending_unpacks, (; c, buffers, grid, side=buffer_side, event=comm_done))
         end
         return nothing
     end
 
-    # Sync: have the default stream wait for comm_stream, then unpack.
-    CUDA.cuStreamWaitEvent(CUDA.stream(), communicator.sync_event, UInt32(0))
+    # Sync: have the default stream wait for this fill's NCCL ops, then unpack.
+    CUDA.cuStreamWaitEvent(CUDA.stream(), comm_done, UInt32(0))
     DC.recv_from_buffers!(c, buffers, grid, buffer_side)
     return nothing
 end
@@ -118,11 +131,36 @@ end
 #####
 
 function synchronize_communication!(field::NCCLDistributedField)
+    arch = DC.architecture(field.grid)
+
+    # Fills that take the mainline MPI path under this architecture (e.g.
+    # fields living on adapted, architecture-stripped grids) pool their async
+    # requests in arch.mpi_requests and rely on synchronize_communication! to
+    # complete them and reset arch.mpi_tag (see the mainline method in
+    # distributed_fields.jl). This override replaces that method for all
+    # prognostic fields, so it must do the same bookkeeping — otherwise the
+    # tag counter grows without bound until it exceeds MPI_TAG_UB (2^23 - 1
+    # for Cray MPICH) and MPI_Irecv aborts with "Invalid tag".
+    #
+    # Unlike the mainline method, do NOT unpack `field`'s MPI receive buffers
+    # here: the pooled requests belong to *other* fields (which unpack their
+    # own buffers), while `field` received its halos via NCCL — its MPI
+    # receive buffers hold stale data, and unpacking them corrupts the halos.
+    if !isempty(arch.mpi_requests)
+        DC.cooperative_waitall!(arch.mpi_requests)
+        arch.mpi_tag[] = 0
+        empty!(arch.mpi_requests)
+    end
+
     lock(pending_unpacks_lock) do
         if !isempty(pending_unpacks)
-            arch = DC.architecture(field.grid)
-            CUDA.cuStreamWaitEvent(CUDA.stream(), arch.communicator.sync_event, UInt32(0))
+            # Wait on each fill's own comm-completion event before unpacking
+            # its buffers. This also fences all subsequent default-stream work
+            # (the next iteration's packs) behind the finished transfers, so
+            # send buffers are never overwritten while NCCL is still reading
+            # them.
             for pending in pending_unpacks
+                CUDA.cuStreamWaitEvent(CUDA.stream(), pending.event, UInt32(0))
                 DC.recv_from_buffers!(pending.c, pending.buffers, pending.grid, pending.side)
             end
             empty!(pending_unpacks)

--- a/ext/OceananigansNCCLExt/nccl_distributed.jl
+++ b/ext/OceananigansNCCLExt/nccl_distributed.jl
@@ -116,7 +116,7 @@ end
 function synchronize_communication!(field::NCCLDistributedField)
     arch = DC.architecture(field.grid)
 
-Synchronize when using heterogeneous NCCL/MPI
+    # Synchronize when using heterogeneous NCCL/MPI
     if !isempty(arch.mpi_requests)
         DC.cooperative_waitall!(arch.mpi_requests)
         arch.mpi_tag[] = 0

--- a/ext/OceananigansNCCLExt/nccl_distributed.jl
+++ b/ext/OceananigansNCCLExt/nccl_distributed.jl
@@ -85,10 +85,6 @@ function DC.distributed_fill_halo_event!(c, kernel!::DistributedFillHalo, bcs, l
     nccl_comm = communicator.nccl
     buffer_side = kernel!.side
 
-    # Each stream dependency uses a fresh event: a CUDA event only remembers its
-    # latest record, so a shared event re-recorded by every fill can leave waits
-    # targeting the wrong record and let unpacks race in-flight transfers.
-
     # Pack send buffers, then make comm_stream wait for the pack to complete.
     DC.fill_send_buffers!(c, buffers, grid, buffer_side)
     pack_done = CUDA.CuEvent(CUDA.EVENT_DISABLE_TIMING)

--- a/ext/OceananigansNCCLExt/nccl_distributed.jl
+++ b/ext/OceananigansNCCLExt/nccl_distributed.jl
@@ -57,14 +57,9 @@ function DC.NCCLDistributed(child_arch = GPU(); partition = nothing, kwargs...)
                           mpi_arch.devices)
 end
 
-# NOTE: do NOT override `sync_device!(::NCCLDistributedArchitecture) = nothing`.
-# The NCCL fill path below is stream-ordered and never calls `sync_device!`,
-# but other code paths still rely on it being a real device sync under this
-# architecture: mainline MPI halo fills (e.g. for fields on adapted,
-# architecture-stripped grids) call it between packing send buffers and
-# GPU-aware `MPI.Isend`, and `maybe_all_reduce!` calls it before MPI
-# reductions on GPU data. A no-op here lets those paths read GPU buffers
-# while the kernels producing them are still in flight.
+# No sync_device! override here: mainline MPI halo fills and `maybe_all_reduce!`
+# need a real device sync before GPU-aware MPI reads GPU buffers. The NCCL fill
+# path below is stream-ordered and never calls it.
 
 #####
 ##### distributed_fill_halo_event! for NCCLDistributedGrid
@@ -90,13 +85,9 @@ function DC.distributed_fill_halo_event!(c, kernel!::DistributedFillHalo, bcs, l
     nccl_comm = communicator.nccl
     buffer_side = kernel!.side
 
-    # Every stream dependency below uses a fresh event, NOT one shared event
-    # stored in the communicator: a CUDA event only remembers its most recent
-    # record, so a single event re-recorded by every fill (twice per call,
-    # several fields per timestep) can leave synchronize_communication!'s
-    # wait targeting a pack record on the default stream instead of the NCCL
-    # ops on comm_stream. The unpack then races the in-flight transfer and
-    # can read a partially received halo. Timing-disabled events are cheap.
+    # Each stream dependency uses a fresh event: a CUDA event only remembers its
+    # latest record, so a shared event re-recorded by every fill can leave waits
+    # targeting the wrong record and let unpacks race in-flight transfers.
 
     # Pack send buffers, then make comm_stream wait for the pack to complete.
     DC.fill_send_buffers!(c, buffers, grid, buffer_side)
@@ -133,19 +124,11 @@ end
 function synchronize_communication!(field::NCCLDistributedField)
     arch = DC.architecture(field.grid)
 
-    # Fills that take the mainline MPI path under this architecture (e.g.
-    # fields living on adapted, architecture-stripped grids) pool their async
-    # requests in arch.mpi_requests and rely on synchronize_communication! to
-    # complete them and reset arch.mpi_tag (see the mainline method in
-    # distributed_fields.jl). This override replaces that method for all
-    # prognostic fields, so it must do the same bookkeeping — otherwise the
-    # tag counter grows without bound until it exceeds MPI_TAG_UB (2^23 - 1
-    # for Cray MPICH) and MPI_Irecv aborts with "Invalid tag".
-    #
-    # Unlike the mainline method, do NOT unpack `field`'s MPI receive buffers
-    # here: the pooled requests belong to *other* fields (which unpack their
-    # own buffers), while `field` received its halos via NCCL — its MPI
-    # receive buffers hold stale data, and unpacking them corrupts the halos.
+    # Complete requests pooled by fills that took the mainline MPI path and reset
+    # the MPI tag, as the mainline method does — otherwise the tag counter grows
+    # past MPI_TAG_UB and MPI_Irecv errors. Unlike mainline, do NOT unpack
+    # `field`'s MPI buffers: the pooled requests belong to other fields, and
+    # `field`'s halos arrived via NCCL, so its MPI buffers hold stale data.
     if !isempty(arch.mpi_requests)
         DC.cooperative_waitall!(arch.mpi_requests)
         arch.mpi_tag[] = 0
@@ -154,11 +137,8 @@ function synchronize_communication!(field::NCCLDistributedField)
 
     lock(pending_unpacks_lock) do
         if !isempty(pending_unpacks)
-            # Wait on each fill's own comm-completion event before unpacking
-            # its buffers. This also fences all subsequent default-stream work
-            # (the next iteration's packs) behind the finished transfers, so
-            # send buffers are never overwritten while NCCL is still reading
-            # them.
+            # Wait on each fill's completion event before unpacking; this also
+            # fences the next iteration's packs behind the finished transfers.
             for pending in pending_unpacks
                 CUDA.cuStreamWaitEvent(CUDA.stream(), pending.event, UInt32(0))
                 DC.recv_from_buffers!(pending.c, pending.buffers, pending.grid, pending.side)


### PR DESCRIPTION
We tested `NCCLDistributed` on a realistic regional ocean setup at 16 GPUs (4 nodes × 4 NVIDIA GH200, Slingshot interconnect via aws-ofi-nccl 1.19.1, NCCL 2.30.4, Cray MPICH 9.1.0): `HydrostaticFreeSurfaceModel` with
split-explicit free surface, WENO-9, CATKE, `ImmersedBoundaryGrid` (`PartialCellBottom`, `active_cells_map = true`), open boundaries (Flather + radiation fed by GLORYS `FieldTimeSeries`), prescribed ERA5 atmosphere. This exercises the **mixed NCCL + MPI** pattern: prognostic fields exchange halos over NCCL, while fields on adapted (architecture-stripped) grids take the mainline MPI path. Three independent bugs, all fixed here:

### 1. Shared `sync_event` aliasing → per-fill events

A CUDA event only remembers its most recent record. The single `communicator.sync_event`, re-recorded twice by every fill (pack on the compute stream, completion on `comm_stream`) across several fields per timestep, can leave `synchronize_communication!`'s `cuStreamWaitEvent` targeting a *pack* record instead of the NCCL ops being unpacked — the unpack then races the in-flight transfer and can read a partially received halo. Each fill now records its own timing-disabled completion event that travels with its pending unpack; the wait also fences the next iteration's
packs behind the finished transfers, so send buffers are never overwritten while NCCL is still reading them. The now-unused `sync_event` field is removed from `NCCLCommunicator`.

### 2. MPI tag counter never reset → `MPI_Irecv: Invalid tag`

`synchronize_communication!(::NCCLDistributedField)` replaces the mainline method for all prognostic fields but previously did only NCCL bookkeeping. Fills that take the mainline MPI path pool async requests and rely on this
method to complete them and reset `arch.mpi_tag`; without that, the tag counter grows without bound until `counter*1000` exceeds `MPI_TAG_UB` (2²³ − 1 on Cray MPICH) and the job aborts with `MPIError: Invalid tag, value is 8389131` (~230 iterations at 16 ranks in our setup). The override now waits the pooled requests, resets the tag, and
empties the pool. Pitfall documented in the code: it must **not** unpack the field's own MPI receive buffers (the mainline method does) — the pooled requests belong to *other* fields, and this field's halos arrived via NCCL,
so its MPI buffers hold stale data; unpacking them corrupts the halos (we reproduced an 8-rank NaN blow-up within 50 iterations doing exactly that).

### 3. `sync_device!` no-op removed

The extension made `sync_device!(::NCCLDistributedArchitecture)` a no-op. The NCCL fill path is stream-ordered and never calls it, but other paths rely on it being a real device sync under this architecture: mainline MPI halo fills call it between packing send buffers and GPU-aware `MPI.Isend`, and `maybe_all_reduce!` calls it before MPI reductions on GPU data. The no-op let those paths read GPU buffers while the kernels producing them were still in flight.

### Validation

With these fixes the setup completes multi-day integrations cleanly (previously: deterministic failures within hundreds of iterations) and NCCL is ~5% faster than Cray MPICH at 16 GPUs on identical physics (0.290 vs 0.306 s/iteration), with transport confirmed as Libfabric/CXI + GPUDirect RDMA. Full write-up, job logs, and benchmarks available on request.

### Heads-up for `ss/open-boundary-conditions` (not part of this PR)

That branch's refactor of the halo machinery (`0cc46af94`) passes `arch` explicitly to `distributed_fill_halo_event!`, which **silently un-dispatches** this extension's fill override — the method never matches, every fill falls back to MPI, and the async unpacks are dropped (halos freeze; we chased this as a "deterministic rank-local NaN at iteration 810" for some time). When these fixes reach the branch, the extension signature there must become `(c, kernel!::DistributedFillHalo, bcs, loc, arch, grid::NCCLDistributedGrid, buffers, args...)`. We have that variant validated too. More generally: the extension shadows a mainline internal signature and breaks silently when it drifts — a typed hook or a dispatch-reachability test would prevent the next one.

cc @glwagner 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
