### PR TITLE
[docs] Temporarily cap Documenter v1.17

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -27,7 +27,7 @@ Oceananigans = {path = ".."}
 [compat]
 CairoMakie = "0.15"
 CUDA = "=5.8.5, 5.9.1, 6.0 - 6.1"
-Documenter = "1"
+Documenter = "1 - 1.17"
 DocumenterCitations = "1"
 DocumenterVitepress = "0.3.1"
 InteractiveUtils = "<0.0.1, 1"


### PR DESCRIPTION
Same as https://github.com/NumericalEarth/Breeze.jl/pull/945, we're running in https://github.com/JuliaDocs/Documenter.jl/issues/2992 also here.