### PR TITLE
Fix the ν index in the z-face vertically-implicit diffusion lower diagonal

### DIFF
--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -102,9 +102,7 @@ end
     return du * !peripheral_node(i, j, k, grid, ℓx, ℓy, c)
 end
 
-# `dl(m)` is the coefficient of `ϕ[m]` in row `m + 1` (LinearAlgebra.Tridiagonal convention). For a
-# field at z-faces the stress between faces `m` and `m + 1` lives at center `m`, so `ν` and `Δzᶜ` are
-# evaluated there while `Δzᶠ` belongs to the row's own face, `m + 1`.
+# `dl(m)` multiplies `ϕ[m]` in row `m + 1`, and the stress between faces `m` and `m + 1` sits at center `m`
 @inline function ivd_lower_diagonal(i, j, m, grid, closure, K, id, ℓx, ℓy, ::Face, Δt, clock, fields)
     closure_ij = getclosure(i, j, closure)
     νᵐ       = ivd_diffusivity(i, j, m,   grid, ℓx, ℓy, c, closure_ij, K, id, clock, fields)

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -102,14 +102,16 @@ end
     return du * !peripheral_node(i, j, k, grid, ℓx, ℓy, c)
 end
 
-@inline function ivd_lower_diagonal(i, j, k, grid, closure, K, id, ℓx, ℓy, ::Face, Δt, clock, fields)
-    k′ = k + 2 # Shift to adjust for Tridiagonal indexing convention
+# `dl(m)` is the coefficient of `ϕ[m]` in row `m + 1` (LinearAlgebra.Tridiagonal convention). For a
+# field at z-faces the stress between faces `m` and `m + 1` lives at center `m`, so `ν` and `Δzᶜ` are
+# evaluated there while `Δzᶠ` belongs to the row's own face, `m + 1`.
+@inline function ivd_lower_diagonal(i, j, m, grid, closure, K, id, ℓx, ℓy, ::Face, Δt, clock, fields)
     closure_ij = getclosure(i, j, closure)
-    νᵏ⁻¹     = ivd_diffusivity(i, j, k′-1, grid, ℓx, ℓy, c, closure_ij, K, id, clock, fields)
-    Δz⁻¹ᶜₖ   = Δz⁻¹(i, j, k′,   grid, ℓx, ℓy, c)
-    Δz⁻¹ᶠₖ₋₁ = Δz⁻¹(i, j, k′-1, grid, ℓx, ℓy, f)
-    dl       = - Δt * νᵏ⁻¹ * (Δz⁻¹ᶜₖ * Δz⁻¹ᶠₖ₋₁)
-    return dl * !peripheral_node(i, j, k, grid, ℓx, ℓy, c)
+    νᵐ       = ivd_diffusivity(i, j, m,   grid, ℓx, ℓy, c, closure_ij, K, id, clock, fields)
+    Δz⁻¹ᶜₘ   = Δz⁻¹(i, j, m,   grid, ℓx, ℓy, c)
+    Δz⁻¹ᶠₘ₊₁ = Δz⁻¹(i, j, m+1, grid, ℓx, ℓy, f)
+    dl       = - Δt * νᵐ * (Δz⁻¹ᶜₘ * Δz⁻¹ᶠₘ₊₁)
+    return dl * !peripheral_node(i, j, m, grid, ℓx, ℓy, c)
 end
 
 ### Diagonal terms

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -642,9 +642,14 @@ end
                                 closure, nothing, nothing, LX(), Center(), LZ(),
                                 Δt, clock, NamedTuple())
 
-            dl = [coefficient(VerticallyImplicitDiffusionLowerDiagonal(), k) for k in 1:Nz]
-            d  = [coefficient(VerticallyImplicitDiffusionDiagonal(),      k) for k in 1:Nz]
-            du = [coefficient(VerticallyImplicitDiffusionUpperDiagonal(), k) for k in 1:Nz]
+            # Assembling the rows on the host reads grid metrics one level at a time, which on a
+            # stretched GPU grid are device arrays. `runtests.jl` happens to wrap the whole suite in
+            # `CUDA.allowscalar`, but say so locally rather than lean on that.
+            dl, d, du = @allowscalar begin
+                ([coefficient(VerticallyImplicitDiffusionLowerDiagonal(), k) for k in 1:Nz],
+                 [coefficient(VerticallyImplicitDiffusionDiagonal(),      k) for k in 1:Nz],
+                 [coefficient(VerticallyImplicitDiffusionUpperDiagonal(), k) for k in 1:Nz])
+            end
 
             # A = I - Δt L with Δt = 1, so L = I - A.
             L = zeros(Nz, Nz)

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -620,14 +620,6 @@ end
     @testset "Vertically-implicit diffusion operator" begin
         @info "  Testing that the vertically-implicit stencil reproduces ∂z(ν ∂z ϕ)..."
 
