### PR TITLE
Interior-aware argmax, argmin, findmax and findmin for Field

### DIFF
--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -865,22 +865,30 @@ function locate_extremum(better, c::AbstractField, condition, mask)
     tiebreak((x, i), (y, j)) = better(x, y) ? (y, j) :
                                isequal(x, y) ? (x, min(i, j)) : (x, i)
 
-    # `OffsetArray` re-axes the linear positions onto windowed (non-1-based) operand axes
-    indices = OffsetArray(LinearIndices(size(operand)), axes(operand))
-    pairs = Broadcast.instantiate(Broadcast.broadcasted(tuple, operand, indices))
-    value, i = fold_pairs(architecture(c), tiebreak, pairs, (mask, 1))
-    return value, CartesianIndices(axes(operand))[i]
+    # Everything is 1-based from here: a windowed interior is a 1-based view and a
+    # `ConditionalOperation` has 1-based axes, so no offset axes enter the search
+    values = operand === c ? interior(c) : operand
+
+    value, i = fold_pairs(architecture(c), tiebreak, values, (mask, 1))
+    positional = CartesianIndices(size(values))[i]
+
+    # Shift into the field's own axes so that `c[argmax(c)] == maximum(c)` holds for
+    # windowed fields too; for default fields the shift vanishes
+    return value, CartesianIndex(Tuple(positional) .+ first.(axes(c)) .- 1)
 end
 
-function fold_pairs(::Architectures.CPU, tiebreak, pairs, init)
+function fold_pairs(::Architectures.CPU, tiebreak, values, init)
     result = init
-    @inbounds for I in CartesianIndices(axes(pairs))
-        result = tiebreak(result, pairs[I])
+    linear = 0
+    @inbounds for I in CartesianIndices(size(values))
+        linear += 1
+        result = tiebreak(result, (values[I], linear))
     end
     return result
 end
 
