### PR TITLE
Add nearest_index(grid, val, dim); fix fractional_*_index on Flat dims

### DIFF
--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -6,7 +6,7 @@ export CenterField, XFaceField, YFaceField, ZFaceField
 export interior, data, xnode, ynode, znode
 export set!, compute!, @compute, regrid!
 export VelocityFields, TracerFields, tracernames
-export interpolate
+export interpolate, nearest_index
 
 using Adapt: Adapt, adapt
 using DocStringExtensions: TYPEDSIGNATURES

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -63,6 +63,7 @@ end
 @inline fractional_x_index(x, locs, grid::XFlatGrid) = zero(grid)
 
 @inline function fractional_x_index(x, locs, grid::XRegularRG)
+    topology(grid, 1) === Flat && return zero(grid)
     x₀ = xnode(1, 1, 1, grid, locs...)
     dx = Δx(1, 1, 1, grid, locs...)
     FT = eltype(grid)
@@ -106,6 +107,7 @@ end
 # interpolate to lie in the λ₀ : λ₀ + 360 range, where λ₀ is the westernmost node
 # of the interpolating grid.
 @inline function fractional_x_index(λ, locs, grid::XRegularLLG)
+    topology(grid, 1) === Flat && return zero(grid)
     λ₀ = λnode(1, 1, 1, grid, locs...)
     λ₁ = λnode(2, 1, 1, grid, locs...)
     Δλ = λ₁ - λ₀
@@ -133,6 +135,7 @@ end
 @inline fractional_y_index(y, locs, grid::YFlatGrid) = zero(grid)
 
 @inline function fractional_y_index(y, locs, grid::YRegularRG)
+    topology(grid, 2) === Flat && return zero(grid)
     y₀ = ynode(1, 1, 1, grid, locs...)
     dy = Δy(1, 1, 1, grid, locs...)
     FT = eltype(grid)
@@ -140,6 +143,7 @@ end
 end
 
 @inline function fractional_y_index(φ, locs, grid::YRegularLLG)
+    topology(grid, 2) === Flat && return zero(grid)
     φ₀ = φnode(1, 1, 1, grid, locs...)
     φ₁ = φnode(1, 2, 1, grid, locs...)
     FT = eltype(grid)
@@ -169,6 +173,7 @@ end
 ZRegGrid = Union{ZRegularRG, ZRegularLLG, ZRegOrthogonalSphericalShellGrid}
 
 @inline function fractional_z_index(z::FT, locs, grid::ZRegGrid) where FT
+    topology(grid, 3) === Flat && return zero(grid)
     z₀ = znode(1, 1, 1, grid, locs...)
     dz = Δz(1, 1, 1, grid, locs...)
     return convert(FT, (z - z₀) / dz) + 1 # 1 - based indexing
@@ -468,3 +473,65 @@ function interpolate!(to_field::Field, from_field::AbstractField)
 
     return to_field
 end
