### PR TITLE
Fix NCCLDistributed runtime failures: CUDA.wait and device-buffer MPI collectives

### DIFF
--- a/ext/OceananigansNCCLExt/nccl_distributed.jl
+++ b/ext/OceananigansNCCLExt/nccl_distributed.jl
@@ -85,7 +85,7 @@ function DC.distributed_fill_halo_event!(c, kernel!::DistributedFillHalo, bcs, l
     DC.fill_send_buffers!(c, buffers, grid, buffer_side)
     pack_done = CUDA.CuEvent(CUDA.EVENT_DISABLE_TIMING)
     CUDA.record(pack_done)
-    CUDA.cuStreamWaitEvent(communicator.comm_stream, pack_done, UInt32(0))
+    CUDA.wait(pack_done, communicator.comm_stream)
 
     NCCL.groupStart()
     enqueue_nccl_send_recv!(kernel!, bcs, nccl_comm, buffers; stream=communicator.comm_stream)
@@ -102,7 +102,7 @@ function DC.distributed_fill_halo_event!(c, kernel!::DistributedFillHalo, bcs, l
     end
 
     # Sync: have the default stream wait for this fill's NCCL ops, then unpack.
-    CUDA.cuStreamWaitEvent(CUDA.stream(), comm_done, UInt32(0))
+    CUDA.wait(comm_done, CUDA.stream())
     DC.recv_from_buffers!(c, buffers, grid, buffer_side)
     return nothing
 end
@@ -128,7 +128,7 @@ function synchronize_communication!(field::NCCLDistributedField)
             # Wait on each fill's completion event before unpacking; this also
             # fences the next iteration's packs behind the finished transfers.
             for pending in pending_unpacks
-                CUDA.cuStreamWaitEvent(CUDA.stream(), pending.event, UInt32(0))
+                CUDA.wait(pending.event, CUDA.stream())
                 DC.recv_from_buffers!(pending.c, pending.buffers, pending.grid, pending.side)
             end
             empty!(pending_unpacks)

--- a/ext/OceananigansNCCLExt/nccl_distributed.jl
+++ b/ext/OceananigansNCCLExt/nccl_distributed.jl
@@ -26,6 +26,33 @@ MPI.Bcast!(buf, c::NCCLCommunicator; kwargs...) = MPI.Bcast!(buf, c.mpi; kwargs.
 MPI.Isend(buf, dest, tag, c::NCCLCommunicator) = MPI.Isend(buf, dest, tag, c.mpi)
 MPI.Irecv!(buf, src, tag, c::NCCLCommunicator) = MPI.Irecv!(buf, src, tag, c.mpi)
 
+# The host MPI library need not be CUDA-aware: device buffers reaching these forwarded
+# collectives (e.g. the tiny result arrays of distributed field reductions) must be
+# staged through the host, or MPI's host memcpy segfaults on the device pointer.
+function MPI.Allreduce!(sendbuf::CUDA.AnyCuArray, recvbuf::CUDA.AnyCuArray, op, c::NCCLCommunicator)
+    host_sendbuf = Array(sendbuf)
+    host_recvbuf = similar(host_sendbuf)
+    MPI.Allreduce!(host_sendbuf, host_recvbuf, op, c.mpi)
+    copyto!(recvbuf, host_recvbuf)
+    return recvbuf
+end
+
+function MPI.Allreduce!(sendrecvbuf::CUDA.AnyCuArray, op, c::NCCLCommunicator)
+    host_buffer = Array(sendrecvbuf)
+    MPI.Allreduce!(host_buffer, op, c.mpi)
+    copyto!(sendrecvbuf, host_buffer)
+    return sendrecvbuf
+end
+
+MPI.Allreduce(sendbuf::CUDA.AnyCuArray, op, c::NCCLCommunicator) = MPI.Allreduce(Array(sendbuf), op, c.mpi)
+
+function MPI.Bcast!(buf::CUDA.AnyCuArray, c::NCCLCommunicator; kwargs...)
+    host_buffer = Array(buf)
+    MPI.Bcast!(host_buffer, c.mpi; kwargs...)
+    copyto!(buf, host_buffer)
+    return buf
+end
+
 #####
 ##### Type aliases for dispatch
 #####


### PR DESCRIPTION
Two runtime failures currently make `NCCLDistributed` unusable; both reproduce on Oceananigans v0.110.14 and current main, verified on 2×A100 (Slurm, MPICH hydra host launch).

**1. `UndefVarError: cuStreamWaitEvent not defined in CUDA`** on every `fill_halo_regions!`: the extension calls the raw driver symbol `CUDA.cuStreamWaitEvent`, which is no longer bound in the `CUDA` module after the CUDA.jl/CUDACore split. Fixed by the high-level `CUDA.wait(event, stream)` (reexported from CUDACore, also present pre-split), which is exactly `cuStreamWaitEvent(stream, event, 0)`.

**2. Segfault in MPI's host memcpy on device-resident buffers** reaching the `NCCLCommunicator` MPI forwarding methods. Distributed field reductions (e.g. `minimum_xspacing` → `maybe_all_reduce!` → `MPI.Allreduce!`) pass small device arrays; forwarding them verbatim to a host MPI library that is not CUDA-aware crashes in `MPIR_Typerep_unpack`/`__memmove`:

```
__memmove_evex_unaligned_erms at /lib64/libc.so.6
MPIR_Typerep_unpack ... libmpi.so
...
Allreduce! at ext/OceananigansNCCLExt/nccl_distributed.jl:20
all_reduce! at src/DistributedComputations/partition_assemble.jl:8
maybe_all_reduce! at src/DistributedComputations/distributed_fields.jl:168
minimum_xspacing ...
```

Fixed by staging `CUDA.AnyCuArray` buffers through the host in `MPI.Allreduce!`/`MPI.Allreduce`/`MPI.Bcast!` on `NCCLCommunicator` — these buffers are tiny (reduction results), so the copies are negligible, and host staging supports every reduction operator (NCCL only covers +, *, min, max).

With both fixes, a 2-rank x-partitioned `CenterField` halo exchange validates end-to-end (each rank's x halos hold the neighbor's rank-constant), and a full nested-model construction proceeds past the previously crashing reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)