-function fold_pairs(arch, tiebreak, pairs, init)
+function fold_pairs(arch, tiebreak, values, init)
+    pairs = Broadcast.instantiate(Broadcast.broadcasted(tuple, values, LinearIndices(size(values))))
     result = on_architecture(arch, fill(init, 1, 1, 1))
     Base.mapreducedim!(identity, tiebreak, result, pairs)
     return first(Array(result))

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -851,15 +851,43 @@ Base.extrema(c::AbstractField; kwargs...) = (minimum(c; kwargs...), maximum(c; k
 Base.extrema(f, c::AbstractField; kwargs...) = (minimum(f, c; kwargs...), maximum(f, c; kwargs...))
 
 # Index reductions: locate extrema within `interior(c)`, consistently with `nodes(c)`.
-# The generic fallbacks scalar-index on the GPU and are blind to immersed boundaries;
-# here immersed or conditioned cells are masked with the neutral element before the search.
-for (locator, neutral) in ((:argmax, -Inf), (:findmax, -Inf), (:argmin, Inf), (:findmin, Inf))
-    @eval function Base.$locator(c::AbstractField; condition = nothing, mask = $neutral)
-        operand = condition_operand(c, condition, convert(eltype(c), mask))
-        values = operand === c ? interior(c) : interior(Field(operand))
-        return Base.$locator(values)
-    end
+# The generic fallbacks scalar-index on the GPU and are blind to immersed boundaries.
+# The search is fused: a lazy broadcast of (value, linear index) pairs is folded in place
+# on the CPU, or consumed by `mapreducedim!` on the GPU — which GPUArrays dispatches on
+# the one-element destination — so neither the operand nor the pairs are materialized.
+function locate_extremum(better, c::AbstractField, condition, mask)
+    mask = convert(eltype(c), mask)
+    operand = condition_operand(c, condition, mask)
+
+    # Ties resolve to the smaller linear index, matching Base
+    tiebreak((x, i), (y, j)) = better(x, y) ? (y, j) :
+                               isequal(x, y) ? (x, min(i, j)) : (x, i)
+
+    # `OffsetArray` re-axes the linear positions onto windowed (non-1-based) operand axes
+    indices = OffsetArray(LinearIndices(size(operand)), axes(operand))
+    pairs = Broadcast.instantiate(Broadcast.broadcasted(tuple, operand, indices))
+    value, i = fold_pairs(architecture(c), tiebreak, pairs, (mask, 1))
+    return value, CartesianIndices(size(operand))[i]
 end
+
+function fold_pairs(::Architectures.CPU, tiebreak, pairs, init)
+    result = init
+    @inbounds for I in CartesianIndices(axes(pairs))
+        result = tiebreak(result, pairs[I])
+    end
+    return result
+end
+
+function fold_pairs(arch, tiebreak, pairs, init)
+    result = on_architecture(arch, fill(init, 1, 1, 1))
+    Base.mapreducedim!(identity, tiebreak, result, pairs)
+    return first(Array(result))
+end
+
+Base.findmax(c::AbstractField; condition = nothing, mask = -Inf) = locate_extremum(Base.isless,    c, condition, mask)
+Base.findmin(c::AbstractField; condition = nothing, mask = Inf)  = locate_extremum(Base.isgreater, c, condition, mask)
+Base.argmax(c::AbstractField; kwargs...) = last(findmax(c; kwargs...))
+Base.argmin(c::AbstractField; kwargs...) = last(findmin(c; kwargs...))
 
 function Statistics._mean(f, c::AbstractField, ::Colon; condition = nothing, mask = 0)
     mask = convert(eltype(c), mask)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -850,8 +850,10 @@ end
 Base.extrema(c::AbstractField; kwargs...) = (minimum(c; kwargs...), maximum(c; kwargs...))
 Base.extrema(f, c::AbstractField; kwargs...) = (minimum(f, c; kwargs...), maximum(f, c; kwargs...))
 
-# Index reductions: locate extrema within `interior(c)`, consistently with `nodes(c)`.
-# The generic fallbacks scalar-index on the GPU and are blind to immersed boundaries.
+# Index reductions: locate extrema over `interior(c)`, returning indices in the field's own
+# axes so that `c[argmax(c)] == maximum(c)` — which for default fields coincide with positional
+# interior (and `nodes`) indices. The generic fallbacks scalar-index on the GPU and are blind
+# to immersed boundaries.
 # The search is fused: a lazy broadcast of (value, linear index) pairs is folded in place
 # on the CPU, or consumed by `mapreducedim!` on the GPU — which GPUArrays dispatches on
 # the one-element destination — so neither the operand nor the pairs are materialized.
@@ -867,7 +869,7 @@ function locate_extremum(better, c::AbstractField, condition, mask)
     indices = OffsetArray(LinearIndices(size(operand)), axes(operand))
     pairs = Broadcast.instantiate(Broadcast.broadcasted(tuple, operand, indices))
     value, i = fold_pairs(architecture(c), tiebreak, pairs, (mask, 1))
-    return value, CartesianIndices(size(operand))[i]
+    return value, CartesianIndices(axes(operand))[i]
 end
 
 function fold_pairs(::Architectures.CPU, tiebreak, pairs, init)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -850,6 +850,17 @@ end
 Base.extrema(c::AbstractField; kwargs...) = (minimum(c; kwargs...), maximum(c; kwargs...))
 Base.extrema(f, c::AbstractField; kwargs...) = (minimum(f, c; kwargs...), maximum(f, c; kwargs...))
 
+# Index reductions: locate extrema within `interior(c)`, consistently with `nodes(c)`.
+# The generic fallbacks scalar-index on the GPU and are blind to immersed boundaries;
+# here immersed or conditioned cells are masked with the neutral element before the search.
+for (locator, neutral) in ((:argmax, -Inf), (:findmax, -Inf), (:argmin, Inf), (:findmin, Inf))
+    @eval function Base.$locator(c::AbstractField; condition = nothing, mask = $neutral)
+        operand = condition_operand(c, condition, convert(eltype(c), mask))
+        values = operand === c ? interior(c) : interior(Field(operand))
+        return Base.$locator(values)
+    end
+end
+
 function Statistics._mean(f, c::AbstractField, ::Colon; condition = nothing, mask = 0)
     mask = convert(eltype(c), mask)
     operator = condition_operand(f, c, condition, mask)

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -103,6 +103,20 @@ function run_field_reduction_tests(grid)
         @test extrema(ϕ) == (minimum(ϕ), maximum(ϕ))
         @test extrema(∛, ϕ) == (minimum(∛, ϕ), maximum(∛, ϕ))
 
+        # Index reductions locate extrema within `interior(ϕ)`, consistently with `nodes(ϕ)`,
+        # and must be blind to the halo regions, poisoned here on a copy
+        ψ = similar(ϕ)
+        parent(ψ) .= convert(eltype(ψ), 1e6)
+        interior(ψ) .= interior(ϕ)
+        interior_values = Array(interior(ψ))
+        @test argmax(ψ) == argmax(interior_values)
+        @test findmax(ψ) == findmax(interior_values)
+
+        parent(ψ) .= convert(eltype(ψ), -1e6)
+        interior(ψ) .= interior(ϕ)
+        @test argmin(ψ) == argmin(interior_values)
+        @test findmin(ψ) == findmin(interior_values)
+
         for dims in dims_to_test
             @test all(isapprox(minimum(ϕ, dims=dims), minimum(ϕ_vals, dims=dims), atol=4ε))
             @test all(isapprox(maximum(ϕ, dims=dims), maximum(ϕ_vals, dims=dims), atol=4ε))
@@ -787,6 +801,17 @@ end
                                  (:variably_spaced_grid => variably_spaced_grid)]
                 @info "    Testing field reductions on $name..."
                 run_field_reduction_tests(grid)
+            end
+
+            @testset "Index reductions on an immersed grid [$(typeof(arch)), $FT]" begin
+                immersed_grid = ImmersedBoundaryGrid(regular_grid, GridFittedBottom(0))
+                c = CenterField(immersed_grid)
+                set!(c, (x, y, z) -> -z) # the raw extremum hides in the immersed region
+                values = Array(interior(c))
+                @test argmax(values) != argmax(c)
+                @test values[argmax(c)] == maximum(c)
+                @test values[argmin(c)] == minimum(c)
+                @test findmax(c) == (maximum(c), argmax(c))
             end
         end
 

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -117,6 +117,16 @@ function run_field_reduction_tests(grid)
         @test argmin(ψ) == argmin(interior_values)
         @test findmin(ψ) == findmin(interior_values)
 
+        # Windowed fields return indices in their own axes, preserving w[argmax(w)] == maximum(w)
+        if size(ϕ, 3) > 1
+            w = view(ϕ, :, :, 2:size(ϕ, 3))
+            windowed_values = Array(interior(w))
+            value, index = findmax(w)
+            positional = argmax(windowed_values)
+            @test value == maximum(windowed_values)
+            @test index == CartesianIndex(Tuple(positional) .+ first.(axes(w)) .- 1)
+        end
+
         for dims in dims_to_test
             @test all(isapprox(minimum(ϕ, dims=dims), minimum(ϕ_vals, dims=dims), atol=4ε))
             @test all(isapprox(maximum(ϕ, dims=dims), maximum(ϕ_vals, dims=dims), atol=4ε))

--- a/test/test_quality_assurance.jl
+++ b/test/test_quality_assurance.jl
@@ -36,7 +36,7 @@ end
     # Do not increase this number. If ambiguities increase, resolve them before merging.
     number_of_ambiguities = length(detect_ambiguities(Oceananigans; recursive=true))
     # When ambiguities are resolved, update the cap accordingly.
-    @test number_of_ambiguities == 314
+    @test number_of_ambiguities == 310
     @info "Number of ambiguities: $number_of_ambiguities"
 
     modules = (

--- a/test/test_quality_assurance.jl
+++ b/test/test_quality_assurance.jl
@@ -36,7 +36,7 @@ end
     # Do not increase this number. If ambiguities increase, resolve them before merging.
     number_of_ambiguities = length(detect_ambiguities(Oceananigans; recursive=true))
     # When ambiguities are resolved, update the cap accordingly.
-    @test number_of_ambiguities == 310
+    @test number_of_ambiguities == 314
     @info "Number of ambiguities: $number_of_ambiguities"
 
     modules = (


### PR DESCRIPTION
Closes #5927.

Specializes the index reductions `argmax`, `argmin`, `findmax` and `findmin` for `AbstractField`, alongside the existing `maximum`/`minimum` family. The search is **fused**, borrowing the structure of GPUArrays' `findminmax` but with one twist: instead of dispatching on the source (which forces materialization), a lazy broadcast of `(value, linear index)` pairs is consumed without ever being materialized — folded in place on the CPU, or reduced by `mapreducedim!` on the GPU, which GPUArrays dispatches on the one-element destination ([mapreduce.jl#L10-L11](https://github.com/JuliaGPU/GPUArrays.jl/blob/v11.5.12/src/host/mapreduce.jl#L10-L11)):

```julia
function locate_extremum(better, c::AbstractField, condition, mask)
    mask = convert(eltype(c), mask)
    operand = condition_operand(c, condition, mask)
    tiebreak((x, i), (y, j)) = better(x, y) ? (y, j) :
                               isequal(x, y) ? (x, min(i, j)) : (x, i)
    indices = OffsetArray(LinearIndices(size(operand)), axes(operand))
    pairs = Broadcast.instantiate(Broadcast.broadcasted(tuple, operand, indices))
    value, i = fold_pairs(architecture(c), tiebreak, pairs, (mask, 1))
    return value, CartesianIndices(axes(operand))[i]
end
```

(The CPU fold exists because Base's `_mapreducedim!` cannot digest a `Broadcasted` source with non-`OneTo` axes — `check_reducedims` wants `axes(A, d)` — while GPUArrays' can.)

(For comparison, GPUArrays' own `findmax` materializes a full copy via `fA = f.(A)` even for `f = identity` — [indexing.jl#L233-L260](https://github.com/JuliaGPU/GPUArrays.jl/blob/v11.5.12/src/host/indexing.jl#L233-L260) — so this path allocates strictly less than the generic GPU one.)

Semantics: extrema are located over `interior(c)` and the returned index is in the field's own axes, so the Base identity `c[argmax(c)] == maximum(c)` holds for every field — windowed included; ties resolve to the smaller linear index (Base's convention). For default fields the index coincides with the positional interior/`nodes` numbering, so `znodes(f)[argmax(f)[3]]`-style diagnostics work unchanged. Compared with the generic `AbstractArray` fallbacks this buys:

- **GPU support**: the fallbacks scalar-index; here the reduction runs in one fused kernel.
- **Immersed-boundary consistency**: on immersed grids the fallbacks can locate an extremum inside the immersed region, while `maximum`/`minimum` mask it; routing through `condition_operand` masks immersed (and user-`condition`ed) cells with the neutral element before the search.
- **`condition` keyword parity** with the other reductions.

The motivating use case, locating diagnostics on the grid (e.g. an inversion height in a single-column model):

```julia
∂zθ = Field(∂z(θ))
zᵢ = znodes(∂zθ)[argmax(∂zθ)[3]]
```

Tests: index reductions added to `run_field_reduction_tests` (against a halo-poisoned copy, so any future fallback that scans halos fails loudly; runs on both architectures and all field locations including reduced fields), plus an immersed-grid testset asserting the raw extremum in the immersed region is skipped and `values[argmax(c)] == maximum(c)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
