### PR TITLE
Correctly dispatch `update_advection!`

### DIFF
--- a/src/Advection/adaptive_implicit_vertical_advection.jl
+++ b/src/Advection/adaptive_implicit_vertical_advection.jl
@@ -116,11 +116,17 @@ end
     return update_tracer_advection!(Base.tail(schemes), Base.tail(tracers), model)
 end
 
-update_advection!(scheme, model, tracer) = nothing
+@inline function update_advection!(scheme, model, tracer)
+    update_adaptive_timestep!(scheme, model)
+    update_bounds_preserving_limiter!(scheme, model.grid, tracer)
+    return nothing
+end
 
 update_advection!(scheme::FluxFormAdvection, model, tracer) = update_advection!(scheme.z, model, tracer)
 
-@inline function update_advection!(scheme::AdaptiveImplicitVerticalAdvection, model, tracer)
+update_adaptive_timestep!(scheme, model) = nothing
+
+@inline function update_adaptive_timestep!(scheme::AdaptiveImplicitVerticalAdvection, model)
     td = TimeSteppers.time_discretization(scheme)
     td.Δt[] = adaptive_advection_timestep(model.timestepper, model.clock)
     return nothing

--- a/src/Advection/bounds_preserving_tracer_advection_operators.jl
+++ b/src/Advection/bounds_preserving_tracer_advection_operators.jl
@@ -99,18 +99,15 @@ end
     @inbounds θ[i, j, k] = bounds_preserving_limiter(i, j, k, grid, scheme, c)
 end
 
-function update_advection!(scheme::BoundsPreservingWENO, model, tracer)
-    isnothing(tracer) && return nothing # the `momentum` entry has no tracer to limit
-    compute_bounds_preserving_limiter!(scheme, model.grid, tracer)
-    return nothing
-end
+update_bounds_preserving_limiter!(scheme, grid, c) = nothing
 
 """
 $(TYPEDSIGNATURES)
 
 Fill the rescaling factor ``θ`` carried by a bounds-preserving `scheme` from the tracer `c`.
 """
-function compute_bounds_preserving_limiter!(scheme, grid, c)
+function update_bounds_preserving_limiter!(scheme::BoundsPreservingWENO, grid, c)
+    isnothing(c) && return nothing # the `momentum` entry has no tracer to limit
     θ = scheme.bounds.limiter
     launch!(architecture(grid), grid, :xyz, _compute_bounds_preserving_limiter!, θ, grid, scheme, c)
     fill_halo_regions!(θ)

--- a/test/test_adaptive_implicit_vertical_advection.jl
+++ b/test/test_adaptive_implicit_vertical_advection.jl
@@ -3,6 +3,7 @@ include("dependencies_for_runtests.jl")
 using Oceananigans.BoundaryConditions: needs_implicit_solver
 
 using Oceananigans.Advection: AdaptiveImplicitVerticalAdvection,
+                              update_advection!,
                               advective_tracer_flux_z,
                               implicit_advection_upper_diagonal,
                               implicit_advection_lower_diagonal,
@@ -275,4 +276,24 @@ end
         # The upwind operator is flux-form, so a closed column conserves ∑ V q (uniform V here).
         @test sum(interior(q)) ≈ mass₀ rtol=1e-10
     end
+end
+
+@testset "AIVA and bounds preservation both refresh" begin
+    grid = RectilinearGrid(CPU(), size=(8, 8, 8), extent=(1, 1, 1), halo=(6, 6, 6))
+    advection = WENO(order=5, bounds=(0, 1), time_discretization=AdaptiveVerticallyImplicitDiscretization())
+    model = NonhydrostaticModel(grid; advection, tracers=:c)
+    scheme = model.advection.c
+
+    @test scheme isa AdaptiveImplicitVerticalAdvection
+
+    set!(model, c=(x, y, z) -> x > 0.5 ? 1.0 : 0.0)
+    time_step!(model, 0.25)
+
+    scheme.time_discretization.Δt[] = NaN
+    fill!(parent(scheme.bounds.limiter), NaN)
+
+    update_advection!(model.advection, model)
+
+    @test isfinite(scheme.time_discretization.Δt[])
+    @test all(isfinite, interior(scheme.bounds.limiter))
 end


### PR DESCRIPTION
The new `update_advection!` is ambiguous, both bounds-preserving weno and adaptive implicit advection need it and only one path could be taken.
This PR fixes the bug by taking both updates into account