### PR TITLE
(0.111.0) Complete implicit advection implementation by including `ZFaceField`s treatment

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.110.20"
+version = "0.111.0"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]

--- a/src/Advection/adaptive_implicit_vertical_advection.jl
+++ b/src/Advection/adaptive_implicit_vertical_advection.jl
@@ -40,7 +40,6 @@ end
     return ifelse(α > td.cfl, td.cfl / α, one(α))
 end
 
-# `w` advects itself: the advecting velocity sits at cell centers, so the hop is `Δzᶜᶜᶜ`.
 @inline function explicit_velocity_scaleᶜᶜᶜ(i, j, k, grid, scheme, td, W)
     Δt = _unwrap_for_gpu(td.Δt)
     Δz = Δzᶜᶜᶜ(i, j, k, grid)

--- a/src/Advection/adaptive_implicit_vertical_advection.jl
+++ b/src/Advection/adaptive_implicit_vertical_advection.jl
@@ -1,4 +1,4 @@
-using Oceananigans.Operators: Δzᶜᶜᶠ, Δzᶠᶜᶠ, Δzᶜᶠᶠ, Az_qᶜᶜᶠ, Azᶜᶜᶠ, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
+using Oceananigans.Operators: Δzᶜᶜᶜ, Δzᶜᶜᶠ, Δzᶠᶜᶠ, Δzᶜᶠᶠ, Az_qᶜᶜᶠ, Azᶜᶜᶠ, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
 using Oceananigans.Grids: Center, Face
 using Oceananigans.BoundaryConditions: BoundaryConditions, _unwrap_for_gpu
 using Oceananigans.TimeSteppers: SplitRungeKuttaTimeStepper, RungeKutta3TimeStepper
@@ -40,6 +40,15 @@ end
     return ifelse(α > td.cfl, td.cfl / α, one(α))
 end
 
+# `w` advects itself: the advecting velocity sits at cell centers, so the hop is `Δzᶜᶜᶜ`.
+@inline function explicit_velocity_scaleᶜᶜᶜ(i, j, k, grid, scheme, td, W)
+    Δt = _unwrap_for_gpu(td.Δt)
+    Δz = Δzᶜᶜᶜ(i, j, k, grid)
+    w  = _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W)
+    α  = abs(w) * Δt / Δz
+    return ifelse(α > td.cfl, td.cfl / α, one(α))
+end
+
 #####
 ##### Flux dispatch, use scaled w velocities for explicit fluxes
 #####
@@ -53,16 +62,15 @@ end
     return s * advective_tracer_flux_z(i, j, k, grid, scheme, ExplicitTimeDiscretization(), W, c)
 end
 
-# Horizontal momentum fluxes (and Ww) are fully explicit with AVID
+# Horizontal momentum fluxes are fully explicit with AVID
 @inline advective_momentum_flux_Uu(i, j, k, grid, scheme, ::AVID, U, u) = advective_momentum_flux_Uu(i, j, k, grid, scheme, ExplicitTimeDiscretization(), U, u)
 @inline advective_momentum_flux_Vu(i, j, k, grid, scheme, ::AVID, V, u) = advective_momentum_flux_Vu(i, j, k, grid, scheme, ExplicitTimeDiscretization(), V, u)
 @inline advective_momentum_flux_Uv(i, j, k, grid, scheme, ::AVID, U, v) = advective_momentum_flux_Uv(i, j, k, grid, scheme, ExplicitTimeDiscretization(), U, v)
 @inline advective_momentum_flux_Vv(i, j, k, grid, scheme, ::AVID, V, v) = advective_momentum_flux_Vv(i, j, k, grid, scheme, ExplicitTimeDiscretization(), V, v)
 @inline advective_momentum_flux_Uw(i, j, k, grid, scheme, ::AVID, U, w) = advective_momentum_flux_Uw(i, j, k, grid, scheme, ExplicitTimeDiscretization(), U, w)
 @inline advective_momentum_flux_Vw(i, j, k, grid, scheme, ::AVID, V, w) = advective_momentum_flux_Vw(i, j, k, grid, scheme, ExplicitTimeDiscretization(), V, w)
-@inline advective_momentum_flux_Ww(i, j, k, grid, scheme, ::AVID, W, w) = advective_momentum_flux_Ww(i, j, k, grid, scheme, ExplicitTimeDiscretization(), W, w)
 
-# Vertical advection of horizontal momentum: scale by explicit_velocity_scale.
+# Vertical advection of momentum: scale by explicit_velocity_scale.
 @inline function advective_momentum_flux_Wu(i, j, k, grid, scheme, td::AVID, W, u)
     s  = explicit_velocity_scaleᶠᶜᶠ(i, j, k, grid, scheme, td, W)
     return s * advective_momentum_flux_Wu(i, j, k, grid, scheme, ExplicitTimeDiscretization(), W, u)
@@ -71,6 +79,11 @@ end
 @inline function advective_momentum_flux_Wv(i, j, k, grid, scheme, td::AVID, W, v)
     s  = explicit_velocity_scaleᶜᶠᶠ(i, j, k, grid, scheme, td, W)
     return s * advective_momentum_flux_Wv(i, j, k, grid, scheme, ExplicitTimeDiscretization(), W, v)
+end
+
+@inline function advective_momentum_flux_Ww(i, j, k, grid, scheme, td::AVID, W, w)
+    s  = explicit_velocity_scaleᶜᶜᶜ(i, j, k, grid, scheme, td, W)
+    return s * advective_momentum_flux_Ww(i, j, k, grid, scheme, ExplicitTimeDiscretization(), W, w)
 end
 
 #####

--- a/src/Advection/implicit_vertical_advection.jl
+++ b/src/Advection/implicit_vertical_advection.jl
@@ -39,6 +39,14 @@ end
     return w * (1 - ifelse(α > td.cfl, td.cfl / α, one(α)))
 end
 
+@inline function implicit_vertical_velocityᶜᶜᶜ(i, j, k, grid, scheme, td, W)
+    Δt = _unwrap_for_gpu(td.Δt)
+    Δz = Δzᶜᶜᶜ(i, j, k, grid)
+    w  = _symmetric_interpolate_zᵃᵃᶜ(i, j, k, grid, scheme, W)
+    α  = abs(w) * Δt / Δz
+    return w * (1 - ifelse(α > td.cfl, td.cfl / α, one(α)))
+end
+
 #####
 ##### Optional density weighting for mass-flux (anelastic / compressible) models.
 #####
@@ -75,22 +83,12 @@ end
 @inline implicit_vertical_velocity(::Face,   ::Center, args...) = implicit_vertical_velocityᶠᶜᶠ(args...)
 @inline implicit_vertical_velocity(::Center, ::Face,   args...) = implicit_vertical_velocityᶜᶠᶠ(args...)
 
