### PR TITLE
Name the copy-versus-interpolate cases and share them with Reactant

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.15"
+version = "0.110.16"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/ext/OceananigansReactantExt/Fields.jl
+++ b/ext/OceananigansReactantExt/Fields.jl
@@ -4,7 +4,7 @@ using Reactant
 
 using Oceananigans: Oceananigans
 using Oceananigans.Architectures: on_architecture, CPU
-using Oceananigans.Fields: Field, interior, interpolate!
+using Oceananigans.Fields: Field, interior, interpolate!, copyable_fields
 
 import Oceananigans.Fields: set_to_field!, set_to_function!, set!
 import Oceananigans.DistributedComputations: reconstruct_global_field, synchronize_communication!
@@ -39,27 +39,18 @@ function set_to_function!(u::ReactantField, f)
     return nothing
 end
 
-# A dimension can be copied by broadcasting when both fields share its location and size,
-# or when v is reduced there (Nothing location, singleton size): broadcasting expands the
-# singleton across u's dimension, as when a 1D reference column is set into a 3D field.
-@inline broadcastable_dimension(ℓu, ℓv, Nu, Nv) = (ℓu == ℓv && Nu == Nv) || (ℓv === Nothing && Nv == 1)
-
-function broadcast_compatible(u, v)
-    ℓu = Oceananigans.location(u)
-    ℓv = Oceananigans.location(v)
-    Nu = size(u)
-    Nv = size(v)
-    return all(broadcastable_dimension(ℓu[d], ℓv[d], Nu[d], Nv[d]) for d in 1:3)
-end
-
-# When v broadcasts against u we can just copy interiors. Otherwise we fall
+# When `v` may be copied into `u` we broadcast interiors, which traces. Otherwise we fall
 # back to interpolation on the CPU, since interpolate!'s KA kernel does not
 # currently trace under Reactant (see Reactant.jl#2364). This mirrors how
 # set_to_function! hops to the CPU. Note that the CPU fallback only works
 # outside of tracing: traced data cannot be materialized on the CPU mid-trace,
-# so under `@compile`/`@jit` only the broadcast path is available.
+# so under `@compile`/`@jit` only the copy path is available.
+#
+# `copyable_fields` is Oceananigans' own copy-versus-interpolate policy; we differ from
+# `copy_to_field!` only in mechanism, copying interiors alone rather than attempting halos
+# through a `try`/`catch` that cannot be traced.
 function set_to_field!(u::ReactantField, v::ReactantField)
-    if broadcast_compatible(u, v)
+    if copyable_fields(u, v)
         interior(u) .= interior(v)
     else
         cpu_grid_u = on_architecture(CPU(), u.grid)

--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -147,7 +147,7 @@ function set_to_array!(u, a)
 end
 
 function set_to_field!(u, v)
-    if matching_field_discretization(u, v)
+    if copyable_fields(u, v)
         copy_to_field!(u, v)
     else
         # Fill halos on v's native architecture so distributed dispatch (if any) is used;
@@ -161,28 +161,44 @@ function set_to_field!(u, v)
     return u
 end
 
-function matching_field_discretization(u, v)
-    sz = size(u)
-    sz == size(v) || return false
+# `u` may be filled from `v` by copying, rather than by interpolating, when every
+# dimension is copyable. Note that sizes need not match: `v` may be reduced.
+function copyable_fields(u, v)
     ℓu = location(u)
     ℓv = location(v)
     iu = indices(u)
     iv = indices(v)
-    return matching_field_dimension(ℓu[1], ℓv[1], iu[1], iv[1], sz[1]) &&
-           matching_field_dimension(ℓu[2], ℓv[2], iu[2], iv[2], sz[2]) &&
-           matching_field_dimension(ℓu[3], ℓv[3], iu[3], iv[3], sz[3])
+    Nu = size(u)
+    Nv = size(v)
+    return copyable_dimension(ℓu[1], ℓv[1], iu[1], iv[1], Nu[1], Nv[1]) &&
+           copyable_dimension(ℓu[2], ℓv[2], iu[2], iv[2], Nu[2], Nv[2]) &&
+           copyable_dimension(ℓu[3], ℓv[3], iu[3], iv[3], Nu[3], Nv[3])
 end
 
-# Two fields share their discretization along a dimension when they have the same
-# location and equivalent indices there. The exception is a reduced (`Nothing`) location
-# in a singleton dimension: a `Nothing` dimension carries no node, so there is nothing
-# to interpolate to and the single slab may be copied directly regardless of the other
-# field's location or absolute index (e.g. a reduced field set from a windowed
-# single-layer field, whose locations are `Nothing` vs `Center` and indices `:` vs `k:k`).
-@inline matching_field_dimension(ℓu, ℓv, iu, iv, N) =
-    (ℓu == ℓv && equivalent_index(iu, iv, N)) || reduced_singleton_dimension(ℓu, ℓv, N)
+# Along a dimension, `u` may be filled from `v` by copying in three mutually exclusive
+# situations: the two fields are discretized equivalently, the dimension is degenerate,
+# or `v` is reduced and stretches across `u`.
+@inline copyable_dimension(ℓu, ℓv, iu, iv, Nu, Nv) =
+    equivalent_dimension(ℓu, ℓv, iu, iv, Nu, Nv) ||
+    degenerate_dimension(ℓu, ℓv, Nu, Nv) ||
+    expandable_source_dimension(ℓv, Nu)
 
