### PR TITLE
Support immersed conservative regridding

### DIFF
--- a/ext/OceananigansConservativeRegriddingExt.jl
+++ b/ext/OceananigansConservativeRegriddingExt.jl
@@ -1,22 +1,96 @@
 module OceananigansConservativeRegriddingExt
 
 using ConservativeRegridding: Regridder, regrid!
-using Oceananigans.AbstractOperations: RegriddedOperation
+using Oceananigans.AbstractOperations: AbstractOperations, RegriddedOperation
 using Oceananigans.Architectures: Architectures, architecture, CPU
 using Oceananigans.Fields: Fields, AbstractField, Field
-using Oceananigans.ImmersedBoundaries: underlying_grid
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, underlying_grid
+using SparseArrays: dropzeros!
 
-function RegriddedOperation(source::AbstractField{LX, LY, LZ}, destination_grid) where {LX, LY, LZ}
+function AbstractOperations.RegriddedOperation(source::AbstractField{LX, LY, LZ}, destination_grid) where {LX, LY, LZ}
     source_architecture = architecture(source)
+    validate_destination_grid(source.grid, destination_grid)
+
     destination_grid = Architectures.on_architecture(source_architecture, destination_grid)
     destination = Field{LX, LY, LZ}(destination_grid)
 
-    source_grid = Architectures.on_architecture(CPU(), underlying_grid(source))
-    regrid_grid = Architectures.on_architecture(CPU(), underlying_grid(destination_grid))
-    regridder = Regridder(regrid_grid, source_grid)
+    source_grid = regridding_grid_on_cpu(source.grid)
+    regrid_grid = regridding_grid_on_cpu(destination_grid)
+    regridder = active_column_regridder(regrid_grid, source_grid)
     regridder = Architectures.on_architecture(source_architecture, regridder)
 
     return RegriddedOperation(destination, regridder, source)
+end
+
+validate_destination_grid(source_grid, destination_grid) = nothing
+
+function validate_destination_grid(source_grid::ImmersedBoundaryGrid, destination_grid)
+    destination_grid isa ImmersedBoundaryGrid && return nothing
+
+    msg = """Regridding from an ImmersedBoundaryGrid to a non-immersed grid is not supported.
+             The source grid has inactive cells. The destination grid must also be an
+             ImmersedBoundaryGrid so later operations know which destination cells are active."""
+
+    return throw(ArgumentError(msg))
+end
+
+regridding_grid_on_cpu(grid) = Architectures.on_architecture(CPU(), grid)
+
+function regridding_grid_on_cpu(grid::ImmersedBoundaryGrid)
+    grid = Architectures.on_architecture(CPU(), grid)
+    return ImmersedBoundaryGrid(grid.underlying_grid, grid.immersed_boundary; active_z_columns=true)
+end
+
+active_column_regridder(destination_grid, source_grid) =
+    Regridder(underlying_grid(destination_grid), underlying_grid(source_grid))
+
+function active_column_regridder(destination_grid::ImmersedBoundaryGrid, source_grid)
+    regridder = active_column_regridder(destination_grid.underlying_grid, source_grid)
+    mask_inactive_destination_columns!(regridder, destination_grid)
+    return regridder
+end
+
+function active_column_regridder(destination_grid, source_grid::ImmersedBoundaryGrid)
+    regridder = active_column_regridder(destination_grid, source_grid.underlying_grid)
+    mask_inactive_source_columns!(regridder, source_grid)
+    return regridder
+end
+
+function active_column_regridder(destination_grid::ImmersedBoundaryGrid, source_grid::ImmersedBoundaryGrid)
+    regridder = active_column_regridder(destination_grid.underlying_grid, source_grid.underlying_grid)
+    mask_inactive_destination_columns!(regridder, destination_grid)
+    mask_inactive_source_columns!(regridder, source_grid)
+    return regridder
+end
+
+function active_column_mask(grid::ImmersedBoundaryGrid)
+    active_columns = grid.active_z_columns
+    isnothing(active_columns) && throw(ArgumentError("Immersed regridding requires `active_z_columns`."))
+
+    mask = falses(grid.Nx * grid.Ny)
+
+    for (i, j) in active_columns
+        n = Int(i) + (Int(j) - 1) * grid.Nx
+        @inbounds mask[n] = true
+    end
+
+    return mask
+end
+
+function mask_inactive_destination_columns!(regridder, grid::ImmersedBoundaryGrid)
+    active_columns = active_column_mask(grid)
+    inactive_columns = findall(!, active_columns)
+    regridder.intersections[inactive_columns, :] .= 0
+    dropzeros!(regridder.intersections)
+    return regridder
+end
+
+function mask_inactive_source_columns!(regridder, grid::ImmersedBoundaryGrid)
+    active_columns = active_column_mask(grid)
+    inactive_columns = findall(!, active_columns)
+    regridder.intersections[:, inactive_columns] .= 0
+    dropzeros!(regridder.intersections)
+    return regridder
 end
 
 function Fields.compute_at!(operation::RegriddedOperation, time)

