### PR TITLE
Defer `NetCDFWriter` file creation to `initialize!`

### DIFF
--- a/ext/OceananigansNCDatasetsExt/OceananigansNCDatasetsExt.jl
+++ b/ext/OceananigansNCDatasetsExt/OceananigansNCDatasetsExt.jl
@@ -21,7 +21,7 @@ using Statistics: mean
 
 import Oceananigans
 
-using Oceananigans: initialize!, prettytime, pretty_filesize, AbstractModel
+using Oceananigans: prettytime, pretty_filesize, AbstractModel
 using Oceananigans.AbstractOperations: KernelFunctionOperation, AbstractOperation
 using Oceananigans.Architectures: CPU, GPU, on_architecture
 using Oceananigans.BoundaryConditions: fill_halo_regions!
@@ -82,7 +82,7 @@ using Oceananigans.Utils:
     versioninfo_with_gpu, oceananigans_versioninfo, prettykeys, add_time_interval
 
 import NCDatasets: defVar
-import Oceananigans: write_output!
+import Oceananigans: initialize!, write_output!
 import Oceananigans.OutputReaders: FieldTimeSeries, set_from_netcdf!
 import Oceananigans.OutputWriters:
     NetCDFWriter,

--- a/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
+++ b/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
@@ -129,22 +129,6 @@ function NetCDFWriter(model::AbstractModel, outputs;
     schedule = materialize_schedule(schedule)
     update_file_splitting_schedule!(file_splitting, filepath)
 
-    if isnothing(overwrite_existing)
-        if isfile(filepath)
-            overwrite_existing = false
-        else
-            overwrite_existing = true
-        end
-    else
-        if isfile(filepath) && !overwrite_existing
-            @warn "$filepath already exists and `overwrite_existing = false`. Mode will be set to append to existing file. " *
-                  "You might experience errors when writing output if the existing file belonged to a different simulation!"
-
-        elseif isfile(filepath) && overwrite_existing
-            @warn "Overwriting existing $filepath."
-        end
-    end
-
     outputs = Dict(string(name) => construct_output(outputs[name], indices, with_halos) for name in keys(outputs))
 
     # Extract grids from outputs, falling back to model grid for non-field outputs
@@ -159,28 +143,15 @@ function NetCDFWriter(model::AbstractModel, outputs;
     # Ensure we can add any kind of metadata to the attributes later by converting to Dict{Any, Any}.
     global_attributes = Dict{Any, Any}(global_attributes)
 
-    dataset, outputs, schedule = initialize_nc_file(model,
-                                                    unique_grids,
-                                                    output_grid_map,
-                                                    filepath,
-                                                    outputs,
-                                                    schedule,
-                                                    array_type,
-                                                    indices,
-                                                    global_attributes,
-                                                    output_attributes,
-                                                    dimensions,
-                                                    with_halos,
-                                                    include_grid_metrics,
-                                                    overwrite_existing,
-                                                    deflatelevel,
-                                                    dimension_name_generator,
-                                                    dimension_type)
+    add_schedule_metadata!(global_attributes, schedule)
+
+    # Convert schedule to TimeInterval and each output to WindowedTimeAverage if
+    # schedule::AveragedTimeInterval
+    schedule, outputs = time_average_outputs(schedule, outputs, model)
 
     return NetCDFWriter(unique_grids,
                         output_grid_map,
                         filepath,
-                        dataset,
                         outputs,
                         schedule,
                         array_type,
@@ -196,7 +167,36 @@ function NetCDFWriter(model::AbstractModel, outputs;
                         part,
                         file_splitting,
                         dimension_name_generator,
-                        dimension_type)
+                        dimension_type,
+                        false)
+end
+
+"""
+    initialize!(writer::NetCDFWriter, model)
+
+Initialize a `NetCDFWriter` by creating its file and writing the dimensions, grid
+reconstruction data, and variable definitions to it.
+"""
+function initialize!(writer::NetCDFWriter, model)
+    writer.initialized && return nothing
+
+    filepath = writer.filepath
+
+    if isnothing(writer.overwrite_existing)
+        writer.overwrite_existing = !isfile(filepath)
+    elseif isfile(filepath) && !writer.overwrite_existing
+        @warn "$filepath already exists and `overwrite_existing = false`. Mode will be set to append to existing file. " *
+              "You might experience errors when writing output if the existing file belonged to a different simulation!"
+
+    elseif isfile(filepath) && writer.overwrite_existing
+        @warn "Overwriting existing $filepath."
+    end
+
+    initialize_nc_file(writer, model)
+
+    writer.initialized = true
+
+    return nothing
 end
 
 #####
@@ -208,7 +208,6 @@ function initialize_nc_file(model,
                             output_grid_map,
                             filepath,
                             outputs,
-                            schedule,
                             array_type,
                             indices,
                             global_attributes,
@@ -234,12 +233,6 @@ function initialize_nc_file(model,
     end
 
     global_attributes = merge(useful_attributes, global_attributes)
-
-    add_schedule_metadata!(global_attributes, schedule)
-
-    # Convert schedule to TimeInterval and each output to WindowedTimeAverage if
-    # schedule::AveragedTimeInterval
-    schedule, outputs = time_average_outputs(schedule, outputs, model)
 
     # Open the NetCDF dataset file
     dataset = NCDataset(filepath, mode, attrib=sort(collect(pairs(global_attributes)), by=first))
@@ -345,7 +338,7 @@ function initialize_nc_file(model,
 
     close(dataset)
 
-    return dataset, outputs, schedule
+    return nothing
 end
 
 initialize_nc_file(ow::NetCDFWriter, model) = initialize_nc_file(model,
@@ -353,7 +346,6 @@ initialize_nc_file(ow::NetCDFWriter, model) = initialize_nc_file(model,
                                                                  ow.output_grid_map,
                                                                  ow.filepath,
                                                                  ow.outputs,
-                                                                 ow.schedule,
                                                                  ow.array_type,
                                                                  ow.indices,
                                                                  ow.global_attributes,
@@ -435,7 +427,6 @@ end
 #####
 
 Base.open(nc::NetCDFWriter) = NCDataset(nc.filepath, "a")
-Base.close(nc::NetCDFWriter) = close(nc.dataset)
 
 # Saving outputs with no time dependence (e.g. grid metrics)
 function save_output!(ds, output, model, output_name, array_type)
@@ -476,12 +467,15 @@ Write output to netcdf file `output_writer.filepath` at specified intervals. Inc
 every time an output is written to the file.
 """
 function write_output!(ow::NetCDFWriter, model::AbstractModel)
+    # Ensure the writer is initialized before writing
+    initialize!(ow, model)
+
     # Start a new file if the file_splitting(model) is true
     ow.file_splitting(model) && start_next_file(model, ow)
     update_file_splitting_schedule!(ow.file_splitting, ow.filepath)
 
-    ow.dataset = open(ow)
-    ds, verbose, filepath = ow.dataset, ow.verbose, ow.filepath
+    ds = open(ow)
+    verbose, filepath = ow.verbose, ow.filepath
 
     time_index = length(ds["time"]) + 1
     ds["time"][time_index] = float_or_date_time(model.clock.time)
@@ -508,7 +502,7 @@ function write_output!(ow::NetCDFWriter, model::AbstractModel)
     end
 
     sync(ds)
-    close(ow)
+    close(ds)
 
     if verbose
         # Time and file size after computing and writing all outputs to disk.
@@ -529,11 +523,49 @@ end
 Base.summary(ow::NetCDFWriter) =
     string("NetCDFWriter writing ", prettykeys(ow.outputs), " to ", ow.filepath, " on ", summary(ow.schedule))
 
-function Base.show(io::IO, ow::NetCDFWriter)
-    dims = NCDataset(ow.filepath, "r") do ds
-        join([dim * "(" * string(length(ds[dim])) * "), "
-              for dim in keys(ds.dim)])[1:end-2]
+"""
+    planned_dimensions(ow::NetCDFWriter)
+
+Return the NetCDF dimensions `ow` will declare when it creates its file, mapping each
+dimension name to its length, in the order `create_spatial_dimensions!` declares them.
+Used to show a writer whose file does not exist yet.
+"""
+function planned_dimensions(ow::NetCDFWriter)
+    planned = OrderedDict{String, Int}("time" => 0)
+
+    for (grid_index, grid) in enumerate(ow.grids)
+        suffix = length(ow.grids) == 1 ? nothing : grid_index
+        dims = gather_dimensions(ow.outputs, grid, ow.indices, ow.with_halos,
+                                 ow.dimension_name_generator; grid_index=suffix)
+
+        for (var_name, entry) in dims
+            var_name == "" && continue
+            arr, var_dims = entry isa NamedTuple ? (entry.array, entry.dims) : (entry, (var_name,))
+            isnothing(arr) && continue
+
+            for (axis, dim_name) in enumerate(var_dims)
+                get!(planned, dim_name, size(arr, axis))
+            end
+        end
     end
+
+    return planned
+end
+
+function Base.show(io::IO, ow::NetCDFWriter)
+    file_exists = isfile(ow.filepath)
+
+    dims = if file_exists
+        NCDataset(ow.filepath, "r") do ds
+            join([dim * "(" * string(length(ds[dim])) * "), "
+                  for dim in keys(ds.dim)])[1:end-2]
+        end
+    else
+        join([dim_name * "(" * string(dim_length) * "), "
+              for (dim_name, dim_length) in planned_dimensions(ow)])[1:end-2]
+    end
+
+    file_size_str = file_exists ? pretty_filesize(filesize(ow.filepath)) : "0 bytes (file not yet created)"
 
     averaging_schedule = output_averaging_schedule(ow)
     num_outputs = length(ow.outputs)
@@ -544,7 +576,7 @@ function Base.show(io::IO, ow::NetCDFWriter)
               "├── $num_outputs outputs: ", prettykeys(ow.outputs), show_averaging_schedule(averaging_schedule), "\n",
               "├── array_type: ", show_array_type(ow.array_type), "\n",
               "├── file_splitting: ", summary(ow.file_splitting), "\n",
-              "└── file size: ", pretty_filesize(filesize(ow.filepath)))
+              "└── file size: ", file_size_str)
 end
 
 #####

--- a/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
+++ b/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
@@ -552,20 +552,21 @@ function planned_dimensions(ow::NetCDFWriter)
     return planned
 end
 
+""" Formats `name => length` pairs as, e.g., "time(0), x_caa(16), z_aac(16)". """
+show_dimensions(dimensions) = join(("$dim_name($dim_length)" for (dim_name, dim_length) in dimensions), ", ")
+
 function Base.show(io::IO, ow::NetCDFWriter)
     file_exists = isfile(ow.filepath)
 
     dims = if file_exists
         NCDataset(ow.filepath, "r") do ds
-            join([dim * "(" * string(length(ds[dim])) * "), "
-                  for dim in keys(ds.dim)])[1:end-2]
+            show_dimensions(dim_name => length(ds[dim_name]) for dim_name in keys(ds.dim))
         end
     else
-        join([dim_name * "(" * string(dim_length) * "), "
-              for (dim_name, dim_length) in planned_dimensions(ow)])[1:end-2]
+        show_dimensions(planned_dimensions(ow))
     end
 
-    file_size_str = file_exists ? pretty_filesize(filesize(ow.filepath)) : "0 bytes (file not yet created)"
+    file_size_str = file_exists ? pretty_filesize(filesize(ow.filepath)) : "(file not yet created)"
 
     averaging_schedule = output_averaging_schedule(ow)
     num_outputs = length(ow.outputs)

--- a/src/OutputWriters/netcdf_writer.jl
+++ b/src/OutputWriters/netcdf_writer.jl
@@ -212,11 +212,12 @@ Optional keyword arguments
                           additional variables. Default: `true`. Note that even with
                           `include_grid_metrics = false`, core grid coordinates are still saved.
 
-- `overwrite_existing`: If `false`, `NetCDFWriter` will append to existing files. If `true`,
-                        it will overwrite existing files or create new ones. Files that do not
-                        exist yet are created in either case. Default: resolved when the output
-                        file is created, at the start of the run: `true` if the file does not
-                        exist by then, `false` if it does.
+- `overwrite_existing`: If `false`, `NetCDFWriter` appends to an existing file. If `true`, it
+                        overwrites an existing file. Files that do not exist yet are created in
+                        either case. Default: `nothing`, which chooses between the two when the
+                        file is created, at the start of the run: a file that exists by then is
+                        appended to rather than overwritten, so output from an earlier run is
+                        never destroyed unless `overwrite_existing = true` is passed.
 
 - `verbose`: Log variable compute times, file write times, and file sizes. Default: `false`.
 
@@ -269,7 +270,7 @@ NetCDFWriter scheduled on TimeInterval(1 minute):
 ├── 2 outputs: (c, u)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 0 bytes (file not yet created)
+└── file size: (file not yet created)
 ```
 
 ```jldoctest netcdf1
@@ -285,7 +286,7 @@ NetCDFWriter scheduled on TimeInterval(1 minute):
 ├── 2 outputs: (c, u)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 0 bytes (file not yet created)
+└── file size: (file not yet created)
 ```
 
 ```jldoctest netcdf1
@@ -302,7 +303,7 @@ NetCDFWriter scheduled on TimeInterval(1 minute):
 ├── 2 outputs: (c, u) averaged on AveragedTimeInterval(window=20 seconds, stride=1, interval=1 minute)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 0 bytes (file not yet created)
+└── file size: (file not yet created)
 ```
 
 `NetCDFWriter` also accepts output functions that write scalars and arrays to disk,
@@ -353,7 +354,7 @@ NetCDFWriter scheduled on IterationInterval(1):
 ├── 3 outputs: (profile, slice, scalar)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 0 bytes (file not yet created)
+└── file size: (file not yet created)
 ```
 
 `NetCDFWriter` supports outputs that live on different grids within a single writer.
@@ -383,7 +384,7 @@ NetCDFWriter scheduled on IterationInterval(1):
 ├── 1 outputs: u
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 0 bytes (file not yet created)
+└── file size: (file not yet created)
 ```
 
 OrthogonalSphericalShellGrid (TripolarGrid, RotatedLatitudeLongitudeGrid, …)

--- a/src/OutputWriters/netcdf_writer.jl
+++ b/src/OutputWriters/netcdf_writer.jl
@@ -100,11 +100,10 @@ add_grid_suffix(name, ::Nothing) = name
 #####
 ##### NetCDFWriter struct definition
 #####
-mutable struct NetCDFWriter{G, GM, D, O, T, A, FS, DN, DT} <: AbstractOutputWriter
+mutable struct NetCDFWriter{G, GM, O, T, A, FS, DN, DT} <: AbstractOutputWriter
     grids :: G
     output_grid_map :: GM
     filepath :: String
-    dataset :: D
     outputs :: O
     schedule :: T
     array_type :: A
@@ -114,13 +113,14 @@ mutable struct NetCDFWriter{G, GM, D, O, T, A, FS, DN, DT} <: AbstractOutputWrit
     dimensions :: Dict
     with_halos :: Bool
     include_grid_metrics :: Bool
-    overwrite_existing :: Bool
+    overwrite_existing :: Union{Nothing, Bool}
     verbose :: Bool
     deflatelevel :: Int
     part :: Int
     file_splitting :: FS
     dimension_name_generator :: DN
     dimension_type :: DT
+    initialized :: Bool
 end
 
 # method in OceananigansNCDatasetsExt
@@ -214,8 +214,9 @@ Optional keyword arguments
 
 - `overwrite_existing`: If `false`, `NetCDFWriter` will append to existing files. If `true`,
                         it will overwrite existing files or create new ones. Files that do not
-                        exist yet are created in either case. Default: `true` if the
-                        file does not exist, `false` if it does.
+                        exist yet are created in either case. Default: resolved when the output
+                        file is created, at the start of the run: `true` if the file does not
+                        exist by then, `false` if it does.
 
 - `verbose`: Log variable compute times, file write times, and file sizes. Default: `false`.
 
@@ -268,7 +269,7 @@ NetCDFWriter scheduled on TimeInterval(1 minute):
 ├── 2 outputs: (c, u)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 32.8 KiB
+└── file size: 0 bytes (file not yet created)
 ```
 
 ```jldoctest netcdf1
@@ -284,7 +285,7 @@ NetCDFWriter scheduled on TimeInterval(1 minute):
 ├── 2 outputs: (c, u)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 32.8 KiB
+└── file size: 0 bytes (file not yet created)
 ```
 
 ```jldoctest netcdf1
@@ -301,7 +302,7 @@ NetCDFWriter scheduled on TimeInterval(1 minute):
 ├── 2 outputs: (c, u) averaged on AveragedTimeInterval(window=20 seconds, stride=1, interval=1 minute)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 34.4 KiB
+└── file size: 0 bytes (file not yet created)
 ```
 
 `NetCDFWriter` also accepts output functions that write scalars and arrays to disk,
@@ -352,7 +353,7 @@ NetCDFWriter scheduled on IterationInterval(1):
 ├── 3 outputs: (profile, slice, scalar)
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 34.7 KiB
+└── file size: 0 bytes (file not yet created)
 ```
 
 `NetCDFWriter` supports outputs that live on different grids within a single writer.
@@ -382,7 +383,7 @@ NetCDFWriter scheduled on IterationInterval(1):
 ├── 1 outputs: u
 ├── array_type: Array{Float32}
 ├── file_splitting: NoFileSplitting
-└── file size: 31.7 KiB
+└── file size: 0 bytes (file not yet created)
 ```
 
 OrthogonalSphericalShellGrid (TripolarGrid, RotatedLatitudeLongitudeGrid, …)

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -1931,6 +1931,10 @@ function test_checkpointing_with_file_splitting(arch, WriterType)
     @test 0 ∈ unique_times
     @test 20 ∈ unique_times
 
+    # The writers create their files when the run starts, by which point pickup has
+    # re-pointed them at the latest part, so no empty base file is left behind.
+    @test !isfile(joinpath(dir, "split_ckpt$ext"))
+
     if WriterType == JLD2Writer
         # Test reading back with FieldTimeSeries (InMemory)
         fts = FieldTimeSeries(joinpath(dir, "split_ckpt.jld2"), "c", architecture=arch)

--- a/test/test_netcdf_writer.jl
+++ b/test/test_netcdf_writer.jl
@@ -1842,6 +1842,44 @@ function test_netcdf_time_file_splitting(arch)
     return nothing
 end
 
+function test_netcdf_deferred_file_creation(arch)
+    dir = mktempdir()
+    filename = "test_deferred_file_creation_$(typeof(arch)).nc"
+    filepath = joinpath(dir, filename)
+
+    grid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1))
+    model = NonhydrostaticModel(grid, tracers=:c)
+
+    simulation = Simulation(model, Δt=1, stop_time=2seconds)
+
+    writer = NetCDFWriter(model, model.tracers;
+        dir = dir,
+        filename = filename,
+        schedule = IterationInterval(1))
+
+    # The file is created when the run starts rather than by the constructor, so that a
+    # writer whose filepath changes in between leaves no empty file behind.
+    @test !writer.initialized
+    @test !isfile(filepath)
+    @test occursin("file not yet created", sprint(show, writer))
+
+    simulation.output_writers[:nc_writer] = writer
+
+    run!(simulation)
+
+    @test writer.initialized
+    @test isfile(filepath)
+
+    ds = NCDataset(filepath, "r")
+    @test collect(ds["time"]) == [0.0, 1.0, 2.0]
+    @test haskey(ds, "c")
+    close(ds)
+
+    rm(dir, recursive=true, force=true)
+
+    return nothing
+end
+
 function test_netcdf_file_splitting_while_appending(arch)
     dir = mktempdir()
     base_filename = "test_file_splitting_while_appending_$(typeof(arch))"
@@ -2561,6 +2599,11 @@ function test_netcdf_overriding_attributes(arch)
         global_attributes,
         output_attributes)
 
+    # The writer creates its file when the run starts.
+    simulation = Simulation(model, Δt=1, stop_iteration=1)
+    simulation.output_writers[:nc_writer] = nc_writer
+    run!(simulation)
+
     ds = NCDataset(nc_filepath)
 
     @test ds.attrib["date"] == "yesterday"
@@ -2913,6 +2956,9 @@ function test_netcdf_buoyancy_force(arch)
                                                          verbose = true)
         # only tests that the writer builds, produces a file at filepath and sets attributes
         @test simulation.output_writers[:b_eos] isa NetCDFWriter
+
+        run!(simulation)
+
         @test isfile(simulation.output_writers[:b_eos].filepath)
         ds = NCDataset(simulation.output_writers[:b_eos].filepath)
         @test ds["T"].attrib["long_name"] == "Conservative temperature"
@@ -3886,6 +3932,11 @@ end
             test_thermal_bubble_netcdf_output(arch, Float32)
             test_thermal_bubble_netcdf_output(arch, Float64, with_halos=true)
             test_thermal_bubble_netcdf_output(arch, Float32, with_halos=true)
+        end
+
+        @testset "Deferred file creation [$A]" begin
+            @info "  Testing deferred file creation [$A]..."
+            test_netcdf_deferred_file_creation(arch)
         end
 
         @testset "File splitting [$A]" begin


### PR DESCRIPTION
Right now `NetCDFWriter` creates the output file in the constructor which can lead to issues with checkpointing and file splitting such as #5870. `JLD2Writer` and `ZarrWriter` create the output file in `initialize!`. So this PR moves file creation for `NetCDFWriter` from the constructor into `initialize!`.

This PR also simplifies the `NetCDFWriter` struct by removing the `dataset` property which was actually not needed because the dataset was always closed unless you were inside `write_output!`.

Resolves #5870