-@inline reduced_singleton_dimension(ℓu, ℓv, N) = N == 1 && (ℓu === Nothing || ℓv === Nothing)
+# `u` and `v` place their nodes identically: same location, same extent, and windows
+# selecting the same absolute indices.
+@inline equivalent_dimension(ℓu, ℓv, iu, iv, Nu, Nv) =
+    ℓu == ℓv && Nu == Nv && equivalent_index(iu, iv, Nu)
+
+# Both fields span a single point and at least one carries no node there. A `Nothing`
+# location has no node to interpolate to, so the single slab copies directly whatever the
+# other field's location and absolute index are (e.g. a reduced field set from a windowed
+# single-layer field, whose locations are `Nothing` vs `Center` and indices `:` vs `k:k`).
+@inline degenerate_dimension(ℓu, ℓv, Nu, Nv) =
+    Nu == Nv == 1 && (ℓu === Nothing || ℓv === Nothing)
+
+# `v` carries no node, so its single value is replicated across `u`'s cells --- a 1D
+# reference column set into a 3D field, say. Only the source may stretch, mirroring
+# broadcasting, so a reduced `u` fed by a many-celled `v` is not copyable.
+@inline expandable_source_dimension(ℓv, Nu) = ℓv === Nothing && Nu > 1
 
 @inline equivalent_index(a, b, N) = a == b
 @inline equivalent_index(::Colon, r::AbstractUnitRange, N) = first(r) == 1 && last(r) == N
@@ -191,6 +207,20 @@ end
 function copy_to_field!(u, v)
     # We implement some niceities in here that attempt to copy halo data,
     # and revert to copying just interior points if that fails.
+
+    if size(u) != size(v)
+        # `v` is reduced along at least one dimension (see `expandable_source_dimension`)
+        # and stretches across `u`. Only interior points participate: `v` spans a single
+        # point along a stretched dimension, so it has no halo data to lend there.
+        if child_architecture(u) === child_architecture(v)
+            interior(u) .= interior(v)
+        else
+            v_data = on_architecture(child_architecture(u), v.data)
+            interior(u) .= interior(v_data, location(v), v.grid, v.indices)
+        end
+
+        return u
+    end
 
     if child_architecture(u) === child_architecture(v)
         # Note: we could try to copy first halo point even when halo

--- a/test/test_set_field_interpolation.jl
+++ b/test/test_set_field_interpolation.jl
@@ -64,8 +64,81 @@ end
         if Nz > 1
             bottom_u = Field{Face, Center, Center}(grid, indices=(:, :, 1:1))
             top_u    = Field{Face, Center, Center}(grid, indices=(:, :, Nz:Nz))
-            @test !Oceananigans.Fields.matching_field_discretization(bottom_u, top_u)
+            @test !Oceananigans.Fields.copyable_fields(bottom_u, top_u)
         end
+    end
+end
+
+@testset "copyable_fields policy" begin
+    copyable_fields = Oceananigans.Fields.copyable_fields
+
+    for arch in archs, FT in float_types
+        grid = RectilinearGrid(arch, FT; size=(4, 4, 8), x=(0, 1), y=(0, 1), z=(0, 1))
+        Nz = size(grid, 3)
+
+        # equivalent_dimension: identical discretization copies.
+        @test copyable_fields(CenterField(grid), CenterField(grid))
+
+        # Differing locations in a non-degenerate dimension must interpolate, which is the
+        # case the policy exists to protect: u and v sit at different physical nodes.
+        @test !copyable_fields(XFaceField(grid), CenterField(grid))
+
+        # degenerate_dimension: a reduced field and a windowed single layer both span one
+        # vertical point, so the slab copies in either direction.
+        reduced = Field{Center, Center, Nothing}(grid)
+        single_layer = Field{Center, Center, Center}(grid, indices=(:, :, Nz:Nz))
+        @test copyable_fields(reduced, single_layer)
+        @test copyable_fields(single_layer, reduced)
+
+        # expandable_source_dimension: a reduced source stretches across a full field.
+        column = Field{Nothing, Nothing, Center}(grid)
+        slice  = Field{Center, Center, Nothing}(grid)
+        @test copyable_fields(CenterField(grid), column)
+        @test copyable_fields(CenterField(grid), slice)
+
+        # ...but only the source may stretch. A reduced *destination* fed by a many-celled
+        # source would have to compress, which broadcasting cannot do, so it interpolates.
+        @test !copyable_fields(column, CenterField(grid))
+        @test !copyable_fields(slice, CenterField(grid))
+
+        # A singleton dimension that still carries a node is not degenerate: stretching a
+        # `Center` value across many cells is not a copy.
+        thin_grid = RectilinearGrid(arch, FT; size=(4, 4, 1), x=(0, 1), y=(0, 1), z=(0, 1))
+        @test !copyable_fields(CenterField(grid), CenterField(thin_grid))
+    end
+end
+
+@testset "set! expands a reduced source by copying" begin
+    for arch in archs, FT in float_types
+        grid = RectilinearGrid(arch, FT; size=(4, 4, 8), x=(0, 1), y=(0, 1), z=(0, 1))
+
+        # A 1D reference column set into a 3D field must reproduce what interpolation
+        # produced before expansion became a copy: a reduced dimension carries no node,
+        # so replicating the single value is exactly the interpolated result.
+        column = Field{Nothing, Nothing, Center}(grid)
+        set!(column, z -> 2z + 1)
+        fill_halo_regions!(column)
+
+        expanded = CenterField(grid)
+        set!(expanded, column)
+
+        expected = CenterField(grid)
+        interpolate!(expected, column)
+
+        @test Array(interior(expanded)) == Array(interior(expected))
+
+        # The same for a horizontal slice stretched over every vertical level.
+        slice = Field{Center, Center, Nothing}(grid)
+        set!(slice, (x, y) -> x + 2y)
+        fill_halo_regions!(slice)
+
+        expanded_slice = CenterField(grid)
+        set!(expanded_slice, slice)
+
+        expected_slice = CenterField(grid)
+        interpolate!(expected_slice, slice)
+
+        @test Array(interior(expanded_slice)) == Array(interior(expected_slice))
     end
 end
 


