### PR TITLE
Throw an error when file splitting limit is below metadata size

### DIFF
--- a/src/OutputWriters/jld2_writer.jl
+++ b/src/OutputWriters/jld2_writer.jl
@@ -83,7 +83,8 @@ Keyword arguments
                     `file_splitting = TimeInterval(30days)`, which will split files every 30 days of
                     simulation time. The default incurs no splitting (`NoFileSplitting()`).
                     A `FileSizeLimit` must exceed the size of the metadata written to every part
-                    file, which compression barely shrinks; see [`FileSizeLimit`](@ref).
+                    file, which compression barely shrinks; otherwise an `ArgumentError` is thrown
+                    at construction. See [`FileSizeLimit`](@ref).
 
 - `overwrite_existing`: Remove an existing file with the same filename when the writer is initialized.
                         Default: `false`.
@@ -191,6 +192,8 @@ function JLD2Writer(model, outputs; filename, schedule,
     # Convert each output to WindowedTimeAverage if schedule::AveragedTimeWindow is specified
     schedule, d_outputs = time_average_outputs(schedule, nt_outputs, model)
 
+    check_file_splitting_overhead(file_splitting, filepath, init, jld2_kw, including, d_outputs, model)
+
     # Note: file initialization is deferred until `initialize!(writer, model)` is called
     # (typically when `run!` is invoked on a Simulation containing this writer)
     return JLD2Writer(filepath, d_outputs, schedule, array_type, init,
@@ -266,6 +269,28 @@ end
 initialize_jld2_file!(writer::JLD2Writer, model) =
     initialize_jld2_file!(writer.filepath, writer.init, writer.jld2_kw, writer.including, writer.outputs, model)
 
+# Measure the per-part metadata overhead by initializing a probe file in a scratch
+# directory, so the error can be thrown at construction time, before the actual
+# output file exists.
+function check_file_splitting_overhead(file_splitting::FileSizeLimit, filepath, init, jld2_kw, including, outputs, model)
+    metadata_size = mktempdir() do dir
+        probe_filepath = joinpath(dir, basename(filepath))
+        initialize_jld2_file!(probe_filepath, init, jld2_kw, including, outputs, model)
+        filesize(probe_filepath)
+    end
+
+    if metadata_size ≥ file_splitting.size_limit
+        throw(ArgumentError(string("The metadata written when initializing ", filepath,
+                                   " (", pretty_filesize(metadata_size), ")",
+                                   " already exceeds the file size limit (", pretty_filesize(file_splitting.size_limit), ").",
+                                   " Every part file would exceed the limit and contain a single output,",
+                                   " and the total output size could be much larger than without file splitting.",
+                                   " Increase the size limit to account for the metadata written to every part file.")))
+    end
+
+    return nothing
+end
+
 """
 $(TYPEDSIGNATURES)
 
@@ -288,8 +313,6 @@ function initialize!(writer::JLD2Writer, model)
 
     # Initialize the JLD2 file with metadata
     initialize_jld2_file!(writer, model)
-
-    check_file_splitting_overhead(writer.file_splitting, writer.filepath)
 
     writer.initialized = true
 

--- a/src/OutputWriters/jld2_writer.jl
+++ b/src/OutputWriters/jld2_writer.jl
@@ -82,6 +82,8 @@ Keyword arguments
                     split the output file when its size exceeds `sz`. Another example is
                     `file_splitting = TimeInterval(30days)`, which will split files every 30 days of
                     simulation time. The default incurs no splitting (`NoFileSplitting()`).
+                    A `FileSizeLimit` must exceed the size of the metadata written to every part
+                    file, which compression barely shrinks; see [`FileSizeLimit`](@ref).
 
 - `overwrite_existing`: Remove an existing file with the same filename when the writer is initialized.
                         Default: `false`.
@@ -286,6 +288,8 @@ function initialize!(writer::JLD2Writer, model)
 
     # Initialize the JLD2 file with metadata
     initialize_jld2_file!(writer, model)
+
+    check_file_splitting_overhead(writer.file_splitting, writer.filepath)
 
     writer.initialized = true
 

--- a/src/OutputWriters/jld2_writer.jl
+++ b/src/OutputWriters/jld2_writer.jl
@@ -192,7 +192,7 @@ function JLD2Writer(model, outputs; filename, schedule,
     # Convert each output to WindowedTimeAverage if schedule::AveragedTimeWindow is specified
     schedule, d_outputs = time_average_outputs(schedule, nt_outputs, model)
 
-    check_file_splitting_overhead(file_splitting, filepath, init, jld2_kw, including, d_outputs, model)
+    validate_file_splitting(file_splitting, filepath, init, jld2_kw, including, d_outputs, model)
 
     # Note: file initialization is deferred until `initialize!(writer, model)` is called
     # (typically when `run!` is invoked on a Simulation containing this writer)
@@ -272,7 +272,7 @@ initialize_jld2_file!(writer::JLD2Writer, model) =
 # Measure the per-part metadata overhead by initializing a probe file in a scratch
 # directory, so the error can be thrown at construction time, before the actual
 # output file exists.
-function check_file_splitting_overhead(file_splitting::FileSizeLimit, filepath, init, jld2_kw, including, outputs, model)
+function validate_file_splitting(file_splitting::FileSizeLimit, filepath, init, jld2_kw, including, outputs, model)
     metadata_size = mktempdir() do dir
         probe_filepath = joinpath(dir, basename(filepath))
         initialize_jld2_file!(probe_filepath, init, jld2_kw, including, outputs, model)

--- a/src/OutputWriters/output_writer_utils.jl
+++ b/src/OutputWriters/output_writer_utils.jl
@@ -31,6 +31,13 @@ the `size_limit`.
 
 The `path` is automatically added and updated when `FileSizeLimit` is
 used with an output writer, and should not be provided manually.
+
+The `size_limit` applies to the on-disk size of the file, which includes
+the metadata the output writer stores in every part file upon initialization.
+Compression typically shrinks the output data much more than the metadata,
+so choose a `size_limit` comfortably larger than the metadata overhead:
+otherwise every part file exceeds the limit and contains a single output,
+and the total output size can end up much larger than without splitting.
 """
 FileSizeLimit(size_limit) = FileSizeLimit(size_limit, "")
 (fsl::FileSizeLimit)(model) = filesize(fsl.path) ≥ fsl.size_limit
@@ -49,6 +56,21 @@ update_file_splitting_schedule!(schedule, filepath) = nothing
 
 function update_file_splitting_schedule!(schedule::FileSizeLimit, filepath)
     schedule.path = filepath
+    return nothing
+end
+
+check_file_splitting_overhead(schedule, filepath) = nothing
+
+function check_file_splitting_overhead(schedule::FileSizeLimit, filepath)
+    metadata_size = filesize(filepath)
+    if metadata_size ≥ schedule.size_limit
+        @warn string("The metadata written when initializing ", filepath,
+                     " (", pretty_filesize(metadata_size), ")",
+                     " already exceeds the file size limit (", pretty_filesize(schedule.size_limit), ").",
+                     " Every part file will exceed the limit and contain a single output,",
+                     " and the total output size may be much larger than without file splitting.",
+                     " Increase the size limit to account for the metadata written to every part file.")
+    end
     return nothing
 end
 

--- a/src/OutputWriters/output_writer_utils.jl
+++ b/src/OutputWriters/output_writer_utils.jl
@@ -59,20 +59,7 @@ function update_file_splitting_schedule!(schedule::FileSizeLimit, filepath)
     return nothing
 end
 
-check_file_splitting_overhead(schedule, filepath) = nothing
-
-function check_file_splitting_overhead(schedule::FileSizeLimit, filepath)
-    metadata_size = filesize(filepath)
-    if metadata_size ≥ schedule.size_limit
-        @warn string("The metadata written when initializing ", filepath,
-                     " (", pretty_filesize(metadata_size), ")",
-                     " already exceeds the file size limit (", pretty_filesize(schedule.size_limit), ").",
-                     " Every part file will exceed the limit and contain a single output,",
-                     " and the total output size may be much larger than without file splitting.",
-                     " Increase the size limit to account for the metadata written to every part file.")
-    end
-    return nothing
-end
+check_file_splitting_overhead(schedule, args...) = nothing
 
 """
 $(TYPEDSIGNATURES)

--- a/src/OutputWriters/output_writer_utils.jl
+++ b/src/OutputWriters/output_writer_utils.jl
@@ -59,7 +59,7 @@ function update_file_splitting_schedule!(schedule::FileSizeLimit, filepath)
     return nothing
 end
 
-check_file_splitting_overhead(schedule, args...) = nothing
+validate_file_splitting(schedule, args...) = nothing
 
 """
 $(TYPEDSIGNATURES)

--- a/test/test_jld2_writer.jl
+++ b/test/test_jld2_writer.jl
@@ -130,7 +130,7 @@ function test_jld2_time_file_splitting(arch)
     return nothing
 end
 
-function test_jld2_file_splitting_overhead_warning(arch)
+function test_jld2_file_splitting_overhead_error(arch)
     grid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1))
     model = NonhydrostaticModel(grid)
 