-# The advected field's vertical location `ℓz` selects the coefficient family: the methods below
-# implement fields at cell Centers in z (tracers and horizontal velocities). Advection schemes
-# without an adaptive-implicit vertical discretization contribute nothing to the implicit system,
-# at any location; likewise fields at z-Faces (`w`), whose `Ww` flux is kept fully explicit.
-# Downstream models may extend these functions at `ℓz::Face` (dispatching on their own advection
-# type) to solve vertical momentum implicitly; an advection type without a matching method raises
-# a `MethodError` rather than silently dropping the advection contribution.
-const ExplicitOrNothing = Union{Nothing, AbstractAdvectionScheme}
+# An advection scheme without an adaptive-implicit vertical discretization contributes nothing.
+const AdvectionOrNothing = Union{Nothing, AbstractAdvectionScheme}
 
-@inline implicit_advection_upper_diagonal(i, j, k, grid, ::ExplicitOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
-@inline implicit_advection_lower_diagonal(i, j, k, grid, ::ExplicitOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
-@inline implicit_advection_diagonal(i, j, k, grid,       ::ExplicitOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
-
-@inline implicit_advection_upper_diagonal(i, j, k, grid, ::AIVA, w, Δt, ℓx, ℓy, ℓz::Face, density=nothing) = zero(grid)
-@inline implicit_advection_lower_diagonal(i, j, k, grid, ::AIVA, w, Δt, ℓx, ℓy, ℓz::Face, density=nothing) = zero(grid)
-@inline implicit_advection_diagonal(i, j, k, grid,       ::AIVA, w, Δt, ℓx, ℓy, ℓz::Face, density=nothing) = zero(grid)
+@inline implicit_advection_upper_diagonal(i, j, k, grid, ::AdvectionOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
+@inline implicit_advection_lower_diagonal(i, j, k, grid, ::AdvectionOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
+@inline implicit_advection_diagonal(i, j, k, grid,       ::AdvectionOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
 
 # Upper diagonal: coefficient of q_{k+1} in the tridiagonal system
 @inline function implicit_advection_upper_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, ℓz::Center, density=nothing)
@@ -138,4 +136,64 @@ end
 
     return Δt * V⁻¹ / ρᶜ * (Az⁺ * ρᶠ⁺ * max(wⁱ⁺, zero(wⁱ⁺)) * active⁺ -
                             Az⁻ * ρᶠ⁻ * min(wⁱ⁻, zero(wⁱ⁻)) * active⁻)
+end
+
+#####
+##### Tridiagonal coefficients for fields at cell Faces in z (`w`).
+#####
+##### Row k is the control volume around face k, bounded by the cell centers k-1 and k where the
+##### upwind fluxes live. With `ρᶜ` the cell density and `ρᶠ` the density at the reconstructed face:
+#####
+#####   Fⁱ_k = Az_k ρᶜ_k [max(wⁱ_k, 0) q_k / ρᶠ_k + min(wⁱ_k, 0) q_{k+1} / ρᶠ_{k+1}],   q = ρ w
+#####
+##### Boundary faces reduce to identity rows, and the coupling of row Nz to the untouched face
+##### Nz+1 vanishes with `w` there.
+#####
+
+@inline function implicit_advection_upper_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, ℓz::Face, density=nothing)
+    scheme = vertical_scheme(advection)
+    td  = TimeSteppers.time_discretization(scheme)
+    wⁱ  = implicit_vertical_velocityᶜᶜᶜ(i, j, k, grid, scheme, td, w)
+    Azᵢ = Az(i, j, k, grid, ℓx, ℓy, Center())
+    ρᶜ  = densityᶜᶜᶜ(i, j, k, grid, density)
+    ρᶠ  = densityᶜᶜᶠ(i, j, k+1, grid, density)
+    V⁻¹ = 1 / volume(i, j, k, grid, ℓx, ℓy, Face())
+    active = !peripheral_node(i, j, k, grid, ℓx, ℓy, Face()) & !peripheral_node(i, j, k, grid, ℓx, ℓy, Center())
+    return Δt * V⁻¹ * Azᵢ * ρᶜ / ρᶠ * min(wⁱ, zero(wⁱ)) * active
+end
+
+@inline function implicit_advection_lower_diagonal(i, j, k′, grid, advection::AIVA, w, Δt, ℓx, ℓy, ℓz::Face, density=nothing)
+    scheme = vertical_scheme(advection)
+    td  = TimeSteppers.time_discretization(scheme)
+    k   = k′ + 1
+    wⁱ  = implicit_vertical_velocityᶜᶜᶜ(i, j, k′, grid, scheme, td, w)
+    Azᵢ = Az(i, j, k′, grid, ℓx, ℓy, Center())
+    ρᶜ  = densityᶜᶜᶜ(i, j, k′, grid, density)
+    ρᶠ  = densityᶜᶜᶠ(i, j, k′, grid, density)
+    V⁻¹ = 1 / volume(i, j, k, grid, ℓx, ℓy, Face())
+    active = !peripheral_node(i, j, k, grid, ℓx, ℓy, Face()) & !peripheral_node(i, j, k′, grid, ℓx, ℓy, Center())
+    return - Δt * V⁻¹ * Azᵢ * ρᶜ / ρᶠ * max(wⁱ, zero(wⁱ)) * active
+end
+
+@inline function implicit_advection_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, ℓz::Face, density=nothing)
+    scheme = vertical_scheme(advection)
+    td     = TimeSteppers.time_discretization(scheme)
+    wⁱ⁺ = implicit_vertical_velocityᶜᶜᶜ(i, j, k,   grid, scheme, td, w)
+    wⁱ⁻ = implicit_vertical_velocityᶜᶜᶜ(i, j, k-1, grid, scheme, td, w)
+
+    Az⁺ = Az(i, j, k,   grid, ℓx, ℓy, Center())
+    Az⁻ = Az(i, j, k-1, grid, ℓx, ℓy, Center())
+
+    ρᶜ⁺ = densityᶜᶜᶜ(i, j, k,   grid, density)
+    ρᶜ⁻ = densityᶜᶜᶜ(i, j, k-1, grid, density)
+    ρᶠ  = densityᶜᶜᶠ(i, j, k,   grid, density)
+
+    active⁺ = !peripheral_node(i, j, k,   grid, ℓx, ℓy, Center())
+    active⁻ = !peripheral_node(i, j, k-1, grid, ℓx, ℓy, Center())
+    active  = !peripheral_node(i, j, k,   grid, ℓx, ℓy, Face())
+
+    V⁻¹ = 1 / volume(i, j, k, grid, ℓx, ℓy, Face())
+
+    return Δt * V⁻¹ / ρᶠ * (Az⁺ * ρᶜ⁺ * max(wⁱ⁺, zero(wⁱ⁺)) * active⁺ -
+                            Az⁻ * ρᶜ⁻ * min(wⁱ⁻, zero(wⁱ⁻)) * active⁻) * active
 end

--- a/src/Advection/implicit_vertical_advection.jl
+++ b/src/Advection/implicit_vertical_advection.jl
@@ -75,8 +75,25 @@ end
 @inline implicit_vertical_velocity(::Face,   ::Center, args...) = implicit_vertical_velocityᶠᶜᶠ(args...)
 @inline implicit_vertical_velocity(::Center, ::Face,   args...) = implicit_vertical_velocityᶜᶠᶠ(args...)
 
+# The advected field's vertical location `ℓz` selects the coefficient family: the methods below
+# implement fields at cell Centers in z (tracers and horizontal velocities). Advection schemes
+# without an adaptive-implicit vertical discretization contribute nothing to the implicit system,
+# at any location; likewise fields at z-Faces (`w`), whose `Ww` flux is kept fully explicit.
+# Downstream models may extend these functions at `ℓz::Face` (dispatching on their own advection
+# type) to solve vertical momentum implicitly; an advection type without a matching method raises
+# a `MethodError` rather than silently dropping the advection contribution.
+const ExplicitOrNothing = Union{Nothing, AbstractAdvectionScheme}
+
+@inline implicit_advection_upper_diagonal(i, j, k, grid, ::ExplicitOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
+@inline implicit_advection_lower_diagonal(i, j, k, grid, ::ExplicitOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
+@inline implicit_advection_diagonal(i, j, k, grid,       ::ExplicitOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
+
+@inline implicit_advection_upper_diagonal(i, j, k, grid, ::AIVA, w, Δt, ℓx, ℓy, ℓz::Face, density=nothing) = zero(grid)
+@inline implicit_advection_lower_diagonal(i, j, k, grid, ::AIVA, w, Δt, ℓx, ℓy, ℓz::Face, density=nothing) = zero(grid)
+@inline implicit_advection_diagonal(i, j, k, grid,       ::AIVA, w, Δt, ℓx, ℓy, ℓz::Face, density=nothing) = zero(grid)
+
 # Upper diagonal: coefficient of q_{k+1} in the tridiagonal system
-@inline function implicit_advection_upper_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, density=nothing)
+@inline function implicit_advection_upper_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, ℓz::Center, density=nothing)
     scheme = vertical_scheme(advection)
     td  = TimeSteppers.time_discretization(scheme)
     wⁱ  = implicit_vertical_velocity(ℓx, ℓy, i, j, k+1, grid, scheme, td, w)
@@ -89,7 +106,7 @@ end
 
 # Lower diagonal: coefficient of q_{k-1} in the tridiagonal system
 # Uses k′ = k-1 indexing convention (LinearAlgebra.Tridiagonal convention, matching ivd_lower_diagonal)
-@inline function implicit_advection_lower_diagonal(i, j, k′, grid, advection::AIVA, w, Δt, ℓx, ℓy, density=nothing)
+@inline function implicit_advection_lower_diagonal(i, j, k′, grid, advection::AIVA, w, Δt, ℓx, ℓy, ℓz::Center, density=nothing)
     scheme = vertical_scheme(advection)
     td  = TimeSteppers.time_discretization(scheme)
     k   = k′ + 1
@@ -101,7 +118,7 @@ end
     return - Δt * V⁻¹ * Azᵢ * ρᶠ / ρᶜ * max(wⁱ, zero(wⁱ)) * !peripheral_node(i, j, k′, grid, ℓx, ℓy, Center())
 end
 
-@inline function implicit_advection_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, density=nothing)
+@inline function implicit_advection_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, ℓz::Center, density=nothing)
     scheme = vertical_scheme(advection)
     td     = TimeSteppers.time_discretization(scheme)
     wⁱ⁺ = implicit_vertical_velocity(ℓx, ℓy, i, j, k+1, grid, scheme, td, w)

--- a/src/Advection/implicit_vertical_advection.jl
+++ b/src/Advection/implicit_vertical_advection.jl
@@ -3,6 +3,7 @@ using Oceananigans.Operators: Az, volume, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃ�
 
 @inline vertical_scheme(advection) = advection
 @inline vertical_scheme(advection::VectorInvariant) = advection.vertical_advection_scheme
+@inline vertical_scheme(advection::FluxFormAdvection) = advection.z
 
 #####
 ##### Implicit vertical velocity: wⁱ = w - wᵉ = w * (1 - 1/f(α, cfl))

--- a/src/Models/NonhydrostaticModels/cache_nonhydrostatic_tendencies.jl
+++ b/src/Models/NonhydrostaticModels/cache_nonhydrostatic_tendencies.jl
@@ -30,7 +30,7 @@ function cache_previous_tendencies!(model::NonhydrostaticModel)
     return nothing
 end
 
-# `w` advects itself so we need to pass a clean `w` without it overriding. Reuse `G⁻.w` that is free between substep kernels.
+# `w` advects itself so we need to pass a clean `w` without it overwriting itself. Reuse `G⁻.w` that is free between substep kernels.
 @inline function implicit_advecting_velocities(model, name)
     (name === :w && needs_implicit_solver(model.advection)) || return model.velocities
     w = model.timestepper.G⁻.w

--- a/src/Models/NonhydrostaticModels/cache_nonhydrostatic_tendencies.jl
+++ b/src/Models/NonhydrostaticModels/cache_nonhydrostatic_tendencies.jl
@@ -29,3 +29,11 @@ function cache_previous_tendencies!(model::NonhydrostaticModel)
 
     return nothing
 end
+
+# `w` advects itself so we need to pass a clean `w` without it overriding. Reuse `G⁻.w` that is free between substep kernels.
+@inline function implicit_advecting_velocities(model, name)
+    (name === :w && needs_implicit_solver(model.advection)) || return model.velocities
+    w = model.timestepper.G⁻.w
+    parent(w) .= parent(model.velocities.w)
+    return (; w)
+end

--- a/src/Models/NonhydrostaticModels/cache_nonhydrostatic_tendencies.jl
+++ b/src/Models/NonhydrostaticModels/cache_nonhydrostatic_tendencies.jl
@@ -30,10 +30,10 @@ function cache_previous_tendencies!(model::NonhydrostaticModel)
     return nothing
 end
 
-# `w` advects itself so we need to pass a clean `w` without it overwriting itself. Reuse `G⁻.w` that is free between substep kernels.
-@inline function implicit_advecting_velocities(model, name)
-    (name === :w && needs_implicit_solver(model.advection)) || return model.velocities
-    w = model.timestepper.G⁻.w
+# Snapshot `wⁿ`, before any field is stepped, for use in the `implicit_step!`.
+function implicit_advecting_velocities(model)
+    w = model.advecting_vertical_velocity
+    isnothing(w) && return model.velocities
     parent(w) .= parent(model.velocities.w)
     return (; w)
 end

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_ab2_step.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_ab2_step.jl
@@ -32,6 +32,8 @@ function pressure_correction_ab2_step!(model, Δt, callbacks)
     model_fields = prognostic_fields(model)
 
     # Prognostic variables stepping
+    advecting_velocities = implicit_advecting_velocities(model)
+
     for (i, name) in enumerate(keys(model_fields))
         field = model_fields[name]
         exclude_periphery = i < 4 # We assume that the first 3 fields are velocity / momentum variables
@@ -47,7 +49,7 @@ function pressure_correction_ab2_step!(model, Δt, callbacks)
                        fields(model),
                        kernel_Δt,
                        model.advection,
-                       implicit_advecting_velocities(model, name))
+                       advecting_velocities)
     end
 
     compute_pressure_correction!(model, kernel_Δt)

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_ab2_step.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_ab2_step.jl
@@ -47,7 +47,7 @@ function pressure_correction_ab2_step!(model, Δt, callbacks)
                        fields(model),
                        kernel_Δt,
                        model.advection,
