### PR TITLE
Read a FieldTimeSeries at a cell with a precomputed TimeInterpolator

### DIFF
--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -225,11 +225,15 @@ end
 # `fts.times`, which a kernel repeats in every thread; `cpu_interpolating_time_indices` does
 # that search once on the host and returns the `TimeInterpolator` accepted here, so a kernel
 # can read a series at an exact cell without touching `times`.
+#
+# The indices are converted because a `TimeInterpolator` reaches a kernel as an argument,
+# where its scalar fields can arrive as `CuTracedRNumber` rather than `Int` (#4230). The
+# `Time` method needs no conversion: it computes its indices inside the kernel.
 @inline Base.getindex(fts::FlavorOfFTS, i::Int, j::Int, k::Int, time_interpolator::TimeInterpolator) =
     time_interpolated_getindex(fts, i, j, k,
                                time_interpolator.fractional_index,
-                               time_interpolator.first_index,
-                               time_interpolator.second_index)
+                               convert(Int, time_interpolator.first_index),
+                               convert(Int, time_interpolator.second_index))
 
 @inline function time_interpolated_getindex(fts, i, j, k, ñ, n₁, n₂)
     @inbounds begin

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -228,8 +228,8 @@ end
 @inline Base.getindex(fts::FlavorOfFTS, i::Int, j::Int, k::Int, time_interpolator::TimeInterpolator) =
     time_interpolated_getindex(fts, i, j, k,
                                time_interpolator.fractional_index,
-                               convert(Int, time_interpolator.first_index),
-                               convert(Int, time_interpolator.second_index))
+                               time_interpolator.first_index,
+                               time_interpolator.second_index)
 
 @inline function time_interpolated_getindex(fts, i, j, k, ñ, n₁, n₂)
     @inbounds begin

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -221,10 +221,10 @@ end
     return time_interpolated_getindex(fts, i, j, k, ñ, n₁, n₂)
 end
 
-# The same read with the time indices already in hand. `interpolating_time_indices` searches
-# `fts.times`, which a kernel repeats in every thread; `cpu_interpolating_time_indices` does
-# that search once on the host and returns the `TimeInterpolator` accepted here, so a kernel
-# can read a series at an exact cell without touching `times`.
+# The same read with the time indices already in hand. The `Time` method recomputes them
+# from `fts.times` in every thread; `cpu_interpolating_time_indices` does that once on the
+# host and returns the `TimeInterpolator` accepted here, so a kernel can read a series at
+# an exact cell without touching `times`.
 #
 # The indices are converted because a `TimeInterpolator` reaches a kernel as an argument,
 # where its scalar fields can arrive as `CuTracedRNumber` rather than `Int` (#4230). The

--- a/src/OutputReaders/field_time_series_indexing.jl
+++ b/src/OutputReaders/field_time_series_indexing.jl
@@ -218,7 +218,20 @@ end
 
 @inline function interpolating_getindex(fts, i, j, k, time_index)
     ñ, n₁, n₂ = interpolating_time_indices(fts.time_indexing, fts.times, time_index.time)
+    return time_interpolated_getindex(fts, i, j, k, ñ, n₁, n₂)
+end
 
+# The same read with the time indices already in hand. `interpolating_time_indices` searches
+# `fts.times`, which a kernel repeats in every thread; `cpu_interpolating_time_indices` does
+# that search once on the host and returns the `TimeInterpolator` accepted here, so a kernel
+# can read a series at an exact cell without touching `times`.
+@inline Base.getindex(fts::FlavorOfFTS, i::Int, j::Int, k::Int, time_interpolator::TimeInterpolator) =
+    time_interpolated_getindex(fts, i, j, k,
+                               time_interpolator.fractional_index,
+                               convert(Int, time_interpolator.first_index),
+                               convert(Int, time_interpolator.second_index))
+
+@inline function time_interpolated_getindex(fts, i, j, k, ñ, n₁, n₂)
     @inbounds begin
         ψ₁ = getindex(fts, i, j, k, n₁)
         ψ₂ = getindex(fts, i, j, k, n₂)

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -2,7 +2,7 @@ include("dependencies_for_runtests.jl")
 
 using Oceananigans.Units: Time
 using Oceananigans.Fields: indices, interpolate!
