### PR TITLE
Add Unicode integral operators

### DIFF
--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -214,6 +214,7 @@ BinaryOperation at (Center, Center, Center)
 ## Averages and integrals
 
 An operation that reduces one or more dimensions of a field is called a [`Reduction`](@ref); some reductions include [`Average`](@ref), [`Integral`](@ref), and [`CumulativeIntegral`](@ref).
+Integrals come with a second interface, introduced below, that spells them with Unicode integral signs and returns a computed `Field` instead of a `Reduction`.
 
 Let's demonstrate now how we can compute the average or the integral of a field over the grid or over some part of the grid.
 We start by creating a latitude-longitude grid that only goes up to 30 degrees latitude.
@@ -258,6 +259,50 @@ Let's check that these values are what we expect:
 # output
 
 true
+```
+
+The Unicode interface writes the same integral more compactly, in notation that mirrors the derivative operators `∂x`, `∂y`, and `∂z`.
+[`∫dx`](@ref), [`∫dy`](@ref), and [`∫dz`](@ref) integrate over one dimension, [`∫∫dxdy`](@ref), [`∫∫dxdz`](@ref), and [`∫∫dydz`](@ref) integrate over two, and [`∫∫∫dxdydz`](@ref), aliased to [`∫dV`](@ref), integrates over all three.
+Each of them builds the corresponding `Integral` and computes it into a `Field`:
+
+```jldoctest operations_avg_int
+∫∫dxdy(c) == Field(Integral(c, dims=(1, 2)))
+
+# output
+
+true
+```
+
+Because the result is a `Field` and not a `Reduction`, it can be used inside other abstract operations.
+Here we divide the horizontal integral at each level by the integral over the whole domain, which for `c = 1` returns the inverse of the domain depth:
+
+```jldoctest operations_avg_int
+Field(∫∫dxdy(c) / ∫dV(c))
+
+# output
+1×1×5 Field{Nothing, Nothing, Center} reduced over dims = (1, 2) on LatitudeLongitudeGrid on CPU
+├── grid: 60×10×5 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
+├── boundary conditions: FieldBoundaryConditions
+│   └── west: Nothing, east: Nothing, south: Nothing, north: Nothing, bottom: ZeroFlux, top: ZeroFlux, immersed: Nothing
+├── operand: BinaryOperation at (⋅, ⋅, Center)
+├── status: time=0.0
+└── data: 1×1×11 OffsetArray(::Array{Float64, 3}, 1:1, 1:1, -2:8) with eltype Float64 with indices 1:1×1:1×-2:8
+    └── max=0.001, min=0.001, mean=0.001
+```
+
+The one-dimensional operators also take `cumulative=true`, which returns the running integral computed by [`CumulativeIntegral`](@ref), and `reverse=true`, which accumulates from the far end of the dimension:
+
+```jldoctest operations_avg_int
+∫ᶻc = ∫dz(c, cumulative=true)
+
+# output
+60×10×6 Field{Center, Center, Face} on LatitudeLongitudeGrid on CPU
+├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (60, 10, 6)
+├── grid: 60×10×5 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
+├── operand: CumulativeIntegral of BinaryOperation at (Center, Center, Center) over dims 3
+├── status: time=0.0
+└── data: 66×16×12 OffsetArray(::Array{Float64, 3}, -2:63, -2:13, -2:9) with eltype Float64 with indices -2:63×-2:13×-2:9
+    └── max=1000.0, min=0.0, mean=500.0
 ```
 
 We can further have conditional reduced operations. Let's compute the above integral but only for North hemisphere.
@@ -307,57 +352,4 @@ conditional_∫c[1, 1, 1] ≈ π * grid.radius^2 # area of spherical zone with 0
 true
 ```
 
