### PR TITLE
Update DocumenterCitations version constraint

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -28,7 +28,7 @@ Oceananigans = {path = ".."}
 CairoMakie = "0.15"
 CUDA = "=5.8.5, 5.9.1, 6.0 - 6.1"
 Documenter = "1 - 1.17"
-DocumenterCitations = "1"
+DocumenterCitations = "~1.4"
 DocumenterVitepress = "0.3.1"
 InteractiveUtils = "<0.0.1, 1"
 Literate = "2.9"


### PR DESCRIPTION
The cap to DocumenterCitations v1.4 is required until https://github.com/LuxDL/DocumenterVitepress.jl/pull/392 is merged; then we can use DocumenterCitation v1.5+

x-ref: https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1239#issuecomment-5482717719