### PR TITLE
Add time_average for FieldTimeSeries

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -112,7 +112,7 @@ export
     SpecifiedTimes, FileSizeLimit, AndSchedule, OrSchedule, written_names,
 
     # Output readers
-    FieldTimeSeries, FieldDataset, InMemory, OnDisk,
+    FieldTimeSeries, FieldDataset, InMemory, OnDisk, time_average,
 
     # Abstract operations
     ∂x, ∂y, ∂z, @at, KernelFunctionOperation, InterpolatedOperation,

--- a/src/OutputReaders/OutputReaders.jl
+++ b/src/OutputReaders/OutputReaders.jl
@@ -5,7 +5,8 @@ export
     FieldTimeSeries,
     TimeSeriesInterpolation,
     InMemory, OnDisk,
-    Cyclical, Linear, Clamp
+    Cyclical, Linear, Clamp,
+    time_average
 
 using DocStringExtensions: TYPEDSIGNATURES
 
@@ -42,6 +43,7 @@ include("field_time_series_indexing.jl")
 include("time_series_interpolated_field.jl")
 include("set_field_time_series.jl")
 include("field_time_series_reductions.jl")
+include("time_average.jl")
 include("show_field_time_series.jl")
 include("extract_field_time_series.jl")
 include("combining_field_time_series.jl")

--- a/src/OutputReaders/time_average.jl
+++ b/src/OutputReaders/time_average.jl
@@ -26,6 +26,7 @@ end
                                             convert(FT, NaN))
 end
 
+# TODO: make this a lazy `FieldTimeSeriesOperation` once #5761 lands.
 """
 $(TYPEDSIGNATURES)
 

--- a/src/OutputReaders/time_average.jl
+++ b/src/OutputReaders/time_average.jl
@@ -1,0 +1,86 @@
+using KernelAbstractions: @kernel, @index
+
+using Oceananigans: location
+using Oceananigans.Architectures: architecture
+using Oceananigans.BoundaryConditions: fill_halo_regions!, FieldBoundaryConditions
+using Oceananigans.Fields: interior
+using Oceananigans.Utils: launch!
+
+# Each cell renormalizes over its own valid samples.
+@kernel function _accumulate_sample!(total, weight, sample, overlap)
+    i, j, k = @index(Global, NTuple)
+    FT = eltype(total)
+    @inbounds begin
+        value = sample[i, j, k]
+        valid = !isnan(value)
+        total[i, j, k] += ifelse(valid, overlap * value, zero(FT))
+        weight[i, j, k] += ifelse(valid, overlap, zero(FT))
+    end
+end
+
+@kernel function _finalize_window!(averaged, total, weight, w)
+    i, j, k = @index(Global, NTuple)
+    FT = eltype(averaged)
+    @inbounds averaged[i, j, k, w] = ifelse(weight[i, j, k] > 0,
+                                            total[i, j, k] / weight[i, j, k],
+                                            convert(FT, NaN))
+end
+
+# TODO: once #5761 (`FieldTimeSeriesOperation`) lands, make this a lazy operation over `fts`
+# whose window `w` is computed from its overlapping samples on slide, and materialize it here.
+"""
+$(TYPEDSIGNATURES)
+
+Average `fts` onto consecutive windows of length `window`, in the units of `fts.times`.
+
+`bounds` has `length(fts.times) + 1` entries and sample `n` covers `[bounds[n], bounds[n+1])`.
+The windows tile `[first(bounds), last(bounds))` from `first(bounds)`, the last one truncated
+at `last(bounds)`, and each sample is weighted by its overlap with the window. `NaN` samples
+are skipped and the remaining weights renormalized, so a window with no valid sample is `NaN`.
+
+The result is a `FieldTimeSeries` with the grid, indices, and time indexing of `fts` and
+times at the window centers. Samples are read one at a time through `fts[n]`, so `fts` may
+keep only part of its record in memory.
+"""
+function time_average(fts::FieldTimeSeries, bounds, window)
+    Nt = length(fts.times)
+    length(bounds) == Nt + 1 ||
+        throw(ArgumentError("bounds must have $(Nt + 1) entries, found $(length(bounds))"))
+
+    edges = collect(first(bounds):window:last(bounds))
+    last(edges) < last(bounds) && push!(edges, last(bounds))
+    Nw = length(edges) - 1
+    times = [(edges[w] + edges[w + 1]) / 2 for w in 1:Nw]
+
+    boundary_conditions = FieldBoundaryConditions(fts.indices, fts.boundary_conditions)
+    LX, LY, LZ = location(fts)
+    output = FieldTimeSeries{LX, LY, LZ}(fts.grid, times; indices = fts.indices,
+                                         time_indexing = fts.time_indexing,
+                                         boundary_conditions)
+
+    grid = fts.grid
+    arch = architecture(grid)
+    FT = eltype(grid)
+    averaged = interior(output)
+    spatial_size = size(averaged)[1:3]
+    total = zeros(arch, FT, spatial_size...)
+    weight = zeros(arch, FT, spatial_size...)
+
+    for w in 1:Nw
+        fill!(total, 0)
+        fill!(weight, 0)
+
+        for n in 1:Nt
+            overlap = min(bounds[n + 1], edges[w + 1]) - max(bounds[n], edges[w])
+            overlap > 0 || continue
+            launch!(arch, grid, spatial_size, _accumulate_sample!,
+                    total, weight, interior(fts[n]), convert(FT, overlap))
+        end
+
+        launch!(arch, grid, spatial_size, _finalize_window!, averaged, total, weight, w)
+    end
+
+    fill_halo_regions!(output)
+
+    return output
+end

--- a/src/OutputReaders/time_average.jl
+++ b/src/OutputReaders/time_average.jl
@@ -26,21 +26,47 @@ end
                                             convert(FT, NaN))
 end
 
-# TODO: once #5761 (`FieldTimeSeriesOperation`) lands, make this a lazy operation over `fts`
-# whose window `w` is computed from its overlapping samples on slide, and materialize it here.
 """
 $(TYPEDSIGNATURES)
 
 Average `fts` onto consecutive windows of length `window`, in the units of `fts.times`.
 
 `bounds` has `length(fts.times) + 1` entries and sample `n` covers `[bounds[n], bounds[n+1])`.
