### PR TITLE
(0.110.18) Center the longitude fold window on Bounded grids

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.17"
+version = "0.110.18"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -15,7 +15,7 @@ using OffsetArrays: OffsetArray
 using Oceananigans: Oceananigans, instantiated_location, location
 using Oceananigans.Architectures: Architectures, child_architecture, on_architecture
 using Oceananigans.BoundaryConditions: BoundaryConditions, fill_halo_regions!
-using Oceananigans.Grids: Grids, AbstractGrid, Bounded, Center, Face, LatitudeLongitudeGrid,
+using Oceananigans.Grids: Grids, AbstractGrid, Bounded, Center, Face, LatitudeLongitudeGrid, Periodic,
     RectilinearGrid, new_data, interior_indices, total_size, topology, nodes, xnodes,
     ynodes, znodes, node, xnode, ynode, znode
 using Oceananigans.Utils: KernelParameters, launch!, prettysummary, interpolator

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -102,6 +102,15 @@ end
     return x + 360 * n
 end
 
+# The 360° window that a queried longitude is folded into. On a `Periodic` grid every
+# longitude belongs to some cell, so the window starts at the western edge. A `Bounded` grid
+# may cover only part of the globe: a query just west of its western edge must stay just west
+# of it rather than reappear at the eastern edge, so the window is centred on the grid. Without
+# this a node one cell west of λ = 0 folds to λ ≈ 360 and indexes far past the grid. Centring
+# on the grid leaves a `Bounded` grid that spans the full globe unchanged.
+@inline longitude_window_start(::Periodic, λᵂ, λᴱ) = λᵂ
+@inline longitude_window_start(topo, λᵂ, λᴱ) = (λᵂ + λᴱ) / 2 - 180
+
 # When interpolating longitude values, we convert the longitude to
 # interpolate to lie in the λ₀ : λ₀ + 360 range, where λ₀ is the westernmost node
 # of the interpolating grid.
@@ -113,7 +122,10 @@ end
 @inline function fractional_x_index(λ, locs, grid::XRegularLLG)
     λ₀ = λnode(1, 1, 1, grid, locs...)
     Δλ = grid.Δλᶜᵃᵃ
-    λc = convert_to_λ₀_λ₀_plus360(λ, λ₀ - Δλ/2) # Making sure we have the right range
+    TX = topology(grid, 1)()
+    λᵂ = λ₀ - Δλ/2
+    λᴱ = λᵂ + grid.Nx * Δλ
+    λc = convert_to_λ₀_λ₀_plus360(λ, longitude_window_start(TX, λᵂ, λᴱ))
     FT = eltype(grid)
     return convert(FT, (λc - λ₀) / Δλ) + 1 # 1 - based indexing
 end
@@ -129,7 +141,8 @@ end
      λ₀ = @inbounds λn[1]
      λ₁ = @inbounds λn[2]
      Δλ = λ₁ - λ₀
-     λc = convert_to_λ₀_λ₀_plus360(λ, λ₀ - Δλ/2)
+     λᴺ = @inbounds λn[Nλ]
+     λc = convert_to_λ₀_λ₀_plus360(λ, longitude_window_start(Tλ, λ₀ - Δλ/2, λᴺ + Δλ/2))
      FT = eltype(grid)
     return convert(FT, fractional_index(λc, λn, Nλ))
 end

--- a/src/Fields/interpolate.jl
+++ b/src/Fields/interpolate.jl
@@ -105,8 +105,8 @@ end
 # The 360° window that a queried longitude is folded into. On a `Periodic` grid every
 # longitude belongs to some cell, so the window starts at the western edge. A `Bounded` grid
 # may cover only part of the globe: a query just west of its western edge must stay just west
-# of it rather than reappear at the eastern edge, so the window is centred on the grid. Without
-# this a node one cell west of λ = 0 folds to λ ≈ 360 and indexes far past the grid. Centring
+# of it rather than reappear at the eastern edge, so the window is centered on the grid. Without
+# this a node one cell west of λ = 0 folds to λ ≈ 360 and indexes far past the grid. Centering
 # on the grid leaves a `Bounded` grid that spans the full globe unchanged.
 @inline longitude_window_start(::Periodic, λᵂ, λᴱ) = λᵂ
 @inline longitude_window_start(topo, λᵂ, λᴱ) = (λᵂ + λᴱ) / 2 - 180

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -963,6 +963,33 @@ end
         end
     end
 
+    @testset "Fractional longitude index on regional grids" begin
+        @info "  Testing fractional longitude indices on regional grids..."
+
+        # A `Bounded` grid covers only part of the globe, so a longitude just west of its
+        # western edge must index just west of the grid rather than folding to λ ≈ 360.
+        regional = LatitudeLongitudeGrid(size = (2, 1, 1), longitude = (0, 20),
+                                         latitude = (0, 10), z = (-1, 0),
+                                         topology = (Bounded, Bounded, Bounded))
+
+        for (λ, expected) in ((-15.0, -1), (-5.0, 0), (5.0, 1), (15.0, 2), (25.0, 3))
+            fi = FractionalIndices((λ, 5.0, 0.0), regional, Center(), Center(), Center())
+            @test fi.i ≈ expected
+        end
+
+        # A grid spanning the full globe is unaffected, whether `Bounded` or `Periodic`.
+        for TX in (Bounded, Periodic)
+            global_grid = LatitudeLongitudeGrid(size = (36, 18, 1), longitude = (0, 360),
+                                                latitude = (-80, 80), z = (-1, 0),
+                                                topology = (TX, Bounded, Bounded))
+
+            for (λ, expected) in ((5.0, 1), (180.0, 18.5), (350.0, 35.5), (357.0, 36.2))
+                fi = FractionalIndices((λ, 0.0, 0.0), global_grid, Center(), Center(), Center())
+                @test fi.i ≈ expected
+            end
+        end
+    end
+
     @testset "Field utils" begin
         @info "  Testing field utils..."
 


### PR DESCRIPTION
`fractional_x_index` folds a queried longitude into `[λᵂ, λᵂ + 360)`, where λᵂ is the grid's western edge. On a `Bounded` grid covering part of the globe, that sends a longitude just *west* of the grid to the far *east* of it. The fold is also asymmetric: a node one cell east of the grid does not fold at all.

On a grid spanning 0° to 20° with two cells, halo included:

| λ | before | after |
|---|---|---|
| −15 | 35.0 | −1.0 |
| −5 | 36.0 | 0.0 |
| 5 | 1.0 | 1.0 |
| 15 | 2.0 | 2.0 |
| 25 | 3.0 | 3.0 |

Index 36 is outside the array even with halos, so interpolating a regional dataset one cell west of λ = 0 reads out of bounds — it hits a `BoundsError` under `--check-bounds=yes` and silently reads past the array otherwise.

This centres the window on the grid when longitude is not `Periodic`, so a node just outside the grid indexes just outside it. A grid spanning the full globe is unchanged in either topology, since a centred window and a west-edge window coincide there — verified for `Bounded` and `Periodic` at λ = 5, 180, 350, 357.

`Fields` 4004793 pass / 2 broken and `OutputReaders` 11549 pass, unchanged from `main`.

Includes the patch bump to v0.110.18 so the fix can be released.