--- a/ext/OceananigansConservativeRegriddingExt.jl
+++ b/ext/OceananigansConservativeRegriddingExt.jl
@@ -44,18 +44,6 @@ end
 active_column_regridder(destination_grid, source_grid) =
     Regridder(underlying_grid(destination_grid), underlying_grid(source_grid))
 
-function active_column_regridder(destination_grid::ImmersedBoundaryGrid, source_grid)
-    regridder = active_column_regridder(destination_grid.underlying_grid, source_grid)
-    mask_inactive_destination_columns!(regridder, destination_grid)
-    return regridder
-end
-
-function active_column_regridder(destination_grid, source_grid::ImmersedBoundaryGrid)
-    regridder = active_column_regridder(destination_grid, source_grid.underlying_grid)
-    mask_inactive_source_columns!(regridder, source_grid)
-    return regridder
-end
-
 function active_column_regridder(destination_grid::ImmersedBoundaryGrid, source_grid::ImmersedBoundaryGrid)
     regridder = active_column_regridder(destination_grid.underlying_grid, source_grid.underlying_grid)
     mask_inactive_destination_columns!(regridder, destination_grid)

--- a/ext/OceananigansConservativeRegriddingExt.jl
+++ b/ext/OceananigansConservativeRegriddingExt.jl
@@ -46,8 +46,8 @@ active_column_regridder(destination_grid, source_grid) =
 
 function active_column_regridder(destination_grid::ImmersedBoundaryGrid, source_grid::ImmersedBoundaryGrid)
     regridder = active_column_regridder(destination_grid.underlying_grid, source_grid.underlying_grid)
-    mask_inactive_destination_columns!(regridder, destination_grid)
-    mask_inactive_source_columns!(regridder, source_grid)
+    mask_inactive_columns!(regridder, destination_grid; dims=1)
+    mask_inactive_columns!(regridder, source_grid; dims=2)
     return regridder
 end
 
@@ -65,18 +65,18 @@ function active_column_mask(grid::ImmersedBoundaryGrid)
     return mask
 end
 
-function mask_inactive_destination_columns!(regridder, grid::ImmersedBoundaryGrid)
+function mask_inactive_columns!(regridder, grid::ImmersedBoundaryGrid; dims)
     active_columns = active_column_mask(grid)
     inactive_columns = findall(!, active_columns)
-    regridder.intersections[inactive_columns, :] .= 0
-    dropzeros!(regridder.intersections)
-    return regridder
-end
 
-function mask_inactive_source_columns!(regridder, grid::ImmersedBoundaryGrid)
-    active_columns = active_column_mask(grid)
-    inactive_columns = findall(!, active_columns)
-    regridder.intersections[:, inactive_columns] .= 0
+    if dims == 1
+        regridder.intersections[inactive_columns, :] .= 0
+    elseif dims == 2
+        regridder.intersections[:, inactive_columns] .= 0
+    else
+        throw(ArgumentError("Inactive conservative regridding columns can only be masked along dims=1 or dims=2."))
+    end
+
     dropzeros!(regridder.intersections)
     return regridder
 end

