### PR TITLE
Fix AMDGPU device index mapping

### DIFF
--- a/ext/OceananigansAMDGPUExt.jl
+++ b/ext/OceananigansAMDGPUExt.jl
@@ -37,7 +37,7 @@ const ROCGPU = AC.GPU{ROCBackend}
 ROCGPU() = AC.GPU(AMDGPU.ROCBackend())
 
 Base.summary(::ROCGPU) = "ROCGPU"
-AC.device!(::ROCGPU, i) = AMDGPU.device_id!(id+1) # AMD devices are numbered 1..ndevices
+AC.device!(::ROCGPU, i) = AMDGPU.device_id!(i + 1) # AMD devices are numbered 1..ndevices
 
 AC.architecture(::ROCArray) = ROCGPU()
 AC.architecture(::Type{ROCArray}) = ROCGPU()

--- a/test/test_amdgpu.jl
+++ b/test/test_amdgpu.jl
@@ -19,6 +19,18 @@ function build_and_timestep_simulation(model)
     return nothing
 end
 
+@testset "AMDGPU device selection" begin
+    arch = GPU(AMDGPU.ROCBackend())
+    original_device_id = AMDGPU.device_id()
+
+    try
+        device!(arch, 0)
+        @test AMDGPU.device_id() == 1
+    finally
+        AMDGPU.device_id!(original_device_id)
+    end
+end
+
 @testset "AMDGPU on RectilinearGrids" begin
     roc = AMDGPU.ROCBackend()
     arch = GPU(roc)

--- a/test/test_amdgpu.jl
+++ b/test/test_amdgpu.jl
@@ -24,7 +24,7 @@ end
     original_device_id = AMDGPU.device_id()
 
     try
-        device!(arch, 0)
+        Oceananigans.Architectures.device!(arch, 0)
         @test AMDGPU.device_id() == 1
     finally
         AMDGPU.device_id!(original_device_id)


### PR DESCRIPTION
This fixes a small typo in the AMDGPU device-selection method that prevents distributed AMD GPU configurations from initializing. The method takes `i` as its device index, but was using the undefined variable `id`. Since Oceananigans uses zero-based indices while AMDGPU uses one-based indices, the correct call is `AMDGPU.device_id!(i + 1)`.

I also added a regression test for the index conversion.