### PR TITLE
Fix Metal kernel launches broken by argument pre-conversion

### DIFF
--- a/ext/OceananigansMetalExt.jl
+++ b/ext/OceananigansMetalExt.jl
@@ -43,10 +43,6 @@ function on_architecture(::MetalGPU, s::StepRangeLen{FT, Float64, Float64}) wher
     return StepRangeLen{FT}(ref, step, len, offset)
 end
 
-# No `convert_to_device` methods for `MetalGPU`: `Metal.mtlconvert` requires the launch-time
-# command encoder to register buffer residency and root arrays until batched command buffers
-# execute, so arguments must reach Metal.jl unconverted (the generic fallback is the identity).
-
 Metal.@device_override @inline function __validindex(ctx::MappedCompilerMetadata)
     if __dynamic_checkbounds(ctx)
         index = @inbounds linear_expand(__iterspace(ctx), threadgroup_position_in_grid().x, thread_position_in_threadgroup().x)

--- a/ext/OceananigansMetalExt.jl
+++ b/ext/OceananigansMetalExt.jl
@@ -10,7 +10,6 @@ using AbstractFFTs: plan_fft!, plan_ifft!
 import KernelAbstractions: __validindex
 import Oceananigans.Architectures:
     architecture,
-    convert_to_device,
     on_architecture
 
 import Oceananigans.Fields as FD
@@ -44,8 +43,9 @@ function on_architecture(::MetalGPU, s::StepRangeLen{FT, Float64, Float64}) wher
     return StepRangeLen{FT}(ref, step, len, offset)
 end
 
-@inline convert_to_device(::MetalGPU, args) = Metal.mtlconvert(args)
-@inline convert_to_device(::MetalGPU, args::Tuple) = map(Metal.mtlconvert, args)
+# No `convert_to_device` methods for `MetalGPU`: `Metal.mtlconvert` requires the launch-time
+# command encoder to register buffer residency and root arrays until batched command buffers
+# execute, so arguments must reach Metal.jl unconverted (the generic fallback is the identity).
 
 Metal.@device_override @inline function __validindex(ctx::MappedCompilerMetadata)
     if __dynamic_checkbounds(ctx)


### PR DESCRIPTION
Closes #5818.

Since #5774, `_launch!` pre-converts kernel arguments with `convert_to_device` before invoking the KernelAbstractions kernel. On Metal this calls `Metal.mtlconvert` without the launch-time command encoder, which skips buffer residency registration (`MTL.use!`) and argument rooting until the batched command buffers execute — kernels then silently read/write invalid memory (fields stay `0.0f0`, wrong Poisson solutions). This is what broke Metal CI on `main`.

Fix: remove the `MetalGPU` `convert_to_device` methods so the generic identity fallback applies and Metal.jl converts arguments at kernel encode time. CUDA, AMDGPU, and oneAPI keep the launch-overhead optimization.

This is not a numerics change — the kernel receives identical arguments either way. Verified on an Apple M-series GPU with the `test_metal.jl` ImmersedBoundaryGrid setup (`max u` after 100 iterations):

| code state | run 1 | run 2 |
|---|---|---|
| CPU Float32 reference | 0.017791448 | — |
| this PR (Metal) | 0.017791448 | 0.017791448 |
| `main` (Metal) | 0.0 | 0.0 |
| `main` before #5774 (Metal) | 0.0035841 | 0.0131003 |

The last row shows Metal results were already nondeterministically corrupted before #5774: `fill_halo_regions!` and the split-explicit substepping pass pre-converted arguments through the same path. That likely explains the FFT Poisson flake #5818, and why #5774's failing Metal PR CI read as that known flake. All `test_metal.jl` testsets pass locally with this change, with and without Metal residency sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)