### PR TITLE
Fix ConservativeRegridding extension

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -167,6 +167,7 @@ steps:
           - "🧅 multi_region"
           - "🌐 multi_region_simulation"
           - "🌍 multi_region_simulation_immersed"
+          - "🧵 conservative_regridding"
           - "🦧 scripts"
 
     retry:

--- a/ext/OceananigansConservativeRegriddingExt.jl
+++ b/ext/OceananigansConservativeRegriddingExt.jl
@@ -1,12 +1,12 @@
 module OceananigansConservativeRegriddingExt
 
 using ConservativeRegridding: Regridder, regrid!
-using Oceananigans.AbstractOperations: RegriddedOperation
+using Oceananigans.AbstractOperations: AbstractOperations, RegriddedOperation
 using Oceananigans.Architectures: Architectures, architecture, CPU
 using Oceananigans.Fields: Fields, AbstractField, Field
 using Oceananigans.ImmersedBoundaries: underlying_grid
 
-function RegriddedOperation(source::AbstractField{LX, LY, LZ}, destination_grid) where {LX, LY, LZ}
+function AbstractOperations.RegriddedOperation(source::AbstractField{LX, LY, LZ}, destination_grid) where {LX, LY, LZ}
     source_architecture = architecture(source)
     destination_grid = Architectures.on_architecture(source_architecture, destination_grid)
     destination = Field{LX, LY, LZ}(destination_grid)

--- a/test/test_conservative_regridding.jl
+++ b/test/test_conservative_regridding.jl
@@ -25,12 +25,12 @@ using ConservativeRegridding
 
     # Test: field of 1's regrids to 1's (fine -> coarse)
     set!(fine_field, 1)
-    regrid!(coarse_field, regridder, fine_field)
+    ConservativeRegridding.regrid!(coarse_field, regridder, fine_field)
     @test all(interior(coarse_field) .≈ 1)
 
     # Test: field of 1's regrids to 1's (coarse -> fine)
     set!(coarse_field, 1)
-    regrid!(fine_field, transpose(regridder), coarse_field)
+    ConservativeRegridding.regrid!(fine_field, transpose(regridder), coarse_field)
     @test all(interior(fine_field) .≈ 1)
 
     # A conservative regridded field remains connected to its source operation.
@@ -77,11 +77,11 @@ using ConservativeRegridding
 
     # Test: field of 1's regrids to 1's (fine -> coarse)
     set!(fine_rect, 1)
-    regrid!(coarse_rect, rect_regridder, fine_rect)
+    ConservativeRegridding.regrid!(coarse_rect, rect_regridder, fine_rect)
     @test all(interior(coarse_rect) .≈ 1)
 
     # Test: field of 1's regrids to 1's (coarse -> fine)
     set!(coarse_rect, 1)
-    regrid!(fine_rect, transpose(rect_regridder), coarse_rect)
+    ConservativeRegridding.regrid!(fine_rect, transpose(rect_regridder), coarse_rect)
     @test all(interior(fine_rect) .≈ 1)
 end


### PR DESCRIPTION
Ths issues is `RegriddingOperation` not being correctly imported from `AbstractOperations`

Also the tests has some issues, but the test was never called in CI.