### PR TITLE
Fix averaged output pickup after interval changes

### DIFF
--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -358,6 +358,10 @@ function Oceananigans.restore_prognostic_state!(restored::Union{JLD2Writer, NetC
                 restore_prognostic_state!(restored.outputs[key], wta_state)
             end
         end
+
+        first_average = first(values(restored.outputs))
+        restored.schedule.first_actuation_time = first_average.schedule.first_actuation_time
+        restored.schedule.actuations = first_average.schedule.actuations
     end
 
     return restored

--- a/src/OutputWriters/windowed_time_average.jl
+++ b/src/OutputWriters/windowed_time_average.jl
@@ -145,14 +145,22 @@ Base.copy(sch::AveragedTimeInterval) = AveragedTimeInterval(sch.interval, window
 #####
 
 function Oceananigans.prognostic_state(schedule::AveragedTimeInterval)
-    return (first_actuation_time = schedule.first_actuation_time,
+    return (interval = schedule.interval,
+            window = schedule.window,
+            first_actuation_time = schedule.first_actuation_time,
             actuations = schedule.actuations,
             collecting = schedule.collecting)
 end
 
 function Oceananigans.restore_prognostic_state!(restored::AveragedTimeInterval, from)
-    restored.first_actuation_time = from.first_actuation_time
-    restored.actuations = from.actuations
+    same_cadence = !hasproperty(from, :interval) ||
+                   (restored.interval == from.interval && restored.window == from.window)
+
+    if same_cadence
+        restored.first_actuation_time = from.first_actuation_time
+        restored.actuations = from.actuations
+    end
+
     restored.collecting = from.collecting
     return restored
 end
@@ -335,7 +343,21 @@ function Oceananigans.restore_prognostic_state!(restored::WindowedTimeAverage, f
     restored.window_start_time = from.window_start_time
     restored.window_start_iteration = from.window_start_iteration
     restored.previous_collection_time = from.previous_collection_time
+
+    same_cadence = !hasproperty(from.schedule, :interval) ||
+                   (restored.schedule.interval == from.schedule.interval &&
+                    restored.schedule.window == from.schedule.window)
+
     restore_prognostic_state!(restored.schedule, from.schedule)
+
+    if !same_cadence
+        window_start_time = from.schedule.collecting ?
+                            from.window_start_time : from.previous_collection_time
+        restored.schedule.first_actuation_time = window_start_time + restored.schedule.window -
+                                                 restored.schedule.interval
+        restored.schedule.actuations = 0
+    end
+
     return restored
 end
 

--- a/src/OutputWriters/windowed_time_average.jl
+++ b/src/OutputWriters/windowed_time_average.jl
@@ -351,10 +351,8 @@ function Oceananigans.restore_prognostic_state!(restored::WindowedTimeAverage, f
     restore_prognostic_state!(restored.schedule, from.schedule)
 
     if !same_cadence
-        window_start_time = from.schedule.collecting ?
-                            from.window_start_time : from.previous_collection_time
-        restored.schedule.first_actuation_time = window_start_time + restored.schedule.window -
-                                                 restored.schedule.interval
+        window_start_time = from.schedule.collecting ? from.window_start_time : from.previous_collection_time
+        restored.schedule.first_actuation_time = window_start_time + restored.schedule.window - restored.schedule.interval
         restored.schedule.actuations = 0
     end
 

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -1432,6 +1432,68 @@ function test_windowed_time_average_continuation_correctness(arch, WriterType)
     return nothing
 end
 
+function test_changed_averaged_time_interval(arch)
+    prefix = "changed_averaged_time_interval_$(typeof(arch))"
+    partial_file = "$(prefix)_partial.jld2"
+    restored_file = "$(prefix)_restored.jld2"
+    clock_time(model) = [model.clock.time]
+    expected_average = 1.05days
+
+    grid = RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 1, 1))
+    partial_model = NonhydrostaticModel(grid)
+    partial_simulation = Simulation(partial_model, Δt=0.1days, stop_time=0.5days)
+    partial_simulation.output_writers[:checkpointer] =
+        Checkpointer(partial_model, schedule=IterationInterval(5), prefix=prefix)
+    partial_simulation.output_writers[:averaged] =
+        JLD2Writer(partial_model, (; clock_time),
+                   schedule = AveragedTimeInterval(1day),
+                   filename = partial_file,
+                   overwrite_existing = true)
+
+    @test_nowarn run!(partial_simulation)
+
+    partial_average = only(values(partial_simulation.output_writers[:averaged].outputs))
+    @test partial_average.schedule.collecting
+    @test partial_average.previous_collection_time - partial_average.window_start_time == 0.5days
+    @test only(Array(partial_average.result)) ≈ 0.3days
+
+    restored_model = NonhydrostaticModel(grid)
+    restored_simulation = Simulation(restored_model, Δt=0.1days, stop_time=2days)
+    restored_simulation.output_writers[:checkpointer] =
+        Checkpointer(restored_model, schedule=IterationInterval(5), prefix=prefix)
+    restored_simulation.output_writers[:averaged] =
+        JLD2Writer(restored_model, (; clock_time),
+                   schedule = AveragedTimeInterval(2days),
+                   filename = restored_file,
+                   overwrite_existing = true)
+
+    @test_nowarn set!(restored_simulation; checkpoint="$(prefix)_iteration5.jld2")
+    restored_cache = only(values(restored_simulation.output_writers[:averaged].outputs))
+    @test restored_cache.previous_collection_time - restored_cache.window_start_time == 0.5days
+    @test only(Array(restored_cache.result)) ≈ 0.3days
+
+    @test_nowarn run!(restored_simulation)
+
+    restored_average = only(values(restored_simulation.output_writers[:averaged].outputs))
+    @test restored_average.window_start_time == 0
+    @test restored_average.previous_collection_time == 2days
+    @test only(Array(restored_average.result)) ≈ expected_average
+
+    jldopen(restored_file, "r") do file
+        iterations = sort(parse.(Int, keys(file["timeseries/t"])))
+        final_iteration = last(iterations)
+        final_time = file["timeseries/t/$final_iteration"]
+        final_average = only(file["timeseries/clock_time/$final_iteration"])
+
+        @test final_time == 2days
+        @test final_average ≈ expected_average
+    end
+
+    rm.(glob("$(prefix)*.jld2"), force=true)
+
+    return nothing
+end
+
 function test_checkpoint_empty_tracers(arch)
     N = 8
     L = 1
@@ -2151,6 +2213,11 @@ for arch in archs
             @info "  Testing WindowedTimeAverage continuation correctness [$WriterType] [$(typeof(arch))]..."
             test_windowed_time_average_continuation_correctness(arch, WriterType)
         end
+    end
+
+    @testset "Changed AveragedTimeInterval checkpointing [$(typeof(arch))]" begin
+        @info "  Testing changed AveragedTimeInterval checkpointing [$(typeof(arch))]..."
+        test_changed_averaged_time_interval(arch)
     end
 
     schemes = [


### PR DESCRIPTION
## Summary

This fixes averaged output after a simulation restarts with a different `AveragedTimeInterval`.

If part of an average already exists at the checkpoint, that work is kept. For example, if the checkpoint contains the first 0.5 days of an average and the new interval is 2 days, Oceananigans keeps those 0.5 days, collects another 1.5 days, and then writes one complete 2-day average.

## What went wrong

`AveragedTimeInterval` stores an internal value named `actuations`. This is the number of averaging windows that have already finished. The end of the next window is calculated as:

```julia
next_time = first_time + (actuations + 1) * interval
```

Before this change, checkpoints stored `actuations`, but did not store the interval and window that produced it. On restart, Oceananigans restored the old value of `actuations` into the newly configured interval.

For example, the reported checkpoint contained:

```text
actuations = 6205
old interval = 1 day
```

With the original interval, the next averaging boundary was approximately:

```text
6206 × 1 day = model year 17
```

After changing the interval to 5 days, the same stored value was interpreted as:

```text
6206 × 5 days = model year 85
```

The simulation was around model year 18, so the averaging calculation would not start another window until approximately year 85. The file writer still ran every 5 days, but it repeatedly wrote the previous cached average. This made temperature, salinity, and other averaged output appear exactly constant while the model itself continued to change.

## Fix

- Store the interval and window with the averaging state.
- If they are unchanged after restart, restore the averaging state exactly as before.
- If they changed, keep the partial cached average and its original start time.
- Schedule the next output at the end of the newly configured averaging window.
- Keep the file writer schedule aligned with that window.

## Test

The new test:

1. Starts with `AveragedTimeInterval(1day)`.
2. Runs for 0.5 days and writes a checkpoint.
3. Confirms that the checkpoint contains a 0.5-day partial average.
4. Restarts with `AveragedTimeInterval(2days)`.
5. Confirms that the 0.5-day cache is restored.
6. Runs to day 2 and checks both the completed average and the value written to the JLD2 file.

`git diff --check` passes. Local tests were not run because this workspace uses GitHub CI for test execution.