### PR TITLE
Type `ℓz` on the implicit-advection zero fallbacks

### DIFF
--- a/src/Advection/implicit_vertical_advection.jl
+++ b/src/Advection/implicit_vertical_advection.jl
@@ -85,11 +85,14 @@ end
 @inline implicit_vertical_velocity(::Center, ::Face,   args...) = implicit_vertical_velocityᶜᶠᶠ(args...)
 
 # An advection scheme without an adaptive-implicit vertical discretization contributes nothing.
+# `ℓz` is typed so that these cannot absorb a call that omits it: an untyped slot would make a stale
+# argument order return zero rather than raise a MethodError.
 const AdvectionOrNothing = Union{Nothing, AbstractAdvectionScheme}
+const CenterOrFace = Union{Center, Face}
 
-@inline implicit_advection_upper_diagonal(i, j, k, grid, ::AdvectionOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
-@inline implicit_advection_lower_diagonal(i, j, k, grid, ::AdvectionOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
-@inline implicit_advection_diagonal(i, j, k, grid,       ::AdvectionOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
+@inline implicit_advection_upper_diagonal(i, j, k, grid, ::AdvectionOrNothing, w, Δt, ℓx, ℓy, ℓz::CenterOrFace, density=nothing) = zero(grid)
+@inline implicit_advection_lower_diagonal(i, j, k, grid, ::AdvectionOrNothing, w, Δt, ℓx, ℓy, ℓz::CenterOrFace, density=nothing) = zero(grid)
+@inline implicit_advection_diagonal(i, j, k, grid,       ::AdvectionOrNothing, w, Δt, ℓx, ℓy, ℓz::CenterOrFace, density=nothing) = zero(grid)
 
 # Upper diagonal: coefficient of q_{k+1} in the tridiagonal system
 @inline function implicit_advection_upper_diagonal(i, j, k, grid, advection::AIVA, w, Δt, ℓx, ℓy, ℓz::Center, density=nothing)

--- a/test/test_adaptive_implicit_vertical_advection.jl
+++ b/test/test_adaptive_implicit_vertical_advection.jl
@@ -276,3 +276,33 @@ end
         @test sum(interior(q)) ≈ mass₀ rtol=1e-10
     end
 end
+
+@testset "Implicit advection coefficients reject a missing location" begin
+    grid = RectilinearGrid(CPU(), size=(2, 2, 16), x=(0, 1), y=(0, 1), z=(0, 1000),
+                           topology=(Periodic, Periodic, Bounded))
+
+    td = AdaptiveVerticallyImplicitDiscretization(cfl=0.3)
+    td.Δt[] = 50.0
+    scheme = WENO(; time_discretization=td)
+
+    W = ZFaceField(grid)
+    set!(W, (x, y, z) -> 5 * sinpi(z / 500))
+    fill_halo_regions!(W)
+
+    ρ = CenterField(grid)
+    set!(ρ, (x, y, z) -> 1 + z / 1000)
+    fill_halo_regions!(ρ)
+
+    c = Center()
+
+    # The zero fallback stands in for a scheme with no adaptive-implicit vertical discretization,
+    # and must keep doing so for every well-formed argument list.
+    @test implicit_advection_diagonal(1, 1, 4, grid, scheme,  W, 50.0, c, c, c, ρ) != 0
+    @test implicit_advection_diagonal(1, 1, 4, grid, WENO(),  W, 50.0, c, c, c, ρ) == 0
+    @test implicit_advection_diagonal(1, 1, 4, grid, nothing, W, 50.0, c, c, c, ρ) == 0
+    @test implicit_advection_diagonal(1, 1, 4, grid, WENO(),  W, 50.0, c, c, c)    == 0
+
+    # It must not stand in for a call that omits `ℓz`: that is a caller error, not a scheme
+    # without implicit advection, and returning zero for it hides the mistake.
+    @test_throws MethodError implicit_advection_diagonal(1, 1, 4, grid, scheme, W, 50.0, c, c, ρ)
+end


### PR DESCRIPTION
#5903 moved `ℓz` into the `implicit_advection_*` signatures and, in the same change, added a
zero-returning fallback with `ℓz` left untyped:

```julia
@inline implicit_advection_upper_diagonal(i, j, k, grid, ::AdvectionOrNothing, w, Δt, ℓx, ℓy, ℓz, density=nothing) = zero(grid)
```

`AdvectionOrNothing` includes `AdaptiveImplicitVerticalAdvection`, so a caller still on the 0.110
argument order passes `density` where `ℓz` belongs, fails the `::Center` / `::Face` bound on both
specializations, and matches the fallback — getting `zero(grid)` rather than the `MethodError` it
would have got before #5903.

Breeze hit this taking the 0.111 bump (NumericalEarth/Breeze.jl@2cda551c): the implicit half of the
split was silently zero while the explicit half still scaled by `s`, and the model went non-finite
about twenty steps later. Diagonal coefficient at k = 4: `3.79487` with `ℓz`, `0.0` without.

Typing `ℓz` keeps the fallback working for every well-formed argument list and makes a stale one fail
loudly. The test asserts both directions; the file passes 303/303 locally.
