### PR TITLE
Make conditional differences Revisable

### DIFF
--- a/src/ImmersedBoundaries/conditional_differences.jl
+++ b/src/ImmersedBoundaries/conditional_differences.jl
@@ -60,11 +60,12 @@ for (d, ξ) in enumerate((:x, :y, :z))
         end
 
         # `other_locs` contains locations in the two "other" directions not being differenced
-        other_locs = []
-        for l in 1:3
-            if l != d
-                push!(other_locs, loc[l])
-            end
+        other_locs = if d == 1
+            (loc[2], loc[3])
+        elseif d == 2
+            (loc[1], loc[3])
+        else
+            (loc[1], loc[2])
         end
 
         @eval begin


### PR DESCRIPTION
Revise signature extraction does not replay standalone mutations, so the `push!` loop left `other_locs` empty when reconstructing generated definitions, causing revising on conditional_differences.jl to fail with a `BoundsError`.

Construct the two locations directly as a tuple so generated operators no longer depend on preceding side effects.

Fixes aviatesk/JET.jl#804