-        # The tridiagonal coefficients must represent ∂z(ν ∂z ϕ). A CONSTANT ν on a UNIFORM grid is
-        # the one combination a mis-indexed stencil still gets right, and it is what every existing
-        # test of this path uses — so ν varies in z here and the grids include a stretched one.
-        #
-        # The coefficients are exactly linear in Δt, so taking Δt = 1 recovers the operator as
-        # L = I - A with no truncation error and nothing to calibrate. Comparing the assembled rows
-        # against the analytic stencil also checks each coefficient individually, rather than only
-        # the operator's action on one field.
         function implicit_operator_rows(arch, LX, LZ, Nz, z, Lz)
             grid = RectilinearGrid(arch, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=z,
                                    topology=(Periodic, Periodic, Bounded))
@@ -651,15 +643,12 @@ end
                  [coefficient(VerticallyImplicitDiffusionUpperDiagonal(), k) for k in 1:Nz])
             end
 
-            # A = I - Δt L with Δt = 1, so L = I - A.
-            L = zeros(Nz, Nz)
+            L = zeros(Nz, Nz) # the coefficients are linear in Δt, so Δt = 1 gives L = I - A exactly
             for k in 1:Nz
                 L[k, k] = 1 - d[k]
                 k < Nz && (L[k, k+1] = -du[k]; L[k+1, k] = -dl[k])
             end
 
-            # Analytic stencil. For a z-face field the stress lives at centers and the row's own
-            # spacing is Δzᶠ; for a z-center field it is the other way round.
             zᶜ = Array(znodes(grid, Center()))
             zᶠ = Array(znodes(grid, Face()))
             Δzᶜ = diff(zᶠ)

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -3,6 +3,11 @@ include("dependencies_for_runtests.jl")
 using Random
 
 using Oceananigans.Grids: znode
+using Oceananigans.Grids: ZDirection
+using Oceananigans.Solvers: get_coefficient
+using Oceananigans.TurbulenceClosures: VerticallyImplicitDiffusionLowerDiagonal,
+                                       VerticallyImplicitDiffusionDiagonal,
+                                       VerticallyImplicitDiffusionUpperDiagonal
 using Oceananigans.TurbulenceClosures: CATKEVerticalDiffusivity, RiBasedVerticalDiffusivity, DiscreteDiffusionFunction,
                                        viscosity_location, diffusivity_location,
                                        required_halo_size_x, required_halo_size_y, required_halo_size_z,
@@ -609,6 +614,82 @@ end
 
         @test Oceananigans.Diagnostics.cell_diffusion_timescale(model) isa Number
         @test Oceananigans.Diagnostics.DiffusiveCFL(0.1)(model) isa Number