-## Unicode notation for integrals
-
-Integrals have Unicode shorthands that mirror the derivative operators `∂x`, `∂y`, and `∂z`.
-[`∫dx`](@ref), [`∫dy`](@ref), and [`∫dz`](@ref) integrate over one dimension, [`∫∫dxdy`](@ref), [`∫∫dxdz`](@ref), and [`∫∫dydz`](@ref) integrate over two, and [`∫∫∫dxdydz`](@ref) integrates over all three.
-[`∫dV`](@ref) is an alias for `∫∫∫dxdydz`.
-
-Each of these wraps `Integral` in a `Field` that is computed on construction, so the horizontal integral we computed above can also be written as
-
-```jldoctest operations_avg_int
-∫c = ∫∫dxdy(c)
-
-# output
-1×1×5 Field{Nothing, Nothing, Center} reduced over dims = (1, 2) on LatitudeLongitudeGrid on CPU
-├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (1, 1, 5)
-├── grid: 60×10×5 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
-├── operand: Integral of BinaryOperation at (Center, Center, Center) over dims (1, 2)
-├── status: time=0.0
-└── data: 1×1×11 OffsetArray(::Array{Float64, 3}, 1:1, 1:1, -2:8) with eltype Float64 with indices 1:1×1:1×-2:8
-    └── max=2.55032e14, min=2.55032e14, mean=2.55032e14
-```
-
-Because they return `Field`s, the Unicode operators compose with the rest of the operations machinery, which a bare `Reduction` cannot do.
-Here, for instance, we normalize the horizontal integral at each level by the integral over the whole domain, which for `c = 1` returns the inverse of the domain depth:
-
-```jldoctest operations_avg_int
-Field(∫∫dxdy(c) / ∫dV(c))
-
-# output
-1×1×5 Field{Nothing, Nothing, Center} reduced over dims = (1, 2) on LatitudeLongitudeGrid on CPU
-├── grid: 60×10×5 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
-├── boundary conditions: FieldBoundaryConditions
-│   └── west: Nothing, east: Nothing, south: Nothing, north: Nothing, bottom: ZeroFlux, top: ZeroFlux, immersed: Nothing
-├── operand: BinaryOperation at (⋅, ⋅, Center)
-├── status: time=0.0
-└── data: 1×1×11 OffsetArray(::Array{Float64, 3}, 1:1, 1:1, -2:8) with eltype Float64 with indices 1:1×1:1×-2:8
-    └── max=0.001, min=0.001, mean=0.001
-```
-
-The one-dimensional operators take `cumulative=true`, which returns the running integral computed by [`CumulativeIntegral`](@ref), and `reverse=true`, which accumulates from the far end of the dimension.
-
-```jldoctest operations_avg_int
-∫ᶻc = ∫dz(c, cumulative=true)
-
-# output
-60×10×6 Field{Center, Center, Face} on LatitudeLongitudeGrid on CPU
-├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (60, 10, 6)
-├── grid: 60×10×5 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
-├── operand: CumulativeIntegral of BinaryOperation at (Center, Center, Center) over dims 3
-├── status: time=0.0
-└── data: 66×16×12 OffsetArray(::Array{Float64, 3}, -2:63, -2:13, -2:9) with eltype Float64 with indices -2:63×-2:13×-2:9
-    └── max=1000.0, min=0.0, mean=500.0
-```
-
-The `condition` and `mask` keyword arguments behave exactly as they do for `Integral`.
+The `condition` and `mask` keyword arguments behave the same way with the Unicode operators, as in `∫∫dxdy(c, condition=cond)`.

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -306,3 +306,58 @@ conditional_∫c[1, 1, 1] ≈ π * grid.radius^2 # area of spherical zone with 0
 # output
 true
 ```
+
+## Unicode notation for integrals
+
+Integrals have Unicode shorthands that mirror the derivative operators `∂x`, `∂y`, and `∂z`.
+[`∫dx`](@ref), [`∫dy`](@ref), and [`∫dz`](@ref) integrate over one dimension, [`∫∫dxdy`](@ref), [`∫∫dxdz`](@ref), and [`∫∫dydz`](@ref) integrate over two, and [`∫∫∫dxdydz`](@ref) integrates over all three.
+[`∫dV`](@ref) is an alias for `∫∫∫dxdydz`.
+
+Each of these wraps `Integral` in a `Field` that is computed on construction, so the horizontal integral we computed above can also be written as
+
+```jldoctest operations_avg_int
+∫c = ∫∫dxdy(c)
+
+# output
+1×1×5 Field{Nothing, Nothing, Center} reduced over dims = (1, 2) on LatitudeLongitudeGrid on CPU
+├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (1, 1, 5)
+├── grid: 60×10×5 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
+├── operand: Integral of BinaryOperation at (Center, Center, Center) over dims (1, 2)
+├── status: time=0.0
+└── data: 1×1×11 OffsetArray(::Array{Float64, 3}, 1:1, 1:1, -2:8) with eltype Float64 with indices 1:1×1:1×-2:8
+    └── max=2.55032e14, min=2.55032e14, mean=2.55032e14
+```
+
+Because they return `Field`s, the Unicode operators compose with the rest of the operations machinery, which a bare `Reduction` cannot do.
+Here, for instance, we normalize the horizontal integral at each level by the integral over the whole domain, which for `c = 1` returns the inverse of the domain depth:
+
+```jldoctest operations_avg_int
+Field(∫∫dxdy(c) / ∫dV(c))
+
+# output
+1×1×5 Field{Nothing, Nothing, Center} reduced over dims = (1, 2) on LatitudeLongitudeGrid on CPU
+├── grid: 60×10×5 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
+├── boundary conditions: FieldBoundaryConditions
+│   └── west: Nothing, east: Nothing, south: Nothing, north: Nothing, bottom: ZeroFlux, top: ZeroFlux, immersed: Nothing
+├── operand: BinaryOperation at (⋅, ⋅, Center)
+├── status: time=0.0
+└── data: 1×1×11 OffsetArray(::Array{Float64, 3}, 1:1, 1:1, -2:8) with eltype Float64 with indices 1:1×1:1×-2:8
+    └── max=0.001, min=0.001, mean=0.001
+```
+
+The one-dimensional operators take `cumulative=true`, which returns the running integral computed by [`CumulativeIntegral`](@ref), and `reverse=true`, which accumulates from the far end of the dimension.
+
+```jldoctest operations_avg_int
+∫ᶻc = ∫dz(c, cumulative=true)
+
+# output
+60×10×6 Field{Center, Center, Face} on LatitudeLongitudeGrid on CPU
+├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (60, 10, 6)
+├── grid: 60×10×5 LatitudeLongitudeGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
+├── operand: CumulativeIntegral of BinaryOperation at (Center, Center, Center) over dims 3
+├── status: time=0.0
+└── data: 66×16×12 OffsetArray(::Array{Float64, 3}, -2:63, -2:13, -2:9) with eltype Float64 with indices -2:63×-2:13×-2:9
+    └── max=1000.0, min=0.0, mean=500.0
+```
+
+The `condition` and `mask` keyword arguments behave exactly as they do for `Integral`.

--- a/examples/horizontal_convection.jl
+++ b/examples/horizontal_convection.jl
@@ -304,13 +304,13 @@ kinetic_energy, Nu = zeros(length(t)), zeros(length(t))
 nothing #hide
 
 # Now we can loop over the fields in the `FieldTimeSeries`, compute kinetic energy and ``Nu``,
-# and plot. We make use of `Integral` to compute the volume integral of fields over our domain.
+# and plot. We make use of `∫dV` to compute the volume integral of fields over our domain.
 
 for n = 1:length(t)
-    ke = Field(Integral(1/2 * s_timeseries[n]^2 / (Lx * H)))
+    ke = ∫dV(1/2 * s_timeseries[n]^2 / (Lx * H))
     kinetic_energy[n] = ke[1, 1, 1]
 
-    χ = Field(Integral(χ_timeseries[n] / (Lx * H)))
+    χ = ∫dV(χ_timeseries[n] / (Lx * H))
     Nu[n] = χ[1, 1, 1] / χ_diff
 end
 

--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -1,6 +1,7 @@
 module AbstractOperations
 
 export ∂x, ∂y, ∂z, @at, @unary, @binary, @multiary
+export ∫dx, ∫dy, ∫dz, ∫∫dxdy, ∫∫dxdz, ∫∫dydz, ∫∫∫dxdydz, ∫dV
 export Δx, Δy, Δz, Ax, Ay, Az, volume
 export Average, Integral, CumulativeIntegral, KernelFunctionOperation, InterpolatedOperation
 export UnaryOperation, Derivative, BinaryOperation, MultiaryOperation, ConditionalOperation
@@ -58,6 +59,7 @@ three-dimensional and would silently drop the time dimension of their operands.
 include("grid_validation.jl")
 include("grid_metrics.jl")
 include("metric_field_reductions.jl")
+include("integral_operators.jl")
 include("unary_operations.jl")
 include("binary_operations.jl")
 include("multiary_operations.jl")

--- a/src/AbstractOperations/integral_operators.jl
+++ b/src/AbstractOperations/integral_operators.jl
@@ -1,0 +1,178 @@
+using Oceananigans.Fields: Field
+
+#####
+##### Unicode integral operators
+#####
+
+function integral_field(field, dims; cumulative=false, kwargs...)
+    integral = cumulative ? CumulativeIntegral(field; dims, kwargs...) :
+                            Integral(field; dims, kwargs...)
+
+    return Field(integral)
+end
+
+"""
+    ∫dx(field; cumulative=false, reverse=false, condition=nothing, mask=0)
+
+Return a `Field` holding ``∫ f \\, dx``, the integral of `field` over ``x``.
+
+The returned `Field` is computed on construction and, unlike the `Reduction` returned by
+[`Integral`](@ref), may be used within other abstract operations, as in `field / ∫dx(field)`.
+
+With `cumulative=true` the running integral ``∫^x f \\, dx'`` computed by
+[`CumulativeIntegral`](@ref) is returned instead, and `reverse=true` accumulates it westward
+from the eastern edge of the domain.
+
+See also [`∫dy`](@ref), [`∫dz`](@ref), [`∫∫dydz`](@ref), and [`∫∫∫dxdydz`](@ref);
+[`ConditionalOperation`](@ref Oceananigans.AbstractOperations.ConditionalOperation)
+documents the `condition` and `mask` keyword arguments.
+"""
+∫dx(field::AbstractField; kwargs...) = integral_field(field, 1; kwargs...)
+
+"""
+    ∫dy(field; cumulative=false, reverse=false, condition=nothing, mask=0)
+
+Return a `Field` holding ``∫ f \\, dy``, the integral of `field` over ``y``.
+
+The returned `Field` is computed on construction and, unlike the `Reduction` returned by
+[`Integral`](@ref), may be used within other abstract operations, as in `field / ∫dy(field)`.
+
+With `cumulative=true` the running integral ``∫^y f \\, dy'`` computed by
+[`CumulativeIntegral`](@ref) is returned instead, and `reverse=true` accumulates it southward
+from the northern edge of the domain.
+
+See also [`∫dx`](@ref), [`∫dz`](@ref), [`∫∫dxdz`](@ref), and [`∫∫∫dxdydz`](@ref);
+[`ConditionalOperation`](@ref Oceananigans.AbstractOperations.ConditionalOperation)
+documents the `condition` and `mask` keyword arguments.
+"""
+∫dy(field::AbstractField; kwargs...) = integral_field(field, 2; kwargs...)
+
+"""
+    ∫dz(field; cumulative=false, reverse=false, condition=nothing, mask=0)
+
+Return a `Field` holding ``∫ f \\, dz``, the integral of `field` over ``z``.
+
+The returned `Field` is computed on construction and, unlike the `Reduction` returned by
+[`Integral`](@ref), may be used within other abstract operations, as in `field / ∫dz(field)`.
+
+With `cumulative=true` the running integral ``∫^z f \\, dz'`` computed by
+[`CumulativeIntegral`](@ref) is returned instead, and `reverse=true` accumulates it downward
+from the top of the domain.
+
+See also [`∫dx`](@ref), [`∫dy`](@ref), [`∫∫dxdy`](@ref), and [`∫∫∫dxdydz`](@ref);
+[`ConditionalOperation`](@ref Oceananigans.AbstractOperations.ConditionalOperation)
+documents the `condition` and `mask` keyword arguments.
+
+Example
+=======
+
+Integrate ``f(z) = z`` over ``z ∈ [0, 1]``, both in full and cumulatively.
+
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = RectilinearGrid(size=8, z=(0, 1), topology=(Flat, Flat, Bounded));
+
+julia> c = CenterField(grid);
+
+julia> set!(c, z -> z);
+
+julia> ∫dz(c)[1, 1, 1]
+0.5
+
+julia> ∫dz(c, cumulative=true)
+1×1×9 Field{Center, Center, Face} on RectilinearGrid on CPU
+├── data: OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}}, size: (1, 1, 9)
+├── grid: 1×1×8 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── operand: CumulativeIntegral of BinaryOperation at (Center, Center, Center) over dims 3
+├── status: time=0.0
+└── data: 1×1×15 OffsetArray(::Array{Float64, 3}, 1:1, 1:1, -2:12) with eltype Float64 with indices 1:1×1:1×-2:12
+    └── max=0.5, min=0.0, mean=0.177083
+```
+"""
+∫dz(field::AbstractField; kwargs...) = integral_field(field, 3; kwargs...)
+
+"""
+    ∫∫dxdy(field; condition=nothing, mask=0)
+
+Return a `Field` holding ``∬ f \\, dx \\, dy``, the integral of `field` over ``x`` and ``y``.
+
+The returned `Field` is computed on construction and, unlike the `Reduction` returned by
+[`Integral`](@ref), may be used within other abstract operations, as in `field / ∫∫dxdy(field)`.
+
+See also [`∫∫dxdz`](@ref), [`∫∫dydz`](@ref), and [`∫∫∫dxdydz`](@ref);
+[`ConditionalOperation`](@ref Oceananigans.AbstractOperations.ConditionalOperation)
+documents the `condition` and `mask` keyword arguments.
+"""
+∫∫dxdy(field::AbstractField; kwargs...) = integral_field(field, (1, 2); kwargs...)
+
+"""
+    ∫∫dxdz(field; condition=nothing, mask=0)
+
+Return a `Field` holding ``∬ f \\, dx \\, dz``, the integral of `field` over ``x`` and ``z``.
+
+The returned `Field` is computed on construction and, unlike the `Reduction` returned by
+[`Integral`](@ref), may be used within other abstract operations, as in `field / ∫∫dxdz(field)`.
+
+See also [`∫∫dxdy`](@ref), [`∫∫dydz`](@ref), and [`∫∫∫dxdydz`](@ref);
+[`ConditionalOperation`](@ref Oceananigans.AbstractOperations.ConditionalOperation)
+documents the `condition` and `mask` keyword arguments.
+"""
+∫∫dxdz(field::AbstractField; kwargs...) = integral_field(field, (1, 3); kwargs...)
+
+"""
+    ∫∫dydz(field; condition=nothing, mask=0)
+
+Return a `Field` holding ``∬ f \\, dy \\, dz``, the integral of `field` over ``y`` and ``z``.
+
+The returned `Field` is computed on construction and, unlike the `Reduction` returned by
+[`Integral`](@ref), may be used within other abstract operations, as in `field / ∫∫dydz(field)`.
+
+See also [`∫∫dxdy`](@ref), [`∫∫dxdz`](@ref), and [`∫∫∫dxdydz`](@ref);
+[`ConditionalOperation`](@ref Oceananigans.AbstractOperations.ConditionalOperation)
+documents the `condition` and `mask` keyword arguments.
+"""
+∫∫dydz(field::AbstractField; kwargs...) = integral_field(field, (2, 3); kwargs...)
+
+"""
+    ∫∫∫dxdydz(field; condition=nothing, mask=0)
+
+Return a `Field` holding ``∭ f \\, dx \\, dy \\, dz``, the integral of `field` over the
+three-dimensional domain. [`∫dV`](@ref) is an alias for `∫∫∫dxdydz`.
+
+The returned `Field` is computed on construction and, unlike the `Reduction` returned by
+[`Integral`](@ref), may be used within other abstract operations, as in `field / ∫dV(field)`.
+
+See also [`∫∫dxdy`](@ref), [`∫∫dxdz`](@ref), and [`∫∫dydz`](@ref);
+[`ConditionalOperation`](@ref Oceananigans.AbstractOperations.ConditionalOperation)
+documents the `condition` and `mask` keyword arguments.
+
+Example
+=======
+
+Compute the integral of ``f(x, y, z) = x y z`` over the domain
+``(x, y, z) ∈ [0, 1] × [0, 1] × [0, 1]``. The analytical answer
+is ``∭ x y z \\, dx \\, dy \\, dz = 1/8``.
+
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = RectilinearGrid(size=(8, 8, 8), x=(0, 1), y=(0, 1), z=(0, 1));
+
+julia> f = CenterField(grid);
+
+julia> set!(f, (x, y, z) -> x * y * z);
+
+julia> ∫dV(f)[1, 1, 1]
+0.125
+```
+"""
+∫∫∫dxdydz(field::AbstractField; kwargs...) = integral_field(field, (1, 2, 3); kwargs...)
+
+"""
+    ∫dV(field; condition=nothing, mask=0)
+
+Alias for [`∫∫∫dxdydz`](@ref): return a `Field` holding ``∭ f \\, dx \\, dy \\, dz``, the
+integral of `field` over the three-dimensional domain.
+"""
+const ∫dV = ∫∫∫dxdydz

--- a/src/AbstractOperations/integral_operators.jl
+++ b/src/AbstractOperations/integral_operators.jl
@@ -172,7 +172,7 @@ julia> ∫dV(f)[1, 1, 1]
 """
     ∫dV(field; condition=nothing, mask=0)
 
-Alias for [`∫∫∫dxdydz`](@ref): return a `Field` holding ``∭ f \\, dx \\, dy \\, dz``, the
+Alias for [`∫∫∫dxdydz`](@ref): return a `Field` holding ``∭ f \\, \\mathrm{d}x \\, \\mathrm{d}y \\, \\mathrm{d}z``, the
 integral of `field` over the three-dimensional domain.
 """
 const ∫dV = ∫∫∫dxdydz

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -115,6 +115,7 @@ export
 
     # Abstract operations
     ∂x, ∂y, ∂z, @at, KernelFunctionOperation, InterpolatedOperation,
+    ∫dx, ∫dy, ∫dz, ∫∫dxdy, ∫∫dxdz, ∫∫dydz, ∫∫∫dxdydz, ∫dV,
 
     # MultiRegion and Cubed sphere
     MultiRegionGrid, MultiRegionField,

--- a/test/test_field_scans.jl
+++ b/test/test_field_scans.jl
@@ -262,6 +262,58 @@ interior_array(a, i, j, k) = Array(interior(a, i, j, k))
             @test mean(results) == 1.0
         end
 
+        @testset "Unicode integral operators [$arch_str]" begin
+            @info "  Testing Unicode integral operators [$arch_str]"
+
+            grid = RectilinearGrid(arch, size = (2, 2, 2),
+                                   x = (0, 2), y = (0, 2), z = (0, 2),
+                                   topology = (Periodic, Periodic, Bounded))
+
+            T = CenterField(grid)
+            set!(T, trilinear)
+            fill_halo_regions!(T)
+
+            unicode_integrals = (∫dx, ∫dy, ∫dz, ∫∫dxdy, ∫∫dxdz, ∫∫dydz, ∫∫∫dxdydz)
+            integrated_dims = (tuple(1), tuple(2), tuple(3), (1, 2), (1, 3), (2, 3), (1, 2, 3))
+
+            for (∫dξ, dims) in zip(unicode_integrals, integrated_dims)
+                ∫T = ∫dξ(T)
+                @test ∫T isa Field
+                @test ∫T.operand isa Reduction
+                @test ∫T.operand.dims === dims
+                @test interior_array(∫T, :, :, :) == interior_array(Field(Integral(T; dims)), :, :, :)
+            end
+
+            @test ∫dV === ∫∫∫dxdydz
+
+            # The returned Field is computed on construction: T = x + y + z integrates to 24 over [0, 2]³
+            @test interior_array(∫dV(T), :, :, :)[1, 1, 1] ≈ 24
+
+            # ... and still composes with other abstract operations
+            @test interior_array(Field(T / ∫dV(T)), :, :, :) ≈ interior_array(T, :, :, :) ./ 24
+
+            # CumulativeIntegral is only supported over a single Bounded dimension
+            @test_throws ArgumentError ∫dx(T, cumulative=true)
+            @test_throws ArgumentError ∫dy(T, cumulative=true)
+            @test_throws ArgumentError ∫∫dxdy(T, cumulative=true)
+
+            Tcz = ∫dz(T, cumulative=true)
+            Trz = ∫dz(T, cumulative=true, reverse=true)
+
+            @test Tcz.operand isa Accumulation
+            @test Tcz.operand.scan! === cumsum!
+            @test Trz.operand.scan! === reverse_cumsum!
+
+            @test interior_array(Tcz, 1, 1, :) ≈ [0, 1.5, 4]
+            @test interior_array(Trz, 1, 1, :) ≈ [4, 2.5, 0]
+
+            upper_half(i, j, k, grid, c) = Oceananigans.Grids.znode(k, grid, Center()) > 1
+
+            ∫TdV = ∫dV(T, condition=upper_half)
+            @test interior_array(∫TdV, :, :, :)[1, 1, 1] ≈ 14
+            @test interior_array(∫TdV, :, :, :) == interior_array(Field(Integral(T, condition=upper_half)), :, :, :)
+        end
+
         @testset "Allocating reductions [$arch_str]" begin
             @info "  Testing allocating reductions [$arch_str]"
 

--- a/test/test_field_scans.jl
+++ b/test/test_field_scans.jl
@@ -281,7 +281,7 @@ interior_array(a, i, j, k) = Array(interior(a, i, j, k))
                 @test ∫T isa Field
                 @test ∫T.operand isa Reduction
                 @test ∫T.operand.dims === dims
-                @test interior_array(∫T, :, :, :) == interior_array(Field(Integral(T; dims)), :, :, :)
+                @test ∫T == Field(Integral(T; dims))
             end
 
             @test ∫dV === ∫∫∫dxdydz
@@ -290,7 +290,7 @@ interior_array(a, i, j, k) = Array(interior(a, i, j, k))
             @test interior_array(∫dV(T), :, :, :)[1, 1, 1] ≈ 24
 
             # ... and still composes with other abstract operations
-            @test interior_array(Field(T / ∫dV(T)), :, :, :) ≈ interior_array(T, :, :, :) ./ 24
+            @test Field(T / ∫dV(T)) ≈ Field(T / 24)
 
             # CumulativeIntegral is only supported over a single Bounded dimension
             @test_throws ArgumentError ∫dx(T, cumulative=true)
@@ -311,7 +311,7 @@ interior_array(a, i, j, k) = Array(interior(a, i, j, k))
 
             ∫TdV = ∫dV(T, condition=upper_half)
             @test interior_array(∫TdV, :, :, :)[1, 1, 1] ≈ 14
-            @test interior_array(∫TdV, :, :, :) == interior_array(Field(Integral(T, condition=upper_half)), :, :, :)
+            @test ∫TdV == Field(Integral(T, condition=upper_half))
         end
 
         @testset "Allocating reductions [$arch_str]" begin


### PR DESCRIPTION
Closes #5816.

Adds `∫dx`, `∫dy`, `∫dz`, `∫∫dxdy`, `∫∫dxdz`, `∫∫dydz`, `∫∫∫dxdydz`, and the alias `∫dV`. Each wraps `Integral` (or `CumulativeIntegral`, via `cumulative=true`) in a computed `Field`, so unlike a `Reduction` the result composes with other abstract operations. `condition` and `mask` pass through.