-                       model.velocities)
+                       implicit_advecting_velocities(model, name))
     end
 
     compute_pressure_correction!(model, kernel_Δt)

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -5,7 +5,7 @@ using Oceananigans.BoundaryConditions: MixedBoundaryCondition, needs_implicit_so
                                        regularize_field_boundary_conditions, validate_implicit_explicit_flux_locations
 using Oceananigans.BuoyancyFormulations: validate_buoyancy, materialize_buoyancy
 using Oceananigans.DistributedComputations: Distributed
-using Oceananigans.Fields: Field, tracernames, VelocityFields, TracerFields, CenterField
+using Oceananigans.Fields: Field, tracernames, VelocityFields, TracerFields, CenterField, ZFaceField
 using Oceananigans.Forcings: model_forcing
 using Oceananigans.Grids: topology, inflate_halo_size, with_halo, architecture
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
@@ -30,7 +30,7 @@ const BFOrNamedTuple = Union{BackgroundFields, NamedTuple}
 struct DefaultHydrostaticPressureAnomaly end
 
 mutable struct NonhydrostaticModel{TS, E, A<:AbstractArchitecture, G, CL, B, R, SD, U, C, Φ, F, FS,
-                                   V, S, K, BG, P, BGC, AF, BT} <: AbstractModel{TS, A}
+                                   V, S, K, BG, P, BGC, AF, BT, AW} <: AbstractModel{TS, A}
 
          architecture :: A        # Computer `Architecture` on which `Model` is run
                  grid :: G        # Grid of physical points on which `Model` is solved
