### PR TITLE
Improve WENO's stencil computation efficiency

### DIFF
--- a/docs/src/field_time_series.md
+++ b/docs/src/field_time_series.md
@@ -70,7 +70,7 @@ fts[4, 4, 4, 4]
 0.269
 ```
 
-```jldoctest field_time_series; filter = r"[0-9\.e-…\s]+"
+```jldoctest field_time_series; filter = r"[0-9\.e…\s-]+"
 interior(fts, :, 1, 1, :) # x-t array
 
 # output

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -510,39 +510,45 @@ for (interp, dir, val) in zip([:xᶠᵃᵃ, :yᵃᶠᵃ, :zᵃᵃᶠ], [:x, :y, 
                                             scheme::WENO{N, FT}, bias,
                                             ψ, args...) where {N, FT}
 
-            S = $stencil(i, j, k, grid, scheme, bias, ψ, args...)
-            δ = weno_differences(scheme, S)
-            ω = biased_weno_weights(δ, grid, scheme, bias, args...)
-            return weno_reconstruction(scheme, weno_anchor(scheme, S), δ, ω)
+            S  = $stencil(i, j, k, grid, scheme, bias, ψ, args...)
+            ψ₀ = weno_anchor(scheme, S)
+            δ  = weno_differences(scheme, S)
+            ω  = biased_weno_weights(δ, grid, scheme, bias, args...)
+            return weno_reconstruction(scheme, ψ₀, δ, ω)
         end
 
         @inline function $interpolate_func(i, j, k, grid,
                                             scheme::WENO{N, FT}, bias,
                                             ψ, VI::AbstractSmoothnessStencil, args...) where {N, FT}
 
-            S = $stencil(i, j, k, grid, scheme, bias, ψ, args...)
-            δ = weno_differences(scheme, S)
-            ω = biased_weno_weights(δ, grid, scheme, bias, VI, args...)
-            return weno_reconstruction(scheme, weno_anchor(scheme, S), δ, ω)
+            S  = $stencil(i, j, k, grid, scheme, bias, ψ, args...)
+            ψ₀ = weno_anchor(scheme, S)
+            δ  = weno_differences(scheme, S)
+            ω  = biased_weno_weights(δ, grid, scheme, bias, VI, args...)
+            return weno_reconstruction(scheme, ψ₀, δ, ω)
         end
 
         @inline function $interpolate_func(i, j, k, grid,
                                             scheme::WENO{N, FT}, bias,
                                             ψ, VI::VelocityStencil, u, v, args...) where {N, FT}
 
-            S = $stencil(i, j, k, grid, scheme, bias, ψ, u, v, args...)
-            ω = biased_weno_weights((i, j, k), grid, scheme, bias, Val($val), VI, u, v)
-            return weno_reconstruction(scheme, weno_anchor(scheme, S), weno_differences(scheme, S), ω)
+            S  = $stencil(i, j, k, grid, scheme, bias, ψ, u, v, args...)
+            ψ₀ = weno_anchor(scheme, S)
+            δ  = weno_differences(scheme, S)
+            ω  = biased_weno_weights((i, j, k), grid, scheme, bias, Val($val), VI, u, v)
+            return weno_reconstruction(scheme, ψ₀, δ, ω)
         end
 
         @inline function $interpolate_func(i, j, k, grid,
                                             scheme::WENO{N, FT}, bias,
                                             ψ, VI::FunctionStencil, args...) where {N, FT}
 
-            S  = $stencil(i, j, k, grid, scheme, bias, ψ,       args...)
+            S  = $stencil(i, j, k, grid, scheme, bias, ψ, args...)
+            ψ₀ = weno_anchor(scheme, S)
+            δ  = weno_differences(scheme, S)
             Sₛ = $stencil(i, j, k, grid, scheme, bias, VI.func, args...)
-            ω = biased_weno_weights(weno_differences(scheme, Sₛ), grid, scheme, bias, VI, args...)
-            return weno_reconstruction(scheme, weno_anchor(scheme, S), weno_differences(scheme, S), ω)
+            ω  = biased_weno_weights(weno_differences(scheme, Sₛ), grid, scheme, bias, VI, args...)
+            return weno_reconstruction(scheme, ψ₀, δ, ω)
         end
     end
 end

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -160,84 +160,139 @@ for buffer in advection_buffers[2:end] # WENO{<:Any, 1} does not exist
     end
 end
 
-# _UNIFORM_ smoothness coefficients (stretched smoothness coefficients are to be fixed!)
-for FT in fully_supported_float_types
-    @eval begin
-        """
-            smoothness_coefficients(::Val{FT}, ::Val{buffer}, ::Val{stencil})
+#####
+##### Smoothness indicators
+#####
 
-        Return the coefficients used to calculate the smoothness indicators for the stencil
-        number `stencil` of a WENO reconstruction of order `buffer * 2 - 1`. β measures the derivatives of
-        the reconstructing polynomial, so it is invariant to a constant shift of the stencil and is a
-        quadratic form in the `buffer - 1` first differences spanned by the stencil rather than in the
-        `buffer` values themselves. The coefficients are ordered to calculate it in the following fashion:
+# Normalization of the smoothness indicators tabulated in the literature relative to the Jiang & Shu definition,
+# for `buffer = 2:6` (orders 3, 5, 7, 9, 11). The orders 7 and 9 follow Balsara & Shu (2000).
+const reference_smoothness_normalization = (1, 3, 6//25, 63//1250, 189//15625)
 
-        ```julia
-        buffer  = 4
-        stencil = 0
+"""
+    exact_smoothness_matrix(buffer, stencil)
 
-        δ = # The three differences spanned by stencil 0 with buffer 4 (7th order WENO)
+Return the `buffer × buffer` matrix `Q` of the Jiang & Shu smoothness indicator
 
-        C = smoothness_coefficients(Val(buffer), Val(0))
+```math
+β = ∑ₗ₌₁ᵇᵘᶠᶠᵉʳ⁻¹ ∫ (dˡpᵣ / dxˡ)² dx = ψᵀ Q ψ
+```
 
-        # The smoothness indicator
-        β = δ[1] * (C[1] * δ[1] + C[2] * δ[2] + C[3] * δ[3]) +
-            δ[2] * (C[4] * δ[2] + C[5] * δ[3]) +
-            δ[3] * (C[6] * δ[3])
-        ```
+of the stencil number `stencil` of a WENO reconstruction of order `2buffer - 1`, computed exactly in rational
+arithmetic. `pᵣ` is the polynomial that reconstructs the cell averages `ψ` of the stencil (ordered from left to
+right), the integral spans the cell whose right face is reconstructed (of unit width), and `Q` is multiplied by
+the normalization of the reference tables.
+"""
+function exact_smoothness_matrix(buffer, stencil)
+    R = Rational{BigInt}
+    k = buffer
 