+
+#####
+##### nearest_index
+#####
+
+@inline _dim_number(dim) =
+    dim === :x || dim == 1 ? 1 :
+    dim === :y || dim == 2 ? 2 :
+    dim === :z || dim == 3 ? 3 :
+    throw(ArgumentError("`dim` must be :x, :y, :z, or 1, 2, 3; got $(repr(dim))"))
+
+@kernel function _fractional_index!(fidx, grid, val, locs, ::Val{n}) where n
+    @inbounds fidx[1] = n === 1 ? fractional_x_index(val, locs, grid) :
+                        n === 2 ? fractional_y_index(val, locs, grid) :
+                                  fractional_z_index(val, locs, grid)
+end
+
+"""
+    nearest_index(grid, val, dim; location=Center())
+
+Return the index along dimension `dim` — `:x`, `:y`, or `:z` (equivalently `1`, `2`, or
+`3`) — whose node at `location` is nearest to `val`, clamped to the valid index range.
+Useful for turning a physical coordinate (a height, a latitude, ...) into the grid index
+closest to it, for example to slice output at a prescribed level.
+
+The index is computed on the `grid`'s architecture (through `fractional_x_index` and
+friends), so no node array is copied to the host. The comparison uses the `grid`'s native
+coordinates, so on a curvilinear grid such as `LatitudeLongitudeGrid` the `:x` and `:y`
+nodes are longitude ``λ`` and latitude ``φ``.
+
+Omitting `dim` and passing a 3-tuple `val = (x, y, z)` returns the `(i, j, k)` tuple of
+nearest indices, `nearest_index(grid, (x, y, z))`.
+
+```jldoctest
+using Oceananigans
+
+grid = RectilinearGrid(size=(4, 4, 10), x=(0, 1), y=(0, 1), z=(0, 1000))
+
+nearest_index(grid, 340, :z)
+
+# output
+4
+```
+"""
+function nearest_index(grid, val, dim; location = Center())
+    n = _dim_number(dim)
+    topology(grid, n) === Flat && return 1 # a Flat dimension has a single point
+    arch = architecture(grid)
+    FT = eltype(grid)
+    locs = (location, location, location)
+
+    fidx = on_architecture(arch, zeros(FT, 1))
+    launch!(arch, grid, KernelParameters(1:1, 1:1, 1:1),
+            _fractional_index!, fidx, grid, convert(FT, val), locs, Val(n))
+
+    fractional = @inbounds Array(fidx)[1]
+    N = length(location, topology(grid, n)(), size(grid, n))
+    return clamp(round(Int, fractional), 1, N)
+end
+
+nearest_index(grid, val::Tuple; location = Center()) =
+    ntuple(n -> nearest_index(grid, val[n], n; location), Val(3))

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -19,7 +19,7 @@ export
     LambertConformalConic, lcc_forward, lcc_inverse, lcc_scale_factor,
     MutableVerticalDiscretization,
     ExponentialDiscretization, ReferenceToStretchedDiscretization, PowerLawStretching, LinearStretching,
-    nodes, xnodes, ynodes, rnodes, znodes, λnodes, φnodes,
+    nodes, nearest_index, xnodes, ynodes, rnodes, znodes, λnodes, φnodes,
     xspacings, yspacings, rspacings, zspacings, λspacings, φspacings,
     minimum_xspacing, minimum_yspacing, minimum_zspacing,
 

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -834,6 +834,61 @@ end
         @test total_extent(Bounded(), 1, 0.2, 1.0) == 1.4
     end
 
+    @testset "nearest_index" begin
+        @info "  Testing nearest_index..."
+        for arch in archs
+            grid = RectilinearGrid(arch, size=(4, 4, 10), x=(0, 1), y=(0, 1), z=(0, 1000))
+            # z centers: 50, 150, …, 950
+            @test nearest_index(grid, 340, :z)  == 4   # nearest 350, not 250
+            @test nearest_index(grid, 350, :z)  == 4   # exact node
+            @test nearest_index(grid, -100, :z) == 1   # below range → clamp to 1
+            @test nearest_index(grid, 1e6, :z)  == 10  # above range → clamp to N
+            @test nearest_index(grid, 340, 3)   == 4   # integer dim
+            @test nearest_index(grid, 0, :z, location=Face()) == 1  # z faces: 0, 100, …
+            # x centers: 0.125, 0.375, 0.625, 0.875
+            @test nearest_index(grid, 0.6, :x)  == 3
+            @test nearest_index(grid, 0.6, 1)   == 3   # integer dim
+            @test_throws ArgumentError nearest_index(grid, 0, :w)
+
+            # tuple form returns the (i, j, k) indices
+            @test nearest_index(grid, (0.6, 0.6, 340)) == (3, 3, 4)
+
+            # stretched z; centers at 0.5, 2, 5, 11, 23
+            sgrid = RectilinearGrid(arch, size=(2, 2, 5), x=(0, 1), y=(0, 1), z=[0, 1, 3, 7, 15, 31])
+            @test nearest_index(sgrid, 4, :z) == 3     # nearest 5 (idx 3), not 2 (idx 2)
+            @test nearest_index(sgrid, 3, :z) == 2     # nearest 2 (idx 2), not 5 (idx 3)
+
+            # LatitudeLongitudeGrid: :x → longitude λ, :y → latitude φ
+            llg = LatitudeLongitudeGrid(arch, size=(8, 6, 2), longitude=(-10, 10),
+                                        latitude=(30, 42), z=(-100, 0))
+            @test nearest_index(llg, 36.5, :y) == 4    # φ centers 31,33,35,37,… → 37
+            @test nearest_index(llg, -8, :x)   == 1    # λ centers -8.75,-6.25,… → -8.75
+        end
+
+        # Flat dimension → 1
+        fgrid = RectilinearGrid(size=(4, 4), x=(0, 1), y=(0, 1), topology=(Bounded, Bounded, Flat))
+        @test nearest_index(fgrid, 12.3, :z) == 1
+    end
+
+    @testset "fractional_index on Flat dimensions" begin
+        @info "  Testing fractional_index on Flat dimensions..."
+        # A Flat dimension is also "regular", so the regular fractional_*_index methods
+        # are dispatched; they must return 0 rather than indexing a `nothing` node.
+        FI = Oceananigans.Fields
+        ccc = (Center(), Center(), Center())
+        for arch in archs
+            fz = RectilinearGrid(arch, size=(4, 4), x=(0, 1), y=(0, 1), topology=(Bounded, Bounded, Flat))
+            @test FI.fractional_z_index(12.3, ccc, fz) == 0
+            fx = RectilinearGrid(arch, size=(4, 4), y=(0, 1), z=(0, 1), topology=(Flat, Bounded, Bounded))
+            @test FI.fractional_x_index(12.3, ccc, fx) == 0
+            fy = RectilinearGrid(arch, size=(4, 4), x=(0, 1), z=(0, 1), topology=(Bounded, Flat, Bounded))
+            @test FI.fractional_y_index(12.3, ccc, fy) == 0
+            llgz = LatitudeLongitudeGrid(arch, size=(4, 4), longitude=(-10, 10), latitude=(30, 40),
+                                         topology=(Bounded, Bounded, Flat))
+            @test FI.fractional_z_index(12.3, ccc, llgz) == 0
+        end
+    end
+
     @testset "Coordinate utils" begin
         @info "  Testing ExponentialDiscretization..."
 


