### PR TITLE
Fix performance problems introduced by IMEX PR

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/barotropic_split_explicit_corrector.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/barotropic_split_explicit_corrector.jl
@@ -1,5 +1,4 @@
 using Oceananigans.ImmersedBoundaries: immersed_peripheral_node, immersed_inactive_node
-using Oceananigans.Grids: peripheral_node
 using Oceananigans.Models: surface_kernel_parameters, volume_kernel_parameters
 
 # Kernels to compute the vertical integral of the velocities
@@ -37,7 +36,7 @@ Project the baroclinic velocities onto the barotropic transport produced by the 
 
     u = u + (U - ∫u dz) / H
 """
-function barotropic_split_explicit_corrector!(u, v, free_surface, grid, Δt)
+function barotropic_split_explicit_corrector!(u, v, free_surface, grid)
     state = free_surface.filtered_state
     U, V  = free_surface.barotropic_velocities
     U̅, V̅  = state.U̅, state.V̅
@@ -47,12 +46,10 @@ function barotropic_split_explicit_corrector!(u, v, free_surface, grid, Δt)
     mask_immersed_field!(v)
 
     compute_barotropic_mode!(U̅, V̅, grid, u, v)
-    launch!(arch, grid, volume_kernel_parameters(grid), _barotropic_split_explicit_corrector!,
-            u, v, U, V, U̅, V̅, grid)
+    launch!(arch, grid, volume_kernel_parameters(grid), _barotropic_split_explicit_corrector!, u, v, U, V, U̅, V̅, grid)
 
     return nothing
 end
-
 
 @kernel function _barotropic_split_explicit_corrector!(u, v, U, V, U̅, V̅, grid)
     i, j, k = @index(Global, NTuple)

--- a/src/Models/HydrostaticFreeSurfaceModels/barotropic_pressure_correction.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/barotropic_pressure_correction.jl
@@ -55,7 +55,7 @@ from the split-explicit substepping.
 function correct_barotropic_mode!(model, ::SplitExplicitFreeSurface, Δt)
     u, v, _ = model.velocities
     grid = model.grid
-    barotropic_split_explicit_corrector!(u, v, model.free_surface, grid, Δt)
+    barotropic_split_explicit_corrector!(u, v, model.free_surface, grid)
 
     return nothing
 end

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -345,7 +345,7 @@ stash_vertical_velocity!(transport_velocities, velocities, free_surface) = updat
 stash_vertical_velocity!(transport_velocities, velocities, ::Union{SplitExplicitFreeSurface, ImplicitFreeSurface}) = nothing
 
 # Only concrete Field types are duplicated (see `copy_velocity` above)
-update_transport_velocity_data!(dst::Field, src::Field) = parent(dst) .= parent(src)
+update_transport_velocity_data!(dst::Field, src::Field) = copyto!(parent(dst), parent(src))
 update_transport_velocity_data!(dst, src) = nothing
 
 validate_velocity_boundary_conditions(grid, velocities) = validate_vertical_velocity_boundary_conditions(velocities.w)

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -140,7 +140,7 @@ end
 
 @inline function boundary_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, top_bc, bottom_bc, immersed_bc)
     # Constant-folds away unless a boundary condition is implicit-explicit
-    if needs_implicit_solver(top_bc) | needs_implicit_solver(bottom_bc) | needs_implicit_solver(immersed_bc) 
+    if !(needs_implicit_solver(top_bc) | needs_implicit_solver(bottom_bc) | needs_implicit_solver(immersed_bc))
         return zero(grid)
     end
 

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -140,7 +140,7 @@ end
 
 @inline function boundary_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, top_bc, bottom_bc, immersed_bc)
     # Constant-folds away unless a boundary condition is implicit-explicit
-    if needs_implicit_solver(top_bc) | needs_implicit_solver(bottom_bc) | needs_implicit_solver(immersed_bc) 
+    if needs_implicit_solver(top_bc) | needs_implicit_solver(bottom_bc) | needs_implicit_solver(immersed_bc)
         return zero(grid)
     end
 

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -139,6 +139,11 @@ end
 #####
 
 @inline function boundary_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, top_bc, bottom_bc, immersed_bc)
+    # Constant-folds away unless a boundary condition is implicit-explicit
+    if needs_implicit_solver(top_bc) | needs_implicit_solver(bottom_bc) | needs_implicit_solver(immersed_bc) 
+        return zero(grid)
+    end
+
     Nz  = size(grid, 3)
     Δzᵏ = Δz(i, j, k, grid, ℓx, ℓy, ℓz)
     λᵗ  = implicit_flux_coefficient(top_bc,    i, j, grid, clk, fields)

--- a/test/test_split_explicit_vertical_integrals.jl
+++ b/test/test_split_explicit_vertical_integrals.jl
@@ -145,7 +145,7 @@ barotropic_boundary_conditions(grid) =
             set!(V, set_V̅)
             set!(v_corrected, set_v_corrected)
 
-            barotropic_split_explicit_corrector!(u, v, sefs, grid, 1)
+            barotropic_split_explicit_corrector!(u, v, sefs, grid)
             @test all(Array((interior(u) .- interior(u_corrected))) .< 1e-14)
             @test all(Array((interior(v) .- interior(v_corrected))) .< 1e-14)
         end


### PR DESCRIPTION
PR #5631 regressed the performance of an hydrostatic model even when no IMEX boundary conditions are present.
The regression is not huge but noticeable and not noise see 42f04ae (the peak in the figure is actually noise)
<img width="1262" height="463" alt="image" src="https://github.com/user-attachments/assets/e318385b-71fe-4f00-8cc6-3d9795b61a90" />

It is not a gigantic regression but we still do not want to allow it and end up in a ``death by thousands cut'' sitation.
This PR attempts to bring the performance back to the previous main.