--- a/test/test_conservative_regridding.jl
+++ b/test/test_conservative_regridding.jl
@@ -59,6 +59,36 @@ using ConservativeRegridding
     compute!(high_level_field)
     @test all(interior(high_level_field) .≈ 4)
 
+    # Immersed source grids carry inactive cells, so the destination must
+    # also be immersed. Otherwise later operations would not know which
+    # destination cells should be ignored.
+    coarse_immersed_grid = RectilinearGrid(size=(2, 2, 1),
+                                           x=(0, 2), y=(0, 2), z=(0, 1),
+                                           topology=(Bounded, Bounded, Bounded))
+
+    fine_immersed_grid = RectilinearGrid(size=(4, 4, 1),
+                                         x=(0, 2), y=(0, 2), z=(0, 1),
+                                         topology=(Bounded, Bounded, Bounded))
+
+    immersed_boundary = GridFittedBoundary((x, y, z) -> x < 1)
+
+    source_immersed_grid = ImmersedBoundaryGrid(fine_immersed_grid, immersed_boundary; active_z_columns=true)
+    destination_immersed_grid = ImmersedBoundaryGrid(coarse_immersed_grid, immersed_boundary; active_z_columns=true)
+
+    source_immersed_field = CenterField(source_immersed_grid)
+    set!(source_immersed_field, (x, y, z) -> x + 2y)
+
+    @test_throws ArgumentError RegriddedOperation(source_immersed_field, coarse_immersed_grid)
+
+    immersed_regridded_operation = RegriddedOperation(source_immersed_field, destination_immersed_grid)
+    destination_immersed_field = Field(immersed_regridded_operation)
+    compute!(destination_immersed_field)
+
+    source_integral = Field(Integral(source_immersed_field)) |> interior |> collect |> only
+    destination_integral = Field(Integral(destination_immersed_field)) |> interior |> collect |> only
+
+    @test destination_integral ≈ source_integral
+
     # Test with RectilinearGrid
     @info "  Testing RectilinearGrid regridding..."
     coarse_rect_grid = RectilinearGrid(size=(50, 50),


### PR DESCRIPTION
## Summary

This PR teaches the ConservativeRegridding extension how to handle `ImmersedBoundaryGrid`s without letting inactive cells participate in the conservative regrid.

Before this change, the high-level `RegriddedOperation(source, destination_grid)` constructor stripped immersed grids down to their `underlying_grid` before building the conservative regridder. That was geometrically convenient, but it meant fully inactive columns still had ordinary regridding rows or columns. If those unused values were later integrated or otherwise reduced, they could show up as real data.

## What changed

The extension now keeps the immersed-grid contract visible while still building the geometric regridder on CPU underlying grids:

1. If the source is an `ImmersedBoundaryGrid`, the destination must also be an `ImmersedBoundaryGrid`.
2. During regridder construction, immersed source and destination grids rebuild their horizontal active-column maps on the CPU.
3. The sparse intersection matrix is then masked so inactive source columns have zero matrix columns and inactive destination columns have zero matrix rows.
4. The destination field remains on the supplied destination grid, so later Oceananigans operations still know which cells are active.

Pedagogically: the conservative regridder still asks, “how much of this source cell overlaps this destination cell?”, but now it first knows which source and destination columns are ocean. Land or otherwise inactive columns are not allowed to donate or receive area-weighted content.

## Tests

Added a focused ConservativeRegridding extension test that checks two user-facing behaviors:

- regridding from an immersed source grid to a regular destination grid throws an `ArgumentError`;
- regridding from a fine immersed source grid to a coarse immersed destination grid preserves the active-cell integral: `Integral(destination) ≈ Integral(source)`.