@@ -53,6 +53,7 @@ mutable struct NonhydrostaticModel{TS, E, A<:AbstractArchitecture, G, CL, B, R, 
       pressure_solver :: S        # Pressure/Poisson solver
      auxiliary_fields :: AF       # User-specified auxiliary fields for forcing functions and boundary conditions
    boundary_transport :: BT       # Container for transports at open boundaries
+   advecting_vertical_velocity :: AW # `wⁿ` for the adaptive-implicit advection split (`nothing` without it)
 end
 
 supported_timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
@@ -293,6 +294,9 @@ function NonhydrostaticModel(grid;
         implicit_solver = implicit_diffusion_solver(VerticallyImplicitTimeDiscretization(), grid)
     end
 
+    # Snapshot of `wⁿ` to solve implicit vertical advection without overwrites.
+    advecting_vertical_velocity = needs_implicit_solver(advection) ? ZFaceField(grid) : nothing
+
     timestepper = TimeStepper(timestepper, grid, prognostic_fields; implicit_solver)
 
     # Materialize forcing for model tracer and velocity fields.
@@ -305,7 +309,8 @@ function NonhydrostaticModel(grid;
 
     model = NonhydrostaticModel(arch, grid, clock, advection, buoyancy, coriolis, stokes_drift,
                                 forcing, closure, free_surface, background_fields, particles, biogeochemistry, velocities, tracers,
-                                pressures, closure_fields, timestepper, pressure_solver, auxiliary_fields, boundary_transport)
+                                pressures, closure_fields, timestepper, pressure_solver, auxiliary_fields, boundary_transport,
+                                advecting_vertical_velocity)
 
     materialize_clock!(clock, timestepper)
     update_state!(model)

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_rk3_substep.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_rk3_substep.jl
@@ -53,7 +53,7 @@ function pressure_correction_rk3_substep!(model, Δt, γⁿ, ζⁿ, callbacks)
                        fields(model),
                        Δτ,
                        model.advection,
-                       model.velocities)
+                       implicit_advecting_velocities(model, name))
     end
 
     compute_pressure_correction!(model, Δτ)

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_rk3_substep.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_rk3_substep.jl
@@ -38,6 +38,8 @@ function pressure_correction_rk3_substep!(model, Δt, γⁿ, ζⁿ, callbacks)
     model_fields = prognostic_fields(model)
 
     # Prognostic variables stepping
+    advecting_velocities = implicit_advecting_velocities(model)
+
     for (i, name) in enumerate(keys(model_fields))
         field = model_fields[name]
         exclude_periphery = i < 4 # We assume that the first 3 fields are velocity / momentum variables
@@ -53,7 +55,7 @@ function pressure_correction_rk3_substep!(model, Δt, γⁿ, ζⁿ, callbacks)
                        fields(model),
                        Δτ,
                        model.advection,
-                       implicit_advecting_velocities(model, name))
+                       advecting_velocities)
     end
 
     compute_pressure_correction!(model, Δτ)

--- a/src/Solvers/conjugate_gradient_poisson_solver.jl
+++ b/src/Solvers/conjugate_gradient_poisson_solver.jl
@@ -338,14 +338,9 @@ end
     return ifelse(inactive_self | isolated, one(grid), -(az⁻ + az⁺) * (1 + ε))
 end
 
