### PR TITLE
Bump semver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.11"
+version = "0.110.12"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]


### PR DESCRIPTION
Need to access `InterpolatedOperation` downstream, which was added after the `0.110.11` release.