### PR TITLE
Fix NetCDF file splitting when `overwrite_existing = false`

### DIFF
--- a/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
+++ b/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
@@ -221,7 +221,7 @@ function initialize_nc_file(model,
                             dimension_name_generator,
                             dimension_type)
 
-    mode = overwrite_existing ? "c" : "a"
+    mode = (overwrite_existing || !isfile(filepath)) ? "c" : "a"
 
     # Add useful metadata
     useful_attributes = Dict("date" => "This file was generated on $(now()) local time ($(now(UTC)) UTC).",

--- a/src/OutputWriters/netcdf_writer.jl
+++ b/src/OutputWriters/netcdf_writer.jl
@@ -213,7 +213,8 @@ Optional keyword arguments
                           `include_grid_metrics = false`, core grid coordinates are still saved.
 
 - `overwrite_existing`: If `false`, `NetCDFWriter` will append to existing files. If `true`,
-                        it will overwrite existing files or create new ones. Default: `true` if the
+                        it will overwrite existing files or create new ones. Files that do not
+                        exist yet are created in either case. Default: `true` if the
                         file does not exist, `false` if it does.
 
 - `verbose`: Log variable compute times, file write times, and file sizes. Default: `false`.

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -1849,19 +1849,33 @@ function test_open_boundary_condition_scheme_checkpointing(arch, timestepper, sc
     return nothing
 end
 
-function test_checkpointing_with_file_splitting(arch)
+function part_file_times(filepath)
+    if endswith(filepath, ".jld2")
+        return jldopen(filepath, "r") do file
+            iterations = sort(parse.(Int, keys(file["timeseries/t"])))
+            [file["timeseries/t/$iteration"] for iteration in iterations]
+        end
+    else
+        return NCDataset(filepath, "r") do ds
+            collect(ds["time"])
+        end
+    end
+end
+
+function test_checkpointing_with_file_splitting(arch, WriterType)
     dir = mktempdir()
+    ext = WriterType == JLD2Writer ? ".jld2" : ".nc"
 
     grid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1))
     model = NonhydrostaticModel(grid, tracers=:c)
     simulation = Simulation(model, Δt=1, stop_time=10)
 
-    simulation.output_writers[:fields] = JLD2Writer(model, model.tracers;
-                                                     filename = "split_ckpt",
-                                                     dir = dir,
-                                                     schedule = IterationInterval(1),
-                                                     file_splitting = TimeInterval(3),
-                                                     overwrite_existing = true)
+    simulation.output_writers[:fields] = WriterType(model, model.tracers;
+                                                    filename = "split_ckpt",
+                                                    dir = dir,
+                                                    schedule = IterationInterval(1),
+                                                    file_splitting = TimeInterval(3),
+                                                    overwrite_existing = true)
 
     simulation.output_writers[:checkpointer] = Checkpointer(model;
                                                               schedule = IterationInterval(5),
@@ -1873,19 +1887,19 @@ function test_checkpointing_with_file_splitting(arch)
 
     w = simulation.output_writers[:fields]
     @test w.part == 4
-    @test occursin("_part4.jld2", w.filepath)
+    @test occursin("_part4$ext", w.filepath)
 
     # Pickup from checkpoint and continue
     grid2 = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1))
     model2 = NonhydrostaticModel(grid2, tracers=:c)
     sim2 = Simulation(model2, Δt=1, stop_time=20)
 
