### PR TITLE
Fix stress tensor nomenclature throughout the code

### DIFF
--- a/docs/src/numerical_implementation/boundary_conditions.md
+++ b/docs/src/numerical_implementation/boundary_conditions.md
@@ -240,11 +240,11 @@ locally determined phase speed. We can show that this is the first-order approxi
 of motion in the predictor velocity step. Consider a right boundary normal to the `u` velocity
 component (the east boundary):
 ```math
-    \partial_t u + u \partial_x u + v \partial_y u + w \partial_z u = (\boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau})_x + F,
+    \partial_t u + u \partial_x u + v \partial_y u + w \partial_z u = - (\boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau})_x + F,
 ```
 let ``\boldsymbol{u} = \boldsymbol{U} + \boldsymbol{u}'`` with ``\boldsymbol{U} = U(x, y, z, t) \hat{\boldsymbol{x}}``
 where ``U`` is an externally determined "background" wall-normal flow in the proximity of the boundary,
-and assume that the stress tensor gradient is small,
+and assume that the divergence of ``\boldsymbol{\tau}`` is small,
 ```math
     \partial_t u = -(U + u') \partial_x(U + u') - v \partial_y (U + u') - w \partial_z (U + u') + F,
 ```

--- a/docs/src/numerical_implementation/time_stepping.md
+++ b/docs/src/numerical_implementation/time_stepping.md
@@ -199,7 +199,7 @@ where, e.g., for the non-hydrostatic model (ignoring background velocities and s
 \boldsymbol{G}_{\boldsymbol{v}} \equiv - \boldsymbol{\nabla}_h p_{\rm{hyd}}
                        - \left ( \boldsymbol{v} \boldsymbol{\cdot} \boldsymbol{\nabla} \right ) \boldsymbol{v}
                        - \boldsymbol{f} \times \boldsymbol{v}
-                       + \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau}
+                       - \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau}
                        + \boldsymbol{F}_{\boldsymbol{v}}
 ```
 

--- a/docs/src/physics/hydrostatic_free_surface_model.md
+++ b/docs/src/physics/hydrostatic_free_surface_model.md
@@ -5,7 +5,7 @@ the Boussinesq and hydrostatic approximations and with an arbitrary number of tr
 equations. Physics associated with individual terms in the momentum and tracer conservation
 equations -- the background rotation rate of the equation's reference frame,
 gravitational effects associated with buoyant tracers under the Boussinesq
-approximation, generalized stresses and tracer fluxes associated with viscous and
+approximation, generalized momentum and tracer fluxes associated with viscous and
 diffusive physics, and arbitrary "forcing functions" -- are determined by the whims of the
 user.
 
@@ -40,7 +40,8 @@ via the Boussinesq approximation are
     0 & = b - \partial_z p \, , \label{eq:hydrostatic}
     \end{align}
 ```
-where ``b`` the is buoyancy, ``\boldsymbol{\tau}`` is the hydrostatic kinematic stress tensor,
+where ``b`` the is buoyancy, ``\boldsymbol{\tau}`` is the hydrostatic kinematic momentum flux
+(i.e. the negative of the hydrostatic kinematic stress tensor),
 ``\boldsymbol{F_u}`` denotes an internal forcing of the horizontal flow ``\boldsymbol{u}``,
 ``\boldsymbol{v} = \boldsymbol{u} + w \hat{\boldsymbol{z}}`` is the three-dimensional flow,
 ``p`` is kinematic pressure, ``\eta`` is the free-surface displacement, and ``\boldsymbol{f}``
@@ -66,7 +67,7 @@ The terms that appear on the right-hand side of the momentum conservation equati
 * Coriolis: ``\boldsymbol{f} \times \boldsymbol{u}``,
 * baroclinic kinematic pressure gradient: ``\boldsymbol{\nabla} p``,
 * barotropic kinematic pressure gradient: ``\boldsymbol{\nabla} (g \eta)``,
-* molecular or turbulence viscous stress: ``\boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau}``, and
+* divergence of the molecular or turbulent momentum flux: ``\boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau}``, and
 * an arbitrary internal source of momentum: ``\boldsymbol{F_u}``.
 
 ## The tracer conservation equation

--- a/docs/src/physics/nonhydrostatic_model.md
+++ b/docs/src/physics/nonhydrostatic_model.md
@@ -5,7 +5,7 @@ Boussinesq approximation and an arbitrary number of tracer conservation equation
 Physics associated with individual terms in the momentum and tracer conservation
 equations -- the background rotation rate of the equation's reference frame,
 gravitational effects associated with buoyant tracers under the Boussinesq
-approximation, generalized stresses and tracer fluxes associated with viscous and
+approximation, generalized momentum and tracer fluxes associated with viscous and
 diffusive physics, and arbitrary "forcing functions" -- are determined by the whims of the
 user.
 