-The windows tile `[first(bounds), last(bounds))` from `first(bounds)`, the last one truncated
-at `last(bounds)`, and each sample is weighted by its overlap with the window. `NaN` samples
-are skipped and the remaining weights renormalized, so a window with no valid sample is `NaN`.
+The windows tile `[first(bounds), last(bounds))` from `first(bounds)`, the last one truncated at
+`last(bounds)` with a warning, and each sample is weighted by its overlap with the window. `NaN`
+samples are skipped and the remaining weights renormalized, so a window with no valid sample is `NaN`.
 
 The result is a `FieldTimeSeries` with the grid, indices, and time indexing of `fts` and
 times at the window centers. Samples are read one at a time through `fts[n]`, so `fts` may
 keep only part of its record in memory.
+
+Example
+=======
+
+Average four daily samples onto two-day windows:
+
+```jldoctest
+using Oceananigans
+using Oceananigans.Units
+
+grid = RectilinearGrid(size=(1, 1, 1), extent=(1, 1, 1))
+daily = FieldTimeSeries{Center, Center, Center}(grid, (0.5:3.5) * days)
+
+sample = CenterField(grid)
+for n in 1:4
+    set!(sample, n)
+    set!(daily, sample, n)
+end
+
+bounds = (0:4) * days # sample n covers [bounds[n], bounds[n+1])
+averaged = time_average(daily, bounds, 2days)
+Array(interior(averaged, 1, 1, 1, :))
+
+# output
+2-element Vector{Float64}:
+ 1.5
+ 3.5
+```
 """
 function time_average(fts::FieldTimeSeries, bounds, window)
     Nt = length(fts.times)
@@ -48,7 +74,10 @@ function time_average(fts::FieldTimeSeries, bounds, window)
         throw(ArgumentError("bounds must have $(Nt + 1) entries, found $(length(bounds))"))
 
     edges = collect(first(bounds):window:last(bounds))
-    last(edges) < last(bounds) && push!(edges, last(bounds))
+    if last(edges) < last(bounds)
+        push!(edges, last(bounds))
+        @warn "The last window spans $(last(bounds) - edges[end - 1]) rather than $window"
+    end
     Nw = length(edges) - 1
     times = [(edges[w] + edges[w + 1]) / 2 for w in 1:Nw]
 

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -714,6 +714,70 @@ function test_interpolation_with_in_memory_backends(filepath_sine)
     return nothing
 end
 
+function test_field_time_series_time_average(arch)
+    grid = RectilinearGrid(arch, size=(2, 1, 4), extent=(1, 1, 1))
+    times = 0:7
+    bounds = 0:8:64
+
+    ramp = FieldTimeSeries{Center, Center, Center}(grid, times)
+    for n in 1:8
+        set!(ramp[n], n)
+    end
+
+    # Windows of 31, 31, and the 2 units left over, so samples 4 and 8 straddle an edge.
+    averaged = time_average(ramp, bounds, 31)
+    values = Array(interior(averaged))
+
+    @test Array(averaged.times) == [15.5, 46.5, 63]
+    @test values[1, 1, 1, 1] ≈ (8 * 1 + 8 * 2 + 8 * 3 + 7 * 4) / 31
+    @test values[1, 1, 1, 2] ≈ (1 * 4 + 8 * 5 + 8 * 6 + 8 * 7 + 6 * 8) / 31
+    @test values[1, 1, 1, 3] ≈ 8
+
+    whole_record = time_average(ramp, bounds, 100)
+    @test Array(whole_record.times) == [32]
+    @test Array(interior(whole_record))[1, 1, 1, 1] ≈ mean(1:8)
+
+    @test_throws ArgumentError time_average(ramp, times, 31)
+
+    # A NaN sample drops out of the cell that carries it and the rest renormalize.
+    gap = Array(interior(ramp[2]))
+    gap[1, 1, :] .= NaN
+    copyto!(interior(ramp[2]), gap)
+    gappy = Array(interior(time_average(ramp, bounds, 31)))
+    @test gappy[1, 1, 1, 1] ≈ (8 * 1 + 8 * 3 + 7 * 4) / 23
+    @test gappy[2, 1, 1, 1] ≈ (8 * 1 + 8 * 2 + 8 * 3 + 7 * 4) / 31
+
+    for n in 1:8
+        set!(ramp[n], NaN)
+    end
+    @test all(isnan, Array(interior(time_average(ramp, bounds, 31))))
+
+    # A partly resident series streamed from disk averages to the same numbers.
+    path = joinpath(mktempdir(), "ramp.jld2")
+    ondisk = FieldTimeSeries{Center, Center, Center}(grid, times; backend=OnDisk(), path, name="ramp")
+    sample = CenterField(grid)
+    for n in 1:8
+        set!(sample, n)
+        set!(ondisk, sample, n)
+    end
+    windowed = FieldTimeSeries(path, "ramp"; architecture=arch, backend=InMemory(2))
+    @test Array(interior(time_average(windowed, bounds, 31))) == values
+
+    surface = FieldTimeSeries{Center, Center, Center}(grid, times; indices=(:, :, 4))
+    for n in 1:8
+        set!(surface[n], n)
+    end
+    sliced = time_average(surface, bounds, 31)
+    @test sliced.indices == surface.indices
+    @test size(interior(sliced)) == (2, 1, 1, 3)
+    @test Array(interior(sliced))[1, 1, 1, 3] ≈ 8
+
+    cyclic = FieldTimeSeries{Center, Center, Center}(grid, times; time_indexing=Cyclical())
+    @test time_average(cyclic, bounds, 31).time_indexing isa Cyclical
+
+    return nothing
+end
+
 #####
 ##### Run tests
 #####
@@ -898,6 +962,12 @@ end
     for arch in archs
         @testset "Precomputed TimeInterpolator [$(typeof(arch))]" begin
             test_precomputed_time_interpolator(arch)
+        end
+    end
+
+    for arch in archs
+        @testset "FieldTimeSeries time_average [$(typeof(arch))]" begin
+            test_field_time_series_time_average(arch)
         end
     end
 

--- a/test/test_output_readers.jl
+++ b/test/test_output_readers.jl
@@ -725,7 +725,7 @@ function test_field_time_series_time_average(arch)
     end
 
     # Windows of 31, 31, and the 2 units left over, so samples 4 and 8 straddle an edge.
-    averaged = time_average(ramp, bounds, 31)
+    averaged = @test_logs (:warn, r"last window") time_average(ramp, bounds, 31)
     values = Array(interior(averaged))
 
     @test Array(averaged.times) == [15.5, 46.5, 63]


### PR DESCRIPTION
`time_average(fts, bounds, window)` is a `FieldTimeSeries` reduction onto a coarser cadence, e.g. eight-day composites onto months: each sample is weighted by its overlap with the window, `NaN` samples drop out cell by cell, and the windows tile the record from `first(bounds)`. A final window shorter than `window` is truncated with a warning. It reads one sample at a time through `fts[n]`, so a partly resident `InMemory(k)` series works, and the result keeps the input's grid, indices and time indexing with times at the window centers.

```julia
using Oceananigans
using Oceananigans.Units

fts = FieldTimeSeries("composites.jld2", "T"; backend=InMemory(2))
bounds = [fts.times; fts.times[end] + 8days]   # sample n covers [bounds[n], bounds[n+1])
monthly = time_average(fts, bounds, 30days)
```

Once #5761 lands, this should become a lazy `FieldTimeSeriesOperation` whose window is computed from its overlapping samples on slide, with `time_average` materializing it. A windowed average changes the time axis, so it isn't one of those operations yet.
