### PR TITLE
Clarify FFT pressure solver warning and error on immersed cells above wet cells in `HydrostaticFreeSurfaceModel`

### DIFF
--- a/docs/src/models/boundary_conditions.md
+++ b/docs/src/models/boundary_conditions.md
@@ -531,6 +531,7 @@ model.velocities.w.boundary_conditions.immersed
 │
 │     using Oceananigans.Solvers: ConjugateGradientPoissonSolver
 │     pressure_solver = ConjugateGradientPoissonSolver(grid)
+│     model = NonhydrostaticModel(grid; pressure_solver)
 │
 │ Please report issues to https://github.com/CliMA/Oceananigans.jl/issues.
 └ @ Oceananigans.Models.NonhydrostaticModels ~/Oceananigans.jl/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl:55
@@ -567,6 +568,7 @@ model = NonhydrostaticModel(grid; boundary_conditions=(u=velocity_bcs, v=velocit
 │
 │     using Oceananigans.Solvers: ConjugateGradientPoissonSolver
 │     pressure_solver = ConjugateGradientPoissonSolver(grid)
+│     model = NonhydrostaticModel(grid; pressure_solver)
 │
 │ Please report issues to https://github.com/CliMA/Oceananigans.jl/issues.
 └ @ Oceananigans.Models.NonhydrostaticModels ~/Oceananigans.jl/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl:55

--- a/examples/polar_vortex_crystal.jl
+++ b/examples/polar_vortex_crystal.jl
@@ -19,8 +19,9 @@ using Printf
 # ## Grid
 #
 # A 128² horizontal × 1 vertical-cell grid covering a 3200 km box on the pole,
-# with a circular wall (an [`ImmersedBoundaryGrid`](@ref) with `GridFittedBoundary`)
-# at 1500 km from the pole forming the polar disk.
+# with a circular wall (an [`ImmersedBoundaryGrid`](@ref) with `GridFittedBottom`
+# whose bottom height reaches the top of the domain) at 1500 km from the pole
+# forming the polar disk.
 
 Nx = Ny = 128
 Δ  = 25kilometers
@@ -38,8 +39,8 @@ grid = LambertConformalConicGrid(Float64;
 
 R_earth = grid.radius
 R_bowl  = 1500kilometers
-bowl_mask(λ, φ, z) = R_earth * (π/2 - deg2rad(φ)) > R_bowl
-ibg = ImmersedBoundaryGrid(grid, GridFittedBoundary(bowl_mask))
+bowl_bottom(λ, φ) = ifelse(R_earth * (π/2 - deg2rad(φ)) > R_bowl, zero(H), -H)
+ibg = ImmersedBoundaryGrid(grid, GridFittedBottom(bowl_bottom))
 
 # ## Model
 #

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -7,8 +7,7 @@ using Oceananigans.DistributedComputations: Distributed
 using Oceananigans.Fields: Field, CenterField, ZeroField, tracernames, TracerFields
 using Oceananigans.Forcings: model_forcing
 using Oceananigans.Grids: AbstractHorizontallyCurvilinearGrid, architecture, halo_size, MutableVerticalDiscretization, Face, Center
-using Oceananigans.AbstractOperations: KernelFunctionOperation
-using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary, immersed_cell
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary
 using Oceananigans.Models: AbstractModel, validate_model_halo, validate_tracer_advection, extract_boundary_conditions
 using Oceananigans.TimeSteppers: Clock, TimeStepper, AbstractLagrangianParticles, materialize_clock!, time_discretization
 using Oceananigans.TurbulenceClosures: validate_closure, with_tracers, build_closure_fields, add_closure_specific_boundary_conditions,
@@ -31,23 +30,15 @@ const AbstractBGCOrNothing = Union{Nothing, AbstractBiogeochemistry}
 
 const GridFittedBoundaryIBG = ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:GridFittedBoundary}
 
-@inline wet_cell_below_immersed_cell(i, j, k, grid) =
-    (k < size(grid, 3)) & !immersed_cell(i, j, k, grid) & immersed_cell(i, j, k+1, grid)
-
 validate_immersed_boundary(grid, free_surface) = nothing
 validate_immersed_boundary(grid::GridFittedBoundaryIBG, ::Nothing) = nothing
 
 function validate_immersed_boundary(grid::GridFittedBoundaryIBG, free_surface)
-    immersed_cell_above_wet_cell = KernelFunctionOperation{Center, Center, Center}(wet_cell_below_immersed_cell, grid)
-    if sum(immersed_cell_above_wet_cell) > 0
-        msg = string("HydrostaticFreeSurfaceModel with a free surface does not support a GridFittedBoundary", '\n',
-                     "that immerses cells above wet cells, such as an immersed boundary at the top", '\n',
-                     "of the domain where the free surface must live.", '\n',
-                     "Use an immersed boundary that represents a bottom height, such as", '\n',
-                     "GridFittedBottom or PartialCellBottom.")
-        throw(ArgumentError(msg))
-    end
-    return nothing
+    msg = string("HydrostaticFreeSurfaceModel with a free surface does not support GridFittedBoundary.", '\n',
+                 "Use an immersed boundary that represents a bottom height, such as", '\n',
+                 "GridFittedBottom or PartialCellBottom. Fully immersed columns (e.g. lateral walls", '\n',
+                 "or land masks) can be built with a bottom height equal to the top of the domain.")
+    throw(ArgumentError(msg))
 end
 
 function default_vertical_coordinate(grid)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -7,7 +7,8 @@ using Oceananigans.DistributedComputations: Distributed
 using Oceananigans.Fields: Field, CenterField, ZeroField, tracernames, TracerFields
 using Oceananigans.Forcings: model_forcing
 using Oceananigans.Grids: AbstractHorizontallyCurvilinearGrid, architecture, halo_size, MutableVerticalDiscretization, Face, Center
-using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
+using Oceananigans.AbstractOperations: KernelFunctionOperation
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary, immersed_cell
 using Oceananigans.Models: AbstractModel, validate_model_halo, validate_tracer_advection, extract_boundary_conditions
 using Oceananigans.TimeSteppers: Clock, TimeStepper, AbstractLagrangianParticles, materialize_clock!, time_discretization
 using Oceananigans.TurbulenceClosures: validate_closure, with_tracers, build_closure_fields, add_closure_specific_boundary_conditions,
@@ -27,6 +28,27 @@ PressureField(grid) = (; pHY′ = CenterField(grid))
 const defaults = Oceananigans.defaults
 const ParticlesOrNothing = Union{Nothing, AbstractLagrangianParticles}
 const AbstractBGCOrNothing = Union{Nothing, AbstractBiogeochemistry}
+
+const GridFittedBoundaryIBG = ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:Any, <:GridFittedBoundary}
+
+@inline wet_cell_below_immersed_cell(i, j, k, grid) =
+    (k < size(grid, 3)) & !immersed_cell(i, j, k, grid) & immersed_cell(i, j, k+1, grid)
+
+validate_immersed_boundary(grid, free_surface) = nothing
+validate_immersed_boundary(grid::GridFittedBoundaryIBG, ::Nothing) = nothing
+
+function validate_immersed_boundary(grid::GridFittedBoundaryIBG, free_surface)
+    immersed_cell_above_wet_cell = KernelFunctionOperation{Center, Center, Center}(wet_cell_below_immersed_cell, grid)
+    if sum(immersed_cell_above_wet_cell) > 0
+        msg = string("HydrostaticFreeSurfaceModel with a free surface does not support a GridFittedBoundary", '\n',
+                     "that immerses cells above wet cells, such as an immersed boundary at the top", '\n',
+                     "of the domain where the free surface must live.", '\n',
+                     "Use an immersed boundary that represents a bottom height, such as", '\n',
+                     "GridFittedBottom or PartialCellBottom.")
+        throw(ArgumentError(msg))
+    end
+    return nothing
+end
 
 function default_vertical_coordinate(grid)
     if grid.z isa MutableVerticalDiscretization
@@ -262,6 +284,7 @@ function HydrostaticFreeSurfaceModel(grid;
 
     free_surface = validate_free_surface(arch, free_surface)
     free_surface = materialize_free_surface(free_surface, velocities, grid)
+    validate_immersed_boundary(grid, free_surface)
 
     # Instantiate timestepper if not already instantiated
     implicit_solver = implicit_diffusion_solver(time_discretization(closure), grid)

--- a/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
+++ b/src/Models/NonhydrostaticModels/NonhydrostaticModels.jl
@@ -63,6 +63,7 @@ function naive_solver_with_warning(arch, ibg, free_surface)
 
               using Oceananigans.Solvers: ConjugateGradientPoissonSolver
               pressure_solver = ConjugateGradientPoissonSolver(grid)
+              model = NonhydrostaticModel(grid; pressure_solver)
 
           Please report issues to https://github.com/CliMA/Oceananigans.jl/issues.
           """

--- a/test/test_hydrostatic_free_surface_immersed_boundaries.jl
+++ b/test/test_hydrostatic_free_surface_immersed_boundaries.jl
@@ -14,13 +14,13 @@ using Oceananigans.TurbulenceClosures
 
         arch_str = string(typeof(arch))
 
-        @testset "GridFittedBoundary [$arch_str]" begin
-            @info "Testing GridFittedBoundary with HydrostaticFreeSurfaceModel [$arch_str]..."
+        @testset "GridFittedBottom [$arch_str]" begin
+            @info "Testing GridFittedBottom with HydrostaticFreeSurfaceModel [$arch_str]..."
 
             underlying_grid = RectilinearGrid(arch, size=(8, 8, 8), x = (-5, 5), y = (-5, 5), z = (0, 2))
 
-            bump(x, y, z) = z < exp(-x^2 - y^2)
-            grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBoundary(bump))
+            bump(x, y) = exp(-x^2 - y^2)
+            grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bump))
 
             for closure in (ScalarDiffusivity(ν=1, κ=0.5),
                             ScalarDiffusivity(VerticallyImplicitTimeDiscretization(), ν=1, κ=0.5))
@@ -47,20 +47,21 @@ using Oceananigans.TurbulenceClosures
             end
         end
 
-        @testset "GridFittedBoundary immersing cells above wet cells [$arch_str]" begin
-            @info "Testing that GridFittedBoundary immersing cells above wet cells throws with HydrostaticFreeSurfaceModel [$arch_str]..."
+        @testset "GridFittedBoundary is not supported [$arch_str]" begin
+            @info "Testing that GridFittedBoundary throws with HydrostaticFreeSurfaceModel [$arch_str]..."
 
             underlying_grid = RectilinearGrid(arch, size=(8, 8, 8), x = (-5, 5), y = (-5, 5), z = (0, 2))
 
             sloping_top(x, y, z) = z > 2 - exp(-x^2 - y^2)
             grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBoundary(sloping_top))
-
             @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid)
 
-            # Fully immersed columns (e.g. lateral walls) remain supported
-            wall(x, y, z) = x < -4
-            grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBoundary(wall))
-            model = HydrostaticFreeSurfaceModel(grid)
+            bump(x, y, z) = z < exp(-x^2 - y^2)
+            grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBoundary(bump))
+            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid)
+
+            # No free surface with PrescribedVelocityFields, so GridFittedBoundary is allowed
+            model = HydrostaticFreeSurfaceModel(grid; velocities=PrescribedVelocityFields(), buoyancy=nothing, tracers=())
             @test model isa HydrostaticFreeSurfaceModel
         end
 

--- a/test/test_hydrostatic_free_surface_immersed_boundaries.jl
+++ b/test/test_hydrostatic_free_surface_immersed_boundaries.jl
@@ -47,6 +47,23 @@ using Oceananigans.TurbulenceClosures
             end
         end
 
+        @testset "GridFittedBoundary immersing cells above wet cells [$arch_str]" begin
+            @info "Testing that GridFittedBoundary immersing cells above wet cells throws with HydrostaticFreeSurfaceModel [$arch_str]..."
+
+            underlying_grid = RectilinearGrid(arch, size=(8, 8, 8), x = (-5, 5), y = (-5, 5), z = (0, 2))
+
+            sloping_top(x, y, z) = z > 2 - exp(-x^2 - y^2)
+            grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBoundary(sloping_top))
+
+            @test_throws ArgumentError HydrostaticFreeSurfaceModel(grid)
+
+            # Fully immersed columns (e.g. lateral walls) remain supported
+            wall(x, y, z) = x < -4
+            grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBoundary(wall))
+            model = HydrostaticFreeSurfaceModel(grid)
+            @test model isa HydrostaticFreeSurfaceModel
+        end
+
         @testset "Surface boundary conditions with immersed boundaries [$arch_str]" begin
             @info "  Testing surface boundary conditions with ImmersedBoundaries in HydrostaticFreeSurfaceModel [$arch_str]..."
 

--- a/test/test_immersed_advection.jl
+++ b/test/test_immersed_advection.jl
@@ -125,7 +125,7 @@ for arch in archs
         @info "Running immersed tracer conservation tests..."
 
         grid = RectilinearGrid(arch, size=(10, 8, 1), extent=(10, 8, 1), halo = (6, 6, 6), topology=(Bounded, Periodic, Bounded))
-        ibg  = ImmersedBoundaryGrid(grid, GridFittedBoundary((x, y, z) -> (x < 2)))
+        ibg  = ImmersedBoundaryGrid(grid, GridFittedBottom((x, y) -> ifelse(x < 2, 0, -1)))
 
         for adv in advection_schemes, buffer in [1, 2, 3, 4, 5]
             scheme = adv(order = advective_order(buffer, adv))


### PR DESCRIPTION
Follows up on the discussion in #5794.

## FFT pressure solver warning

In https://github.com/CliMA/Oceananigans.jl/issues/5794, a user built the `ConjugateGradientPoissonSolver` suggested by the warning but did not pass it into the model, silently keeping the approximate FFT solver (which produced a garbage solution for a sloping top boundary). The warning now also shows the model construction step:

```
using Oceananigans.Solvers: ConjugateGradientPoissonSolver
pressure_solver = ConjugateGradientPoissonSolver(grid)
model = NonhydrostaticModel(grid; pressure_solver)
```

The corresponding doctest output in `docs/src/models/boundary_conditions.md` is updated to match.

## Error for `GridFittedBoundary` with a free surface

As noted in https://github.com/CliMA/Oceananigans.jl/issues/5794#issuecomment-5012064390, `HydrostaticFreeSurfaceModel` should fail with a `GridFittedBoundary` that immerses the top of the domain, which the free surface machinery does not support.

Following review, support for `GridFittedBoundary` in `HydrostaticFreeSurfaceModel` with a free surface is discontinued entirely: any mask the free surface machinery supports is exactly representable with `GridFittedBottom` or `PartialCellBottom`, so the constructor now throws an `ArgumentError` directing users there (fully immersed columns like lateral walls or land masks are built with a bottom height equal to the top of the domain). `PrescribedVelocityFields` configurations (no free surface) still construct, including with an immersed top (used e.g. in Lagrangian particle tests).

In-repo users of `GridFittedBoundary` with a free surface are migrated to `GridFittedBottom`: the hydrostatic immersed boundary bump test, the immersed tracer conservation test wall, and the circular wall in the polar vortex crystal example. Tests are added for both the throwing and non-throwing cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)