### PR TITLE
Fix "Vertically-implicit diffusion operator" test after get_coefficient API change

### DIFF
--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -632,7 +632,8 @@ end
             coefficient(marker, k) =
                 get_coefficient(1, 1, k, grid, marker, nothing, ZDirection(),
                                 closure, nothing, nothing, LX(), Center(), LZ(),
-                                Δt, clock, NamedTuple())
+                                Δt, clock, NamedTuple(),
+                                nothing, nothing, nothing, nothing, nothing, nothing)
 
             # Assembling the rows on the host reads grid metrics one level at a time, which on a
             # stretched GPU grid are device arrays. `runtests.jl` happens to wrap the whole suite in


### PR DESCRIPTION
This is just an unfortunate conflict between #5903 and #5904. Ref: https://github.com/CliMA/Oceananigans.jl/pull/5903#issuecomment-5480134383.