-@inline get_coefficient(i, j, k, grid, ::ColumnwiseTridiagonalLowerDiagonal, p, ::ZDirection, args...) =
-    columnwise_tridiagonal_offdiagonal(i, j, k, grid)
-
-@inline get_coefficient(i, j, k, grid, ::ColumnwiseTridiagonalUpperDiagonal, p, ::ZDirection, args...) =
-    columnwise_tridiagonal_offdiagonal(i, j, k, grid)
-
-@inline get_coefficient(i, j, k, grid, ::ColumnwiseTridiagonalDiagonal, p, ::ZDirection, args...) =
-    columnwise_tridiagonal_diagonal(i, j, k, grid)
+@inline get_coefficient(i, j, k, grid, ::ColumnwiseTridiagonalLowerDiagonal, p, ::ZDirection, args...) = columnwise_tridiagonal_offdiagonal(i, j, k, grid)
+@inline get_coefficient(i, j, k, grid, ::ColumnwiseTridiagonalUpperDiagonal, p, ::ZDirection, args...) = columnwise_tridiagonal_offdiagonal(i, j, k, grid)
+@inline get_coefficient(i, j, k, grid, ::ColumnwiseTridiagonalDiagonal, p, ::ZDirection,      args...) = columnwise_tridiagonal_diagonal(i, j, k, grid)
 
 """
     ColumnwiseTridiagonalPreconditioner(grid)

--- a/src/TurbulenceClosures/implicit_explicit_time_discretization.jl
+++ b/src/TurbulenceClosures/implicit_explicit_time_discretization.jl
@@ -2,7 +2,6 @@ using Oceananigans.TimeSteppers: TimeSteppers,
                                  AbstractTimeDiscretization,
                                  ExplicitTimeDiscretization,
                                  VerticallyImplicitTimeDiscretization
-using Oceananigans.Advection: AdaptiveImplicitVerticalAdvection
 
 @inline TimeSteppers.time_discretization(::AbstractTurbulenceClosure{TimeDiscretization}) where TimeDiscretization = TimeDiscretization()
 @inline TimeSteppers.time_discretization(::Nothing) = ExplicitTimeDiscretization() # placeholder for closure::Nothing

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -1,5 +1,4 @@
-using Oceananigans.Advection: AdaptiveImplicitVerticalAdvection,
-                              implicit_advection_upper_diagonal,
+using Oceananigans.Advection: implicit_advection_upper_diagonal,
                               implicit_advection_lower_diagonal,
                               implicit_advection_diagonal
 using Oceananigans.BoundaryConditions: implicit_flux_coefficient, immersed_implicit_flux_coefficient
@@ -212,42 +211,33 @@ end
 
 # Extend `get_coefficient` to retrieve `ivd_diagonal`, `_ivd_lower_diagonal` and `_ivd_upper_diagonal`.
 # Note that we use the "periphery-aware" upper and lower diagonals. The trailing arguments are supplied
-# by the extended `implicit_step!` below; a non-adaptive advection scheme contributes nothing.
-@inline get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionLowerDiagonal, p, ::ZDirection, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields, args...) =
-    _ivd_lower_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
-
-@inline get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionUpperDiagonal, p, ::ZDirection, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields, args...) =
-    _ivd_upper_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
-
-@inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionDiagonal, p, ::ZDirection, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection=nothing, w=nothing, density=nothing, top_bc=nothing, bottom_bc=nothing, immersed_bc=nothing)
-    dκ = ivd_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
-    db = boundary_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, top_bc, bottom_bc, immersed_bc)
-    return dκ + db
-end
-
-const AIVA = AdaptiveImplicitVerticalAdvection
-
-# `density` selects volume-conserving (Boussinesq) versus density-weighted (mass-flux) advection coefficients.
+# by the extended `implicit_step!` below. The advection contribution is always routed through
+# `implicit_advection_*`, which dispatch on the advection scheme and the field's vertical location
+# `ℓz`: explicit schemes (and `advection = nothing`) contribute zero, adaptive-implicit schemes
+# return the z-Center coefficients, and unknown advection types raise a `MethodError` — this is
+# the seam downstream models extend, without touching `get_coefficient`. `density` selects
+# volume-conserving (Boussinesq) versus density-weighted (mass-flux) advection coefficients.
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionUpperDiagonal, p, ::ZDirection,
-                                 clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields, advection::AIVA, w, density, args...)
+                                 clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
+                                 advection=nothing, w=nothing, density=nothing, args...)
     duκ = _ivd_upper_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
-    duw = implicit_advection_upper_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, density)
+    duw = implicit_advection_upper_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, ℓz, density)
     return duκ + duw
 end
 
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionLowerDiagonal, p, ::ZDirection,
-                                 clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields, advection::AIVA, w, density, args...)
+                                 clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
+                                 advection=nothing, w=nothing, density=nothing, args...)
     dlκ = _ivd_lower_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
-    dlw = implicit_advection_lower_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, density)
+    dlw = implicit_advection_lower_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, ℓz, density)
     return dlκ + dlw
 end
 
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionDiagonal, p, ::ZDirection,
                                  clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection::AIVA, w, density, top_bc, bottom_bc, immersed_bc)
+                                 advection=nothing, w=nothing, density=nothing, top_bc=nothing, bottom_bc=nothing, immersed_bc=nothing)
     dκ  = ivd_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
-    dw  = implicit_advection_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, density)
+    dw  = implicit_advection_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, ℓz, density)
     dbc = boundary_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, top_bc, bottom_bc, immersed_bc)
     return dκ + dw + dbc
 end

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -1,7 +1,7 @@
 using Oceananigans.Advection: implicit_advection_upper_diagonal,
                               implicit_advection_lower_diagonal,
                               implicit_advection_diagonal
-using Oceananigans.BoundaryConditions: implicit_flux_coefficient, immersed_implicit_flux_coefficient
+using Oceananigans.BoundaryConditions: implicit_flux_coefficient, immersed_implicit_flux_coefficient, needs_implicit_solver
 using Oceananigans.Fields: location
 using Oceananigans.Grids: Periodic, ZDirection, topology
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, ImmersedBoundaryCondition, immersed_inactive_node
@@ -211,15 +211,11 @@ end
 
 # Extend `get_coefficient` to retrieve `ivd_diagonal`, `_ivd_lower_diagonal` and `_ivd_upper_diagonal`.
 # Note that we use the "periphery-aware" upper and lower diagonals. The trailing arguments are supplied
-# by the extended `implicit_step!` below. The advection contribution is always routed through
-# `implicit_advection_*`, which dispatch on the advection scheme and the field's vertical location
-# `ℓz`: explicit schemes (and `advection = nothing`) contribute zero, adaptive-implicit schemes
-# return the z-Center coefficients, and unknown advection types raise a `MethodError` — this is
-# the seam downstream models extend, without touching `get_coefficient`. `density` selects
-# volume-conserving (Boussinesq) versus density-weighted (mass-flux) advection coefficients.
+# by `implicit_step!` below. `density` selects volume-conserving (Boussinesq) versus
+# density-weighted (mass-flux) advection coefficients.
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionUpperDiagonal, p, ::ZDirection,
                                  clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection=nothing, w=nothing, density=nothing, args...)
+                                 advection, w, density, top_bc, bottom_bc, immersed_bc)
     duκ = _ivd_upper_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
     duw = implicit_advection_upper_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, ℓz, density)
     return duκ + duw
@@ -227,7 +223,7 @@ end
 
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionLowerDiagonal, p, ::ZDirection,
                                  clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection=nothing, w=nothing, density=nothing, args...)
+                                 advection, w, density, top_bc, bottom_bc, immersed_bc)
     dlκ = _ivd_lower_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
     dlw = implicit_advection_lower_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, ℓz, density)
     return dlκ + dlw
@@ -235,7 +231,7 @@ end
 
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionDiagonal, p, ::ZDirection,
                                  clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection=nothing, w=nothing, density=nothing, top_bc=nothing, bottom_bc=nothing, immersed_bc=nothing)
+                                 advection, w, density, top_bc, bottom_bc, immersed_bc)
     dκ  = ivd_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
     dw  = implicit_advection_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, ℓz, density)
     dbc = boundary_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, top_bc, bottom_bc, immersed_bc)
@@ -248,8 +244,6 @@ end
 
 is_vertically_implicit(closure) = TimeSteppers.time_discretization(closure) isa VerticallyImplicitTimeDiscretization
 
-# When closure is nothing but solver exists (e.g., created for AIVA),
-# the pure-diffusion implicit step is a no-op (no diffusion to solve).
 """
 $(TYPEDSIGNATURES)
 