-        This last operation is metaprogrammed in the function `metaprogrammed_smoothness_operation`
-        """
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{2}, ::Val{0}) = $(FT.((1,)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{2}, ::Val{1}) = $(FT.((1,)))
+    # Cell averages of the monomials xⁿ over the cells of the stencil, centered at m - (stencil + 1)
+    A = zeros(R, k, k)
+    for m in 1:k, n in 0:k-1
+        c = R(m - (stencil + 1))
+        A[m, n+1] = ((c + 1//2)^(n+1) - (c - 1//2)^(n+1)) / (n + 1)
+    end
+    B = inv(A) # polynomial coefficients aₙ = ∑ⱼ B[n+1, j] ψⱼ
 
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{3}, ::Val{0}) = $(FT.((10, -11, 4)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{3}, ::Val{1}) = $(FT.((4, -5, 4)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{3}, ::Val{2}) = $(FT.((4, -11, 10)))
+    # Integrals ∫ xᵃ xᵇ dx over the reconstructed cell [-1/2, 1/2]
+    M = zeros(R, k, k)
+    for a in 0:k-1, b in 0:k-1
+        M[a+1, b+1] = iseven(a + b) ? R(2, (a + b + 1) * BigInt(2)^(a + b + 1)) : zero(R)
+    end
 
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{0}) = $(FT.((2.107, -5.188, 1.854, 3.708, -2.788, 0.547)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{1}) = $(FT.((0.547, -1.428, 0.494, 1.468, -1.108, 0.267)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{2}) = $(FT.((0.267, -1.108, 0.494, 1.468, -1.428, 0.547)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{3}) = $(FT.((0.547, -2.788, 1.854, 3.708, -5.188, 2.107)))
+    Q = zeros(R, k, k)
+    for l in 1:k-1
+        Dₗ = zeros(R, k, k) # coefficients of the l-th derivative, xⁿ → n! / (n - l)! xⁿ⁻ˡ
+        for n in l:k-1, j in 1:k
+            Dₗ[n-l+1, j] = B[n+1, j] * prod(n-l+1:n)
+        end
+        Q += Dₗ' * M * Dₗ
+    end
 
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{0}) = $(FT.((1.07918, -4.33665, 3.25158, -0.86329, 4.7898, -7.45293, 2.01678, 2.9712, -1.63185, 0.22658)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{1}) = $(FT.((0.22658, -0.94935, 0.70218, -0.18079, 1.2513, -1.96563, 0.52158, 0.846, -0.47055, 0.06908)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{2}) = $(FT.((0.06908, -0.37185, 0.30738, -0.08209, 0.6087, -1.09413, 0.30738, 0.6087, -0.37185, 0.06908)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{3}) = $(FT.((0.06908, -0.47055, 0.52158, -0.18079, 0.846, -1.96563, 0.70218, 1.2513, -0.94935, 0.22658)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{4}) = $(FT.((0.22658, -1.63185, 2.01678, -0.86329, 2.9712, -7.45293, 3.25158, 4.7898, -4.33665, 1.07918)))
+    return Q * reference_smoothness_normalization[buffer - 1]
+end
 
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{0}) = $(FT.((0.6150211, -3.5160042, 4.1046694, -2.234743, 0.471274, 5.3540984, -12.848254, 7.1025008, -1.512161, 7.8421848, -8.765266, 1.8797194, 2.4683064, -1.0645062, 0.1152561)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{1}) = $(FT.((0.1152561, -0.681287, 0.792961, -0.4254026, 0.0880548, 1.1400536, -2.7680692, 1.5189424, -0.318647, 1.7580984, -1.98067, 0.4222438, 0.5706008, -0.247217, 0.0271779)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{2}) = $(FT.((0.0271779, -0.1837242, 0.224911, -0.1213142, 0.024562, 0.3544296, -0.925294, 0.518984, -0.1079386, 0.6713736, -0.7947412, 0.1713274, 0.2534504, -0.115071, 0.0139633)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{3}) = $(FT.((0.0139633, -0.115071, 0.1713274, -0.1079386, 0.024562, 0.2534504, -0.7947412, 0.518984, -0.1213142, 0.6713736, -0.925294, 0.224911, 0.3544296, -0.1837242, 0.0271779)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{4}) = $(FT.((0.0271779, -0.247217, 0.4222438, -0.318647, 0.0880548, 0.5706008, -1.98067, 1.5189424, -0.4254026, 1.7580984, -2.7680692, 0.792961, 1.1400536, -0.681287, 0.1152561)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{5}) = $(FT.((0.1152561, -1.0645062, 1.8797194, -1.512161, 0.471274, 2.4683064, -8.765266, 7.1025008, -2.234743, 7.8421848, -12.848254, 4.1046694, 5.3540984, -3.5160042, 0.6150211)))
+# LDLᵀ factorization of the quadratic form β = δᵀ Qδ δ, packed as, for each l, the strictly-lower column of L
+# followed by Dₗ, so that β = ∑ₗ Dₗ (δₗ + ∑ᵢ₌ₗ₊₁ Lᵢₗ δᵢ)²
+function ldlt_smoothness_coefficients(Qδ)
+    N = size(Qδ, 1)
+    R = eltype(Qδ)
+    L = zeros(R, N, N)
+    D = zeros(R, N)
+
+    for j in 1:N
+        L[j, j] = 1
+        D[j] = Qδ[j, j] - sum((L[j, k]^2 * D[k] for k in 1:j-1); init=zero(R))
+        for i in j+1:N
+            L[i, j] = (Qδ[i, j] - sum((L[i, k] * L[j, k] * D[k] for k in 1:j-1); init=zero(R))) / D[j]
+        end
+    end
+
+    C = R[]
+    for l in 1:N
+        append!(C, L[l+1:N, l])
+        push!(C, D[l])
+    end
+
+    return Tuple(C)
+end
+
+"""
+    smoothness_coefficients(::Val{FT}, ::Val{buffer}, ::Val{stencil})
+
+Return the coefficients used to calculate the smoothness indicator for the stencil number `stencil`
+of a WENO reconstruction of order `buffer * 2 - 1`: the packed LDLᵀ factorization of the smoothness
+indicator as a quadratic form in the `buffer - 1` first differences `δ` spanned by the stencil, computed
+exactly and rounded to `FT`. They are ordered to calculate β in the following fashion:
+
+```julia
+buffer  = 4
+stencil = 0
+
+δ = # The three differences spanned by stencil 0 with buffer 4 (7th order WENO)
+
+C = smoothness_coefficients(Val(Float64), Val(buffer), Val(stencil))
+
+# The smoothness indicator
+β = C[3] * (δ[1] + C[1] * δ[2] + C[2] * δ[3])^2 +
+    C[5] * (δ[2] + C[4] * δ[3])^2 +
+    C[6] *  δ[3]^2
+```
+
+This last operation is metaprogrammed in the function `metaprogrammed_smoothness_operation`
+"""
+@inline smoothness_coefficients(::Val{FT}, ::Val{buffer}, ::Val{stencil}) where {FT, buffer, stencil} = nothing # Fallback only for documentation purposes
+
+for buffer in advection_buffers[2:end], stencil in 0:buffer-1
+    Q = exact_smoothness_matrix(buffer, stencil)
+
+    # β is invariant to a constant shift of the stencil, so substituting ψₘ = ψ₁ + ∑ᵢ₌₁ᵐ⁻¹ δᵢ = ψ₁ + (T δ)ₘ
+    # makes it a quadratic form in the first differences δ
+    T = [i < m ? 1 : 0 for m in 1:buffer, i in 1:buffer-1]
+    C = ldlt_smoothness_coefficients(T' * Q * T)
+
+    for FT in fully_supported_float_types
+        @eval @inline smoothness_coefficients(::Val{$FT}, ::Val{$buffer}, ::Val{$stencil}) = $(FT.(C))
     end
 end
 
 # The rule for calculating smoothness indicators is the following (example WENO{4} which is seventh order),
 # where δ are the three differences spanned by the stencil
-# δ[1] (C[1] * δ[1] + C[2] * δ[2] + C[3] * δ[3]) +
-# δ[2] (C[4] * δ[2] + C[5] * δ[3]) +
-# δ[3] (C[6] * δ[3])
+# C[3] * (δ[1] + C[1] * δ[2] + C[2] * δ[3])^2 +
+# C[5] * (δ[2] + C[4] * δ[3])^2 +
+# C[6] *  δ[3]^2
 # This expression is the output of metaprogrammed_smoothness_operation(4)
 
 # Trick to force compilation of Val(stencil-1) and avoid loops on the GPU
 @inline function metaprogrammed_smoothness_operation(buffer)
     N = buffer - 1
-
     elem = Vector{Expr}(undef, N)
-    c_idx = 1
-
-    for stencil = 1:N - 1
-        local c = c_idx # Avoid capturing `c_idx` in the generator expression below
-        stencil_sum   = Expr(:call, :+, (:(C[$(c + i - stencil)] * δ[$i]) for i in stencil:N)...)
-        elem[stencil] = :(δ[$stencil] * $stencil_sum)
-        c_idx += N - stencil + 1
+    p = 1
+    for l in 1:N
+        t = Expr(:call, :+, :(δ[$l]), (:(C[$(p + i - l - 1)] * δ[$i]) for i in l+1:N)...)
+        elem[l] = :(C[$(p + N - l)] * $t * $t)
+        p += N - l + 1
     end
-
-    elem[N] = :(δ[$N] * δ[$N] * C[$c_idx])
-
     return Expr(:call, :+, elem...)
 end
 
@@ -245,38 +300,33 @@ end
 $(TYPEDSIGNATURES)
 
 Return the smoothness indicator β for the stencil number `stencil` of a WENO reconstruction of order `buffer * 2 - 1`,
-from the `buffer - 1` first differences `δ` spanned by that stencil.
-The smoothness indicator (β) is calculated as follows
+from the `buffer - 1` first differences `δ` spanned by that stencil. β is evaluated as a sum of squares from the packed
+LDLᵀ coefficients `C = smoothness_coefficients(Val(FT), Val(buffer), Val(stencil))`:
 
 ```julia
-C = smoothness_coefficients(Val(buffer), Val(stencil))
-
-# The smoothness indicator
+N = buffer - 1
 β = 0
-c_idx = 1
-for stencil = 1:buffer - 2
-    partial_sum = [C[c_idx + i - stencil)] * δ[i]) for i in stencil:buffer-1]
-    β          += δ[stencil] * partial_sum
-    c_idx += buffer - stencil
+p = 1
+for l = 1:N
+    t  = δ[l] + sum(C[p + i - l - 1] * δ[i] for i in l+1:N)
+    β += C[p + N - l] * t^2
+    p += N - l + 1
 end
-
-β += δ[buffer-1] * δ[buffer-1] * C[c_idx])
 ```
 
-This last operation is metaprogrammed in the function `metaprogrammed_smoothness_operation` (to avoid loops)
+This operation is metaprogrammed in the function `metaprogrammed_smoothness_operation` (to avoid loops)
 and, for `buffer == 3` unrolls into
 
 ```julia
-β = δ[1] * (C[1] * δ[1] + C[2] * δ[2]) +
-    δ[2] * (C[3] * δ[2])
+β = C[2] * (δ[1] + C[1] * δ[2])^2 + C[3] * δ[2]^2
 ```
 
 while for `buffer == 4` unrolls into
 
 ```julia
-β = δ[1] * (C[1] * δ[1] + C[2] * δ[2] + C[3] * δ[3]) +
-    δ[2] * (C[4] * δ[2] + C[5] * δ[3]) +
-    δ[3] * (C[6] * δ[3])
+β = C[3] * (δ[1] + C[1] * δ[2] + C[2] * δ[3])^2 +
+    C[5] * (δ[2] + C[4] * δ[3])^2 +
+    C[6] *  δ[3]^2
 ```
 """
 @inline smoothness_indicator(δ, args...) = zero(δ[1]) # This is a fallback method, here only for documentation purposes

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -268,7 +268,7 @@ for buffer in advection_buffers[2:end], stencil in 0:buffer-1
 
     # β is invariant to a constant shift of the stencil, so substituting ψₘ = ψ₁ + ∑ᵢ₌₁ᵐ⁻¹ δᵢ = ψ₁ + (T δ)ₘ
     # makes it a quadratic form in the first differences δ
