### PR TITLE
Document `AveragedTimeInterval`'s quadrature as right-endpoint

### DIFF
--- a/docs/src/simulations/output_writers.md
+++ b/docs/src/simulations/output_writers.md
@@ -221,7 +221,7 @@ See [`JLD2Writer`](@ref) for more information.
 Time-averaged output is specified by setting the `schedule` keyword argument for either `NetCDFWriter` or
 `JLD2Writer` to [`AveragedTimeInterval`](@ref).
 
-With `AveragedTimeInterval`, the time-average of ``a`` is taken as a left Riemann sum corresponding to
+With `AveragedTimeInterval`, the time-average of ``a`` is taken as a right Riemann sum corresponding to
 
 ```math
 \langle a \rangle = \frac{1}{T} \int_{t_i-T}^{t_i} a \, \mathrm{d} t \, ,

--- a/src/OutputWriters/windowed_time_average.jl
+++ b/src/OutputWriters/windowed_time_average.jl
@@ -35,7 +35,7 @@ during the averaging window. For example, `stride=1` computes output every itera
 whereas `stride=2` computes output every other iteration. Time-averages with
 longer `stride`s are faster to compute, but less accurate.
 
-The time-average of ``a`` is a left Riemann sum corresponding to
+The time-average of ``a`` is a right Riemann sum corresponding to
 
 ```math
 ⟨a⟩ = T⁻¹ \\int_{tᵢ-T}^{tᵢ} a \\mathrm{d} t \\, ,
@@ -253,7 +253,7 @@ function accumulate_result!(wta, clock::Clock, integrand=wta.operand)
     T_current = period_to_number(clock.time - wta.window_start_time)
     T_previous = period_to_number(wta.previous_collection_time - wta.window_start_time)
 
-    # Accumulate left Riemann sum
+    # Accumulate right Riemann sum
     @. wta.result = (wta.result * T_previous + integrand * Δt) / T_current
 
     # Save time of integrand collection

--- a/test/test_averaged_specified_times.jl
+++ b/test/test_averaged_specified_times.jl
@@ -61,7 +61,9 @@ function test_averaging_scalar_window(model)
 
     # Test with discrete ramp: u will be set to iteration number
     # With dt=0.1, at t=1.0 we have 10 iterations (0 through 9)
-    # Left Riemann sum: ⟨u⟩ = (1/1.0) × 0.1 × (0+1+2+...+9) = 4.5
+    # The accumulator samples at the end of each subinterval, but the callback that sets u
+    # runs after the diagnostics, so the sampled value lags one iteration and the composite
+    # is a left Riemann sum in u: ⟨u⟩ = (1/1.0) × 0.1 × (0+1+2+...+9) = 4.5
 
     dt = 0.1
     output_time = 1
@@ -92,7 +94,7 @@ function test_averaging_scalar_window(model)
     u_ts = FieldTimeSeries(jld_filename, "u")
     recorded_u = interior(u_ts, 1, 1, 1, :)
 
-    # Expected: left Riemann sum
+    # Expected: left Riemann sum in u, from the one-iteration callback lag
     # Execution order: diagnostics run, then callbacks run
     # So at each iteration i, diagnostic samples the value set by callback at iteration i-1
     # We sample u=0,1,2,...,9 (values from iterations 0-9)
@@ -132,7 +134,7 @@ function test_averaging_varying_windows(model)
     # Window 1 at t=0.5 with window=0.5: samples from t=0.0 to t=0.5
     #   Iterations 0-4 (times 0.0, 0.1, 0.2, 0.3, 0.4)
     #   u values: 0, 1, 2, 3, 4
-    #   Left Riemann sum: dt × (0+1+2+3+4) = 0.1 × 10 = 1.0
+    #   Left Riemann sum in u (callback lag): dt × (0+1+2+3+4) = 0.1 × 10 = 1.0
     #   BUT: averaging normalizes by window duration, so we need to recalculate:
     #   At each diagnostic call, we accumulate (result * T_prev + integrand * dt) / T_current
     #   This gives us the average over the window, which is: (0.1 × 10) / 0.5 = 2.0
@@ -140,7 +142,7 @@ function test_averaging_varying_windows(model)
     # Window 2 at t=1.0 with window=0.4: samples from t=0.6 to t=1.0
     #   Iterations 6-9 (times 0.6, 0.7, 0.8, 0.9)
     #   u values: 6, 7, 8, 9
-    #   Left Riemann sum: dt × (6+7+8+9) = 0.1 × 30 = 3.0
+    #   Left Riemann sum in u (callback lag): dt × (6+7+8+9) = 0.1 × 30 = 3.0
     #   Average: (0.1 × 30) / 0.4 = 7.5
 
     expected_values = [FT(2.0), FT(7.5)]


### PR DESCRIPTION
`accumulate_result!` samples the integrand at the current clock time and weights it by the
interval that just elapsed, so each subinterval contributes its right endpoint. The docstring,
the manual, and the comment all called this a left Riemann sum.

The sign of the first-order error follows from which rule it is — a left sum underestimates an
increasing integrand, a right sum overestimates it — so the label matters when reconciling
averaged output against an offline calculation.

Measured with `f(t) = t/T` over a single window with `Δt = T/60`, where the exact mean is 0.5,
the left sum 0.4916667 and the right sum 0.5083333. Two operands in one run, differing only in
whether the accumulator sees a current or a stale value:

```julia
@inline ramp(i, j, k, grid, clock) = clock.time / T

# recomputed whenever the accumulator reads it, so at tₖ it holds f(tₖ)
fresh = Field(KernelFunctionOperation{Center, Center, Center}(ramp, grid, model.clock))

# holds whatever the callback last wrote; callbacks run after diagnostics,
# so at tₖ it still holds f(tₖ₋₁)
lagged = CenterField(grid)
sim.callbacks[:set] = Callback(s -> set!(lagged, s.model.clock.time / T), IterationInterval(1))
```

| operand | written | matches |
|---|---|---|
| `fresh` | 0.5083333 | right sum |
| `lagged` | 0.4916667 | left sum |

So the quadrature is right-endpoint, and the left sum appears only when the operand lags. The
lagged case is what `test_averaged_specified_times.jl` exercises, which is why the label went
unnoticed; those test comments now attribute the left sum to the lag rather than to the
quadrature.

**Docs and comments only** — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
