### PR TITLE
Support multi-dimensional conservative regridding with `regrid!`

### DIFF
--- a/src/Fields/regridding_fields.jl
+++ b/src/Fields/regridding_fields.jl
@@ -215,12 +215,9 @@ function dimension_swapped_grid(source_grid, target_grid, dimension)
 end
 
 function regrid_multiple_dimensions!(a, target_grid, source_grid, b)
+    # At least two dimensions differ here: with fewer, one of the single-dimension
+    # paths in regrid! passes its size checks and is dispatched to instead.
     differing_dimensions = Tuple(n for n in 1:3 if dimension_differs(target_grid, source_grid, n))
-
-    if isempty(differing_dimensions)
-        interior(a) .= interior(b)
-        return a
-    end
 
     regrid_dimension! = (regrid_in_x!, regrid_in_y!, regrid_in_z!)
 

--- a/src/Fields/regridding_fields.jl
+++ b/src/Fields/regridding_fields.jl
@@ -3,6 +3,8 @@ using KernelAbstractions: @kernel, @index
 using Oceananigans.Architectures: architecture
 using Oceananigans.Operators: Δzᶜᶜᶜ, Azᶜᶜᶜ
 using Oceananigans.Grids: Flat, hack_sind, ξnode, ηnode
+using Oceananigans.Grids: constructor_arguments, halo_size, pop_flat_elements, reconstruction_faces,
+                          cpu_face_constructor_x, cpu_face_constructor_y, cpu_face_constructor_z
 
 using Base: ForwardOrdering
 
@@ -12,10 +14,16 @@ const c = Center()
 """
 $(TYPEDSIGNATURES)
 
-Regrid `src_field` onto the grid of `dst_field`.
+Regrid `src_field` onto the grid of `dst_field`, conserving the integral of `src_field`.
 
-Example
-=======
+When the grids differ in more than one dimension, the field is regridded one dimension at
+a time, through intermediate fields on grids that combine the coordinates of the target grid
+in the dimensions already regridded with the coordinates of the source grid in the remaining
+ones. This requires grids of the same type (`RectilinearGrid` or `LatitudeLongitudeGrid`)
+with the same topology, and `Center` locations in the differing dimensions.
+
+Examples
+========
 
 Generate a tracer field on a vertically stretched grid and regrid it on a regular grid.
 
@@ -42,6 +50,28 @@ output_field[1, 1, :]
  2.333333333333333
  3.0
  0.0
+```
+
+Regrid a field between grids that differ in both `x` and `z`.
+
+```jldoctest
+using Oceananigans
+
+topology = (Bounded, Flat, Bounded)
+
+input_grid = RectilinearGrid(size=(2, 2), x=[0, 0.25, 1], z=[0, 0.5, 1], topology=topology, halo=(1, 1))
+input_field = CenterField(input_grid)
+input_field[1:2, 1, 1:2] = [1 2; 3 4]
+
+output_grid = RectilinearGrid(size=(1, 1), x=(0, 1), z=(0, 1), topology=topology, halo=(1, 1))
+output_field = CenterField(output_grid)
+
+regrid!(output_field, input_field)
+
+output_field[1, 1, 1]
+
+# output
+3.0
 ```
 """
 regrid!(dst_field, src_field) =
@@ -90,7 +120,8 @@ function regrid_in_y!(a, target_grid, source_grid, b)
     location(a, 2) == Center || throw(ArgumentError("Can only regrid fields in y with Center y-locations."))
     arch = architecture(a)
     source_y_faces = nodes(source_grid, c, f, c)[2]
-    Nx_source_faces = size(source_grid, (Face, Center, Center), 1)
+    # A Periodic dimension has a closing face in the halo, so the face count is N+1 as for Bounded
+    Nx_source_faces = topology(source_grid, 1) == Flat ? 1 : source_grid.Nx + 1
     launch!(arch, target_grid, :xz, _regrid_in_y!, a, b, target_grid, source_grid, source_y_faces, Nx_source_faces)
     return a
 end
@@ -99,7 +130,8 @@ function regrid_in_x!(a, target_grid, source_grid, b)
     location(a, 1) == Center || throw(ArgumentError("Can only regrid fields in x with Center x-locations."))
     arch = architecture(a)
     source_x_faces = nodes(source_grid, f, c, c)[1]