-    T = [i < m ? 1 : 0 for m in 1:buffer, i in 1:buffer-1]
+    T = [Int(i < m) for m in 1:buffer, i in 1:buffer-1]
     C = ldlt_smoothness_coefficients(T' * Q * T)
 
     for FT in fully_supported_float_types

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -289,8 +289,9 @@ end
     elem = Vector{Expr}(undef, N)
     p = 1
     for l in 1:N
-        t = Expr(:call, :+, :(δ[$l]), (:(C[$(p + i - l - 1)] * δ[$i]) for i in l+1:N)...)
-        elem[l] = :(C[$(p + N - l)] * $t * $t)
+        q = p # Avoid boxing
+        t = Expr(:call, :+, :(δ[$l]), (:(C[$(q + i - l - 1)] * δ[$i]) for i in l+1:N)...)
+        elem[l] = :(C[$(q + N - l)] * $t * $t)
         p += N - l + 1
     end
     return Expr(:call, :+, elem...)

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -147,74 +147,77 @@ for FT in fully_supported_float_types
 
         Return the coefficients used to calculate the smoothness indicators for the stencil
         number `stencil` of a WENO reconstruction of order `buffer * 2 - 1`. The coefficients
-        are ordered in such a way to calculate the smoothness in the following fashion:
+        β measures the derivatives of the reconstructing polynomial, so it is invariant to a constant shift of
+        the stencil and is a quadratic form in the `buffer - 1` differences `δ[i] = ψ[i+1] - ψ[i]` rather than in
+        the `buffer` values themselves. The coefficients are ordered to calculate it in the following fashion:
 
         ```julia
         buffer  = 4
         stencil = 0
 
         ψ = # The stencil corresponding to S₀ with buffer 4 (7th order WENO)
+        δ = (ψ[2] - ψ[1], ψ[3] - ψ[2], ψ[4] - ψ[3])
 
         C = smoothness_coefficients(Val(buffer), Val(0))
 
         # The smoothness indicator
-        β = ψ[1] * (C[1]  * ψ[1] + C[2] * ψ[2] + C[3] * ψ[3] + C[4] * ψ[4]) +
-            ψ[2] * (C[5]  * ψ[2] + C[6] * ψ[3] + C[7] * ψ[4]) +
-            ψ[3] * (C[8]  * ψ[3] + C[9] * ψ[4])
-            ψ[4] * (C[10] * ψ[4])
+        β = δ[1] * (C[1] * δ[1] + C[2] * δ[2] + C[3] * δ[3]) +
+            δ[2] * (C[4] * δ[2] + C[5] * δ[3]) +
+            δ[3] * (C[6] * δ[3])
         ```
 
         This last operation is metaprogrammed in the function `metaprogrammed_smoothness_operation`
         """
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{2}, ::Val{0}) = $(FT.((1, -2, 1)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{2}, ::Val{1}) = $(FT.((1, -2, 1)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{2}, ::Val{0}) = $(FT.((1,)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{2}, ::Val{1}) = $(FT.((1,)))
 
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{3}, ::Val{0}) = $(FT.((10, -31, 11, 25, -19,  4)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{3}, ::Val{1}) = $(FT.((4,  -13, 5,  13, -13,  4)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{3}, ::Val{2}) = $(FT.((4,  -19, 11, 25, -31, 10)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{3}, ::Val{0}) = $(FT.((10, -11, 4)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{3}, ::Val{1}) = $(FT.((4, -5, 4)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{3}, ::Val{2}) = $(FT.((4, -11, 10)))
 
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{0}) = $(FT.((2.107,  -9.402, 7.042, -1.854, 11.003,  -17.246,  4.642,  7.043,  -3.882, 0.547)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{1}) = $(FT.((0.547,  -2.522, 1.922, -0.494,  3.443,  - 5.966,  1.602,  2.843,  -1.642, 0.267)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{2}) = $(FT.((0.267,  -1.642, 1.602, -0.494,  2.843,  - 5.966,  1.922,  3.443,  -2.522, 0.547)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{3}) = $(FT.((0.547,  -3.882, 4.642, -1.854,  7.043,  -17.246,  7.042, 11.003,  -9.402, 2.107)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{0}) = $(FT.((2.107, -5.188, 1.854, 3.708, -2.788, 0.547)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{1}) = $(FT.((0.547, -1.428, 0.494, 1.468, -1.108, 0.267)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{2}) = $(FT.((0.267, -1.108, 0.494, 1.468, -1.428, 0.547)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{4}, ::Val{3}) = $(FT.((0.547, -2.788, 1.854, 3.708, -5.188, 2.107)))
 
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{0}) = $(FT.((1.07918,  -6.49501, 7.58823, -4.11487,  0.86329,  10.20563, -24.62076, 13.58458, -2.88007, 15.21393, -17.04396, 3.64863,  4.82963, -2.08501, 0.22658)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{1}) = $(FT.((0.22658,  -1.40251, 1.65153, -0.88297,  0.18079,   2.42723,  -6.11976,  3.37018, -0.70237,  4.06293,  -4.64976, 0.99213,  1.38563, -0.60871, 0.06908)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{2}) = $(FT.((0.06908,  -0.51001, 0.67923, -0.38947,  0.08209,   1.04963,  -2.99076,  1.79098, -0.38947,  2.31153,  -2.99076, 0.67923,  1.04963, -0.51001, 0.06908)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{3}) = $(FT.((0.06908,  -0.60871, 0.99213, -0.70237,  0.18079,   1.38563,  -4.64976,  3.37018, -0.88297,  4.06293,  -6.11976, 1.65153,  2.42723, -1.40251, 0.22658)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{4}) = $(FT.((0.22658,  -2.08501, 3.64863, -2.88007,  0.86329,   4.82963, -17.04396, 13.58458, -4.11487, 15.21393, -24.62076, 7.58823, 10.20563, -6.49501, 1.07918)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{0}) = $(FT.((1.07918, -4.33665, 3.25158, -0.86329, 4.7898, -7.45293, 2.01678, 2.9712, -1.63185, 0.22658)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{1}) = $(FT.((0.22658, -0.94935, 0.70218, -0.18079, 1.2513, -1.96563, 0.52158, 0.846, -0.47055, 0.06908)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{2}) = $(FT.((0.06908, -0.37185, 0.30738, -0.08209, 0.6087, -1.09413, 0.30738, 0.6087, -0.37185, 0.06908)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{3}) = $(FT.((0.06908, -0.47055, 0.52158, -0.18079, 0.846, -1.96563, 0.70218, 1.2513, -0.94935, 0.22658)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{5}, ::Val{4}) = $(FT.((0.22658, -1.63185, 2.01678, -0.86329, 2.9712, -7.45293, 3.25158, 4.7898, -4.33665, 1.07918)))
 
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{0}) = $(FT.((0.6150211, -4.7460464, 7.6206736, -6.3394124, 2.7060170, -0.4712740,  9.4851237, -31.1771244, 26.2901672, -11.3206788,  1.9834350, 26.0445372, -44.4003904, 19.2596472, -3.3918804, 19.0757572, -16.6461044, 2.9442256, 3.6480687, -1.2950184, 0.1152561)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{1}) = $(FT.((0.1152561, -0.9117992, 1.4742480, -1.2183636, 0.5134574, -0.0880548,  1.9365967,  -6.5224244,  5.5053752,  -2.3510468,  0.4067018,  5.6662212,  -9.7838784,  4.2405032, -0.7408908,  4.3093692,  -3.7913324, 0.6694608, 0.8449957, -0.3015728, 0.0271779)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{2}) = $(FT.((0.0271779, -0.2380800, 0.4086352, -0.3462252, 0.1458762, -0.0245620,  0.5653317,  -2.0427884,  1.7905032,  -0.7727988,  0.1325006,  1.9510972,  -3.5817664,  1.5929912, -0.2792660,  1.7195652,  -1.5880404, 0.2863984, 0.3824847, -0.1429976, 0.0139633)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{3}) = $(FT.((0.0139633, -0.1429976, 0.2863984, -0.2792660, 0.1325006, -0.0245620,  0.3824847,  -1.5880404,  1.5929912,  -0.7727988,  0.1458762,  1.7195652,  -3.5817664,  1.7905032, -0.3462252,  1.9510972,  -2.0427884, 0.4086352, 0.5653317, -0.2380800, 0.0271779)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{4}) = $(FT.((0.0271779, -0.3015728, 0.6694608, -0.7408908, 0.4067018, -0.0880548,  0.8449957,  -3.7913324,  4.2405032,  -2.3510468,  0.5134574,  4.3093692,  -9.7838784,  5.5053752, -1.2183636,  5.6662212,  -6.5224244, 1.4742480, 1.9365967, -0.9117992, 0.1152561)))
-        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{5}) = $(FT.((0.1152561, -1.2950184, 2.9442256, -3.3918804, 1.9834350, -0.4712740,  3.6480687, -16.6461044, 19.2596472, -11.3206788,  2.7060170, 19.0757572, -44.4003904, 26.2901672, -6.3394124, 26.0445372, -31.1771244, 7.6206736, 9.4851237, -4.7460464, 0.6150211)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{0}) = $(FT.((0.6150211, -3.5160042, 4.1046694, -2.234743, 0.471274, 5.3540984, -12.848254, 7.1025008, -1.512161, 7.8421848, -8.765266, 1.8797194, 2.4683064, -1.0645062, 0.1152561)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{1}) = $(FT.((0.1152561, -0.681287, 0.792961, -0.4254026, 0.0880548, 1.1400536, -2.7680692, 1.5189424, -0.318647, 1.7580984, -1.98067, 0.4222438, 0.5706008, -0.247217, 0.0271779)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{2}) = $(FT.((0.0271779, -0.1837242, 0.224911, -0.1213142, 0.024562, 0.3544296, -0.925294, 0.518984, -0.1079386, 0.6713736, -0.7947412, 0.1713274, 0.2534504, -0.115071, 0.0139633)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{3}) = $(FT.((0.0139633, -0.115071, 0.1713274, -0.1079386, 0.024562, 0.2534504, -0.7947412, 0.518984, -0.1213142, 0.6713736, -0.925294, 0.224911, 0.3544296, -0.1837242, 0.0271779)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{4}) = $(FT.((0.0271779, -0.247217, 0.4222438, -0.318647, 0.0880548, 0.5706008, -1.98067, 1.5189424, -0.4254026, 1.7580984, -2.7680692, 0.792961, 1.1400536, -0.681287, 0.1152561)))
+        @inline smoothness_coefficients(::Val{$FT}, ::Val{6}, ::Val{5}) = $(FT.((0.1152561, -1.0645062, 1.8797194, -1.512161, 0.471274, 2.4683064, -8.765266, 7.1025008, -2.234743, 7.8421848, -12.848254, 4.1046694, 5.3540984, -3.5160042, 0.6150211)))
     end
 end
 
-# The rule for calculating smoothness indicators is the following (example WENO{4} which is seventh order)
-# ψ[1] (C[1]  * ψ[1] + C[2] * ψ[2] + C[3] * ψ[3] + C[4] * ψ[4]) +
-# ψ[2] (C[5]  * ψ[2] + C[6] * ψ[3] + C[7] * ψ[4]) +
-# ψ[3] (C[8]  * ψ[3] + C[9] * ψ[4])
-# ψ[4] (C[10] * ψ[4])
+# The rule for calculating smoothness indicators is the following (example WENO{4} which is seventh order),
+# where δ[i] = ψ[i+1] - ψ[i]
+# δ[1] (C[1] * δ[1] + C[2] * δ[2] + C[3] * δ[3]) +
+# δ[2] (C[4] * δ[2] + C[5] * δ[3]) +
+# δ[3] (C[6] * δ[3])
 # This expression is the output of metaprogrammed_smoothness_operation(4)
 
 # Trick to force compilation of Val(stencil-1) and avoid loops on the GPU
-@inline function metaprogrammed_smoothness_operation(buffer; shift=false)
-    elem = Vector{Expr}(undef, buffer)
+@inline function metaprogrammed_smoothness_operation(buffer)
+    N = buffer - 1
+    δ(i) = :(ψ[$(i+1)] - ψ[$i])
+
+    elem = Vector{Expr}(undef, N)
     c_idx = 1
 
-    ψ_expr(i) = shift ? :(ψ[$i] - ψ̂) : :(ψ[$i])
-
-    for stencil = 1:buffer - 1
+    for stencil = 1:N - 1
         local c = c_idx # Avoid capturing `c_idx` in the generator expression below
-        stencil_sum   = Expr(:call, :+, (:(C[$(c + i - stencil)] * $(ψ_expr(i))) for i in stencil:buffer)...)
-        elem[stencil] = :($(ψ_expr(stencil)) * $stencil_sum)
-        c_idx += buffer - stencil + 1
+        stencil_sum   = Expr(:call, :+, (:(C[$(c + i - stencil)] * $(δ(i))) for i in stencil:N)...)
+        elem[stencil] = :($(δ(stencil)) * $stencil_sum)
+        c_idx += N - stencil + 1
     end
 
-    elem[buffer] = :($(ψ_expr(buffer)) * $(ψ_expr(buffer)) * C[$c_idx])
+    elem[N] = :($(δ(N)) * $(δ(N)) * C[$c_idx])
 
     return Expr(:call, :+, elem...)
 end
@@ -227,35 +230,34 @@ The smoothness indicator (β) is calculated as follows
 
 ```julia
 C = smoothness_coefficients(Val(buffer), Val(stencil))
+δ = ntuple(i -> ψ[i+1] - ψ[i], buffer - 1)
 
 # The smoothness indicator
 β = 0
 c_idx = 1
-for stencil = 1:buffer - 1
-    partial_sum = [C[c_idx + i - stencil)] * ψ[i]) for i in stencil:buffer]
-    β          += ψ[stencil] * partial_sum
-    c_idx += buffer - stencil + 1
+for stencil = 1:buffer - 2
+    partial_sum = [C[c_idx + i - stencil)] * δ[i]) for i in stencil:buffer-1]
+    β          += δ[stencil] * partial_sum
+    c_idx += buffer - stencil
 end
 
-β += ψ[buffer] * ψ[buffer] * C[c_idx])
+β += δ[buffer-1] * δ[buffer-1] * C[c_idx])
 ```
 
 This last operation is metaprogrammed in the function `metaprogrammed_smoothness_operation` (to avoid loops)
 and, for `buffer == 3` unrolls into
 
 ```julia
-β = ψ[1] * (C[1]  * ψ[1] + C[2] * ψ[2] + C[3] * ψ[3]) +
-    ψ[2] * (C[4]  * ψ[2] + C[5] * ψ[3]) +
-    ψ[3] * (C[6])
+β = δ[1] * (C[1] * δ[1] + C[2] * δ[2]) +
+    δ[2] * (C[3] * δ[2])
 ```
 
 while for `buffer == 4` unrolls into
 
 ```julia
-β = ψ[1] * (C[1]  * ψ[1] + C[2] * ψ[2] + C[3] * ψ[3] + C[4] * ψ[4]) +
-    ψ[2] * (C[5]  * ψ[2] + C[6] * ψ[3] + C[7] * ψ[4]) +
-    ψ[3] * (C[8]  * ψ[3] + C[9] * ψ[4])
-    ψ[4] * (C[10] * ψ[4])
+β = δ[1] * (C[1] * δ[1] + C[2] * δ[2] + C[3] * δ[3]) +
+    δ[2] * (C[4] * δ[2] + C[5] * δ[3]) +
+    δ[3] * (C[6] * δ[3])
 ```
 """
 @inline smoothness_indicator(ψ, args...) = zero(ψ[1]) # This is a fallback method, here only for documentation purposes
@@ -265,20 +267,8 @@ for buffer in advection_buffers[2:end] # WENO{<:Any, 1} does not exist
     @eval @inline smoothness_operation(scheme::WENO{$buffer}, ψ, C) = @inbounds @muladd $(metaprogrammed_smoothness_operation(buffer))
 
     for stencil in 0:buffer-1, FT in fully_supported_float_types
-        if FT in (Float64, BigFloat)
-            @eval @inline smoothness_indicator(ψ, scheme::WENO{$buffer, $FT}, ::Val{$stencil}) =
-                          smoothness_operation(scheme, ψ, $(smoothness_coefficients(Val(FT), Val(buffer), Val(stencil))))
-        else
-            # Subtract central stencil value before computing smoothness indicators to avoid
-            # catastrophic cancellation for Float32 when stencil values are large.
-            # β is invariant to constant shifts (it measures polynomial derivatives),
-            # so subtracting any constant preserves correctness.
-            @eval @inline function smoothness_indicator(ψ, scheme::WENO{$buffer, $FT}, ::Val{$stencil})
-                C = $(smoothness_coefficients(Val(FT), Val(buffer), Val(stencil)))
-                ψ̂ = ψ[$(buffer ÷ 2 + 1)]
-                @inbounds @muladd $(metaprogrammed_smoothness_operation(buffer; shift=true))
-            end
-        end
+        @eval @inline smoothness_indicator(ψ, scheme::WENO{$buffer, $FT}, ::Val{$stencil}) =
+                      smoothness_operation(scheme, ψ, $(smoothness_coefficients(Val(FT), Val(buffer), Val(stencil))))
     end
 end
 

--- a/src/Advection/weno_interpolants.jl
+++ b/src/Advection/weno_interpolants.jl
@@ -102,39 +102,60 @@ for FT in fully_supported_float_types
     end
 end
 
+# Reconstruction coefficients on the first differences `δ[i] = S[i+1] - S[i]`, relative to the anchor
+# `S[buffer]`. The change of basis is exact because `∑ⱼ cⱼ = 1`.
+function difference_reconstruction_coefficients(FT, buffer, stencil)
+    c = stencil_coefficients(BigFloat, 50, stencil, collect(1:100), collect(1:100); order=buffer)
+    d = zeros(BigFloat, buffer - 1)
+
+    for k in 1:buffer - 1
+        i = buffer - stencil + k - 1 # the difference δ[i] that d[k] multiplies
+
+        for j in 1:buffer
+            mⱼ = buffer - stencil + j - 1 # the stencil value S[mⱼ] that c[j] multiplies
+
+            if i ≥ buffer && mⱼ > i
+                d[k] += c[j]
+            elseif i < buffer && mⱼ ≤ i
+                d[k] -= c[j]
+            end
+        end
+    end
+
+    return FT.(tuple(d...))
+end
+
 # ENO reconstruction procedure per stencil
 for buffer in advection_buffers[2:end] # WENO{<:Any, 1} does not exist
     for stencil in collect(0:1:buffer-1)
         for FT in fully_supported_float_types
-            # ENO coefficients for uniform direction (when T<:Nothing) and stretched directions (when T<:Any)
             @eval begin
                 """
-                    coeff_p(::WENO{buffer, FT}, bias, ::Val{stencil})
+                    coeff_p(::WENO{buffer, FT}, ::Val{stencil})
 
                 Reconstruction coefficients for the stencil number `stencil` of a WENO reconstruction
-                of order `buffer * 2 - 1`.
+                of order `buffer * 2 - 1`, expressed in the first differences of the stencil.
                 """
-                @inline coeff_p(::WENO{$buffer, $FT}, bias, ::Val{$stencil}) =
-                    @inbounds $(stencil_coefficients(FT, 50, stencil, collect(1:100), collect(1:100); order=buffer))
+                @inline coeff_p(::WENO{$buffer, $FT}, ::Val{$stencil}) =
+                    @inbounds $(difference_reconstruction_coefficients(FT, buffer, stencil))
             end
         end
 
-        # left biased and right biased reconstruction value for each stencil
         @eval begin
             """
-                biased_p(scheme::WENO{buffer}, bias, ::Val{stencil}, ψ)
+                biased_p(scheme::WENO{buffer}, ::Val{stencil}, δ)
 
-            Biased reconstruction of `ψ` from the stencil `stencil` of a WENO reconstruction of
-            order `buffer * 2 - 1`. The reconstruction is calculated as
+            Reconstruction from the stencil `stencil` of a WENO reconstruction of order `buffer * 2 - 1`,
+            relative to the anchor value `ψ₀`. `δ` are the `buffer - 1` first differences spanned by the
+            stencil, and the reconstruction is calculated as
 
             ```math
-            ψ★ = ∑ᵣ cᵣ ⋅ ψᵣ
+            ψ★ - ψ₀ = ∑ᵢ dᵢ ⋅ δᵢ
             ```
 
-            where ``cᵣ`` is computed from the function `coeff_p`
+            where ``dᵢ`` is computed from the function `coeff_p`
             """
-            @inline biased_p(scheme::WENO{$buffer}, bias, ::Val{$stencil}, ψ) =
-                @inbounds sum(coeff_p(scheme, bias, Val($stencil)) .* ψ)
+            @inline biased_p(scheme::WENO{$buffer}, ::Val{$stencil}, δ) = @inbounds sum(coeff_p(scheme, Val($stencil)) .* δ)
         end
     end
 end
@@ -146,17 +167,16 @@ for FT in fully_supported_float_types
             smoothness_coefficients(::Val{FT}, ::Val{buffer}, ::Val{stencil})
 
         Return the coefficients used to calculate the smoothness indicators for the stencil
-        number `stencil` of a WENO reconstruction of order `buffer * 2 - 1`. The coefficients
-        β measures the derivatives of the reconstructing polynomial, so it is invariant to a constant shift of
-        the stencil and is a quadratic form in the `buffer - 1` differences `δ[i] = ψ[i+1] - ψ[i]` rather than in
-        the `buffer` values themselves. The coefficients are ordered to calculate it in the following fashion:
+        number `stencil` of a WENO reconstruction of order `buffer * 2 - 1`. β measures the derivatives of
+        the reconstructing polynomial, so it is invariant to a constant shift of the stencil and is a
+        quadratic form in the `buffer - 1` first differences spanned by the stencil rather than in the
+        `buffer` values themselves. The coefficients are ordered to calculate it in the following fashion:
 
         ```julia
         buffer  = 4
         stencil = 0
 
-        ψ = # The stencil corresponding to S₀ with buffer 4 (7th order WENO)
-        δ = (ψ[2] - ψ[1], ψ[3] - ψ[2], ψ[4] - ψ[3])
+        δ = # The three differences spanned by stencil 0 with buffer 4 (7th order WENO)
 
         C = smoothness_coefficients(Val(buffer), Val(0))
 
@@ -196,7 +216,7 @@ for FT in fully_supported_float_types
 end
 
 # The rule for calculating smoothness indicators is the following (example WENO{4} which is seventh order),
-# where δ[i] = ψ[i+1] - ψ[i]
+# where δ are the three differences spanned by the stencil
 # δ[1] (C[1] * δ[1] + C[2] * δ[2] + C[3] * δ[3]) +
 # δ[2] (C[4] * δ[2] + C[5] * δ[3]) +
 # δ[3] (C[6] * δ[3])
@@ -205,19 +225,18 @@ end
 # Trick to force compilation of Val(stencil-1) and avoid loops on the GPU
 @inline function metaprogrammed_smoothness_operation(buffer)
     N = buffer - 1
-    δ(i) = :(ψ[$(i+1)] - ψ[$i])
 
     elem = Vector{Expr}(undef, N)
     c_idx = 1
 
     for stencil = 1:N - 1
         local c = c_idx # Avoid capturing `c_idx` in the generator expression below
-        stencil_sum   = Expr(:call, :+, (:(C[$(c + i - stencil)] * $(δ(i))) for i in stencil:N)...)
-        elem[stencil] = :($(δ(stencil)) * $stencil_sum)
+        stencil_sum   = Expr(:call, :+, (:(C[$(c + i - stencil)] * δ[$i]) for i in stencil:N)...)
+        elem[stencil] = :(δ[$stencil] * $stencil_sum)
         c_idx += N - stencil + 1
     end
 
-    elem[N] = :($(δ(N)) * $(δ(N)) * C[$c_idx])
+    elem[N] = :(δ[$N] * δ[$N] * C[$c_idx])
 
     return Expr(:call, :+, elem...)
 end
@@ -225,12 +244,12 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Return the smoothness indicator β for the stencil number `stencil` of a WENO reconstruction of order `buffer * 2 - 1`.
+Return the smoothness indicator β for the stencil number `stencil` of a WENO reconstruction of order `buffer * 2 - 1`,
+from the `buffer - 1` first differences `δ` spanned by that stencil.
 The smoothness indicator (β) is calculated as follows
 
 ```julia
 C = smoothness_coefficients(Val(buffer), Val(stencil))
-δ = ntuple(i -> ψ[i+1] - ψ[i], buffer - 1)
 
 # The smoothness indicator
 β = 0
@@ -260,15 +279,15 @@ while for `buffer == 4` unrolls into
     δ[3] * (C[6] * δ[3])
 ```
 """
-@inline smoothness_indicator(ψ, args...) = zero(ψ[1]) # This is a fallback method, here only for documentation purposes
+@inline smoothness_indicator(δ, args...) = zero(δ[1]) # This is a fallback method, here only for documentation purposes
 
 # Smoothness indicators for stencil `stencil` for left and right biased reconstruction
 for buffer in advection_buffers[2:end] # WENO{<:Any, 1} does not exist
-    @eval @inline smoothness_operation(scheme::WENO{$buffer}, ψ, C) = @inbounds @muladd $(metaprogrammed_smoothness_operation(buffer))
+    @eval @inline smoothness_operation(scheme::WENO{$buffer}, δ, C) = @inbounds @muladd $(metaprogrammed_smoothness_operation(buffer))
 
     for stencil in 0:buffer-1, FT in fully_supported_float_types
-        @eval @inline smoothness_indicator(ψ, scheme::WENO{$buffer, $FT}, ::Val{$stencil}) =
-                      smoothness_operation(scheme, ψ, $(smoothness_coefficients(Val(FT), Val(buffer), Val(stencil))))
+        @eval @inline smoothness_indicator(δ, scheme::WENO{$buffer, $FT}, ::Val{$stencil}) =
+                      smoothness_operation(scheme, δ, $(smoothness_coefficients(Val(FT), Val(buffer), Val(stencil))))
     end
 end
 
@@ -282,11 +301,14 @@ end
     return :($(elem...),)
 end
 
+# The `buffer - 1` differences spanned by stencil number `stencil`
+stencil_differences(buffer, stencil) = Expr(:tuple, (:(δ[$i]) for i in (buffer - stencil):(2buffer - 2 - stencil))...)
+
 # smoothness_indicator calculation for scheme and stencil = 0:buffer - 1
 @inline function metaprogrammed_beta_loop(buffer)
     elem = Vector(undef, buffer)
     for stencil = 1:buffer
-        elem[stencil] = :(smoothness_indicator(ψ[$stencil], scheme, Val($(stencil-1))))
+        elem[stencil] = :(smoothness_indicator($(stencil_differences(buffer, stencil-1)), scheme, Val($(stencil-1))))
     end
 
     return :($(elem...),)
@@ -305,7 +327,7 @@ end
 for buffer in advection_buffers[2:end]
     @eval begin
         @inline         beta_sum(scheme::WENO{$buffer, FT}, β₁, β₂)    where FT = @inbounds $(metaprogrammed_beta_sum(buffer))
-        @inline        beta_loop(scheme::WENO{$buffer, FT}, ψ)         where FT = @inbounds $(metaprogrammed_beta_loop(buffer))
+        @inline        beta_loop(scheme::WENO{$buffer, FT}, δ)         where FT = @inbounds $(metaprogrammed_beta_loop(buffer))
         @inline zweno_alpha_loop(scheme::WENO{$buffer, FT, WCT}, β, τ) where {FT, WCT} = @inbounds $(metaprogrammed_zweno_alpha_loop(buffer))
     end
 end
@@ -335,8 +357,8 @@ where
 
 The ``α`` values are normalized before returning
 """
-@inline function biased_weno_weights(ψ, grid, scheme::WENO{N, FT}, args...) where {N, FT}
-    β = beta_loop(scheme, ψ)
+@inline function biased_weno_weights(δ, grid, scheme::WENO{N, FT}, args...) where {N, FT}
+    β = beta_loop(scheme, δ)
     τ = global_smoothness_indicator(Val(N), β)
     α = zweno_alpha_loop(scheme, β, τ)
     Σα⁻¹ =  1 / sum(α)
@@ -348,8 +370,8 @@ end
 
     uₛ = tangential_stencil_u(i, j, k, grid, scheme, bias, dir, u)
     vₛ = tangential_stencil_v(i, j, k, grid, scheme, bias, dir, v)
-    βᵤ = beta_loop(scheme, uₛ)
-    βᵥ = beta_loop(scheme, vₛ)
+    βᵤ = beta_loop(scheme, weno_differences(scheme, uₛ))
+    βᵥ = beta_loop(scheme, weno_differences(scheme, vₛ))
     β  = beta_sum(scheme, βᵤ, βᵥ)
 
     τ = global_smoothness_indicator(Val(N), β)
@@ -402,63 +424,39 @@ julia> load_weno_stencil(2, :x)
     return :($(stencil...),)
 end
 
-# Stencils for left and right biased reconstruction ((ψ̅ᵢ₋ᵣ₊ⱼ for j in 0:k) for r in 0:k) to calculate v̂ᵣ = ∑ⱼ(cᵣⱼψ̅ᵢ₋ᵣ₊ⱼ)
-# where `k = N - 1`. Coefficients (cᵣⱼ for j in 0:N) for stencil r are given by `coeff_side_p(scheme, Val(r), ...)`
+# The right-biased stencil is the mirror of the left-biased one, so both use the left-biased coefficients
 for dir in (:x, :y, :z), (T, f) in zip((:Any, :Function), (false, true))
     stencil = Symbol(:weno_stencil_, dir)
     @eval begin
         @inline function $stencil(i, j, k, grid, ::WENO{2}, bias, ψ::$T, args...)
             S = @inbounds $(load_weno_stencil(2, dir, f))
-            return S₀₂(S, bias), S₁₂(S, bias)
+            return @inbounds ifelse(bias == LeftBias, (S[1], S[2], S[3]), (S[4], S[3], S[2]))
         end
 
         @inline function $stencil(i, j, k, grid, ::WENO{3}, bias, ψ::$T, args...)
             S = @inbounds $(load_weno_stencil(3, dir, f))
-            return S₀₃(S, bias), S₁₃(S, bias), S₂₃(S, bias)
+            return @inbounds ifelse(bias == LeftBias, (S[1], S[2], S[3], S[4], S[5]), (S[6], S[5], S[4], S[3], S[2]))
         end
 
         @inline function $stencil(i, j, k, grid, ::WENO{4}, bias, ψ::$T, args...)
             S = @inbounds $(load_weno_stencil(4, dir, f))
-            return S₀₄(S, bias), S₁₄(S, bias), S₂₄(S, bias), S₃₄(S, bias)
+            return @inbounds ifelse(bias == LeftBias, (S[1], S[2], S[3], S[4], S[5], S[6], S[7]), (S[8], S[7], S[6], S[5], S[4], S[3], S[2]))
         end
 
         @inline function $stencil(i, j, k, grid, ::WENO{5}, bias, ψ::$T, args...)
             S = @inbounds $(load_weno_stencil(5, dir, f))
-            return S₀₅(S, bias), S₁₅(S, bias), S₂₅(S, bias), S₃₅(S, bias), S₄₅(S, bias)
+            return @inbounds ifelse(bias == LeftBias, (S[1], S[2], S[3], S[4], S[5], S[6], S[7], S[8], S[9]), (S[10], S[9], S[8], S[7], S[6], S[5], S[4], S[3], S[2]))
         end
 
         @inline function $stencil(i, j, k, grid, ::WENO{6}, bias, ψ::$T, args...)
             S = @inbounds $(load_weno_stencil(6, dir, f))
-            return S₀₆(S, bias), S₁₆(S, bias), S₂₆(S, bias), S₃₆(S, bias), S₄₆(S, bias), S₅₆(S, bias)
+            return @inbounds ifelse(bias == LeftBias, (S[1], S[2], S[3], S[4], S[5], S[6], S[7], S[8], S[9], S[10], S[11]), (S[12], S[11], S[10], S[9], S[8], S[7], S[6], S[5], S[4], S[3], S[2]))
         end
     end
 end
 
-# WENO stencils
-@inline S₀₂(S, bias) = @inbounds ifelse(bias == LeftBias, (S[2], S[3]), (S[3], S[2]))
-@inline S₁₂(S, bias) = @inbounds ifelse(bias == LeftBias, (S[1], S[2]), (S[4], S[3]))
-
-@inline S₀₃(S, bias) = @inbounds ifelse(bias == LeftBias, (S[3], S[4], S[5]), (S[4], S[3], S[2]))
-@inline S₁₃(S, bias) = @inbounds ifelse(bias == LeftBias, (S[2], S[3], S[4]), (S[5], S[4], S[3]))
-@inline S₂₃(S, bias) = @inbounds ifelse(bias == LeftBias, (S[1], S[2], S[3]), (S[6], S[5], S[4]))
-
-@inline S₀₄(S, bias) = @inbounds ifelse(bias == LeftBias, (S[4], S[5], S[6], S[7]), (S[5], S[4], S[3], S[2]))
-@inline S₁₄(S, bias) = @inbounds ifelse(bias == LeftBias, (S[3], S[4], S[5], S[6]), (S[6], S[5], S[4], S[3]))
-@inline S₂₄(S, bias) = @inbounds ifelse(bias == LeftBias, (S[2], S[3], S[4], S[5]), (S[7], S[6], S[5], S[4]))
-@inline S₃₄(S, bias) = @inbounds ifelse(bias == LeftBias, (S[1], S[2], S[3], S[4]), (S[8], S[7], S[6], S[5]))
-
-@inline S₀₅(S, bias) = @inbounds ifelse(bias == LeftBias, (S[5], S[6], S[7], S[8], S[9]), (S[6],  S[5], S[4], S[3], S[2]))
-@inline S₁₅(S, bias) = @inbounds ifelse(bias == LeftBias, (S[4], S[5], S[6], S[7], S[8]), (S[7],  S[6], S[5], S[4], S[3]))
-@inline S₂₅(S, bias) = @inbounds ifelse(bias == LeftBias, (S[3], S[4], S[5], S[6], S[7]), (S[8],  S[7], S[6], S[5], S[4]))
-@inline S₃₅(S, bias) = @inbounds ifelse(bias == LeftBias, (S[2], S[3], S[4], S[5], S[6]), (S[9],  S[8], S[7], S[6], S[5]))
-@inline S₄₅(S, bias) = @inbounds ifelse(bias == LeftBias, (S[1], S[2], S[3], S[4], S[5]), (S[10], S[9], S[8], S[7], S[6]))
-
-@inline S₀₆(S, bias) = @inbounds ifelse(bias == LeftBias, (S[6], S[7], S[8], S[9], S[10], S[11]), (S[7],  S[6],  S[5],  S[4], S[3], S[2]))
-@inline S₁₆(S, bias) = @inbounds ifelse(bias == LeftBias, (S[5], S[6], S[7], S[8], S[9],  S[10]), (S[8],  S[7],  S[6],  S[5], S[4], S[3]))
-@inline S₂₆(S, bias) = @inbounds ifelse(bias == LeftBias, (S[4], S[5], S[6], S[7], S[8],  S[9]),  (S[9],  S[8],  S[7],  S[6], S[5], S[4]))
-@inline S₃₆(S, bias) = @inbounds ifelse(bias == LeftBias, (S[3], S[4], S[5], S[6], S[7],  S[8]),  (S[10], S[9],  S[8],  S[7], S[6], S[5]))
-@inline S₄₆(S, bias) = @inbounds ifelse(bias == LeftBias, (S[2], S[3], S[4], S[5], S[6],  S[7]),  (S[11], S[10], S[9],  S[8], S[7], S[6]))
-@inline S₅₆(S, bias) = @inbounds ifelse(bias == LeftBias, (S[1], S[2], S[3], S[4], S[5],  S[6]),  (S[12], S[11], S[10], S[9], S[8], S[7]))
+@inline weno_anchor(::WENO{N}, S) where N = @inbounds S[N]
+@inline weno_differences(::WENO{N}, S) where N = @inbounds ntuple(i -> S[i+1] - S[i], Val(2N - 2))
 
 # Stencil for vector invariant calculation of smoothness indicators in the horizontal direction
 # Parallel to the interpolation direction! (same as left/right stencil)
@@ -471,39 +469,35 @@ end
 @inline function metaprogrammed_weno_reconstruction(buffer)
     elem = Vector(undef, buffer)
     for stencil = 1:buffer
-        elem[stencil] = :(ω[$stencil] * biased_p(scheme, bias, Val($(stencil-1)), ψ[$stencil]))
+        elem[stencil] = :(ω[$stencil] * biased_p(scheme, Val($(stencil-1)), $(stencil_differences(buffer, stencil-1))))
     end
 
-    return Expr(:call, :+, elem...)
+    return Expr(:call, :+, :ψ₀, elem...)
 end
 
 """
 $(TYPEDSIGNATURES)
 
-`bias`ed reconstruction of stencils `ψ` for a WENO scheme of order `buffer * 2 - 1` weighted by WENO
-weights `ω`. `ψ` is a `Tuple` of `buffer` stencils of size `buffer` and `ω` is a `Tuple` of size `buffer`
-containing the computed weights for each of the reconstruction stencils.
-
-The location `loc` and index `idx` that appear in the unrolled example below are used internally by
-[`biased_p`](@ref) for stretched WENO directions.
+Reconstruction of a WENO scheme of order `buffer * 2 - 1` from the anchor value `ψ₀` and the `2buffer - 2`
+first differences `δ` of the bias-ordered stencil, weighted by the WENO weights `ω`.
 
 The calculation of the reconstruction is metaprogrammed in the `metaprogrammed_weno_reconstruction` function which, for
 `buffer == 4` (seventh order WENO), unrolls to:
 
 ```julia
-ψ̂ = ω[1] * biased_p(scheme, bias, Val(0), ψ[1], cT, Val(val), idx, loc) +
-    ω[2] * biased_p(scheme, bias, Val(1), ψ[2], cT, Val(val), idx, loc) +
-    ω[3] * biased_p(scheme, bias, Val(2), ψ[3], cT, Val(val), idx, loc) +
-    ω[4] * biased_p(scheme, bias, Val(3), ψ[4], cT, Val(val), idx, loc))
+ψ̂ = ψ₀ + ω[1] * biased_p(scheme, Val(0), (δ[4], δ[5], δ[6])) +
+         ω[2] * biased_p(scheme, Val(1), (δ[3], δ[4], δ[5])) +
+         ω[3] * biased_p(scheme, Val(2), (δ[2], δ[3], δ[4])) +
+         ω[4] * biased_p(scheme, Val(3), (δ[1], δ[2], δ[3]))
 ```
 
 Here, [`biased_p`](@ref) is the function that computes the linear reconstruction of the individual stencils.
 """
-@inline weno_reconstruction(scheme, bias, ψ, args...) = zero(ψ[1][1]) # Fallback only for documentation purposes
+@inline weno_reconstruction(scheme, ψ₀, δ, args...) = ψ₀ # Fallback only for documentation purposes
 
 # Calculation of WENO reconstructed value v⋆ = ∑ᵣ(wᵣv̂ᵣ)
 for buffer in advection_buffers[2:end]
-    @eval @inline weno_reconstruction(scheme::WENO{$buffer}, bias, ψ, ω) = @inbounds @muladd $(metaprogrammed_weno_reconstruction(buffer))
+    @eval @inline weno_reconstruction(scheme::WENO{$buffer}, ψ₀, δ, ω) = @inbounds @muladd $(metaprogrammed_weno_reconstruction(buffer))
 end
 
 # Interpolation functions
@@ -516,37 +510,39 @@ for (interp, dir, val) in zip([:xᶠᵃᵃ, :yᵃᶠᵃ, :zᵃᵃᶠ], [:x, :y, 
                                             scheme::WENO{N, FT}, bias,
                                             ψ, args...) where {N, FT}
 
-            ψₜ = $stencil(i, j, k, grid, scheme, bias, ψ, args...)
-            ω = biased_weno_weights(ψₜ, grid, scheme, bias, args...)
-            return weno_reconstruction(scheme, bias, ψₜ, ω)
+            S = $stencil(i, j, k, grid, scheme, bias, ψ, args...)
+            δ = weno_differences(scheme, S)
+            ω = biased_weno_weights(δ, grid, scheme, bias, args...)
+            return weno_reconstruction(scheme, weno_anchor(scheme, S), δ, ω)
         end
 
         @inline function $interpolate_func(i, j, k, grid,
                                             scheme::WENO{N, FT}, bias,
                                             ψ, VI::AbstractSmoothnessStencil, args...) where {N, FT}
 
-            ψₜ = $stencil(i, j, k, grid, scheme, bias, ψ, args...)
-            ω = biased_weno_weights(ψₜ, grid, scheme, bias, VI, args...)
-            return weno_reconstruction(scheme, bias, ψₜ, ω)
+            S = $stencil(i, j, k, grid, scheme, bias, ψ, args...)
+            δ = weno_differences(scheme, S)
+            ω = biased_weno_weights(δ, grid, scheme, bias, VI, args...)
+            return weno_reconstruction(scheme, weno_anchor(scheme, S), δ, ω)
         end
 
         @inline function $interpolate_func(i, j, k, grid,
                                             scheme::WENO{N, FT}, bias,
                                             ψ, VI::VelocityStencil, u, v, args...) where {N, FT}
 
-            ψₜ = $stencil(i, j, k, grid, scheme, bias, ψ, u, v, args...)
+            S = $stencil(i, j, k, grid, scheme, bias, ψ, u, v, args...)
             ω = biased_weno_weights((i, j, k), grid, scheme, bias, Val($val), VI, u, v)
-            return weno_reconstruction(scheme, bias, ψₜ, ω)
+            return weno_reconstruction(scheme, weno_anchor(scheme, S), weno_differences(scheme, S), ω)
         end
 
         @inline function $interpolate_func(i, j, k, grid,
                                             scheme::WENO{N, FT}, bias,
                                             ψ, VI::FunctionStencil, args...) where {N, FT}
 
-            ψₜ = $stencil(i, j, k, grid, scheme, bias, ψ,       args...)
-            ψₛ = $stencil(i, j, k, grid, scheme, bias, VI.func, args...)
-            ω = biased_weno_weights(ψₛ, grid, scheme, bias, VI, args...)
-            return weno_reconstruction(scheme, bias, ψₜ, ω)
+            S  = $stencil(i, j, k, grid, scheme, bias, ψ,       args...)
+            Sₛ = $stencil(i, j, k, grid, scheme, bias, VI.func, args...)
+            ω = biased_weno_weights(weno_differences(scheme, Sₛ), grid, scheme, bias, VI, args...)
+            return weno_reconstruction(scheme, weno_anchor(scheme, S), weno_differences(scheme, S), ω)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,7 @@ CUDA.allowscalar() do
             include("test_bounds_preserving_advection.jl")
             include("test_adaptive_implicit_vertical_advection.jl")
             include("test_weno_smoothness.jl")
+            include("test_weno_smoothness_reference.jl")
         end
     end
 

--- a/test/test_weno_smoothness.jl
+++ b/test/test_weno_smoothness.jl
@@ -15,22 +15,15 @@ using Oceananigans.Advection: beta_loop, biased_weno_weights
         S_f64 = ntuple(i -> 300.0 + 0.1 * sinpi(2 * (i - 1) / n_stencil), n_stencil)
         S_f32 = ntuple(i -> Float32(S_f64[i]), n_stencil)
 
-        # Build sub-stencils (left-bias ordering, matching S₀ₙ … S₍ₙ₋₁₎ₙ)
-        ψ_f64 = ntuple(Val(buffer)) do k
-            start = buffer - k + 1
-            ntuple(j -> S_f64[start + j - 1], Val(buffer))
-        end
-
-        ψ_f32 = ntuple(Val(buffer)) do k
-            start = buffer - k + 1
-            ntuple(j -> S_f32[start + j - 1], Val(buffer))
-        end
+        # First differences of the left-bias-ordered stencil, which is S[1] … S[2buffer - 1]
+        δ_f64 = ntuple(i -> S_f64[i+1] - S_f64[i], Val(2buffer - 2))
+        δ_f32 = ntuple(i -> S_f32[i+1] - S_f32[i], Val(2buffer - 2))
 
         scheme_f64 = WENO(Float64; order, weight_computation=Oceananigans.Utils.NormalDivision)
         scheme_f32 = WENO(Float32; order, weight_computation=Oceananigans.Utils.NormalDivision)
 
-        β_f64 = beta_loop(scheme_f64, ψ_f64)
-        β_f32 = beta_loop(scheme_f32, ψ_f32)
+        β_f64 = beta_loop(scheme_f64, δ_f64)
+        β_f32 = beta_loop(scheme_f32, δ_f32)
 
         @info "WENO order $order β (Float64): $β_f64"
         @info "WENO order $order β (Float32): $β_f32"
@@ -50,8 +43,8 @@ using Oceananigans.Advection: beta_loop, biased_weno_weights
             end
 
             # Weights must sum to 1 and match Float64 reference
-            ω_f64 = biased_weno_weights(ψ_f64, nothing, scheme_f64)
-            ω_f32 = biased_weno_weights(ψ_f32, nothing, scheme_f32)
+            ω_f64 = biased_weno_weights(δ_f64, nothing, scheme_f64)
+            ω_f32 = biased_weno_weights(δ_f32, nothing, scheme_f32)
 
             @test sum(ω_f64) ≈ 1
             @test sum(ω_f32) ≈ 1

--- a/test/test_weno_smoothness_reference.jl
+++ b/test/test_weno_smoothness_reference.jl
@@ -53,9 +53,7 @@ end
 
         for stencil in 0:buffer-1, FT in (Float64, Float32)
             scheme = WENO(FT; order)
-            # The exact coefficients are rounded to FT and the sum of squares has no cancellation,
-            # so the result is accurate to a few ulps (the tolerance leaves room for the rounding of δ)
-            rtol = FT == Float64 ? 1e-13 : 1e-4
+            rtol = 20eps(FT)
 
             for _ in 1:20
                 # A stencil with a large mean and O(1) variations, in BigFloat for the reference

--- a/test/test_weno_smoothness_reference.jl
+++ b/test/test_weno_smoothness_reference.jl
@@ -1,0 +1,72 @@
+include("dependencies_for_runtests.jl")
+
+using Oceananigans.Advection: smoothness_indicator
+using Random
+
+# Smoothness indicator coefficients tabulated in the literature (Balsara & Shu, 2000, for orders 7 and 9), in
+# the value form β = ∑ᵢ ψᵢ (Cᵢᵢ ψᵢ + ∑ⱼ₌ᵢ₊₁ Cᵢⱼ ψⱼ) over the stencil values ψ ordered from left to right.
+# The tables are exact: they are integers divided by `reference_smoothness_denominator[buffer]`.
+const reference_smoothness_denominator = Dict(2 => 1, 3 => 1, 4 => 1000, 5 => 100000, 6 => 10000000)
+
+const reference_smoothness_coefficients = Dict(
+    (2, 0) => (1, -2, 1),
+    (2, 1) => (1, -2, 1),
+    (3, 0) => (10, -31, 11, 25, -19, 4),
+    (3, 1) => (4, -13, 5, 13, -13, 4),
+    (3, 2) => (4, -19, 11, 25, -31, 10),
+    (4, 0) => (2107, -9402, 7042, -1854, 11003, -17246, 4642, 7043, -3882, 547),
+    (4, 1) => (547, -2522, 1922, -494, 3443, -5966, 1602, 2843, -1642, 267),
+    (4, 2) => (267, -1642, 1602, -494, 2843, -5966, 1922, 3443, -2522, 547),
+    (4, 3) => (547, -3882, 4642, -1854, 7043, -17246, 7042, 11003, -9402, 2107),
+    (5, 0) => (107918, -649501, 758823, -411487, 86329, 1020563, -2462076, 1358458, -288007, 1521393, -1704396, 364863, 482963, -208501, 22658),
+    (5, 1) => (22658, -140251, 165153, -88297, 18079, 242723, -611976, 337018, -70237, 406293, -464976, 99213, 138563, -60871, 6908),
+    (5, 2) => (6908, -51001, 67923, -38947, 8209, 104963, -299076, 179098, -38947, 231153, -299076, 67923, 104963, -51001, 6908),
+    (5, 3) => (6908, -60871, 99213, -70237, 18079, 138563, -464976, 337018, -88297, 406293, -611976, 165153, 242723, -140251, 22658),
+    (5, 4) => (22658, -208501, 364863, -288007, 86329, 482963, -1704396, 1358458, -411487, 1521393, -2462076, 758823, 1020563, -649501, 107918),
+    (6, 0) => (6150211, -47460464, 76206736, -63394124, 27060170, -4712740, 94851237, -311771244, 262901672, -113206788, 19834350, 260445372, -444003904, 192596472, -33918804, 190757572, -166461044, 29442256, 36480687, -12950184, 1152561),
+    (6, 1) => (1152561, -9117992, 14742480, -12183636, 5134574, -880548, 19365967, -65224244, 55053752, -23510468, 4067018, 56662212, -97838784, 42405032, -7408908, 43093692, -37913324, 6694608, 8449957, -3015728, 271779),
+    (6, 2) => (271779, -2380800, 4086352, -3462252, 1458762, -245620, 5653317, -20427884, 17905032, -7727988, 1325006, 19510972, -35817664, 15929912, -2792660, 17195652, -15880404, 2863984, 3824847, -1429976, 139633),
+    (6, 3) => (139633, -1429976, 2863984, -2792660, 1325006, -245620, 3824847, -15880404, 15929912, -7727988, 1458762, 17195652, -35817664, 17905032, -3462252, 19510972, -20427884, 4086352, 5653317, -2380800, 271779),
+    (6, 4) => (271779, -3015728, 6694608, -7408908, 4067018, -880548, 8449957, -37913324, 42405032, -23510468, 5134574, 43093692, -97838784, 55053752, -12183636, 56662212, -65224244, 14742480, 19365967, -9117992, 1152561),
+    (6, 5) => (1152561, -12950184, 29442256, -33918804, 19834350, -4712740, 36480687, -166461044, 192596472, -113206788, 27060170, 190757572, -444003904, 262901672, -63394124, 260445372, -311771244, 76206736, 94851237, -47460464, 6150211),
+)
+
+# The reference smoothness indicator of the `buffer` stencil values `ψ`, evaluated exactly (in BigFloat from
+# the rational coefficients)
+function reference_smoothness_indicator(ψ, buffer, stencil)
+    C = reference_smoothness_coefficients[(buffer, stencil)] .// reference_smoothness_denominator[buffer]
+    β = zero(BigFloat)
+    c = 1
+    for i in 1:buffer
+        β += ψ[i] * sum(BigFloat(C[c + j - i]) * ψ[j] for j in i:buffer)
+        c += buffer - i + 1
+    end
+    return β
+end
+
+@testset "WENO smoothness indicators match the reference tables" begin
+    Random.seed!(1234)
+
+    for buffer in 2:6
+        order = 2buffer - 1
+        @info "Testing WENO$order smoothness indicators against the reference tables..."
+
+        for stencil in 0:buffer-1, FT in (Float64, Float32)
+            scheme = WENO(FT; order)
+            # The exact coefficients are rounded to FT and the sum of squares has no cancellation,
+            # so the result is accurate to a few ulps (the tolerance leaves room for the rounding of δ)
+            rtol = FT == Float64 ? 1e-13 : 1e-4
+
+            for _ in 1:20
+                # A stencil with a large mean and O(1) variations, in BigFloat for the reference
+                ψ = ntuple(_ -> 300 + randn(BigFloat), buffer)
+                δ = ntuple(i -> FT(ψ[i+1] - ψ[i]), buffer - 1)
+
+                β_ref = reference_smoothness_indicator(ψ, buffer, stencil)
+                β     = smoothness_indicator(δ, scheme, Val(stencil))
+
+                @test β ≈ β_ref rtol=rtol
+            end
+        end
+    end
+end


### PR DESCRIPTION
This is actually something I have not thought about before, but it might allows us to gain a lot of efficiency and it became very easy with claude that can compute and test the coefficients correctly:

WENO's smoothness computation take by far the largest share of computation in WENO (~70% of the flops). These smoothness operators are computed as straight coefficients times the WENO stencil values themselves, because the reference we used gave that explicit form. However, we know already that all smoothness operators are quadratic in the values and can be rewritten in terms of differences. The example is the typical 5th order weno stencil computation that can be rewritten as 

```math
\begin{align}
  \beta_0 &= \tfrac{13}{12}\left(\psi_1 - 2\psi_2 + \psi_3\right)^2
           + \tfrac{1}{4}\left(3\psi_1 - 4\psi_2 + \psi_3\right)^2, \\[2pt]
  \beta_1 &= \tfrac{13}{12}\left(\psi_1 - 2\psi_2 + \psi_3\right)^2
           + \tfrac{1}{4}\left(\psi_1 - \psi_3\right)^2, \\[2pt]
  \beta_2 &= \tfrac{13}{12}\left(\psi_1 - 2\psi_2 + \psi_3\right)^2
           + \tfrac{1}{4}\left(\psi_1 - 4\psi_2 + 3\psi_3\right)^2 .