### PR DESCRIPTION
## Summary

`set!(u, v)` decides whether to copy or interpolate, and the Reactant extension kept its own copy of that decision. The two drifted, so a `set!` that works on CPU fails under Reactant — because of the Reactant extension.

cc @bgroenks96 @maximilian-gelbrecht — Oceananigans side of https://github.com/NumericalEarth/Terrarium.jl/pull/157#discussion_r3778664243. With this merged, `set!(state.skin_temperature, state.ground_temperature)` copies rather than interpolating, including inside `@compile`/`@jit`, so the `interior(...) .= interior(...)` workaround can revert to `set!`.

## What was wrong

#5652 taught the base predicate that a degenerate dimension may be copied whichever side is reduced. The extension's `broadcast_compatible`, added later in #5840, accepted only a reduced **source**. Terrarium sets a `Field{Center, Center, Nothing}` from a windowed single layer, so `ℓu === Nothing` and `ℓv === Center` with `Nu == Nv == 1` — rejected, despite the two interiors having identical shapes and the assignment being elementwise. Falling off that fast path is fatal rather than slow: on `main` the case fails inside `@jit` with `Scalar indexing is disallowed`, because the CPU fallback materializes traced data mid-trace.

## The three cases, named

```julia
@inline copyable_dimension(ℓu, ℓv, iu, iv, Nu, Nv) =
    equivalent_dimension(ℓu, ℓv, iu, iv, Nu, Nv) ||   # same location, extent, window
    degenerate_dimension(ℓu, ℓv, Nu, Nv) ||           # both span one point, one carries no node
    expandable_source_dimension(ℓv, Nu)               # v carries no node, stretches across u
```

Mutually exclusive, so each is independently testable. `expandable_source_dimension` is the only asymmetric member, which is correct and self-documenting: broadcasting stretches only the right-hand side, so a reduced `u` fed by a many-celled `v` still interpolates.

`matching_field_discretization` → `copyable_fields`, `matching_field_dimension` → `copyable_dimension`. Callers branch on whether a copy is valid, not on whether discretizations coincide — and a one-cell column and an eight-cell field don't share a discretization, yet copying by expansion is exactly right. Both were private, but flagging the rename in case downstream reaches for them.

## Notes

**Base behavior change.** Expansion is new to the base predicate; it previously routed to `interpolate!`. Broadcast expansion is bit-identical wherever the source carries no node, so this only skips a kernel — verified `maxdiff = 0.0` across 13 configurations (`Face` sources, stretched `z`, vertical and scalar reductions, `LatitudeLongitudeGrid`). `copy_to_field!` now takes that path explicitly rather than through the `try`/`catch` fallback.

**Second bug fixed.** The extension's predicate never received indices, so same-size same-location fields windowed at different levels (`view(c, :, :, 1:4)` vs `view(c, :, :, 5:8)`) were copied raw, silently offset, where base interpolates by physical position.

**Extension.** `broadcast_compatible`/`broadcastable_dimension` deleted; it now overrides only mechanism — interior-only copy plus the CPU `interpolate!` fallback (Reactant.jl#2364 is closed, so native `interpolate!` is worth revisiting separately). No policy remains there, so base fixes reach Reactant automatically.

## Verification

- `test_set_field_interpolation.jl`: 24 pass, covering all three clauses, both cases that must stay rejected, and expansion agreeing with `interpolate!`.
- `test_field.jl`: 4,004,793 pass, 0 fail.
- Reactant smoke test, eager and under `@jit`, for the Terrarium shape and the Breeze shape from #5840 (NumericalEarth/Breeze.jl#863). All pass; the Terrarium case fails on `main` under `@jit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