-    Ny_source_faces = size(source_grid, (Center, Face, Center), 2)
+    # A Periodic dimension has a closing face in the halo, so the face count is N+1 as for Bounded
+    Ny_source_faces = topology(source_grid, 2) == Flat ? 1 : source_grid.Ny + 1
     launch!(arch, target_grid, :yz, _regrid_in_x!, a, b, target_grid, source_grid, source_x_faces, Ny_source_faces)
     return a
 end
@@ -117,6 +149,8 @@ function regrid!(a, target_grid, source_grid, b)
         return regrid_in_y!(a, target_grid, source_grid, b)
     elseif we_can_regrid_in_x(a, target_grid, source_grid, b)
         return regrid_in_x!(a, target_grid, source_grid, b)
+    elseif we_can_regrid_multiple_dimensions(a, target_grid, source_grid, b)
+        return regrid_multiple_dimensions!(a, target_grid, source_grid, b)
     else
         msg = """Regridding
                  $(summary(b)) on $(summary(source_grid))
@@ -125,6 +159,84 @@ function regrid!(a, target_grid, source_grid, b)
 
         return throw(ArgumentError(msg))
     end
+end
+
+#####
+##### Multi-dimensional regridding, one dimension at a time
+#####
+
+coordinate_keys(::RectilinearGrid) = (:x, :y, :z)
+coordinate_keys(::LatitudeLongitudeGrid) = (:longitude, :latitude, :z)
+
+function dimension_faces(grid, dimension)
+    face_constructor = (cpu_face_constructor_x, cpu_face_constructor_y, cpu_face_constructor_z)[dimension]
+    return reconstruction_faces(face_constructor(grid), size(grid, dimension))
+end
+
+function dimension_differs(target_grid, source_grid, dimension)
+    topology(source_grid, dimension) == Flat && return false
+    size(source_grid, dimension) == size(target_grid, dimension) || return true
+    return !isapprox(dimension_faces(source_grid, dimension), dimension_faces(target_grid, dimension))
+end
+
+function we_can_regrid_multiple_dimensions(a, target_grid, source_grid, b)
+    typeof(source_grid).name.wrapper === typeof(target_grid).name.wrapper || return false
+    target_grid isa Union{RectilinearGrid, LatitudeLongitudeGrid} || return false
+    topology(source_grid) == topology(target_grid) || return false
+
+    for dimension in 1:3
+        if dimension_differs(target_grid, source_grid, dimension)
+            location(a, dimension) == Center && location(b, dimension) == Center || return false
+        elseif size(a)[dimension] != size(b)[dimension]
+            return false
+        end
+    end
+
+    return true
+end
+
+# Return a grid identical to `source_grid` except along `dimension`, which takes the
+# coordinate, size, and halo of `target_grid`.
+function dimension_swapped_grid(source_grid, target_grid, dimension)
+    args, kwargs = constructor_arguments(source_grid)
+    target_kwargs = constructor_arguments(target_grid)[2]
+
+    key = coordinate_keys(source_grid)[dimension]
+    kwargs[key] = target_kwargs[key]
+
+    grid_size = ntuple(n -> n == dimension ? size(target_grid, n) : size(source_grid, n), 3)
+    grid_halo = ntuple(n -> n == dimension ? halo_size(target_grid, n) : halo_size(source_grid, n), 3)
+    grid_topology = topology(source_grid)
+    kwargs[:size] = pop_flat_elements(grid_size, grid_topology)
+    kwargs[:halo] = pop_flat_elements(grid_halo, grid_topology)
+
+    GridConstructor = typeof(source_grid).name.wrapper
+    return GridConstructor(args[:architecture], args[:number_type]; kwargs...)
+end
+
+function regrid_multiple_dimensions!(a, target_grid, source_grid, b)
+    differing_dimensions = Tuple(n for n in 1:3 if dimension_differs(target_grid, source_grid, n))
+
+    if isempty(differing_dimensions)
+        interior(a) .= interior(b)
+        return a
+    end
+
+    regrid_dimension! = (regrid_in_x!, regrid_in_y!, regrid_in_z!)
+
+    field = b
+    grid = source_grid
+
+    for (step, dimension) in enumerate(differing_dimensions)
+        final_step = step == length(differing_dimensions)
+        next_grid = final_step ? target_grid : dimension_swapped_grid(grid, target_grid, dimension)
+        next_field = final_step ? a : Field{location(b)...}(next_grid)
+        regrid_dimension![dimension](next_field, next_grid, grid, field)
+        field = next_field
+        grid = next_grid
+    end
+
+    return a
 end
 
 #####

--- a/src/Fields/regridding_fields.jl
+++ b/src/Fields/regridding_fields.jl
@@ -107,10 +107,15 @@ function we_can_regrid_in_x(a, target_grid, source_grid, b)
     return false
 end
 
+# The face search in the regridding kernels spans indices 1:N+1, so the face array must
+# include the closing face, which for a Periodic dimension lives in the halo.
+closed_face_nodes(grid, ℓx, ℓy, ℓz, dimension) =
+    view(nodes(grid, ℓx, ℓy, ℓz; with_halos=true)[dimension], 1:size(grid, dimension)+1)
+
 function regrid_in_z!(a, target_grid, source_grid, b)
     location(a, 3) == Center || throw(ArgumentError("Can only regrid fields in z with Center z-locations."))
     arch = architecture(a)
-    source_z_faces = znodes(source_grid, f)
+    source_z_faces = closed_face_nodes(source_grid, c, c, f, 3)
     launch!(arch, target_grid, :xy, _regrid_in_z!, a, b, target_grid, source_grid, source_z_faces)
 
     return a
@@ -119,7 +124,7 @@ end
 function regrid_in_y!(a, target_grid, source_grid, b)
     location(a, 2) == Center || throw(ArgumentError("Can only regrid fields in y with Center y-locations."))
     arch = architecture(a)
-    source_y_faces = nodes(source_grid, c, f, c)[2]
+    source_y_faces = closed_face_nodes(source_grid, c, f, c, 2)
     # A Periodic dimension has a closing face in the halo, so the face count is N+1 as for Bounded
     Nx_source_faces = topology(source_grid, 1) == Flat ? 1 : source_grid.Nx + 1
     launch!(arch, target_grid, :xz, _regrid_in_y!, a, b, target_grid, source_grid, source_y_faces, Nx_source_faces)
@@ -129,7 +134,7 @@ end
 function regrid_in_x!(a, target_grid, source_grid, b)
     location(a, 1) == Center || throw(ArgumentError("Can only regrid fields in x with Center x-locations."))
     arch = architecture(a)
-    source_x_faces = nodes(source_grid, f, c, c)[1]
+    source_x_faces = closed_face_nodes(source_grid, f, c, c, 1)
     # A Periodic dimension has a closing face in the halo, so the face count is N+1 as for Bounded
     Ny_source_faces = topology(source_grid, 2) == Flat ? 1 : source_grid.Ny + 1
     launch!(arch, target_grid, :yz, _regrid_in_x!, a, b, target_grid, source_grid, source_x_faces, Ny_source_faces)

--- a/test/test_regrid.jl
+++ b/test/test_regrid.jl
@@ -150,3 +150,151 @@ using Oceananigans.Fields: regrid_in_x!, regrid_in_y!, regrid_in_z!
         end
     end
 end
+
+overlap_length(left1, right1, left2, right2) = max(0, min(right1, right2) - max(left1, left2))
+
+dimension_face_coordinates(grid::RectilinearGrid) =
+    (xnodes(grid, Face()), ynodes(grid, Face()), znodes(grid, Face()))
+
+dimension_face_coordinates(grid::LatitudeLongitudeGrid) =
+    (λnodes(grid, Face()), sind.(φnodes(grid, Face())), znodes(grid, Face()))
+
+collected_faces(grid) = Tuple(faces === nothing ? [0, 1] : collect(faces)
+                              for faces in dimension_face_coordinates(grid))
+
+# Reference multi-dimensional conservative regridding by brute-force cell-overlap integrals.
+# Cell volumes factorize per dimension on RectilinearGrid (Δx Δy Δz) and LatitudeLongitudeGrid
+# (R² Δλ Δsinφ Δz, constant factors cancel in the volume-weighted average).
+function brute_force_regrid(target_grid, source_grid, c)
+    target_faces = collected_faces(target_grid)
+    source_faces = collected_faces(source_grid)
+
+    Nx, Ny, Nz = size(target_grid)
+    expected = zeros(Nx, Ny, Nz)
+
+    for i in 1:Nx, j in 1:Ny, k in 1:Nz
+        target_intervals = ((target_faces[1][i], target_faces[1][i+1]),
+                            (target_faces[2][j], target_faces[2][j+1]),
+                            (target_faces[3][k], target_faces[3][k+1]))
+
+        integral = 0.0
+        for i′ in 1:size(source_grid, 1), j′ in 1:size(source_grid, 2), k′ in 1:size(source_grid, 3)
+            volume = overlap_length(target_intervals[1]..., source_faces[1][i′], source_faces[1][i′+1]) *
+                     overlap_length(target_intervals[2]..., source_faces[2][j′], source_faces[2][j′+1]) *
+                     overlap_length(target_intervals[3]..., source_faces[3][k′], source_faces[3][k′+1])
+            integral += c[i′, j′, k′] * volume
+        end
+
+        target_volume = prod(interval[2] - interval[1] for interval in target_intervals)
+        expected[i, j, k] = integral / target_volume
+    end
+
+    return expected
+end
+
+total_integral(field) = @allowscalar compute!(Field(Integral(field)))[1, 1, 1]
+
+@testset "Multi-dimensional regridding" begin
+    @info "  Testing multi-dimensional regridding..."
+
+    for arch in archs
+        @testset "Multi-dimensional regridding on RectilinearGrid [$(typeof(arch))]" begin
+            source_grid = RectilinearGrid(arch, size=(4, 4, 4),
+                                          x=[0, 0.1, 0.3, 0.65, 1.1],
+                                          y=[0, 0.2, 0.5, 0.9, 1.4],
+                                          z=[-1, -0.7, -0.45, -0.2, 0],
+                                          topology=(Bounded, Bounded, Bounded))
+
+            target_grid = RectilinearGrid(arch, size=(2, 3, 2), x=(0, 1.1), y=(0, 1.4), z=(-1, 0),
+                                          topology=(Bounded, Bounded, Bounded))
+
+            c = reshape(collect(1.0:64.0) .+ sin.(1:64) ./ 2, 4, 4, 4)
+            source_field = CenterField(source_grid)
+            set!(source_field, c)
+            target_field = CenterField(target_grid)
+            regrid!(target_field, source_field)
+
+            expected = brute_force_regrid(target_grid, source_grid, c)
+            @test all(isapprox.(Array(interior(target_field)), expected, atol=1e-12))
+            @test total_integral(target_field) ≈ total_integral(source_field)
+
+            # Refinement in all three dimensions reproduces piecewise-constant data
+            fine_grid = RectilinearGrid(arch, size=(8, 9, 11), x=(0, 1.1), y=(0, 1.4), z=(-1, 0),
+                                        topology=(Bounded, Bounded, Bounded))
+            fine_field = CenterField(fine_grid)
+            regrid!(fine_field, target_field)
+
+            expected = brute_force_regrid(fine_grid, target_grid, Array(interior(target_field)))
+            @test all(isapprox.(Array(interior(fine_field)), expected, atol=1e-12))
+            @test total_integral(fine_field) ≈ total_integral(target_field)
+        end
+
+        @testset "Multi-dimensional regridding with Periodic dimensions [$(typeof(arch))]" begin
+            source_grid = RectilinearGrid(arch, size=(5, 4, 3),
+                                          x=[0, 0.1, 0.3, 0.35, 0.7, 1], y=(0, 2), z=[-1, -0.5, -0.2, 0],
+                                          topology=(Periodic, Bounded, Bounded))
+
+            target_grid = RectilinearGrid(arch, size=(3, 2, 5), x=(0, 1), y=(0, 2), z=(-1, 0),
+                                          topology=(Periodic, Bounded, Bounded))
+
+            source_field = CenterField(source_grid)
+            set!(source_field, 3.7)
+            target_field = CenterField(target_grid)
+            regrid!(target_field, source_field)
+
+            @test all(isapprox.(Array(interior(target_field)), 3.7))
+        end
+
+        @testset "Multi-dimensional regridding on LatitudeLongitudeGrid [$(typeof(arch))]" begin
+            source_grid = LatitudeLongitudeGrid(arch, size=(8, 8, 4),
+                                                longitude=(0, 40), latitude=(10, 50), z=[-1, -0.6, -0.3, -0.1, 0],
+                                                topology=(Bounded, Bounded, Bounded))
+
+            target_grid = LatitudeLongitudeGrid(arch, size=(4, 5, 2),
+                                                longitude=(0, 40), latitude=(10, 50), z=(-1, 0),
+                                                topology=(Bounded, Bounded, Bounded))
+
+            c = reshape(collect(1.0:256.0), 8, 8, 4) ./ 256 .+ 1
+            source_field = CenterField(source_grid)
+            set!(source_field, c)
+            target_field = CenterField(target_grid)
+            regrid!(target_field, source_field)
+
+            expected = brute_force_regrid(target_grid, source_grid, c)
+            @test all(isapprox.(Array(interior(target_field)), expected, atol=1e-12))
+            @test total_integral(target_field) ≈ total_integral(source_field)
+
+            constant_source_field = CenterField(source_grid)
+            set!(constant_source_field, 2.5)
+            constant_target_field = CenterField(target_grid)
+            regrid!(constant_target_field, constant_source_field)
+            @test all(isapprox.(Array(interior(constant_target_field)), 2.5))
+
+            # Horizontal-only regridding of a two-dimensional field
+            source_grid = LatitudeLongitudeGrid(arch, size=(6, 6), longitude=(-30, 30), latitude=(-20, 40),
+                                                topology=(Bounded, Bounded, Flat))
+            target_grid = LatitudeLongitudeGrid(arch, size=(3, 2), longitude=(-30, 30), latitude=(-20, 40),
+                                                topology=(Bounded, Bounded, Flat))
+
+            c = reshape(collect(1.0:36.0), 6, 6, 1)
+            source_field = CenterField(source_grid)
+            set!(source_field, c)
+            target_field = CenterField(target_grid)
+            regrid!(target_field, source_field)
+
+            expected = brute_force_regrid(target_grid, source_grid, c)
+            @test all(isapprox.(Array(interior(target_field)), expected, atol=1e-12))
+        end
+
+        @testset "Unsupported multi-dimensional regridding [$(typeof(arch))]" begin
+            rectilinear_grid = RectilinearGrid(arch, size=(4, 4, 4), x=(0, 1), y=(0, 1), z=(0, 1),
+                                               topology=(Bounded, Bounded, Bounded))
+            latlon_grid = LatitudeLongitudeGrid(arch, size=(2, 2, 2), longitude=(0, 1), latitude=(0, 1), z=(0, 1),
+                                                topology=(Bounded, Bounded, Bounded))
+
+            latlon_field = CenterField(latlon_grid)
+            rectilinear_field = CenterField(rectilinear_grid)
+            @test_throws ArgumentError regrid!(latlon_field, rectilinear_field)
+        end
+    end
+end


### PR DESCRIPTION
Closes #5716. `regrid!` now composes the existing single-dimension conservative regrids when the grids differ in more than one dimension (including all three), instead of throwing. Intermediate grids are built with `constructor_arguments`, swapping one dimension at a time toward the target, so the result is exact for `RectilinearGrid` and `LatitudeLongitudeGrid` since cell volumes factorize per dimension.

- Same constraints as single-dimension `regrid!`: same grid class and topology, `Center` locations along the regridded dimensions, GPU-native.
- Also fixes #5825: `regrid_in_x!`/`regrid_in_y!` with a `Periodic` transverse dimension — the source face count was `N` instead of `N + 1`, so the last row/column lost all fractional-cell contributions (a constant field regridded to half its value there).
- Also fixes #5830: the kernels' face search probes index `N + 1`, past the end of the face array of a swept `Periodic` dimension — a silent out-of-bounds read, and a `BoundsError` under `--check-bounds=yes`. Faces now include the closing halo face.
- Tests check against brute-force cell-overlap integrals and integral conservation on both grid classes.

```julia
using Oceananigans

source_grid = RectilinearGrid(size=(4, 4, 4), x=[0, 0.1, 0.3, 0.65, 1.1], y=[0, 0.2, 0.5, 0.9, 1.4],
                              z=[-1, -0.7, -0.45, -0.2, 0], topology=(Bounded, Bounded, Bounded))
target_grid = RectilinearGrid(size=(2, 3, 2), x=(0, 1.1), y=(0, 1.4), z=(-1, 0),
                              topology=(Bounded, Bounded, Bounded))

c = CenterField(source_grid)
set!(c, (x, y, z) -> x + y * z)

regrid!(CenterField(target_grid), c)  # previously an ArgumentError
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