@@ -257,44 +251,16 @@ Initialize the right hand side array `solver.batched_tridiagonal_solver.f`, and 
 tridiagonal system for vertically-implicit diffusion, passing the arguments into the coefficient
 functions that return coefficients of the lower diagonal, diagonal, and upper diagonal of the
 resulting tridiagonal system.
+
+`advection` and `velocities` add the implicit vertical-advection contribution of an adaptive-implicit
+scheme; `density` selects density-weighted coefficients for mass-flux (anelastic / compressible)
+models, while `nothing` keeps the volume-conserving Boussinesq behavior.
 """
-implicit_step!(::Field, ::BatchedTridiagonalSolver, ::Nothing, closure_fields, tracer_index, clock, fields, Δt) = nothing
-
-function implicit_step!(field::Field,
-                        implicit_solver::BatchedTridiagonalSolver,
-                        closure::Union{AbstractTurbulenceClosure, AbstractArray{<:AbstractTurbulenceClosure}, Tuple},
-                        closure_fields,
-                        tracer_index,
-                        clock,
-                        fields,
-                        Δt)
-
-    if closure isa Tuple
-        N = length(closure)
-        vi_closure        = Tuple(closure[n]        for n = 1:N if is_vertically_implicit(closure[n]))
-        vi_closure_fields = Tuple(closure_fields[n] for n = 1:N if is_vertically_implicit(closure[n]))
-    else
-        vi_closure = closure
-        vi_closure_fields = closure_fields
-    end
-
-    LX, LY, LZ = location(field)
-    return solve!(field, implicit_solver, field,
-                  vi_closure, vi_closure_fields, tracer_index, LX(), LY(), LZ(), Δt, clock, fields)
-end
-
-#####
-##### Extended implicit_step! that passes advection and vertical velocity through
-#####
-##### The trailing `density` (default `nothing`) selects density-weighted advection coefficients for
-##### mass-flux (anelastic / compressible) models; `nothing` keeps the volume-conserving Boussinesq behavior.
-#####
-
 function implicit_step!(field::Field,
                         implicit_solver::BatchedTridiagonalSolver,
                         closure, closure_fields, tracer_index,
                         clock, fields, Δt,
-                        advection, velocities, density=nothing)
+                        advection=nothing, velocities=nothing, density=nothing)
 
     if closure isa Tuple
         N = length(closure)
@@ -308,13 +274,14 @@ function implicit_step!(field::Field,
         vi_closure_fields = closure_fields
     end
 
+    bcs = field.boundary_conditions
+    isnothing(vi_closure) && !needs_implicit_solver(advection) && !needs_implicit_solver(bcs) && return nothing
+
     LX, LY, LZ = location(field)
-    top_bc      = field.boundary_conditions.top
-    bottom_bc   = field.boundary_conditions.bottom
-    immersed_bc = field.boundary_conditions.immersed
+    w = isnothing(velocities) ? nothing : velocities.w
 
     return solve!(field, implicit_solver, field,
                   vi_closure, vi_closure_fields, tracer_index,
                   LX(), LY(), LZ(), Δt, clock, fields,
-                  advection, velocities.w, density, top_bc, bottom_bc, immersed_bc)
+                  advection, w, density, bcs.top, bcs.bottom, bcs.immersed)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -40,6 +40,7 @@ oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
 
 [sources]
 Oceananigans = {path = ".."}
+ConservativeRegridding = {url = "https://github.com/JuliaGeo/ConservativeRegridding.jl", rev = "ss/widen-oceananigans"}
 
 [compat]
 AMDGPU = "1.3.6, 2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -40,7 +40,6 @@ oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
 
 [sources]
 Oceananigans = {path = ".."}
-ConservativeRegridding = {url = "https://github.com/JuliaGeo/ConservativeRegridding.jl", rev = "ss/widen-oceananigans"}
 
 [compat]
 AMDGPU = "1.3.6, 2"

--- a/test/test_adaptive_implicit_vertical_advection.jl
+++ b/test/test_adaptive_implicit_vertical_advection.jl
@@ -185,23 +185,30 @@ end
     @test momentum_height(q) > height₀
 end
 
-@testset "NonhydrostaticModel time-steps every prognostic field under AIVA" begin
-    grid = RectilinearGrid(CPU(), size=(4, 4, 8), x=(0, 1), y=(0, 1), z=(0, 1000),
+@testset "NonhydrostaticModel steps w at vertical CFL ≫ 1" begin
+    Nz = 32
+    Δt = 100.0
+    grid = RectilinearGrid(CPU(), size=(8, 8, Nz), x=(0, 1000), y=(0, 1000), z=(0, 1000),
                            halo=(4, 4, 4), topology=(Periodic, Periodic, Bounded))
 
-    Δt = 50.0
     td = AdaptiveVerticallyImplicitDiscretization(cfl=0.3)
     td.Δt[] = Δt
-    scheme = WENO(; time_discretization=td)
+    model = NonhydrostaticModel(grid; advection=WENO(; time_discretization=td), tracers=:c)
 
-    model = NonhydrostaticModel(grid; advection=scheme, tracers=:c)
-    set!(model, u=(x, y, z) -> sinpi(2z / 1000), w=(x, y, z) -> 5 * sinpi(z / 500), c=(x, y, z) -> z / 1000)
-    time_step!(model, Δt)
-    time_step!(model, Δt)
+    # α = |w| Δt / Δz ≈ 16, the regime the adaptive split exists for. `w` advects itself, so the
+    # implicit coefficients must be evaluated on a `w` the tridiagonal sweep is not overwriting.
+    set!(model.velocities.w, (x, y, z) -> 5 * sinpi(2x / 1000) * exp(-(z - 500)^2 / (2 * 150^2)))
+    fill_halo_regions!(model.velocities.w)
+    set!(model.tracers.c, (x, y, z) -> z / 1000)
 
-    @test model.clock.iteration == 2
-    @test all(isfinite, parent(model.velocities.w))
-    @test all(isfinite, parent(model.tracers.c))
+    for _ in 1:3
+        time_step!(model, Δt)
+    end
+
+    @test model.clock.iteration == 3
+    @test all(isfinite, interior(model.velocities.w))
+    @test maximum(abs, interior(model.velocities.w)) < 10
+    @test all(isfinite, interior(model.tracers.c))
 end
 
 @testset "Density-weighted implicit advection (mass-flux models)" begin

--- a/test/test_adaptive_implicit_vertical_advection.jl
+++ b/test/test_adaptive_implicit_vertical_advection.jl
@@ -7,7 +7,7 @@ using Oceananigans.Advection: AdaptiveImplicitVerticalAdvection,
                               implicit_advection_upper_diagonal,
                               implicit_advection_lower_diagonal,
                               implicit_advection_diagonal
-using Oceananigans.Grids: Center
+using Oceananigans.Grids: Center, Face
 using Oceananigans.Operators: ℑzᵃᵃᶠ
 using Oceananigans.TimeSteppers: AdaptiveVerticallyImplicitDiscretization, ExplicitTimeDiscretization,
                                  time_discretization, implicit_step!, reset!
@@ -138,6 +138,40 @@ end
     @test all(isfinite, parent(model.velocities.v))
 end
 
+@testset "AIVA contributes no implicit coefficients at z-Faces (w is fully explicit)" begin
+    # The `Ww` momentum flux is kept fully explicit under an adaptive-implicit discretization,
+    # so the matching implicit-advection coefficients must vanish for z-Face fields (`w`):
+    # otherwise the implicit solve for `w` would apply z-Center tracer coefficients on top of
+    # the unscaled explicit flux.
+    grid = RectilinearGrid(CPU(), size=(4, 4, 8), x=(0, 1), y=(0, 1), z=(0, 1000),
+                           halo=(4, 4, 4), topology=(Periodic, Periodic, Bounded))
+
+    Δt = 50.0
+    td = AdaptiveVerticallyImplicitDiscretization(cfl=0.3)
+    td.Δt[] = Δt
+    scheme = WENO(; time_discretization=td)
+
+    W = ZFaceField(grid)
+    set!(W, (x, y, z) -> 5 * sinpi(z / 500))   # exceeds the target CFL over part of the column
+    fill_halo_regions!(W)
+
+    ℓx = ℓy = Center()
+    for k in 2:8, j in 1:4, i in 1:4
+        @test implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, Face()) == 0
+        @test implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, Face()) == 0
+        @test implicit_advection_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, Face()) == 0
+    end
+
+    # End-to-end: a NonhydrostaticModel implicit-steps every prognostic field, including `w`.
+    model = NonhydrostaticModel(grid; advection=scheme, tracers=:c)
+    set!(model, u=(x, y, z) -> sinpi(2z / 1000), c=(x, y, z) -> z / 1000)
+    time_step!(model, Δt)
+    time_step!(model, Δt)
+    @test model.clock.iteration == 2
+    @test all(isfinite, parent(model.velocities.w))
+    @test all(isfinite, parent(model.tracers.c))
+end
+
 @testset "Density-weighted implicit advection (mass-flux models)" begin
     grid = RectilinearGrid(CPU(), size=(2, 2, 16), x=(0, 1), y=(0, 1), z=(0, 1000),
                            topology=(Periodic, Periodic, Bounded))
@@ -151,19 +185,19 @@ end
     set!(W, (x, y, z) -> 5 * sinpi(z / 500))   # exceeds the target CFL over part of the column
     fill_halo_regions!(W)
 
-    ℓx = ℓy = Center()
+    ℓx = ℓy = ℓz = Center()
 
     @testset "ρ ≡ 1 reproduces the volume-conserving coefficients" begin
         ρ = CenterField(grid)
         set!(ρ, 1)
         fill_halo_regions!(ρ)
         for k in 2:15, j in 1:2, i in 1:2
-            @test implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ρ) ≈
-                  implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy)
-            @test implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ρ) ≈
-                  implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy)
-            @test implicit_advection_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ρ) ≈
-                  implicit_advection_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy)
+            @test implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ℓz, ρ) ≈
+                  implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ℓz)
+            @test implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ℓz, ρ) ≈
+                  implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ℓz)
+            @test implicit_advection_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ℓz, ρ) ≈
+                  implicit_advection_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ℓz)
         end
     end
 
@@ -172,12 +206,12 @@ end
         set!(ρ, (x, y, z) -> 1 + z / 1000)   # ρ varies smoothly from 1 to 2
         fill_halo_regions!(ρ)
         for k in 2:15, j in 1:2, i in 1:2
-            uw = implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ρ)
-            u0 = implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy)
+            uw = implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ℓz, ρ)
+            u0 = implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ℓz)
             @test uw ≈ u0 * ℑzᵃᵃᶠ(i, j, k+1, grid, ρ) / ρ[i, j, k+1]
 
-            lw = implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ρ)
-            l0 = implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy)
+            lw = implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ℓz, ρ)
+            l0 = implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, ℓz)
             @test lw ≈ l0 * ℑzᵃᵃᶠ(i, j, k+1, grid, ρ) / ρ[i, j, k]
         end
     end

--- a/test/test_adaptive_implicit_vertical_advection.jl
+++ b/test/test_adaptive_implicit_vertical_advection.jl
@@ -7,8 +7,8 @@ using Oceananigans.Advection: AdaptiveImplicitVerticalAdvection,
                               implicit_advection_upper_diagonal,
                               implicit_advection_lower_diagonal,
                               implicit_advection_diagonal
-using Oceananigans.Grids: Center, Face
-using Oceananigans.Operators: ℑzᵃᵃᶠ
+using Oceananigans.Grids: Center, Face, znode
+using Oceananigans.Operators: volume, ℑzᵃᵃᶠ
 using Oceananigans.TimeSteppers: AdaptiveVerticallyImplicitDiscretization, ExplicitTimeDiscretization,
                                  time_discretization, implicit_step!, reset!
 using Oceananigans.TurbulenceClosures: implicit_diffusion_solver, VerticallyImplicitTimeDiscretization
@@ -138,11 +138,54 @@ end
     @test all(isfinite, parent(model.velocities.v))
 end
 
-@testset "AIVA contributes no implicit coefficients at z-Faces (w is fully explicit)" begin
-    # The `Ww` momentum flux is kept fully explicit under an adaptive-implicit discretization,
-    # so the matching implicit-advection coefficients must vanish for z-Face fields (`w`):
-    # otherwise the implicit solve for `w` would apply z-Center tracer coefficients on top of
-    # the unscaled explicit flux.
+@testset "AIVA implicit vertical advection of w (z-Face fields)" begin
+    Nz = 16
+    grid = RectilinearGrid(CPU(), size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=(0, 1000),
+                           halo=(1, 1, 4), topology=(Periodic, Periodic, Bounded))
+
+    Δt = 50.0
+    td = AdaptiveVerticallyImplicitDiscretization(cfl=0.3)
+    scheme = WENO(; time_discretization=td)
+    solver = implicit_diffusion_solver(VerticallyImplicitTimeDiscretization(), grid)
+    clock = Clock(grid)
+
+    W = ZFaceField(grid)
+    set!(W, (x, y, z) -> 5 * exp(-(z - 500)^2 / (2 * 100^2)))   # vanishes in the boundary-adjacent cells
+    fill_halo_regions!(W)
+
+    q₀(x, y, z) = exp(-(z - 400)^2 / (2 * 150^2))
+    q = ZFaceField(grid)
+
+    Vᶜᶜᶠ(k) = volume(1, 1, k, grid, Center(), Center(), Face())
+    column_momentum(q) = sum(Vᶜᶜᶠ(k) * q[1, 1, k] for k in 1:Nz)
+    momentum_height(q) = sum(Vᶜᶜᶠ(k) * q[1, 1, k] * znode(1, 1, k, grid, Center(), Center(), Face()) for k in 1:Nz) /
+                         column_momentum(q)
+
+    # Explicit limit: below the target CFL the implicit velocity vanishes and the solve is the identity.
+    set!(q, q₀)
+    fill_halo_regions!(q)
+    td.Δt[] = 1e-3
+    before = Array(interior(q))
+    implicit_step!(q, solver, nothing, nothing, nothing, clock, (;), 1e-3, scheme, (; w=W))
+    @test Array(interior(q)) == before
+
+    # Strong splitting: the upwind system conserves the column momentum ∑ Vᶜᶜᶠ w (interior fluxes
+    # telescope; wⁱ vanishes at the boundary-adjacent centers), preserves positivity and transports
+    # upward, since the advecting velocity is an updraft.
+    set!(q, q₀)
+    fill_halo_regions!(q)
+    td.Δt[] = Δt
+    momentum₀ = column_momentum(q)
+    height₀ = momentum_height(q)
+    implicit_step!(q, solver, nothing, nothing, nothing, clock, (;), Δt, scheme, (; w=W))
+
+    @test all(isfinite, interior(q))
+    @test column_momentum(q) ≈ momentum₀
+    @test minimum(q[1, 1, k] for k in 1:Nz) ≥ -sqrt(eps(eltype(grid)))
+    @test momentum_height(q) > height₀
+end
+
+@testset "NonhydrostaticModel time-steps every prognostic field under AIVA" begin
     grid = RectilinearGrid(CPU(), size=(4, 4, 8), x=(0, 1), y=(0, 1), z=(0, 1000),
                            halo=(4, 4, 4), topology=(Periodic, Periodic, Bounded))
 
@@ -151,22 +194,11 @@ end
     td.Δt[] = Δt
     scheme = WENO(; time_discretization=td)
 
-    W = ZFaceField(grid)
-    set!(W, (x, y, z) -> 5 * sinpi(z / 500))   # exceeds the target CFL over part of the column
-    fill_halo_regions!(W)
-
-    ℓx = ℓy = Center()
-    for k in 2:8, j in 1:4, i in 1:4
-        @test implicit_advection_upper_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, Face()) == 0
-        @test implicit_advection_lower_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, Face()) == 0
-        @test implicit_advection_diagonal(i, j, k, grid, scheme, W, Δt, ℓx, ℓy, Face()) == 0
-    end
-
-    # End-to-end: a NonhydrostaticModel implicit-steps every prognostic field, including `w`.
     model = NonhydrostaticModel(grid; advection=scheme, tracers=:c)
-    set!(model, u=(x, y, z) -> sinpi(2z / 1000), c=(x, y, z) -> z / 1000)
+    set!(model, u=(x, y, z) -> sinpi(2z / 1000), w=(x, y, z) -> 5 * sinpi(z / 500), c=(x, y, z) -> z / 1000)
     time_step!(model, Δt)
     time_step!(model, Δt)
+
     @test model.clock.iteration == 2
     @test all(isfinite, parent(model.velocities.w))
     @test all(isfinite, parent(model.tracers.c))


### PR DESCRIPTION
This PR completes the adaptive-implicit vertical advection (AVID) implementation by treating `w` itself implicitly.
Until now `advective_momentum_flux_Ww` was left fully explicit, so the vertical momentum equation was still limited by the vertical CFL. The tridiagonal coefficients are now dispatched on the vertical location `ℓz` of the field being stepped.

!!!NOTE:
Since `w` is both the advecting velocity and the advected quantity, `NonhydrostaticModel` now carries an `advecting_vertical_velocity` field holding a snapshot of `wⁿ` taken before any prognostic field is stepped, so that the implicit solve is not contaminated by the partially updated `w`. The field is `nothing` when the advection scheme does not need an implicit solver, and the version is bumped to `0.111.0` because of the added model field.

The dispatch of `get_coefficient` is also cleaned up. There is now a single method per diagonal with the full argument list, and the advection contribution falls back to zero for any scheme without an adaptive-implicit discretization. Alos the two `implicit_step!` methods are merged into one with defaulted `advection`, `velocities` and `density`, returning early when there is neither a vertically-implicit closure, nor an implicit advection scheme, nor a boundary condition requiring the solve.