@@ -142,14 +142,13 @@ function test_jld2_file_splitting_overhead_warning(arch)
                                              overwrite_existing = true)
 
     mktempdir() do dir
-        # The metadata written at initialization alone exceeds this limit
-        @test_logs (:warn, r"exceeds the file size limit") match_mode=:any begin
-            Oceananigans.initialize!(writer(dir, FileSizeLimit(1KiB)), model)
-        end
+        # The metadata written at initialization alone exceeds this limit,
+        # and the error is thrown at construction, before any time step.
+        @test_throws ArgumentError writer(dir, FileSizeLimit(1KiB))
     end
 
     mktempdir() do dir
-        @test_logs Oceananigans.initialize!(writer(dir, FileSizeLimit(10MiB)), model)
+        @test writer(dir, FileSizeLimit(10MiB)) isa JLD2Writer
     end
 
     return nothing
@@ -476,7 +475,7 @@ for arch in archs
 
         test_jld2_size_file_splitting(arch)
         test_jld2_time_file_splitting(arch)
-        test_jld2_file_splitting_overhead_warning(arch)
+        test_jld2_file_splitting_overhead_error(arch)
 
         #####
         ##### Time-averaging

--- a/test/test_jld2_writer.jl
+++ b/test/test_jld2_writer.jl
@@ -130,6 +130,31 @@ function test_jld2_time_file_splitting(arch)
     return nothing
 end
 
