### PR TITLE
Find a series held by any boundary condition, not just four listed ones

### DIFF
--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -58,24 +58,12 @@ extract_field_time_series(t::Union{Tuple, NamedTuple}) =
     has_field_time_series(typeof(t)) ?
         concatenate_extracted(map(extract_field_time_series, values(t))) : ()
 
-const CPUFTSBC = BoundaryCondition{<:Any, <:FieldTimeSeries}
-const GPUFTSBC = BoundaryCondition{<:Any, <:GPUAdaptedFieldTimeSeries}
-const DFBC     = BoundaryCondition{<:Any, <:DiscreteBoundaryFunction}
-const CFBC     = BoundaryCondition{<:Any, <:ContinuousBoundaryFunction}
-const FTSBC = Union{CPUFTSBC, GPUFTSBC, DFBC, CFBC}
-
-const WFTSBCS = FieldBoundaryConditions{<:FTSBC}
-const EFTSBCS = FieldBoundaryConditions{<:Any, <:FTSBC}
-const SFTSBCS = FieldBoundaryConditions{<:Any, <:Any, <:FTSBC}
-const NFTSBCS = FieldBoundaryConditions{<:Any, <:Any, <:Any, <:FTSBC}
-const BFTSBCS = FieldBoundaryConditions{<:Any, <:Any, <:Any, <:Any, <:FTSBC}
-const TFTSBCS = FieldBoundaryConditions{<:Any, <:Any, <:Any, <:Any, <:Any, <:FTSBC}
-const IFTSBCS = FieldBoundaryConditions{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:FTSBC}
-
-const FieldBCsFTS = Union{WFTSBCS, EFTSBCS, SFTSBCS, NFTSBCS, BFTSBCS, TFTSBCS, IFTSBCS}
-const FieldFTS = Field{LX, LY, LZ, O, G, I, D, T, <:FieldBCsFTS} where {LX, LY, LZ, O, G, I, D, T}
-
-extract_field_time_series(f::FieldFTS) = extract_field_time_series(f.boundary_conditions)
+# A field's boundary conditions may hold a series inside a condition of any type — a `FieldTimeSeries`
+# used directly, a boundary function's `parameters`, or a condition type defined downstream. Ask
+# `has_field_time_series` rather than enumerating condition types: it is `@generated`, so a field whose
+# boundary conditions cannot contain a series still resolves to `()` at compile time. The guard lives in
+# the `FieldBoundaryConditions` method below, so none is needed here.
+extract_field_time_series(f::Field) = extract_field_time_series(f.boundary_conditions)
 
 extract_field_time_series(bcs::FieldBoundaryConditions) =
     has_field_time_series(typeof(bcs)) ?

--- a/src/OutputReaders/extract_field_time_series.jl
+++ b/src/OutputReaders/extract_field_time_series.jl
@@ -58,11 +58,7 @@ extract_field_time_series(t::Union{Tuple, NamedTuple}) =
     has_field_time_series(typeof(t)) ?
         concatenate_extracted(map(extract_field_time_series, values(t))) : ()
 
-# A field's boundary conditions may hold a series inside a condition of any type — a `FieldTimeSeries`
-# used directly, a boundary function's `parameters`, or a condition type defined downstream. Ask
-# `has_field_time_series` rather than enumerating condition types: it is `@generated`, so a field whose
-# boundary conditions cannot contain a series still resolves to `()` at compile time. The guard lives in
-# the `FieldBoundaryConditions` method below, so none is needed here.
+# A field's boundary conditions may hold a series inside a condition of any type
 extract_field_time_series(f::Field) = extract_field_time_series(f.boundary_conditions)
 
 extract_field_time_series(bcs::FieldBoundaryConditions) =

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -2,10 +2,19 @@ include("dependencies_for_runtests.jl")
 
 using Oceananigans.Units: Time
 using Oceananigans.Fields: indices, interpolate!
-using Oceananigans.OutputReaders: Cyclical, Clamp, Linear, SplitFilePath, cpu_interpolating_time_indices
+using Oceananigans.OutputReaders: Cyclical, Clamp, Linear, SplitFilePath, cpu_interpolating_time_indices,
+                                  extract_field_time_series, has_field_time_series
 
 using Random
 using NCDatasets
+
+# A boundary condition that stores a `FieldTimeSeries` rather than being one. No `getbc` method is
+# needed: the fallback `getbc(condition, args...) = condition(args...)` accepts any callable.
+struct SeriesHoldingCondition{S}
+    series :: S
+end
+
+@inline (c::SeriesHoldingCondition)(args...) = @inbounds c.series[1, 1, 1, 1]
 
 function generate_nonzero_simulation_data(Lx, Δt, FT; architecture=CPU())
     grid = RectilinearGrid(architecture, size=10, x=(0, Lx), topology=(Periodic, Flat, Flat))
@@ -906,4 +915,46 @@ end
         test_interpolation_with_in_memory_backends(filepath_sine)
     end
     rm(filepath_sine)
