### PR TITLE
Test Zarr output writing and reading without scalar indexing

### DIFF
--- a/test/test_zarr_writer.jl
+++ b/test/test_zarr_writer.jl
@@ -857,12 +857,13 @@ guarding_scalar_indexing(f, arch) = f()
         model = HydrostaticFreeSurfaceModel(grid; free_surface, tracers=:T)
 
         filename = "test_zarr_scalar_indexing"
-        filepath = joinpath(mktemp(), filename * ".zarr")
+        directory = mktempdir()
+        filepath = joinpath(directory, filename * ".zarr")
 
         simulation = Simulation(model; Δt=1, stop_iteration=1)
         simulation.output_writers[:zarr] = ZarrWriter(model, (; T=model.tracers.T);
                                                       filename,
-                                                      dir = ".",
+                                                      dir = directory,
                                                       schedule = IterationInterval(1),
                                                       with_halos,
                                                       overwrite_existing = true)

--- a/test/test_zarr_writer.jl
+++ b/test/test_zarr_writer.jl
@@ -875,7 +875,5 @@ guarding_scalar_indexing(f, arch) = f()
             @test length(time_series.times) == 2
             @test size(time_series.grid) == size(grid)
         end
-
-        rm(filepath; recursive=true, force=true)
     end
 end

--- a/test/test_zarr_writer.jl
+++ b/test/test_zarr_writer.jl
@@ -822,3 +822,61 @@ using Oceananigans.OrthogonalSphericalShellGrids: TripolarGrid
         rm(zarrpath; recursive=true, force=true)
     end
 end
+
+#####
+##### Scalar indexing
+#####
+#
+# Zarr grid serialization and reconstruction touch device-backed grid coordinates and
+# metrics, which must never fall back to elementwise iteration on a GPU. The rest of the
+# test suite runs inside `CUDA.allowscalar()`, which masks that class of regression, so
+# these testsets opt back out for the duration of a write and a read.
+
+# `allowscalar(f)` scopes the *enabling* of scalar indexing; this is its inverse. The
+# previous setting is restored on exit so it cannot leak into subsequent testsets.
+disallowing_scalar_indexing(f) =
+    task_local_storage(f, :ScalarIndexing, GPUArraysCore.ScalarDisallowed)
+
+# Scalar indexing is only restricted for GPU arrays, so the guard is a no-op on the CPU.
+guarding_scalar_indexing(f, arch::GPU) = disallowing_scalar_indexing(f)
+guarding_scalar_indexing(f, arch) = f()
+
+@testset "ZarrWriter [scalar indexing]" begin
+    @info "  Testing ZarrWriter and FieldTimeSeries without scalar indexing..."
+
+    for arch in archs, with_halos in (false, true)
+        # An OrthogonalSphericalShellGrid exercises the widest device-backed surface:
+        # two-dimensional λ/φ auxiliary coordinates and horizontal metrics on write, and
+        # metric halo filling on read.
+        grid = TripolarGrid(arch;
+                            size = (8, 8, 2),
+                            z = (-100, 0),
+                            first_pole_longitude = 75,
+                            north_poles_latitude = 35,
+                            southernmost_latitude = -35)
+        free_surface = SplitExplicitFreeSurface(grid; substeps=5)
+        model = HydrostaticFreeSurfaceModel(grid; free_surface, tracers=:T)
+
+        filename = "test_zarr_scalar_indexing"
+        filepath = abspath(filename * ".zarr")
+        isdir(filepath) && rm(filepath; recursive=true, force=true)
+
+        simulation = Simulation(model; Δt=1, stop_iteration=1)
+        simulation.output_writers[:zarr] = ZarrWriter(model, (; T=model.tracers.T);
+                                                      filename,
+                                                      dir = ".",
+                                                      schedule = IterationInterval(1),
+                                                      with_halos,
+                                                      overwrite_existing = true)
+
+        guarding_scalar_indexing(arch) do
+            run!(simulation)
+
+            time_series = FieldTimeSeries(filepath, "T"; architecture=arch)
+            @test length(time_series.times) == 2
+            @test size(time_series.grid) == size(grid)
+        end
+
+        rm(filepath; recursive=true, force=true)
+    end
+end