@@ -30,7 +30,7 @@ at the top of the domain via the Craik-Leibovich approximation are
     \end{align}
 ```
 where ``b \boldsymbol{\hat g}`` the is the buoyancy (a vector whose default direction is upward),
-``\boldsymbol{\tau}`` is the kinematic stress tensor, ``\boldsymbol{F_v}``
+``\boldsymbol{\tau}`` is the momentum flux (i.e. the negative of the kinematic stress tensor), ``\boldsymbol{F_v}``
 denotes an internal forcing of the velocity field ``\boldsymbol{v}``, ``p`` is the kinematic
 pressure, ``\boldsymbol{u}^S`` is the horizontal, two-dimensional 'Stokes drift' velocity field associated with surface gravity
 waves, and ``\boldsymbol{f}`` is the Coriolis parameter, or the background vorticity associated
@@ -50,7 +50,7 @@ The terms that appear on the right-hand side of the momentum conservation equati
 * kinematic pressure gradient: ``\boldsymbol{\nabla} p``,
 * buoyant acceleration: ``b``,
 * vertical unit vector (pointing to the direction opposite to gravity): ``\boldsymbol{\hat g}``,
-* molecular or turbulence viscous stress: ``\boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau}``,
+* divergence of the molecular or turbulent momentum flux: ``\boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau}``,
 * a source of momentum due to forcing or damping of surface waves: ``\partial_t \boldsymbol{u}^S``, and
 * an arbitrary internal source of momentum: ``\boldsymbol{F_v}``.
 

--- a/docs/src/physics/turbulence_closures.md
+++ b/docs/src/physics/turbulence_closures.md
@@ -1,15 +1,15 @@
 # Turbulence closures
 
-The turbulence closure selected by the user determines the form of stress divergence
+The turbulence closure selected by the user determines the form of the momentum flux divergence
 ``\boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau}`` and diffusive flux divergence
 ``\boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{q}_c`` in the momentum and tracer
 conservation equations.
 
 ## Constant isotropic diffusivity
 
-In a constant isotropic diffusivity model, the kinematic stress tensor is defined
+In a constant isotropic diffusivity model, the momentum flux (i.e. the negative of the kinematic stress tensor) is defined
 ```math
-\tau_{ij} = - \nu \Sigma_{ij} \, ,
+\tau_{ij} = - 2 \nu \Sigma_{ij} \, ,
 ```
 where ``\nu`` is a constant viscosity and
 ``\Sigma_{ij} \equiv \tfrac{1}{2} \left ( v_{i, j} + v_{j, i} \right )`` is the strain-rate
@@ -27,9 +27,9 @@ Each tracer may have a unique diffusivity ``\kappa``.
 ## Constant anisotropic diffusivity
 
 A constant anisotropic diffusivity implies a constant tensor
-diffusivity ``\nu_{j k}`` and stress ``\boldsymbol{\tau}_{ij} = \nu_{j k} u_{i, k}`` with non-zero
-components ``\nu_{11} = \nu_{22} = \nu_h`` and ``\nu_{33} = \nu_z``.
-With this form the kinematic stress divergence becomes
+diffusivity ``\nu_{j k}`` and negative of the stress ``\boldsymbol{\tau}_{ij} = - \nu_{j k} u_{i, k}``
+with non-zero components ``\nu_{11} = \nu_{22} = \nu_h`` and ``\nu_{33} = \nu_z``.
+With this form the divergence of ``\boldsymbol{\tau}`` becomes
 ```math
 \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau} = - \left [ \nu_h \left ( \partial_x^2 + \partial_y^2 \right )
                                     + \nu_v \partial_z^2 \right ] \boldsymbol{v} \, ,
@@ -46,10 +46,10 @@ diffusivity components ``\kappa_h`` and ``\kappa_v``.
 ## Scalar biharmonic diffusivity
 
 A constant biharmonic diffusivity implies a constant tensor diffusivity ``\nu_{j k}`` and
-stress``\boldsymbol{\tau}_{ij} = \nu_{j k} \partial_k^3 u_i`` with non-zero components
-``\nu_{11} = \nu_{22} = \nu_h`` and ``\nu_{33} = \nu_z``.
+momentum flux ``\boldsymbol{\tau}_{ij} = - \nu_{j k} \partial_k^3 u_i`` with non-zero
+components ``\nu_{11} = \nu_{22} = \nu_h`` and ``\nu_{33} = \nu_z``.
 
-With this form the kinematic stress divergence becomes
+With this form the divergence of ``\boldsymbol{\tau}`` becomes
 ```math
 \boldsymbol{\nabla} \boldsymbol{\cdot} \boldsymbol{\tau} = - \left [ \nu_h \left ( \partial_x^2 + \partial_y^2 \right )^2
                                     + \nu_v \partial_z^4 \right ] \boldsymbol{v} \, ,
@@ -66,7 +66,8 @@ diffusivity components ``\kappa_h`` and ``\kappa_z``.
 ## Smagorinsky-Lilly turbulence closure
 
 In the turbulence closure proposed by [Lilly62](@citet) and [Smagorinsky63](@citet),
-the subgrid stress associated with unresolved turbulent motions is modeled diffusively via
+the negative of the subgrid stress tensor associated with unresolved turbulent motions is modeled
+diffusively via
 ```math
 \tau_{ij} = - 2 \nu_e \Sigma_{ij} \, ,
 ```

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -101,7 +101,7 @@ end
     return du * !peripheral_node(i, j, k, grid, ℓx, ℓy, c)
 end
 
-# `dl(m)` multiplies `ϕ[m]` in row `m + 1`, and the stress between faces `m` and `m + 1` sits at center `m`
+# `dl(m)` multiplies `ϕ[m]` in row `m + 1`, and the viscous flux between faces `m` and `m + 1` sits at center `m`
 @inline function ivd_lower_diagonal(i, j, m, grid, closure, K, id, ℓx, ℓy, ::Face, Δt, clock, fields)
     closure_ij = getclosure(i, j, closure)
     νᵐ       = ivd_diffusivity(i, j, m,   grid, ℓx, ℓy, c, closure_ij, K, id, clock, fields)


### PR DESCRIPTION
Closes https://github.com/CliMA/Oceananigans.jl/issues/5910

@glwagner I explicitly used the term "momentum flux" instead of "negative of the stress tensor" since otherwise I think it would be too verbose and a bit more confusing.

Claude also found a couple of places where $\tau$ was actually used in equations as the actual stress tensor. Since we calculate it in the code as the momentum flux, I changed those to be consistent. It also found a missing factor of 2.