### PR TITLE
Improve type inference for `Advection.needs_implicit_solver`

### DIFF
--- a/src/Advection/adaptive_implicit_vertical_advection.jl
+++ b/src/Advection/adaptive_implicit_vertical_advection.jl
@@ -79,7 +79,9 @@ end
 
 needs_implicit_solver(advection) = false
 needs_implicit_solver(::AdaptiveImplicitVerticalAdvection) = true
-needs_implicit_solver(a::NamedTuple) = any(needs_implicit_solver, values(a))
+# `any` follows the three-valued logic and _may_ return `missing` in some cases.  Let's
+# inform the compiler with the `::Bool` annotation that we know we only deal with booleans.
+needs_implicit_solver(a::NamedTuple) = any(needs_implicit_solver, values(a))::Bool
 
 """
 $(TYPEDSIGNATURES)


### PR DESCRIPTION
Currently we have
```julia-repl
julia> using Oceananigans

julia> unique(Base.return_types(Oceananigans.Advection.needs_implicit_solver, (NamedTuple,)))
1-element Vector{Any}:
 Union{Missing, Bool}

julia> unique(Base.return_types(Oceananigans.Advection.needs_implicit_solver, (Any,)))
2-element Vector{Any}:
 Bool
 Union{Missing, Bool}
```
because [`any`](https://docs.julialang.org/en/v1/base/collections/#Base.any-Tuple%7BAbstractArray,%20Any%7D) follows the [three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic) and it _may_ return `missing` in some cases, but we know we only have booleans here, so we need to give the compiler a nudge to know that.  With the proposed change:
```julia-repl
julia> using Oceananigans

julia> unique(Base.return_types(Oceananigans.Advection.needs_implicit_solver, (NamedTuple,)))
1-element Vector{Any}:
 Bool

julia> unique(Base.return_types(Oceananigans.Advection.needs_implicit_solver, (Any,)))
1-element Vector{Any}:
 Bool
```

Issue detected by using JETLS.jl downstream in Breeze.jl.