### PR TITLE
Bump version from 0.111.0 to 0.112.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["Climate Modeling Alliance and contributors"]
 
 [deps]


### PR DESCRIPTION
captures the breaking change to bounds-preserving WENO on #5924 