### PR DESCRIPTION
## Summary

`nearest_index(grid, val, dim; location=Center())` — the index along dimension `dim` (`:x`, `:y`, `:z`, or `1`/`2`/`3`) whose node at `location` is nearest to `val`, clamped to the valid range. Omit `dim` and pass a 3-tuple to get the `(i, j, k)` indices:

```julia
nearest_index(grid, 2000, :z)     # level nearest 2 km
nearest_index(llg,  36.6, :y)     # row nearest 36.6°N
nearest_index(grid, (x, y, z))    # → (i, j, k)
```

## Motivation

Turning a physical coordinate into the nearest grid index is a common need — the output level nearest a height, the row nearest a latitude, etc. It's usually hand-rolled as `searchsortedfirst(Array(znodes(grid, Center())), val)`, which copies the node vector to the host, returns the first node ≥ `val` rather than the *nearest*, and returns `N+1` out of range.

## Behavior

- Computed on the grid's architecture via `fractional_x/y/z_index` (a one-thread `launch!`), so **no node array is copied to the host** — analytic for regular grids, a device-side search for stretched ones.
- Uses the grid's **native** coordinates, so `:x`/`:y` are longitude/latitude on a `LatitudeLongitudeGrid`.
- Returns the *nearest* node index; clamps out-of-range to `1`/`N`; `Flat` dims → `1`.
- `dim` accepts `:x`/`:y`/`:z` or `1`/`2`/`3`.

Lives in `Fields` (it uses the interpolation helpers), exported and re-exported at the top level.

## Also fixes: `fractional_*_index` on `Flat` dimensions

A `Flat` dimension is also "regular", so `fractional_x/y/z_index` dispatched to the *regular* methods — which look up node `1` via `x/y/znode(1, …)` that is `nothing` on a Flat dimension — and errored (`MethodError: -(::Float64, ::Nothing)`). The `ZFlatGrid`/`XFlatGrid`/`YFlatGrid` methods that return `zero(grid)` exist but lost the dispatch. The regular methods now short-circuit to `zero(grid)` for `Flat` dimensions (a compile-time-folded `topology(grid, dim) === Flat` check). Regression test included.

## Tests

`test/test_grids.jl` covers `nearest_index` (uniform & stretched `RectilinearGrid`, `LatitudeLongitudeGrid` `:x`→λ/`:y`→φ, integer dims, `Face` location, tuple form, clamping, `Flat`, invalid-`dim` error) and `fractional_*_index` on `Flat` dimensions (`RectilinearGrid` x/y/z + `LatitudeLongitudeGrid` z); the `nearest_index` docstring has a `jldoctest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
