### PR TITLE
Allow host arrays as `GridFittedBottom` height on GPU grids

### DIFF
--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -118,8 +118,15 @@ booleans that indicates whether a cell is immersed or not.
 function materialize_immersed_boundary(grid, ib::GridFittedBottom)
     bottom_field = Field{Center, Center, Nothing}(grid)
     set_bottom_height!(bottom_field, ib.bottom_height)
-    @apply_regionally compute_numerical_bottom_height!(bottom_field, grid, ib)
+
+    # The kernel only needs `ib.immersed_condition`, but `ib.bottom_height` may be a host
+    # array even when `grid` lives on a GPU, in which case `ib` cannot be passed to a kernel.
+    # Hand the kernel a boundary built from the materialized `bottom_field` instead.
+    compute_ib = GridFittedBottom(bottom_field, ib.immersed_condition)
+
+    @apply_regionally compute_numerical_bottom_height!(bottom_field, grid, compute_ib)
     fill_halo_regions!(bottom_field)
+
     return GridFittedBottom(bottom_field.data, ib.immersed_condition)
 end
 

--- a/src/ImmersedBoundaries/grid_fitted_bottom.jl
+++ b/src/ImmersedBoundaries/grid_fitted_bottom.jl
@@ -119,9 +119,6 @@ function materialize_immersed_boundary(grid, ib::GridFittedBottom)
     bottom_field = Field{Center, Center, Nothing}(grid)
     set_bottom_height!(bottom_field, ib.bottom_height)
 
-    # The kernel only needs `ib.immersed_condition`, but `ib.bottom_height` may be a host
-    # array even when `grid` lives on a GPU, in which case `ib` cannot be passed to a kernel.
-    # Hand the kernel a boundary built from the materialized `bottom_field` instead.
     compute_ib = GridFittedBottom(bottom_field, ib.immersed_condition)
 
     @apply_regionally compute_numerical_bottom_height!(bottom_field, grid, compute_ib)

--- a/test/test_immersed_boundary_grid.jl
+++ b/test/test_immersed_boundary_grid.jl
@@ -37,15 +37,22 @@ function test_immersed_boundary_grid_with_array_bottom(FT, arch, boundary_type)
     underlying_grid = RectilinearGrid(arch, FT, size=(3, 3, 4), extent=(1, 1, 1))
 
     Nx, Ny = size(underlying_grid)[1:2]
-    bottom_array = zeros(FT, Nx, Ny) .+ 0.3
-    bottom_array = on_architecture(arch, bottom_array)
+    host_bottom_array = zeros(FT, Nx, Ny) .- 0.3
+    device_bottom_array = on_architecture(arch, host_bottom_array)
 
-    ib = boundary_type(bottom_array)
-    ibg = ImmersedBoundaryGrid(underlying_grid, ib)
+    # A host array must work as bottom height even when the grid lives on a GPU
+    bottom_heights = map((host_bottom_array, device_bottom_array)) do bottom_array
+        ib = boundary_type(bottom_array)
+        ibg = ImmersedBoundaryGrid(underlying_grid, ib)
 
-    @test architecture(ibg) === arch
-    @test eltype(ibg) === FT
-    @test size(ibg) == size(underlying_grid)
+        @test architecture(ibg) === arch
+        @test eltype(ibg) === FT
+        @test size(ibg) == size(underlying_grid)
+
+        return Array(interior(bottom_height_field(ibg)))
+    end
+
+    @test bottom_heights[1] == bottom_heights[2]
 
     return nothing
 end


### PR DESCRIPTION
Spotted in https://github.com/NumericalEarth/Breeze.jl/pull/939#discussion_r3886420870.  Unclear why this wasn't done before here in Oceananigans, feels like an oversight, but let me know if I'm missing something more fundamental.