+    end
+
+
+    @testset "Vertically-implicit diffusion operator" begin
+        @info "  Testing that the vertically-implicit stencil reproduces ∂z(ν ∂z ϕ)..."
+
+        # The tridiagonal coefficients must represent ∂z(ν ∂z ϕ). A CONSTANT ν on a UNIFORM grid is
+        # the one combination a mis-indexed stencil still gets right, and it is what every existing
+        # test of this path uses — so ν varies in z here and the grids include a stretched one.
+        #
+        # The coefficients are exactly linear in Δt, so taking Δt = 1 recovers the operator as
+        # L = I - A with no truncation error and nothing to calibrate. Comparing the assembled rows
+        # against the analytic stencil also checks each coefficient individually, rather than only
+        # the operator's action on one field.
+        function implicit_operator_rows(arch, LX, LZ, Nz, z, Lz)
+            grid = RectilinearGrid(arch, size=(1, 1, Nz), x=(0, 1), y=(0, 1), z=z,
+                                   topology=(Periodic, Periodic, Bounded))
+
+            ν(x, y, z, t) = 1 + 0.8 * sinpi(2z / Lz)
+            closure = VerticalScalarDiffusivity(VerticallyImplicitTimeDiscretization(); ν)
+            clock = Clock(time=0.0)
+            Δt = 1
+
+            coefficient(marker, k) =
+                get_coefficient(1, 1, k, grid, marker, nothing, ZDirection(),
+                                closure, nothing, nothing, LX(), Center(), LZ(),
+                                Δt, clock, NamedTuple())
+
+            dl = [coefficient(VerticallyImplicitDiffusionLowerDiagonal(), k) for k in 1:Nz]
+            d  = [coefficient(VerticallyImplicitDiffusionDiagonal(),      k) for k in 1:Nz]
+            du = [coefficient(VerticallyImplicitDiffusionUpperDiagonal(), k) for k in 1:Nz]
+
+            # A = I - Δt L with Δt = 1, so L = I - A.
+            L = zeros(Nz, Nz)
+            for k in 1:Nz
+                L[k, k] = 1 - d[k]
+                k < Nz && (L[k, k+1] = -du[k]; L[k+1, k] = -dl[k])
+            end
+
+            # Analytic stencil. For a z-face field the stress lives at centers and the row's own
+            # spacing is Δzᶠ; for a z-center field it is the other way round.
+            zᶜ = Array(znodes(grid, Center()))
+            zᶠ = Array(znodes(grid, Face()))
+            Δzᶜ = diff(zᶠ)
+            Δzᶠ = diff(zᶜ)
+
+            L̂ = zeros(Nz, Nz)
+            for k in 2:Nz-1
+                if LZ === Face      # ϕ at faces, ν and Δzᶜ at centers, row spacing Δzᶠ
+                    a = ν(0, 0, zᶜ[k-1], 0) / (Δzᶠ[k-1] * Δzᶜ[k-1])
+                    b = ν(0, 0, zᶜ[k],   0) / (Δzᶠ[k-1] * Δzᶜ[k])
+                else                # ϕ at centers, ν and Δzᶠ at faces, row spacing Δzᶜ
+                    a = ν(0, 0, zᶠ[k],   0) / (Δzᶜ[k] * Δzᶠ[k-1])
+                    b = ν(0, 0, zᶠ[k+1], 0) / (Δzᶜ[k] * Δzᶠ[k])
+                end
+                L̂[k, k-1] = a
+                L̂[k, k+1] = b
+                L̂[k, k]   = -(a + b)
+            end
+
+            rows = 2:Nz-1
+            return maximum(abs, L[rows, :] .- L̂[rows, :]) / maximum(abs, L̂[rows, :])
+        end
+
+        Nz, Lz = 32, 1000.0
+        uniform = (0, Lz)
+        stretched = [Lz * (k / Nz)^1.3 for k in 0:Nz]
+
+        for arch in archs,
+            (LX, LZ) in ((Face, Center), (Center, Face)),
+            z in (uniform, stretched)
+
+            grid_kind = z isa Tuple ? "uniform" : "stretched"
+            @info "    Testing implicit diffusion operator [$arch, ($LX, Center, $LZ), $grid_kind]..."
+            @test implicit_operator_rows(arch, LX, LZ, Nz, z, Lz) < 1e-12
+        end
     end
 
     @testset "Closure tuples" begin


### PR DESCRIPTION
Closes #5901.

## The fix

Drop the `k′ = k + 2` shift in the z-face `ivd_lower_diagonal` and evaluate `ν` and `Δzᶜ` at center `m`, `Δzᶠ` at the row's own face `m + 1`. That corrects both index errors at once, since the shift was the source of each. `ivd_upper_diagonal` and `ivd_diagonal` are untouched.

## The test

A new testset in `test_turbulence_closures.jl` assembles the tridiagonal directly from `get_coefficient` and compares it against the analytic `∂z(ν ∂z ϕ)` stencil, coefficient by coefficient. The coefficients are exactly linear in `Δt`, so taking `Δt = 1` recovers the operator as `L = I − A`.

It covers both stencils — `u` at `(Face, Center, Center)` and `w` at `(Center, Center, Face)` — on uniform and stretched grids, with **`ν` varying in `z`**. That combination is what the existing tests lack: they use `ν = 1` on uniform grids, which is the one case a mis-indexed stencil still gets right. Both locations take their coefficient from the viscosity, so neither needs a tracer index.

Max relative error against the analytic stencil, interior rows, `Nz = 32`, `Lz = 1000`:

| case | before | after |
|---|---|---|
| `u` (z-center), uniform | 5.41e-14 | 5.41e-14 |
| `u` (z-center), stretched | 1.88e-14 | 1.88e-14 |
| **`w` (z-face), uniform** | **4.37e-02** | **3.94e-14** |
| **`w` (z-face), stretched** | **2.17e-01** | **1.48e-14** |

The z-center rows are identical before and after, which is the control that the change is confined to the z-face stencil.

## Regressions

`test_turbulence_closures.jl`: 261/261, including the 4 new assertions.

`test_dynamics.jl`: 503 pass, 1 fail, 1 broken. The failure is in `"Tilted gravity"`, which constructs its model with `closure = nothing` and so never reaches the vertically-implicit solver. Confirmed pre-existing by running that testset in isolation against unmodified `main` — identical 47/1 with and without this change.

Also verified on an NVIDIA T4 with `TEST_ARCHITECTURE=GPU`: 4/4. The assembly loop reads grid
metrics per level, which are device arrays on a stretched GPU grid, so it says `@allowscalar`
locally rather than lean on the `CUDA.allowscalar` wrapper `runtests.jl` puts around the suite.