-    sim2.output_writers[:fields] = JLD2Writer(model2, model2.tracers;
-                                               filename = "split_ckpt",
-                                               dir = dir,
-                                               schedule = IterationInterval(1),
-                                               file_splitting = TimeInterval(3),
-                                               overwrite_existing = false)
+    sim2.output_writers[:fields] = WriterType(model2, model2.tracers;
+                                              filename = "split_ckpt",
+                                              dir = dir,
+                                              schedule = IterationInterval(1),
+                                              file_splitting = TimeInterval(3),
+                                              overwrite_existing = false)
 
     sim2.output_writers[:checkpointer] = Checkpointer(model2;
                                                         schedule = IterationInterval(5),
@@ -1903,24 +1917,25 @@ function test_checkpointing_with_file_splitting(arch)
     @test w2.part > 4
 
     # Verify all output files have contiguous data
-    output_files = sort(filter(f -> startswith(f, "split_ckpt_part"), readdir(dir)))
+    output_files = filter(f -> startswith(f, "split_ckpt_part") && endswith(f, ext), readdir(dir))
+    sort!(output_files, by = f -> parse(Int, match(r"_part(\d+)\.", f)[1]))
     @test length(output_files) > 4
 
-    all_iterations = Int[]
+    all_times = Float64[]
     for f in output_files
-        jldopen(joinpath(dir, f), "r") do file
-            append!(all_iterations, parse.(Int, keys(file["timeseries/t"])))
-        end
+        append!(all_times, part_file_times(joinpath(dir, f)))
     end
 
-    # Should have iterations 0 through 20 without gaps (some overlap at 10 is ok)
-    unique_iters = sort(unique(all_iterations))
-    @test 0 ∈ unique_iters
-    @test 20 ∈ unique_iters
+    # Should have times 0 through 20 without gaps (some overlap at 10 is ok)
+    unique_times = sort(unique(all_times))
+    @test 0 ∈ unique_times
+    @test 20 ∈ unique_times
 
-    # Test reading back with FieldTimeSeries (InMemory)
-    fts = FieldTimeSeries(joinpath(dir, "split_ckpt.jld2"), "c", architecture=arch)
-    @test length(fts.times) >= 21
+    if WriterType == JLD2Writer
+        # Test reading back with FieldTimeSeries (InMemory)
+        fts = FieldTimeSeries(joinpath(dir, "split_ckpt.jld2"), "c", architecture=arch)
+        @test length(fts.times) >= 21
+    end
 
     rm(dir, recursive=true, force=true)
     return nothing
@@ -2180,9 +2195,11 @@ for arch in archs
         test_checkpoint_at_end(arch)
     end
 
-    @testset "Checkpointing with file splitting [$(typeof(arch))]" begin
-        @info "  Testing checkpointing with file splitting [$(typeof(arch))]..."
-        test_checkpointing_with_file_splitting(arch)
+    for WriterType in (JLD2Writer, NetCDFWriter)
+        @testset "Checkpointing with file splitting [$WriterType, $(typeof(arch))]" begin
+            @info "  Testing checkpointing with file splitting [$WriterType, $(typeof(arch))]..."
+            test_checkpointing_with_file_splitting(arch, WriterType)
+        end
     end
 
     @testset "Checkpointing with moved-away part files [$(typeof(arch))]" begin

--- a/test/test_netcdf_writer.jl
+++ b/test/test_netcdf_writer.jl
@@ -1842,6 +1842,62 @@ function test_netcdf_time_file_splitting(arch)
     return nothing
 end
 
+function test_netcdf_file_splitting_while_appending(arch)
+    dir = mktempdir()
+    base_filename = "test_file_splitting_while_appending_$(typeof(arch))"
+
+    grid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid, tracers=:c)
+
+    simulation = Simulation(model, Δt=1, stop_time=2seconds)
+
+    simulation.output_writers[:nc_writer] = NetCDFWriter(model, model.tracers;
+        dir = dir,
+        filename = base_filename,
+        schedule = IterationInterval(1),
+        overwrite_existing = true)
+
+    run!(simulation)
+
+    # Splitting has to create every new part file, including when the writer appends
+    # to an existing file rather than overwriting it.
+    simulation = Simulation(model, Δt=1, stop_time=8seconds)
+
+    simulation.output_writers[:nc_writer] = NetCDFWriter(model, model.tracers;
+        dir = dir,
+        filename = base_filename,
+        schedule = IterationInterval(1),
+        file_splitting = TimeInterval(3seconds),
+        overwrite_existing = false)
+
+    run!(simulation)
+
+    part_filenames = filter(f -> occursin(Regex("^$(base_filename)_part\\d+\\.nc\$"), f), readdir(dir))
+    sort!(part_filenames, by = f -> parse(Int, match(r"_part(\d+)\.nc$", f)[1]))
+
+    @test length(part_filenames) > 1
+
+    all_times = Float64[]
+
+    for part_filename in part_filenames
+        ds = NCDataset(joinpath(dir, part_filename), "r")
+
+        # Every part gets the full metadata, not just the part written in creation mode.
+        @test haskey(ds, "time")
+        @test haskey(ds, "c")
+        @test length(ds["time"]) > 0
+
+        append!(all_times, collect(ds["time"]))
+        close(ds)
+    end
+
+    @test all_times == collect(0.0:8.0)
+
+    rm(dir, recursive=true, force=true)
+
+    return nothing
+end
+
 function test_netcdf_function_output(arch)
     Nx = Ny = Nz = N = 16
     L = 1
@@ -3836,6 +3892,7 @@ end
             @info "  Testing file splitting [$A]..."
             test_netcdf_size_file_splitting(arch)
             test_netcdf_time_file_splitting(arch)
+            test_netcdf_file_splitting_while_appending(arch)
         end
 
         @testset "Function and alignment output [$A]" begin


### PR DESCRIPTION
Right now `NetCDFWriter` picks its NetCDF open mode from `overwrite_existing` alone which mean you cannot do file splitting with `overwrite_existing = false` or with checkpoints.

The PR creates the file whenever it isn't there and adds two tests to make sure NetCDF file splitting works while appending and with checkpointing.

Resolves #5868

---

Bit more context:

You can only open a NetCDF file in three modes: "c" for clobber (or create?), "a" for append, and "r" for reading.

Both "a" and "r" require the file to exist as they call `nc_open` under the hood. So if the file does not exist, you have to use "c" so `nc_create` gets called.

And when `overwrite_existing = true`, "c" is used and when `nc_create` is called any existing file is overwritten.

Before this PR, the mode was chosen via `mode = overwrite_existing ? "c" : "a"` but this is wrong in the case where `overwrite_existing = false` and the output file does not exist.

That happens in the constructor if the path doesn't exist yet, because either it's a fresh run, or a restart where a previous run's splitting renamed `output.nc` to `output_part1.nc`.

So the solution to both cases is to make sure we always create the file if it doesn't exist with `mode = (overwrite_existing || !isfile(filepath)) ? "c" : "a"`.