-using Oceananigans.OutputReaders: Cyclical, Clamp, Linear, SplitFilePath
+using Oceananigans.OutputReaders: Cyclical, Clamp, Linear, SplitFilePath, cpu_interpolating_time_indices
 
 using Random
 using NCDatasets
@@ -718,6 +718,29 @@ end
 ##### Run tests
 #####
 
+function test_precomputed_time_interpolator(arch)
+    grid = RectilinearGrid(arch, size=(2, 2, 2), extent=(1, 1, 1))
+    times = [0, 1, 3]
+
+    for time_indexing in (Linear(), Clamp(), Cyclical())
+        fts = FieldTimeSeries{Center, Center, Center}(grid, times; time_indexing)
+        for n in 1:length(times)
+            set!(fts[n], (x, y, z) -> n * x)
+        end
+
+        # A `TimeInterpolator` built on the host reads the same value as `Time(t)`, which
+        # searches `times` at the point of use.
+        for t in (-1, 0, 0.5, 1, 2.25, 3, 4)
+            time_interpolator = cpu_interpolating_time_indices(arch, fts.times, fts.time_indexing, t)
+            for (i, j, k) in ((1, 1, 1), (2, 1, 2))
+                @test @allowscalar fts[i, j, k, time_interpolator] == fts[i, j, k, Time(t)]
+            end
+        end
+    end
+
+    return nothing
+end
+
 @testset "OutputReaders" begin
     @info "Testing output readers..."
 
@@ -870,6 +893,12 @@ end
 
     @testset "Time Interpolation" begin
         test_time_interpolation()
+    end
+
+    for arch in archs
+        @testset "Precomputed TimeInterpolator [$(typeof(arch))]" begin
+            test_precomputed_time_interpolator(arch)
+        end
     end
 
     filepath_sine = "one_dimensional_sine.jld2"


### PR DESCRIPTION
Closes #5885.

`fts[i, j, k, Time(t)]` calls `interpolating_time_indices(fts.time_indexing, fts.times, t)`, a search over `times` at the point of use — which a kernel repeats in every thread. `cpu_interpolating_time_indices` already does that search once on the host, but the resulting `TimeInterpolator` could only be consumed through `interpolate`, which interpolates in space as well and takes raw `data` rather than the series. So a kernel reading a series at an exact cell had to hand-roll the two-snapshot blend, or pass `FractionalIndices(i, j, nothing)` with integer indices — which gives `interpolator(i) == (i, i + 1, 0)` and reads the neighbor at `i + 1` under `_interpolate`'s `@inbounds`, silent until `--check-bounds=yes`.

This accepts a `TimeInterpolator` in `getindex`, sharing the blend with the `Time` path via `time_interpolated_getindex`:

```julia
@inline Base.getindex(fts::FlavorOfFTS, i::Int, j::Int, k::Int, time_interpolator::TimeInterpolator)
```

The integer `getindex(::FlavorOfFTS, i, j, k, n::Int)` already applies `memory_index`, so `Cyclical`/`Clamp` indexing and partly-in-memory backends need nothing extra. The new testset checks the result against `fts[i, j, k, Time(t)]` across those three time-indexing modes, inside and outside the time domain.

### Follow-up for #5761

#5761 introduces `AbstractFieldTimeSeries` and widens the reduced-series aliases from `FlavorOfFTS` to `SomeTimeSeries`, which also covers lazy `FieldTimeSeriesOperation`s. Once it lands, this signature should widen the same way so in-kernel cell reads work on operations too. The blend factored out here is the kernel-side counterpart of #5761's host-side `materialized_time_slice` / `time_interpolable_slice` split, so the two are worth reconciling into one place at that point. Kept on `FlavorOfFTS` here to stay independent of that branch.