### PR TITLE
(0.110.20) Bump version from 0.110.19 to 0.110.20

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.19"
+version = "0.110.20"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]


### PR DESCRIPTION
to capture #5631 for use in NumericalEarth.jl