--- a/test/test_zarr_writer.jl
+++ b/test/test_zarr_writer.jl
@@ -858,8 +858,7 @@ guarding_scalar_indexing(f, arch) = f()
         model = HydrostaticFreeSurfaceModel(grid; free_surface, tracers=:T)
 
         filename = "test_zarr_scalar_indexing"
-        filepath = abspath(filename * ".zarr")
-        isdir(filepath) && rm(filepath; recursive=true, force=true)
+        filepath = joinpath(mktemp(), filename * ".zarr")
 
         simulation = Simulation(model; Δt=1, stop_iteration=1)
         simulation.output_writers[:zarr] = ZarrWriter(model, (; T=model.tracers.T);

--- a/test/test_zarr_writer.jl
+++ b/test/test_zarr_writer.jl
@@ -834,8 +834,7 @@ end
 
 # `allowscalar(f)` scopes the *enabling* of scalar indexing; this is its inverse. The
 # previous setting is restored on exit so it cannot leak into subsequent testsets.
-disallowing_scalar_indexing(f) =
-    task_local_storage(f, :ScalarIndexing, GPUArraysCore.ScalarDisallowed)
+disallowing_scalar_indexing(f) = task_local_storage(f, :ScalarIndexing, GPUArraysCore.ScalarDisallowed)
 
 # Scalar indexing is only restricted for GPU arrays, so the guard is a no-op on the CPU.
 guarding_scalar_indexing(f, arch::GPU) = disallowing_scalar_indexing(f)


### PR DESCRIPTION
## Summary

Adds a GPU regression test that runs a `ZarrWriter` write and a `FieldTimeSeries` read with scalar indexing **disabled**, closing a blind spot that allowed several GPU-unsafe defects to pass CI during #5610.

## Motivation

`test/runtests.jl` wraps the entire suite in `CUDA.allowscalar() do ... end`. Scalar indexing of GPU arrays is therefore permitted everywhere in the tests, while `docs/make.jl` has no such wrapper and its GPU examples run with the default `allowscalar(false)`.

The consequence is that genuinely GPU-unsafe code can pass every GPU shard. During #5610 this happened repeatedly: `collect` on device-backed `Field`s and on `OffsetArray`-wrapped coordinate/metric arrays, and most recently a change to `halo_fill_2d_metric` that broke `FieldTimeSeries` readback of every OSSG Zarr store while CI reported 76/76 green. Each was caught by the documentation build or by ad-hoc GPU runs, never by the test suite.

Grid serialization and reconstruction are the paths most exposed to this, because they touch device-backed coordinates and metrics on write and fill metric halos on read.

## What this adds

One testset in `test/test_zarr_writer.jl` that, for each architecture and for both interior and halo stores:

1. writes a Zarr store from a `TripolarGrid` (widest device-backed surface: 2D λ/φ auxiliary coordinates and horizontal metrics on write, metric halo filling on read), then
2. reconstructs it with `FieldTimeSeries`,

with scalar indexing disabled for the duration on GPU architectures.

Two details worth noting for review:

- **The guard cannot leak.** `disallowing_scalar_indexing` uses `task_local_storage(f, :ScalarIndexing, ScalarDisallowed)`, mirroring how `GPUArraysCore` implements the scoped *enable*, so the previous setting is restored on exit. An earlier iteration of this guard in #5610 used a bare `CUDA.allowscalar(false)`, which silently persisted into every subsequent testset and had to be walked back.
- **It is a no-op on CPU**, via dispatch on `::GPU`, so the CPU shard still exercises the write/read path without a pointless guard.

## Verification

Run on a Tesla T4, both directions:

- **Against `main` as-is:** the testset passes.
- **With the `halo_fill_2d_metric` fix reverted** (`old_interior = view(old_data, 1:Ni, 1:Nj)` instead of the materialized slice): the testset fails with `Scalar indexing is disallowed`.

The second run is the point: it demonstrates the test detects the exact regression that previously shipped through a fully green CI board, rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