+
+    # A series reachable only through a boundary condition must still be found, so that
+    # `update_field_time_series!` advances its in-memory window. A condition that stores a series
+    # without being one used to be missed, because the search consulted a list of condition types
+    # instead of `has_field_time_series`. The window then stayed at the frames it was built with and
+    # the time interpolation eventually indexed past them.
+    for arch in archs
+    @testset "Series held by a boundary condition are extracted [$(typeof(arch))]" begin
+        @info "  Testing extraction of series held by boundary conditions [$(typeof(arch))]..."
+
+        grid  = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1), topology=(Bounded, Bounded, Bounded))
+        times = [0.0, 1.0, 2.0, 3.0]
+        fts   = FieldTimeSeries{Center, Center, Center}(grid, times)
+
+        plain(v) = ValueBoundaryCondition(v)
+        west_driven(bc) = CenterField(grid; boundary_conditions =
+            FieldBoundaryConditions(west = bc, east = plain(0.0), south = plain(0.0),
+                                    north = plain(0.0), bottom = plain(0.0), top = plain(0.0)))
+
+        @inline read_series(y, z, t, p) = @inbounds p.series[1, 1, 1, 1]
+
+        conditions = (plain(fts),                                                        # the series itself
+                      ValueBoundaryCondition(read_series; parameters = (; series = fts)), # a boundary function
+                      plain(SeriesHoldingCondition(fts)))                                 # a condition storing it
+
+        for bc in conditions
+            c = west_driven(bc)
+            @test has_field_time_series(typeof(c.boundary_conditions))
+            @test length(extract_field_time_series(c)) == 1
+            @test first(extract_field_time_series(c)) === fts
+            # Reaching the series through the field must agree with reaching it directly.
+            @test length(extract_field_time_series(c)) ==
+                  length(extract_field_time_series(c.boundary_conditions))
+        end
+
+        # A field that cannot hold a series still resolves to `()` at compile time, so a model owning
+        # no series pays nothing for the check.
+        @test extract_field_time_series(CenterField(grid)) == ()
+        @test Base.return_types(extract_field_time_series, (typeof(CenterField(grid)),))[1] === Tuple{}
+    end
+    end
+
 end

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -8,8 +8,7 @@ using Oceananigans.OutputReaders: Cyclical, Clamp, Linear, SplitFilePath, cpu_in
 using Random
 using NCDatasets
 
-# A boundary condition that stores a `FieldTimeSeries` rather than being one. No `getbc` method is
-# needed: the fallback `getbc(condition, args...) = condition(args...)` accepts any callable.
+# A boundary condition that stores a `FieldTimeSeries` rather than being one.
 struct SeriesHoldingCondition{S}
     series :: S
 end
@@ -917,10 +916,7 @@ end
     rm(filepath_sine)
 
     # A series reachable only through a boundary condition must still be found, so that
-    # `update_field_time_series!` advances its in-memory window. A condition that stores a series
-    # without being one used to be missed, because the search consulted a list of condition types
-    # instead of `has_field_time_series`. The window then stayed at the frames it was built with and
-    # the time interpolation eventually indexed past them.
+    # `update_field_time_series!` advances its in-memory window.
     for arch in archs
     @testset "Series held by a boundary condition are extracted [$(typeof(arch))]" begin
         @info "  Testing extraction of series held by boundary conditions [$(typeof(arch))]..."
@@ -950,8 +946,6 @@ end
                   length(extract_field_time_series(c.boundary_conditions))
         end
 
-        # A field that cannot hold a series still resolves to `()` at compile time, so a model owning
-        # no series pays nothing for the check.
         @test extract_field_time_series(CenterField(grid)) == ()
         @test Base.return_types(extract_field_time_series, (typeof(CenterField(grid)),))[1] === Tuple{}
     end


### PR DESCRIPTION
Closes #5902.

Whether a field's boundary conditions are opened was decided by `FTSBC`, a list of four condition
types. A condition that holds a `FieldTimeSeries` without being one is not on it, so the series is
never found and its in-memory window never advances — silently on CPU, as `CUDA error 700` on GPU.

Ask `has_field_time_series` instead, the check #5740 introduced and already uses for the generic,
`Tuple`, `NamedTuple` and `FieldBoundaryConditions` paths. A model that owns no series still pays
nothing: the `FieldBoundaryConditions` method begins with that check, so such a field resolves to
`Tuple{}` at compile time and nothing runs.

`FTSBC`, `FieldBCsFTS`, `FieldFTS` and the seven `*FTSBCS` aliases have no remaining users and have
been removed.

The test runs over `archs` and covers all three ways to attach a series to a boundary condition;
reverting the fix fails it. Locally `test_output_readers.jl` (11605) and `test_boundary_conditions.jl`
(312) pass on CPU, and on a Tesla T4 with `TEST_ARCHITECTURE=GPU` (10739 and 312).