\end{align}
```

while in main, the same operation is written as
```math
\beta = \psi_1(C_1\psi_1 + C_2\psi_2 + C_3\psi_3) + \psi_2(C_4\psi_2 + C_5\psi_3) + \psi_3 C_6 \psi_3
```
which expands to
```math
\begin{align}
\beta_0 &= 10\,\psi_1^2 - 31\,\psi_1\psi_2 + 11\,\psi_1\psi_3 + 25\,\psi_2^2 - 19\,\psi_2\psi_3 +  4\,\psi_3^2, \\[2pt]
\beta_1 &=  4\,\psi_1^2 - 13\,\psi_1\psi_2 +  5\,\psi_1\psi_3 + 13\,\psi_2^2 - 13\,\psi_2\psi_3 +  4\,\psi_3^2, \\[2pt]
\beta_2 &=  4\,\psi_1^2 - 19\,\psi_1\psi_2 + 11\,\psi_1\psi_3 + 25\,\psi_2^2 - 31\,\psi_2\psi_3 + 10\,\psi_3^2 .
\end{align}
```

many more coefficients and operations. 
The same for WENO3, where this identity is a bit more explicit:
main:
```math 
\begin{align}
\beta_0 &= \psi_1^2 - 2\,\psi_1\psi_2 + \psi_2^2, \\
\beta_1 &= \psi_1^2 - 2\,\psi_1\psi_2 + \psi_2^2 .
\end{align}
```
diff form:
```math
\begin{align}
\beta_0 &= \left(\psi_2 - \psi_1\right)^2, \\
\beta_1 &= \left(\psi_2 - \psi_1\right)^2 .
\end{align}
```

Exactly like WENO5 and WENO3, also all the other smoothness operators can be rewritten in that form, provided we recompute all the coefficients to fit the difference form rather than the straight value form, for which Claude is quite amazing (he verified all the coefficients and formulations and matched them to machine precision). This allows us to reduce the smoothness operations by ~33 - 50%, so I am quite excited to see if this translates to an effective speed up of the code.

The nice thing of this rewriting is that it is very simple and localized to one function. Another advantage is that, for the Float32 smoothness, we not need to subtract a mean to the values, given the difference form already deals with a ``normalized'' operation.