+function test_jld2_file_splitting_overhead_warning(arch)
+    grid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid)
+
+    writer(dir, file_splitting) = JLD2Writer(model, model.velocities;
+                                             dir,
+                                             filename = "file_splitting_overhead_test.jld2",
+                                             schedule = IterationInterval(1),
+                                             file_splitting,
+                                             overwrite_existing = true)
+
+    mktempdir() do dir
+        # The metadata written at initialization alone exceeds this limit
+        @test_logs (:warn, r"exceeds the file size limit") match_mode=:any begin
+            Oceananigans.initialize!(writer(dir, FileSizeLimit(1KiB)), model)
+        end
+    end
+
+    mktempdir() do dir
+        @test_logs Oceananigans.initialize!(writer(dir, FileSizeLimit(10MiB)), model)
+    end
+
+    return nothing
+end
+
 function test_jld2_time_averaging_of_horizontal_averages(model)
 
     model.clock.iteration = 0
@@ -451,6 +476,7 @@ for arch in archs
 
         test_jld2_size_file_splitting(arch)
         test_jld2_time_file_splitting(arch)
+        test_jld2_file_splitting_overhead_warning(arch)
 
         #####
         ##### Time-averaging

--- a/test/test_jld2_writer.jl
+++ b/test/test_jld2_writer.jl
@@ -155,7 +155,7 @@ function test_jld2_file_splitting_overhead_error(arch)
         @test writer(dir, FileSizeLimit(10MiB)) isa JLD2Writer
     end
 end
-  
+
 function test_jld2_compression(arch)
     grid = RectilinearGrid(arch, size=(16, 16, 16), extent=(1, 1, 1))
     model = NonhydrostaticModel(grid; tracers=:c)


### PR DESCRIPTION
Taken out of #5851 