### PR TITLE
Fix two Float64 leaks into Float32 kernels (CATKE on Metal)

### DIFF
--- a/ext/OceananigansMetalExt.jl
+++ b/ext/OceananigansMetalExt.jl
@@ -8,6 +8,7 @@ using Oceananigans.Architectures: Architectures
 using Oceananigans.Grids: Bounded, Periodic
 using Oceananigans.Solvers: Solvers
 using Oceananigans.Utils: linear_expand, __linear_ndrange, MappedCompilerMetadata
+import Oceananigans.Utils as UT
 
 const MetalGPU = GPU{<:Metal.MetalBackend}
 MetalGPU() = GPU(Metal.MetalBackend())
@@ -42,6 +43,12 @@ function Solvers.plan_backward_transform(A::MtlArray, ::Union{Bounded, Periodic}
     length(dims) == 0 && return nothing
     return plan_ifft!(A, dims)
 end
+
+# `Base.cbrt(::Float32)` refines its estimate in Float64, which Metal cannot compile,
+# and Metal provides no native cube-root intrinsic (there is no `air.cbrt.f32`).
+# Compute it with `air.pow.f32` instead, which `^(::Float32, ::Float32)` lowers to,
+# taking the sign convention of `cbrt` for negative arguments.
+Metal.@device_override @inline UT.f32_safe_cbrt(x::Float32) = copysign(abs(x)^(1f0/3f0), x)
 
 Metal.@device_override @inline function KernelAbstractions.__validindex(ctx::MappedCompilerMetadata)
     if __dynamic_checkbounds(ctx)

--- a/ext/OceananigansMetalExt.jl
+++ b/ext/OceananigansMetalExt.jl
@@ -44,10 +44,9 @@ function Solvers.plan_backward_transform(A::MtlArray, ::Union{Bounded, Periodic}
     return plan_ifft!(A, dims)
 end
 
-# `Base.cbrt(::Float32)` refines its estimate in Float64, which Metal cannot compile,
-# and Metal provides no native cube-root intrinsic (there is no `air.cbrt.f32`).
-# Compute it with `air.pow.f32` instead, which `^(::Float32, ::Float32)` lowers to,
-# taking the sign convention of `cbrt` for negative arguments.
+# Metal has no `air.cbrt.f32` intrinsic and cannot compile the Float64 refinement in
+# `Base.cbrt(::Float32)`; `^(::Float32, ::Float32)` lowers to `air.pow.f32`.
+# Remove, with `f32_safe_cbrt` itself, once JuliaGPU/Metal.jl#952 is resolved.
 Metal.@device_override @inline UT.f32_safe_cbrt(x::Float32) = copysign(abs(x)^(1f0/3f0), x)
 
 Metal.@device_override @inline function KernelAbstractions.__validindex(ctx::MappedCompilerMetadata)

--- a/ext/OceananigansMetalExt.jl
+++ b/ext/OceananigansMetalExt.jl
@@ -47,6 +47,8 @@ end
 # Metal has no `air.cbrt.f32` intrinsic and cannot compile the Float64 refinement in
 # `Base.cbrt(::Float32)`; `^(::Float32, ::Float32)` lowers to `air.pow.f32`.
 # Remove, with `f32_safe_cbrt` itself, once JuliaGPU/Metal.jl#952 is resolved.
+# Subnormal arguments return zero, as they do for every other arithmetic operation on
+# Metal, which flushes subnormal operands.
 Metal.@device_override @inline UT.f32_safe_cbrt(x::Float32) = copysign(abs(x)^(1f0/3f0), x)
 
 Metal.@device_override @inline function KernelAbstractions.__validindex(ctx::MappedCompilerMetadata)

--- a/ext/OceananigansMetalExt.jl
+++ b/ext/OceananigansMetalExt.jl
@@ -44,11 +44,8 @@ function Solvers.plan_backward_transform(A::MtlArray, ::Union{Bounded, Periodic}
     return plan_ifft!(A, dims)
 end
 
-# Metal has no `air.cbrt.f32` intrinsic and cannot compile the Float64 refinement in
-# `Base.cbrt(::Float32)`; `^(::Float32, ::Float32)` lowers to `air.pow.f32`.
-# Remove, with `f32_safe_cbrt` itself, once JuliaGPU/Metal.jl#952 is resolved.
-# Subnormal arguments return zero, as they do for every other arithmetic operation on
-# Metal, which flushes subnormal operands.
+# `Base.cbrt(::Float32)` refines in Float64 and Metal has no `air.cbrt.f32`; `^` lowers to
+# `air.pow.f32`, which zeroes subnormals. Remove after JuliaGPU/Metal.jl#952.
 Metal.@device_override @inline UT.f32_safe_cbrt(x::Float32) = copysign(abs(x)^(1f0/3f0), x)
 
 Metal.@device_override @inline function KernelAbstractions.__validindex(ctx::MappedCompilerMetadata)

--- a/ext/OceananigansReactantExt/Utils.jl
+++ b/ext/OceananigansReactantExt/Utils.jl
@@ -3,7 +3,12 @@ module Utils
 using Oceananigans
 using Reactant
 
-import Oceananigans.Utils: prettytime, prettysummary
+import Oceananigans.Utils: prettytime, prettysummary, kernel_time_step
+
+using Oceananigans.Architectures: ReactantState
+
+# Reactant tracing breaks if Δt is converted outside the kernel, so pass it through.
+@inline kernel_time_step(::ReactantState, grid, Δt) = Δt
 
 function prettytime(concrete_number::Union{ConcretePJRTNumber,ConcreteIFRTNumber})
     number = Reactant.to_number(concrete_number)

--- a/src/Models/HydrostaticFreeSurfaceModels/deferred_barotropic_acceleration.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/deferred_barotropic_acceleration.jl
@@ -14,8 +14,7 @@ function add_deferred_barotropic_acceleration!(velocities, grid, free_surface::U
     u, v = velocities.u, velocities.v
     needs_implicit_solver(u.boundary_conditions) | needs_implicit_solver(v.boundary_conditions) || return nothing
 
-    g  = free_surface.gravitational_acceleration
-    Δt = convert(eltype(grid), Δt)
+    g = free_surface.gravitational_acceleration
 
     launch!(architecture(grid), grid, :xyz, _add_deferred_barotropic_acceleration!, u, v, grid, free_surface.displacement, g, Δt; exclude_periphery=true)
 

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_ab2_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_ab2_step.jl
@@ -37,7 +37,6 @@ The order of operations for explicit free surfaces is:
 function hydrostatic_ab2_step!(model, free_surface, grid, Δt, callbacks)
     FT = eltype(grid)
     χ  = convert(FT, model.timestepper.χ)
-    Δt = convert(FT, Δt)
 
     @apply_regionally begin
         update_transport_velocities!(model.transport_velocities, model.velocities, model.free_surface)
@@ -88,7 +87,6 @@ For implicit free surfaces, a predictor-corrector approach is used:
 function hydrostatic_ab2_step!(model, free_surface::ImplicitFreeSurface, grid, Δt, callbacks)
     FT = eltype(grid)
     χ  = convert(FT, model.timestepper.χ)
-    Δt = convert(FT, Δt)
 
     @apply_regionally begin
         update_transport_velocities!(model.transport_velocities, model.velocities, model.free_surface)
@@ -242,8 +240,7 @@ end
     tracer_field = model.tracers[tracer_name]
     grid = model.grid
 
-    FT = eltype(grid)
-    launch!(architecture(grid), grid, :xyz, _ab2_step_tracer_field!, tracer_field, grid, convert(FT, Δt), χ, Gⁿ, G⁻)
+    launch!(architecture(grid), grid, :xyz, _ab2_step_tracer_field!, tracer_field, grid, Δt, χ, Gⁿ, G⁻)
 
     @inbounds c_advection = model.advection[tracer_name]
     implicit_step!(tracer_field,

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk_step.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_rk_step.jl
@@ -158,14 +158,13 @@ end
 
 @inline function rk_substep_velocity!(velocities, model, Δt, ::Val{name}) where name
     grid = model.grid
-    FT = eltype(grid)
 
     Gⁿ = model.timestepper.Gⁿ[name]
     Ψ⁻ = model.timestepper.Ψ⁻[name]
     velocity_field = velocities[name]
 
     launch!(architecture(grid), grid, :xyz,
-            _rk_substep_field!, velocity_field, convert(FT, Δt), Gⁿ, Ψ⁻; exclude_periphery=true)
+            _rk_substep_field!, velocity_field, Δt, Gⁿ, Ψ⁻; exclude_periphery=true)
 
     return nothing
 end
@@ -222,14 +221,13 @@ end
     (hasclosure(closure, FlavorOfCATKE) && tracer_name == :e) && return nothing
 
     grid = model.grid
-    FT = eltype(grid)
 
     Gⁿ = model.timestepper.Gⁿ[tracer_name]
     Ψ⁻ = model.timestepper.Ψ⁻[tracer_name]
     c  = model.tracers[tracer_name]
 
     launch!(architecture(grid), grid, :xyz,
-            _rk_substep_tracer_field!, c, grid, convert(FT, Δt), Gⁿ, Ψ⁻)
+            _rk_substep_tracer_field!, c, grid, Δt, Gⁿ, Ψ⁻)
 
     @inbounds c_advection = model.advection[tracer_name]
     implicit_step!(c,

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_ab2_step.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_ab2_step.jl
@@ -25,7 +25,6 @@ This predictor-corrector scheme:
 """
 function pressure_correction_ab2_step!(model, Δt, callbacks)
     grid = model.grid
-    kernel_Δt = convert(eltype(grid), Δt)
 
     # Compute flux bc tendencies
     compute_flux_bc_tendencies!(model)
@@ -38,7 +37,7 @@ function pressure_correction_ab2_step!(model, Δt, callbacks)
         field = model_fields[name]
         exclude_periphery = i < 4 # We assume that the first 3 fields are velocity / momentum variables
         field_advection = exclude_periphery ? model.advection.momentum : model.advection[name]
-        kernel_args = (field, kernel_Δt, model.timestepper.χ, model.timestepper.Gⁿ[name], model.timestepper.G⁻[name])
+        kernel_args = (field, Δt, model.timestepper.χ, model.timestepper.Gⁿ[name], model.timestepper.G⁻[name])
         launch!(architecture(grid), grid, :xyz, _ab2_step_field!, kernel_args...; exclude_periphery)
 
         implicit_step!(field,
@@ -48,13 +47,13 @@ function pressure_correction_ab2_step!(model, Δt, callbacks)
                        Val(i-3), # We assume that the first 3 fields are velocity / momentum variables
                        model.clock,
                        fields(model),
-                       kernel_Δt,
+                       Δt,
                        field_advection,
                        advecting_velocities)
     end
 
-    compute_pressure_correction!(model, kernel_Δt)
-    make_pressure_correction!(model, kernel_Δt)
+    compute_pressure_correction!(model, Δt)
+    make_pressure_correction!(model, Δt)
 
     return nothing
 end

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_rk3_substep.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_rk3_substep.jl
@@ -30,9 +30,7 @@ are corrected to satisfy the incompressibility constraint.
 """
 function pressure_correction_rk3_substep!(model, Δt, γⁿ, ζⁿ, callbacks)
     grid = model.grid
-    FT        = eltype(grid)
-    kernel_Δt = convert(FT, Δt)
-    Δτ        = convert(FT, stage_Δt(Δt, γⁿ, ζⁿ))
+    Δτ = stage_Δt(Δt, γⁿ, ζⁿ)
 
     compute_flux_bc_tendencies!(model)
     model_fields = prognostic_fields(model)
@@ -44,7 +42,7 @@ function pressure_correction_rk3_substep!(model, Δt, γⁿ, ζⁿ, callbacks)
         field = model_fields[name]
         exclude_periphery = i < 4 # We assume that the first 3 fields are velocity / momentum variables
         field_advection = exclude_periphery ? model.advection.momentum : model.advection[name]
-        kernel_args = (field, kernel_Δt, γⁿ, ζⁿ, model.timestepper.Gⁿ[name], model.timestepper.G⁻[name])
+        kernel_args = (field, Δt, γⁿ, ζⁿ, model.timestepper.Gⁿ[name], model.timestepper.G⁻[name])
         launch!(architecture(grid), grid, :xyz, _rk3_substep_field!, kernel_args...; exclude_periphery)
 
         implicit_step!(field,

--- a/src/Models/ShallowWaterModels/shallow_water_ab2_step.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_ab2_step.jl
@@ -17,14 +17,13 @@ function ab2_step!(model::ShallowWaterModel, Δt, callbacks)
 
     compute_tendencies!(model, callbacks)
     grid = model.grid
-    kernel_Δt = convert(eltype(grid), Δt)
 
     fields = prognostic_fields(model)
 
     for key in keys(fields)
         launch!(architecture(grid), grid, :xyz, _ab2_step_field!,
                 fields[key],
-                kernel_Δt,
+                Δt,
                 model.timestepper.χ,
                 model.timestepper.Gⁿ[key],
                 model.timestepper.G⁻[key])

--- a/src/Models/ShallowWaterModels/shallow_water_rk3_substep.jl
+++ b/src/Models/ShallowWaterModels/shallow_water_rk3_substep.jl
@@ -18,11 +18,10 @@ function rk3_substep!(model::ShallowWaterModel, Δt, γⁿ, ζⁿ, callbacks)
 
     compute_tendencies!(model, callbacks)
     grid = model.grid
-    kernel_Δt = convert(eltype(grid), Δt)
 
     launch!(architecture(grid), grid, :xyz, _rk_substep_solution!,
             model.solution,
-            kernel_Δt, γⁿ, ζⁿ,
+            Δt, γⁿ, ζⁿ,
             model.timestepper.Gⁿ,
             model.timestepper.G⁻)
 
@@ -33,7 +32,7 @@ function rk3_substep!(model::ShallowWaterModel, Δt, γⁿ, ζⁿ, callbacks)
         @inbounds Gcⁿ = model.timestepper.Gⁿ[i+3]
         @inbounds Gc⁻ = model.timestepper.G⁻[i+3]
 
-        _tracer_kernel!(c, kernel_Δt, γⁿ, ζⁿ, Gcⁿ, Gc⁻)
+        _tracer_kernel!(c, Δt, γⁿ, ζⁿ, Gcⁿ, Gc⁻)
     end
 
     return nothing

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -7,7 +7,6 @@ export
     time_step!,
     Clock,
     convert_time,
-    kernel_time_step,
     AbstractTimeDiscretization,
     ExplicitTimeDiscretization,
     VerticallyImplicitTimeDiscretization,
@@ -19,9 +18,11 @@ using DocStringExtensions: TYPEDSIGNATURES
 using KernelAbstractions: @kernel, @index
 
 using Oceananigans: Oceananigans, AbstractModel, initialize!, prognostic_fields
+using Oceananigans.Architectures: architecture
 using Oceananigans.Utils: AbstractTimeDiscretization, ExplicitTimeDiscretization,
                           VerticallyImplicitTimeDiscretization,
-                          AdaptiveVerticallyImplicitDiscretization
+                          AdaptiveVerticallyImplicitDiscretization,
+                          kernel_time_step
 
 """
     abstract type AbstractTimeStepper

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -7,6 +7,7 @@ export
     time_step!,
     Clock,
     convert_time,
+    kernel_time_step,
     AbstractTimeDiscretization,
     ExplicitTimeDiscretization,
     VerticallyImplicitTimeDiscretization,

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -115,6 +115,23 @@ Clock(grid::AbstractGrid{FT}) where {FT} = Clock{Float64}(; time=0, kernel_time_
 
 kernel_time_type(::Clock{TT, KT, DT, IT, S}) where {TT, KT, DT, IT, S} = KT
 
+"""
+$(TYPEDSIGNATURES)
+
+Return `Δt` converted to the time-step type used _inside_ kernels, which follows
+`kernel_time_type(clock)`.
+
+`Clock.time` accumulates in high precision (`Float64` by default, see [`Clock`](@ref)),
+but a `Float64` `Δt` must not reach kernels: it promotes otherwise-`Float32` arithmetic,
+which costs performance on every GPU and is unsupported outright on architectures
+without double precision (e.g. Metal). Call this at the top of `time_step!` so that
+every `Δt` handed to the model --- and thus to kernels --- carries the kernel time type.
+"""
+@inline kernel_time_step(clock, Δt::Number) = clock_convert(time_step_type(kernel_time_type(clock)), Δt)
+
+# Fallback for non-numeric time steps, eg `Dates.Period`.
+@inline kernel_time_step(clock, Δt) = Δt
+
 function Base.summary(clock::Clock)
     TT = typeof(clock.time)
     DT = typeof(clock.last_Δt)

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -115,20 +115,6 @@ Clock(grid::AbstractGrid{FT}) where {FT} = Clock{Float64}(; time=0, kernel_time_
 
 kernel_time_type(::Clock{TT, KT, DT, IT, S}) where {TT, KT, DT, IT, S} = KT
 
-"""
-$(TYPEDSIGNATURES)
-
-Return `Δt` converted to the time-step type used _inside_ kernels, which follows
-`kernel_time_type(clock)`.
-
-`Clock.time` accumulates in high precision, so arithmetic involving it promotes `Δt`
-even for a lower-precision model. Kernels must not see that promotion.
-"""
-@inline kernel_time_step(clock, Δt::Number) = clock_convert(time_step_type(kernel_time_type(clock)), Δt)
-
-# eg `Dates.Period`
-@inline kernel_time_step(clock, Δt) = Δt
-
 function Base.summary(clock::Clock)
     TT = typeof(clock.time)
     DT = typeof(clock.last_Δt)

--- a/src/TimeSteppers/clock.jl
+++ b/src/TimeSteppers/clock.jl
@@ -121,15 +121,12 @@ $(TYPEDSIGNATURES)
 Return `Δt` converted to the time-step type used _inside_ kernels, which follows
 `kernel_time_type(clock)`.
 
-`Clock.time` accumulates in high precision (`Float64` by default, see [`Clock`](@ref)),
-but a `Float64` `Δt` must not reach kernels: it promotes otherwise-`Float32` arithmetic,
-which costs performance on every GPU and is unsupported outright on architectures
-without double precision (e.g. Metal). Call this at the top of `time_step!` so that
-every `Δt` handed to the model --- and thus to kernels --- carries the kernel time type.
+`Clock.time` accumulates in high precision, so arithmetic involving it promotes `Δt`
+even for a lower-precision model. Kernels must not see that promotion.
 """
 @inline kernel_time_step(clock, Δt::Number) = clock_convert(time_step_type(kernel_time_type(clock)), Δt)
 
-# Fallback for non-numeric time steps, eg `Dates.Period`.
+# eg `Dates.Period`
 @inline kernel_time_step(clock, Δt) = Δt
 
 function Base.summary(clock::Clock)

--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -92,8 +92,6 @@ function time_step!(model::AbstractModel{<:QuasiAdamsBashforth2TimeStepper}, Δt
 
     Δt == 0 && @warn "Δt == 0 may cause model blowup!"
 
-    # Demote Δt to the kernel time type: clock.time accumulates in high precision,
-    # but Δt is passed straight into kernels and must match the grid's precision.
     Δt = kernel_time_step(model.clock, Δt)
 
     # Take an euler step if:

--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -137,7 +137,6 @@ Time step fields via the 2nd-order quasi Adams-Bashforth method
     i, j, k = @index(Global, NTuple)
 
     FT = eltype(u)
-    Δt = convert(FT, Δt)
     α = convert(FT, 3/2) + χ
     β = convert(FT, 1/2) + χ
     not_euler = χ != convert(FT, -0.5) # use to prevent corruption by leftover NaNs in G⁻

--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -92,7 +92,7 @@ function time_step!(model::AbstractModel{<:QuasiAdamsBashforth2TimeStepper}, Δt
 
     Δt == 0 && @warn "Δt == 0 may cause model blowup!"
 
-    Δt = kernel_time_step(architecture(model.grid), model.grid, Δt)
+    kernel_Δt = kernel_time_step(architecture(model.grid), model.grid, Δt)
 
     # Take an euler step if:
     #   * We detect that the time-step size has changed.
@@ -111,15 +111,15 @@ function time_step!(model::AbstractModel{<:QuasiAdamsBashforth2TimeStepper}, Δt
     χ₀ = ab2_timestepper.χ # Save initial value
     ab2_timestepper.χ = χ
 
-    ab2_step!(model, Δt, callbacks)
+    ab2_step!(model, kernel_Δt, callbacks)
     cache_previous_tendencies!(model)
 
     tick!(model.clock, Δt)
 
-    step_closure_prognostics!(model, Δt)
+    step_closure_prognostics!(model, kernel_Δt)
     update_state!(model, callbacks)
 
-    step_lagrangian_particles!(model, Δt)
+    step_lagrangian_particles!(model, kernel_Δt)
 
     # Return χ to initial value
     ab2_timestepper.χ = χ₀

--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -92,6 +92,10 @@ function time_step!(model::AbstractModel{<:QuasiAdamsBashforth2TimeStepper}, Δt
 
     Δt == 0 && @warn "Δt == 0 may cause model blowup!"
 
+    # Demote Δt to the kernel time type: clock.time accumulates in high precision,
+    # but Δt is passed straight into kernels and must match the grid's precision.
+    Δt = kernel_time_step(model.clock, Δt)
+
     # Take an euler step if:
     #   * We detect that the time-step size has changed.
     #   * We detect that this is the "first" time-step, which means we

--- a/src/TimeSteppers/quasi_adams_bashforth_2.jl
+++ b/src/TimeSteppers/quasi_adams_bashforth_2.jl
@@ -92,7 +92,7 @@ function time_step!(model::AbstractModel{<:QuasiAdamsBashforth2TimeStepper}, Δt
 
     Δt == 0 && @warn "Δt == 0 may cause model blowup!"
 
-    Δt = kernel_time_step(model.clock, Δt)
+    Δt = kernel_time_step(architecture(model.grid), model.grid, Δt)
 
     # Take an euler step if:
     #   * We detect that the time-step size has changed.

--- a/src/TimeSteppers/runge_kutta_3.jl
+++ b/src/TimeSteppers/runge_kutta_3.jl
@@ -195,14 +195,14 @@ Time step velocity fields via the 3rd-order Runge-Kutta method
 
 where `m` denotes the substage.
 """
-@kernel function _rk3_substep_field!(U, Δt, γⁿ::FT, ζⁿ, Gⁿ, G⁻) where FT
+@kernel function _rk3_substep_field!(U, Δt, γⁿ, ζⁿ, Gⁿ, G⁻)
     i, j, k = @index(Global, NTuple)
-    @inbounds U[i, j, k] += convert(FT, Δt) * (γⁿ * Gⁿ[i, j, k] + ζⁿ * G⁻[i, j, k])
+    @inbounds U[i, j, k] += Δt * (γⁿ * Gⁿ[i, j, k] + ζⁿ * G⁻[i, j, k])
 end
 
-@kernel function _rk3_substep_field!(U, Δt, γ¹::FT, ::Nothing, G¹, G⁰) where FT
+@kernel function _rk3_substep_field!(U, Δt, γ¹, ::Nothing, G¹, G⁰)
     i, j, k = @index(Global, NTuple)
-    @inbounds U[i, j, k] += convert(FT, Δt) * γ¹ * G¹[i, j, k]
+    @inbounds U[i, j, k] += Δt * γ¹ * G¹[i, j, k]
 end
 
 """

--- a/src/TimeSteppers/runge_kutta_3.jl
+++ b/src/TimeSteppers/runge_kutta_3.jl
@@ -103,6 +103,9 @@ The specific implementation of `rk3_substep!` varies by model type.
 function time_step!(model::AbstractModel{<:RungeKutta3TimeStepper}, Δt; callbacks=[])
     Δt == 0 && @warn "Δt == 0 may cause model blowup!"
 
+    # See the note in `time_step!` for `QuasiAdamsBashforth2TimeStepper`.
+    Δt = kernel_time_step(model.clock, Δt)
+
     # Be paranoid and prepare at iteration 0, in case run! is not used:
     maybe_prepare_first_time_step!(model, Δt, callbacks)
 

--- a/src/TimeSteppers/runge_kutta_3.jl
+++ b/src/TimeSteppers/runge_kutta_3.jl
@@ -103,7 +103,7 @@ The specific implementation of `rk3_substep!` varies by model type.
 function time_step!(model::AbstractModel{<:RungeKutta3TimeStepper}, Δt; callbacks=[])
     Δt == 0 && @warn "Δt == 0 may cause model blowup!"
 
-    Δt = kernel_time_step(model.clock, Δt)
+    Δt = kernel_time_step(architecture(model.grid), model.grid, Δt)
 
     # Be paranoid and prepare at iteration 0, in case run! is not used:
     maybe_prepare_first_time_step!(model, Δt, callbacks)

--- a/src/TimeSteppers/runge_kutta_3.jl
+++ b/src/TimeSteppers/runge_kutta_3.jl
@@ -103,7 +103,7 @@ The specific implementation of `rk3_substep!` varies by model type.
 function time_step!(model::AbstractModel{<:RungeKutta3TimeStepper}, Δt; callbacks=[])
     Δt == 0 && @warn "Δt == 0 may cause model blowup!"
 
-    Δt = kernel_time_step(architecture(model.grid), model.grid, Δt)
+    kernel_Δt = kernel_time_step(architecture(model.grid), model.grid, Δt)
 
     # Be paranoid and prepare at iteration 0, in case run! is not used:
     maybe_prepare_first_time_step!(model, Δt, callbacks)
@@ -118,7 +118,10 @@ function time_step!(model::AbstractModel{<:RungeKutta3TimeStepper}, Δt; callbac
 
     first_stage_Δt  = stage_Δt(Δt, γ¹, ζ¹)      # =  γ¹ * Δt
     second_stage_Δt = stage_Δt(Δt, γ², ζ²)      # = (γ² + ζ²) * Δt
-    third_stage_Δt  = stage_Δt(Δt, γ³, ζ³)      # = (γ³ + ζ³) * Δt
+
+    kernel_first_stage_Δt  = stage_Δt(kernel_Δt, γ¹, ζ¹)
+    kernel_second_stage_Δt = stage_Δt(kernel_Δt, γ², ζ²)
+    kernel_third_stage_Δt  = stage_Δt(kernel_Δt, γ³, ζ³)
 
     # Compute tⁿ⁺¹ a priori to reduce floating point error accumulation
     tⁿ⁺¹ = next_time(model.clock, Δt)
@@ -127,33 +130,33 @@ function time_step!(model::AbstractModel{<:RungeKutta3TimeStepper}, Δt; callbac
     # First stage
     #
 
-    rk3_substep!(model, Δt, γ¹, nothing, callbacks)
+    rk3_substep!(model, kernel_Δt, γ¹, nothing, callbacks)
     cache_previous_tendencies!(model)
 
     tick_stage!(model.clock, first_stage_Δt)
 
-    step_closure_prognostics!(model, first_stage_Δt)
+    step_closure_prognostics!(model, kernel_first_stage_Δt)
     update_state!(model, callbacks)
-    step_lagrangian_particles!(model, first_stage_Δt)
+    step_lagrangian_particles!(model, kernel_first_stage_Δt)
 
     #
     # Second stage
     #
 
-    rk3_substep!(model, Δt, γ², ζ², callbacks)
+    rk3_substep!(model, kernel_Δt, γ², ζ², callbacks)
     cache_previous_tendencies!(model)
 
     tick_stage!(model.clock, second_stage_Δt)
 
-    step_closure_prognostics!(model, second_stage_Δt)
+    step_closure_prognostics!(model, kernel_second_stage_Δt)
     update_state!(model, callbacks)
-    step_lagrangian_particles!(model, second_stage_Δt)
+    step_lagrangian_particles!(model, kernel_second_stage_Δt)
 
     #
     # Third stage
     #
 
-    rk3_substep!(model, Δt, γ³, ζ³, callbacks)
+    rk3_substep!(model, kernel_Δt, γ³, ζ³, callbacks)
     cache_previous_tendencies!(model)
 
     # Correct the third stage Δt to reduce floating point error accumulation.
@@ -162,9 +165,9 @@ function time_step!(model::AbstractModel{<:RungeKutta3TimeStepper}, Δt; callbac
     corrected_third_stage_Δt = time_difference_seconds(tⁿ⁺¹, model.clock.time)
     tick_stage!(model.clock, corrected_third_stage_Δt, Δt)
 
-    step_closure_prognostics!(model, third_stage_Δt)
+    step_closure_prognostics!(model, kernel_third_stage_Δt)
     update_state!(model, callbacks)
-    step_lagrangian_particles!(model, third_stage_Δt)
+    step_lagrangian_particles!(model, kernel_third_stage_Δt)
 
     return nothing
 end

--- a/src/TimeSteppers/runge_kutta_3.jl
+++ b/src/TimeSteppers/runge_kutta_3.jl
@@ -103,7 +103,6 @@ The specific implementation of `rk3_substep!` varies by model type.
 function time_step!(model::AbstractModel{<:RungeKutta3TimeStepper}, Δt; callbacks=[])
     Δt == 0 && @warn "Δt == 0 may cause model blowup!"
 
-    # See the note in `time_step!` for `QuasiAdamsBashforth2TimeStepper`.
     Δt = kernel_time_step(model.clock, Δt)
 
     # Be paranoid and prepare at iteration 0, in case run! is not used:

--- a/src/TimeSteppers/split_runge_kutta.jl
+++ b/src/TimeSteppers/split_runge_kutta.jl
@@ -164,6 +164,9 @@ After all substeps, Lagrangian particles are stepped and the `model.clock`s is a
 """
 function time_step!(model::AbstractModel{<:SplitRungeKuttaTimeStepper}, Δt; callbacks=[])
 
+    # See the note in `time_step!` for `QuasiAdamsBashforth2TimeStepper`.
+    Δt = kernel_time_step(model.clock, Δt)
+
     maybe_prepare_first_time_step!(model, Δt, callbacks)
 
     cache_current_fields!(model)

--- a/src/TimeSteppers/split_runge_kutta.jl
+++ b/src/TimeSteppers/split_runge_kutta.jl
@@ -164,7 +164,7 @@ After all substeps, Lagrangian particles are stepped and the `model.clock`s is a
 """
 function time_step!(model::AbstractModel{<:SplitRungeKuttaTimeStepper}, Δt; callbacks=[])
 
-    Δt = kernel_time_step(architecture(model.grid), model.grid, Δt)
+    kernel_Δt = kernel_time_step(architecture(model.grid), model.grid, Δt)
 
     maybe_prepare_first_time_step!(model, Δt, callbacks)
 
@@ -179,14 +179,15 @@ function time_step!(model::AbstractModel{<:SplitRungeKuttaTimeStepper}, Δt; cal
 
         # Update the clock stage
         Δτ = Δt / β
+        kernel_Δτ = kernel_Δt / β
         model.clock.stage = stage
         model.clock.last_stage_Δt = Δτ
 
         # Perform the substep
-        rk_substep!(model, Δτ, callbacks)
+        rk_substep!(model, kernel_Δτ, callbacks)
 
         # Step closure prognostics
-        step_closure_prognostics!(model, Δτ)
+        step_closure_prognostics!(model, kernel_Δτ)
 
         # Tick the clock if we ended the stages
         if stage == model.timestepper.Nstages
@@ -198,7 +199,7 @@ function time_step!(model::AbstractModel{<:SplitRungeKuttaTimeStepper}, Δt; cal
     end
 
     # Step particles
-    step_lagrangian_particles!(model, Δt)
+    step_lagrangian_particles!(model, kernel_Δt)
 
     model.clock.iteration += 1
 

--- a/src/TimeSteppers/split_runge_kutta.jl
+++ b/src/TimeSteppers/split_runge_kutta.jl
@@ -164,7 +164,7 @@ After all substeps, Lagrangian particles are stepped and the `model.clock`s is a
 """
 function time_step!(model::AbstractModel{<:SplitRungeKuttaTimeStepper}, Δt; callbacks=[])
 
-    Δt = kernel_time_step(model.clock, Δt)
+    Δt = kernel_time_step(architecture(model.grid), model.grid, Δt)
 
     maybe_prepare_first_time_step!(model, Δt, callbacks)
 

--- a/src/TimeSteppers/split_runge_kutta.jl
+++ b/src/TimeSteppers/split_runge_kutta.jl
@@ -164,7 +164,6 @@ After all substeps, Lagrangian particles are stepped and the `model.clock`s is a
 """
 function time_step!(model::AbstractModel{<:SplitRungeKuttaTimeStepper}, Δt; callbacks=[])
 
-    # See the note in `time_step!` for `QuasiAdamsBashforth2TimeStepper`.
     Δt = kernel_time_step(model.clock, Δt)
 
     maybe_prepare_first_time_step!(model, Δt, callbacks)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/Smagorinskys/Smagorinskys.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/Smagorinskys/Smagorinskys.jl
@@ -10,6 +10,7 @@ using Oceananigans.Operators: Operators, Δxᶜᶜᶜ, Δyᶜᶜᶜ, Δzᶜᶜ�
                               ℑxyᶜᶜᵃ, ℑxyᶜᶠᵃ, ℑxyᶠᶜᵃ, ℑxyᶠᶠᵃ,
                               ℑxzᶜᵃᶜ, ℑxzᶜᵃᶠ, ℑxzᶠᵃᶜ, ℑxzᶠᵃᶠ,
                               ℑyzᵃᶜᶜ, ℑyzᵃᶜᶠ, ℑyzᵃᶠᶜ, ℑyzᵃᶠᶠ
+using Oceananigans.Utils: f32_safe_cbrt
 
 
 import Oceananigans.TurbulenceClosures: buoyancy_force, buoyancy_tracers, step_closure_prognostics!,

--- a/src/TurbulenceClosures/turbulence_closure_implementations/Smagorinskys/smagorinsky.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/Smagorinskys/smagorinsky.jl
@@ -95,7 +95,7 @@ end
 
     # Filter width
     Δ³ = Δxᶜᶜᶜ(i, j, k, grid) * Δyᶜᶜᶜ(i, j, k, grid) * Δzᶜᶜᶜ(i, j, k, grid)
-    Δᶠ = cbrt(Δ³)
+    Δᶠ = f32_safe_cbrt(Δ³)
     cˢ² = square_smagorinsky_coefficient(i, j, k, grid, closure, closure_fields, Σ², buoyancy, tracers)
 
     νₑ = closure_fields.νₑ

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/TKEBasedVerticalDiffusivities.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/TKEBasedVerticalDiffusivities.jl
@@ -23,7 +23,7 @@ using Oceananigans.Operators: Δzᶜᶜᶜ, Δzᶜᶠᶠ, Δzᶠᶜᶠ, Δz⁻¹
 using Oceananigans.TimeSteppers: TimeSteppers, time_discretization
 using Oceananigans.TurbulenceClosures: getclosure, AbstractScalarDiffusivity, VerticalFormulation,
                                        VerticallyImplicitTimeDiscretization
-using Oceananigans.Utils: Utils, launch!, prettysummary, get_active_cells_map
+using Oceananigans.Utils: Utils, launch!, prettysummary, get_active_cells_map, f32_safe_cbrt
 
 import Oceananigans: prognostic_state, restore_prognostic_state!
 import Oceananigans.TurbulenceClosures:

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_vertical_diffusivity.jl
@@ -289,7 +289,7 @@ end
     Jᵇᵋ = closure.minimum_convective_buoyancy_flux
     Jᵇᵢⱼ = @inbounds Jᵇ[i, j, 1]
     Jᵇ⁺ = max(Jᵇᵋ, Jᵇᵢⱼ, Jᵇ★) # selects fastest (dominant) time-scale
-    t★ = cbrt(ℓᴰ^2 / Jᵇ⁺)
+    t★ = f32_safe_cbrt(ℓᴰ^2 / Jᵇ⁺)
     ϵ = Δt / t★
 
     @inbounds Jᵇ[i, j, 1] = (Jᵇᵢⱼ + ϵ * Jᵇ★) / (1 + ϵ)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/time_step_catke_equation.jl
@@ -253,7 +253,6 @@ end
 
     # Advance TKE and store tendency
     FT = eltype(χ)
-    Δτ = convert(FT, Δτ)
     e  = tracers.e
 
     # See below.
@@ -308,9 +307,6 @@ end
 
     σᶜᶜⁿ = σⁿ(i, j, k, grid, Center(), Center(), Center())
     active = !inactive_cell(i, j, k, grid)
-
-    FT = eltype(grid)
-    Δτ = convert(FT, Δτ)
 
     @inbounds begin
         total_Gⁿ = slow_Gⁿe[i, j, k] + fast_Gⁿe * σᶜᶜⁿ

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_equations.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_equations.jl
@@ -42,7 +42,6 @@ function time_step_tke_dissipation_equations!(model, Δt)
     active_cells_map = get_active_cells_map(grid, Val(:xyz))
 
     FT = eltype(model.tracers.e)
-    Δt = convert(FT, Δt)
     Δτ = get_time_step(closure)
 
     if isnothing(Δτ)
@@ -175,7 +174,6 @@ end
 
     # Advance TKE and store tendency
     FT = eltype(e)
-    Δτ = convert(FT, Δτ)
     χ = convert(FT, χ)
 
     # See below.

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -1,6 +1,6 @@
 module Utils
 
-export configure_kernel, launch!, KernelParameters
+export configure_kernel, launch!, KernelParameters, kernel_time_step
 export prettytime, pretty_filesize
 export tupleit, parenttuple, datatuple, datatuples
 export ordered_dict_show

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -13,6 +13,7 @@ export TimeInterval, IterationInterval, WallTimeInterval, SpecifiedTimes, AndSch
 export apply_regionally!, construct_regionally, @apply_regionally, MultiRegionObject
 export isregional, getregion, _getregion, regions, sync_device!
 export newton_div, NormalDivision, ConvertingDivision, BackendOptimizedDivision
+export f32_safe_cbrt
 export TabulatedFunction
 export interpolator, _interpolate
 export ϕ₁, ϕ₂, ϕ₃, ϕ₄, ϕ₅, ϕ₆, ϕ₇, ϕ₈
@@ -49,6 +50,7 @@ include("user_function_arguments.jl")
 include("multi_region_transformation.jl")
 include("sum_of_arrays.jl")
 include("newton_div.jl")
+include("f32_safe_cbrt.jl")
 include("interpolation.jl")
 include("tabulated_function.jl")
 

--- a/src/Utils/f32_safe_cbrt.jl
+++ b/src/Utils/f32_safe_cbrt.jl
@@ -1,16 +1,14 @@
+# This file works around `Base.cbrt(::Float32)` emitting double-precision instructions,
+# and can be deleted in its entirety once that compiles on every backend we support.
+# Upstream issue: https://github.com/JuliaGPU/Metal.jl/issues/952
+
 """
 $(TYPEDSIGNATURES)
 
-Return the cube root of `x`, computed without recourse to double precision when
-`x isa Float32`.
+Return the cube root of `x`, without recourse to double precision when `x isa Float32`.
 
-`Base.cbrt(x::Float32)` performs its Newton refinement in `Float64` (see
-`Base._improve_cbrt` in `base/special/cbrt.jl`), so it emits double-precision
-instructions even for a `Float32` argument. That is a performance pitfall on most
-GPUs, and invalid IR on architectures that have no double precision at all
-(e.g. Metal, which additionally provides no native cube-root intrinsic).
-
-The fallback defined here simply calls `Base.cbrt`. Architectures that cannot compile
-it override this function in the corresponding package extension.
+`Base.cbrt(::Float32)` refines its estimate in `Float64`, which is invalid on
+architectures with no double precision (e.g. Metal). Backends that cannot compile
+`Base.cbrt` override this function in their package extension.
 """
 @inline f32_safe_cbrt(x) = cbrt(x)

--- a/src/Utils/f32_safe_cbrt.jl
+++ b/src/Utils/f32_safe_cbrt.jl
@@ -1,14 +1,9 @@
-# This file works around `Base.cbrt(::Float32)` emitting double-precision instructions,
-# and can be deleted in its entirety once that compiles on every backend we support.
-# Upstream issue: https://github.com/JuliaGPU/Metal.jl/issues/952
+# Delete this file once `Base.cbrt(::Float32)` compiles everywhere: JuliaGPU/Metal.jl#952
 
 """
 $(TYPEDSIGNATURES)
 
-Return the cube root of `x`, without recourse to double precision when `x isa Float32`.
-
-`Base.cbrt(::Float32)` refines its estimate in `Float64`, which is invalid on
-architectures with no double precision (e.g. Metal). Backends that cannot compile
-`Base.cbrt` override this function in their package extension.
+Cube root of `x`, avoiding the `Float64` refinement in `Base.cbrt(::Float32)` that
+architectures without double precision cannot compile. Overridden in their extensions.
 """
 @inline f32_safe_cbrt(x) = cbrt(x)

--- a/src/Utils/f32_safe_cbrt.jl
+++ b/src/Utils/f32_safe_cbrt.jl
@@ -1,0 +1,16 @@
+"""
+$(TYPEDSIGNATURES)
+
+Return the cube root of `x`, computed without recourse to double precision when
+`x isa Float32`.
+
+`Base.cbrt(x::Float32)` performs its Newton refinement in `Float64` (see
+`Base._improve_cbrt` in `base/special/cbrt.jl`), so it emits double-precision
+instructions even for a `Float32` argument. That is a performance pitfall on most
+GPUs, and invalid IR on architectures that have no double precision at all
+(e.g. Metal, which additionally provides no native cube-root intrinsic).
+
+The fallback defined here simply calls `Base.cbrt`. Architectures that cannot compile
+it override this function in the corresponding package extension.
+"""
+@inline f32_safe_cbrt(x) = cbrt(x)

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -2,6 +2,13 @@
 ##### Utilities for launching kernels
 #####
 
+# Convert Δt to the kernel-compatible time type for `grid`'s architecture.
+# Metal cannot load Float64 kernel arguments, so we must convert at the launch
+# site for Float32 grids. Reactant tracing breaks if we convert outside the
+# kernel — OceananigansReactantExt overrides this for `ReactantState` archs to
+# pass Δt through unchanged.
+@inline kernel_time_step(arch, grid, Δt) = convert(eltype(grid), Δt)
+
 using Adapt: Adapt
 using Base: @pure
 using KernelAbstractions: Kernel,

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -2,11 +2,8 @@
 ##### Utilities for launching kernels
 #####
 
-# Convert Δt to the kernel-compatible time type for `grid`'s architecture.
-# Metal cannot load Float64 kernel arguments, so we must convert at the launch
-# site for Float32 grids. Reactant tracing breaks if we convert outside the
-# kernel — OceananigansReactantExt overrides this for `ReactantState` archs to
-# pass Δt through unchanged.
+# Δt for kernel arguments: Metal cannot load Float64 ones. Reactant needs it unconverted,
+# and overrides this in OceananigansReactantExt.
 @inline kernel_time_step(arch, grid, Δt) = convert(eltype(grid), Δt)
 
 using Adapt: Adapt

--- a/test/test_metal.jl
+++ b/test/test_metal.jl
@@ -2,6 +2,9 @@ include("dependencies_for_runtests.jl")
 include("dependencies_for_poisson_solvers.jl")
 
 using Metal
+using Oceananigans.Utils: f32_safe_cbrt
+using Oceananigans.TurbulenceClosures: CATKEVerticalDiffusivity
+using SeawaterPolynomials.TEOS10: TEOS10EquationOfState
 
 Oceananigans.defaults.FloatType = Float32
 
@@ -171,4 +174,56 @@ end
     arch = GPU(Metal.MetalBackend())
     faces = collect(0:8) .^ 1.2
     @test stretched_poisson_solver_correct_answer(Float32, arch, (Periodic, Periodic, Bounded), 8, 8, faces)
+end
+
+@testset "MetalGPU: f32_safe_cbrt" begin
+    # `Base.cbrt(::Float32)` refines in Float64, which Metal cannot compile, so
+    # `f32_safe_cbrt` is overridden in `OceananigansMetalExt` --- see
+    # https://github.com/CliMA/Oceananigans.jl/issues/5939.
+    x = Float32[8, 27, 1000, 0.125, 1, 0, -8, -0.125]
+    mtl_x = MtlArray(x)
+    mtl_y = f32_safe_cbrt.(mtl_x) # compiles and runs a Metal kernel
+
+    y = Array(mtl_y)
+    @test eltype(y) == Float32
+    @test y ≈ cbrt.(x) rtol=1e-6
+end
+
+@testset "MetalGPU: CATKEVerticalDiffusivity" begin
+    # Regression test for https://github.com/CliMA/Oceananigans.jl/issues/5939: a Float64
+    # `Δt` used to leak into `_ab2_substep_turbulent_kinetic_energy!`, and `Base.cbrt` into
+    # `compute_average_surface_buoyancy_flux!`.
+    arch = GPU(Metal.MetalBackend())
+    grid = RectilinearGrid(arch; size=(8, 8, 16), x=(0, 128), y=(0, 128), z=(-64, 0),
+                           topology=(Periodic, Periodic, Bounded))
+
+    @test eltype(grid) == Float32
+
+    Tbcs = FieldBoundaryConditions(top=FluxBoundaryCondition(1e-4)) # surface cooling
+
+    model = HydrostaticFreeSurfaceModel(grid;
+                                        momentum_advection = WENO(),
+                                        tracer_advection = WENO(),
+                                        buoyancy = SeawaterBuoyancy(equation_of_state=TEOS10EquationOfState()),
+                                        tracers = (:T, :S),
+                                        closure = CATKEVerticalDiffusivity(),
+                                        boundary_conditions = (; T=Tbcs))
+
+    @test model.clock isa Clock{Float64} # accumulate time in Float64...
+    @test Oceananigans.TimeSteppers.kernel_time_type(model.clock) == Float32 # ...but Float32 in kernels
+
+    set!(model, T=(x, y, z) -> 20f0 + 0.01f0 * z, S=35f0)
+    set!(model, e=1f-6) # note: a Float64 scalar cannot be `set!` on Metal
+
+    @test maximum(model.tracers.e) == 1f-6
+
+    simulation = Simulation(model, Δt=1minute, stop_iteration=3)
+    run!(simulation)
+
+    @test iteration(simulation) == 3
+    @test time(simulation) == 3minutes
+
+    # Surface cooling should generate turbulence and cool the surface
+    @test maximum(model.tracers.e) > 1f-6
+    @test maximum(model.tracers.T) < 20
 end

--- a/test/test_metal.jl
+++ b/test/test_metal.jl
@@ -179,7 +179,7 @@ end
 @testset "MetalGPU: f32_safe_cbrt" begin
     x = Float32[8, 27, 1000, 0.125, 1, 0, -8, -0.125]
     mtl_x = MtlArray(x)
-    mtl_y = f32_safe_cbrt.(mtl_x) # compiles and runs a Metal kernel
+    mtl_y = f32_safe_cbrt.(mtl_x)
 
     y = Array(mtl_y)
     @test eltype(y) == Float32
@@ -187,7 +187,7 @@ end
 end
 
 @testset "MetalGPU: CATKEVerticalDiffusivity" begin
-    # Regression test for https://github.com/CliMA/Oceananigans.jl/issues/5939
+    # https://github.com/CliMA/Oceananigans.jl/issues/5939
     arch = GPU(Metal.MetalBackend())
     grid = RectilinearGrid(arch; size=(8, 8, 16), x=(0, 128), y=(0, 128), z=(-64, 0),
                            topology=(Periodic, Periodic, Bounded))
@@ -204,8 +204,8 @@ end
                                         closure = CATKEVerticalDiffusivity(),
                                         boundary_conditions = (; T=Tbcs))
 
-    @test model.clock isa Clock{Float64} # accumulate time in Float64...
-    @test Oceananigans.TimeSteppers.kernel_time_type(model.clock) == Float32 # ...but Float32 in kernels
+    @test model.clock isa Clock{Float64}
+    @test Oceananigans.TimeSteppers.kernel_time_type(model.clock) == Float32
 
     set!(model, T=(x, y, z) -> 20f0 + 0.01f0 * z, S=35f0)
     set!(model, e=1f-6)

--- a/test/test_metal.jl
+++ b/test/test_metal.jl
@@ -177,9 +177,6 @@ end
 end
 
 @testset "MetalGPU: f32_safe_cbrt" begin
-    # `Base.cbrt(::Float32)` refines in Float64, which Metal cannot compile, so
-    # `f32_safe_cbrt` is overridden in `OceananigansMetalExt` --- see
-    # https://github.com/CliMA/Oceananigans.jl/issues/5939.
     x = Float32[8, 27, 1000, 0.125, 1, 0, -8, -0.125]
     mtl_x = MtlArray(x)
     mtl_y = f32_safe_cbrt.(mtl_x) # compiles and runs a Metal kernel
@@ -190,9 +187,7 @@ end
 end
 
 @testset "MetalGPU: CATKEVerticalDiffusivity" begin
-    # Regression test for https://github.com/CliMA/Oceananigans.jl/issues/5939: a Float64
-    # `Δt` used to leak into `_ab2_substep_turbulent_kinetic_energy!`, and `Base.cbrt` into
-    # `compute_average_surface_buoyancy_flux!`.
+    # Regression test for https://github.com/CliMA/Oceananigans.jl/issues/5939
     arch = GPU(Metal.MetalBackend())
     grid = RectilinearGrid(arch; size=(8, 8, 16), x=(0, 128), y=(0, 128), z=(-64, 0),
                            topology=(Periodic, Periodic, Bounded))
@@ -213,7 +208,7 @@ end
     @test Oceananigans.TimeSteppers.kernel_time_type(model.clock) == Float32 # ...but Float32 in kernels
 
     set!(model, T=(x, y, z) -> 20f0 + 0.01f0 * z, S=35f0)
-    set!(model, e=1f-6) # note: a Float64 scalar cannot be `set!` on Metal
+    set!(model, e=1f-6)
 
     @test maximum(model.tracers.e) == 1f-6
 
@@ -223,7 +218,6 @@ end
     @test iteration(simulation) == 3
     @test time(simulation) == 3minutes
 
-    # Surface cooling should generate turbulence and cool the surface
     @test maximum(model.tracers.e) > 1f-6
     @test maximum(model.tracers.T) < 20
 end

--- a/test/test_metal.jl
+++ b/test/test_metal.jl
@@ -2,7 +2,6 @@ include("dependencies_for_runtests.jl")
 include("dependencies_for_poisson_solvers.jl")
 
 using Metal
-using Oceananigans.Utils: f32_safe_cbrt
 using Oceananigans.TurbulenceClosures: CATKEVerticalDiffusivity
 using SeawaterPolynomials.TEOS10: TEOS10EquationOfState
 
@@ -174,16 +173,6 @@ end
     arch = GPU(Metal.MetalBackend())
     faces = collect(0:8) .^ 1.2
     @test stretched_poisson_solver_correct_answer(Float32, arch, (Periodic, Periodic, Bounded), 8, 8, faces)
-end
-
-@testset "MetalGPU: f32_safe_cbrt" begin
-    x = Float32[8, 27, 1000, 0.125, 1, 0, -8, -0.125]
-    mtl_x = MtlArray(x)
-    mtl_y = f32_safe_cbrt.(mtl_x)
-
-    y = Array(mtl_y)
-    @test eltype(y) == Float32
-    @test y ≈ cbrt.(x) rtol=1e-6
 end
 
 @testset "MetalGPU: CATKEVerticalDiffusivity" begin

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -2,9 +2,9 @@ include("dependencies_for_runtests.jl")
 
 using Adapt: Adapt
 using TimesDates: TimeDate
-using Dates: Minute
 using Oceananigans.Grids: topological_tuple_length
-using Oceananigans.TimeSteppers: Clock, kernel_time_step
+using Oceananigans.TimeSteppers: Clock
+using Oceananigans.Utils: kernel_time_step
 using Oceananigans.Advection: EnergyConserving, EnstrophyConserving
 using Oceananigans.TurbulenceClosures: CATKEVerticalDiffusivity
 using Oceananigans.TurbulenceClosures.Smagorinskys: LagrangianAveraging, DynamicSmagorinsky, Smagorinsky
@@ -383,22 +383,14 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
         @test Oceananigans.TimeSteppers.kernel_time_type(explicit_clock) == Float32
     end
 
-    @testset "kernel_time_step demotes Δt to the kernel time type" begin
+    @testset "kernel_time_step demotes Δt to the grid eltype" begin
         for arch in archs, FT in float_types
             grid = RectilinearGrid(arch, FT; size=(1, 1, 1), extent=(1, 1, 1))
-            clock = Clock(grid)
 
-            @test kernel_time_step(clock, 60.0) isa FT
-            @test kernel_time_step(clock, 60.0f0) isa FT
-            @test kernel_time_step(clock, 60) isa FT
+            @test kernel_time_step(arch, grid, 60.0) isa FT
+            @test kernel_time_step(arch, grid, 60.0f0) isa FT
+            @test kernel_time_step(arch, grid, 60) isa FT
         end
-
-        # `Δt` for DateTime clocks is Float64 seconds
-        datetime_clock = Clock(time=DateTime(2020))
-        @test kernel_time_step(datetime_clock, 60.0) isa Float64
-        @test kernel_time_step(datetime_clock, 60.0f0) isa Float64
-
-        @test kernel_time_step(datetime_clock, Minute(1)) === Minute(1)
     end
 
     # Regression test for https://github.com/CliMA/Oceananigans.jl/issues/5939. See `ΔtTypeRecorder` above.

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -19,10 +19,7 @@ function time_stepping_works_with_flat_dimensions(arch, topology)
     return true # Test that no errors/crashes happen when time stepping.
 end
 
-"""
-Records the type of the `Δt` that `time_step!` hands to the model, via the `dynamics`
-interface of `LagrangianParticles`, which receives the same `Δt` that kernels do.
-"""
+# `LagrangianParticles` dynamics receive the same Δt that kernels do
 mutable struct ΔtTypeRecorder
     Δt_type :: Any
 end
@@ -393,7 +390,7 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
         end
     end
 
-    # Regression test for https://github.com/CliMA/Oceananigans.jl/issues/5939. See `ΔtTypeRecorder` above.
+    # https://github.com/CliMA/Oceananigans.jl/issues/5939
     @testset "time_step! demotes Δt to the kernel time type" begin
         for arch in archs, FT in float_types
             grid = RectilinearGrid(arch, FT; size=(2, 2, 2), extent=(1, 1, 1))

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -2,8 +2,9 @@ include("dependencies_for_runtests.jl")
 
 using Adapt: Adapt
 using TimesDates: TimeDate
+using Dates: Minute
 using Oceananigans.Grids: topological_tuple_length
-using Oceananigans.TimeSteppers: Clock
+using Oceananigans.TimeSteppers: Clock, kernel_time_step
 using Oceananigans.Advection: EnergyConserving, EnstrophyConserving
 using Oceananigans.TurbulenceClosures: CATKEVerticalDiffusivity
 using Oceananigans.TurbulenceClosures.Smagorinskys: LagrangianAveraging, DynamicSmagorinsky, Smagorinsky
@@ -17,6 +18,21 @@ function time_stepping_works_with_flat_dimensions(arch, topology)
     time_step!(model, 1)
     return true # Test that no errors/crashes happen when time stepping.
 end
+
+"""
+Records the type of the `Δt` that `time_step!` hands to the model, via the `dynamics`
+interface of `LagrangianParticles` (which receives the same `Δt` that kernels do).
+
+`Clock.time` accumulates in Float64, so a Float64 `Δt` can reach `time_step!` even for a
+Float32 model. `time_step!` must demote it with `kernel_time_step`, or the Float64 leaks
+into kernels --- which promotes Float32 arithmetic everywhere and is invalid IR on
+architectures without double precision (e.g. Metal).
+"""
+mutable struct ΔtTypeRecorder
+    Δt_type :: Any
+end
+
+(recorder::ΔtTypeRecorder)(particles, model, Δt) = (recorder.Δt_type = typeof(Δt); nothing)
 
 function euler_time_stepping_doesnt_propagate_NaNs(arch)
     grid = RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 2, 3))
@@ -370,6 +386,58 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
         explicit_clock = Clock(time=0.0f0)
         @test explicit_clock isa Clock{Float32}
         @test Oceananigans.TimeSteppers.kernel_time_type(explicit_clock) == Float32
+    end
+
+    @testset "kernel_time_step demotes Δt to the kernel time type" begin
+        for arch in archs, FT in float_types
+            grid = RectilinearGrid(arch, FT; size=(1, 1, 1), extent=(1, 1, 1))
+            clock = Clock(grid)
+
+            # `aligned_time_step` mixes `clock.time` (Float64) into Δt, so Δt reaching
+            # `time_step!` may be Float64 even for a Float32 model. It must not reach kernels.
+            @test kernel_time_step(clock, 60.0) isa FT
+            @test kernel_time_step(clock, 60.0f0) isa FT
+            @test kernel_time_step(clock, 60) isa FT
+        end
+
+        # `Δt` for DateTime clocks is interpreted as Float64 seconds, and stays Float64.
+        datetime_clock = Clock(time=DateTime(2020))
+        @test kernel_time_step(datetime_clock, 60.0) isa Float64
+        @test kernel_time_step(datetime_clock, 60.0f0) isa Float64
+
+        # Non-numeric time steps are passed through untouched.
+        @test kernel_time_step(datetime_clock, Minute(1)) === Minute(1)
+    end
+
+    # Regression test for https://github.com/CliMA/Oceananigans.jl/issues/5939. See `ΔtTypeRecorder` above.
+    @testset "time_step! demotes Δt to the kernel time type" begin
+        for arch in archs, FT in float_types
+            grid = RectilinearGrid(arch, FT; size=(2, 2, 2), extent=(1, 1, 1))
+
+            x = on_architecture(arch, FT[0.5])
+            y = on_architecture(arch, FT[0.5])
+            z = on_architecture(arch, FT[-0.5])
+
+            # Probe Δt where it is handed to the model, via the `dynamics` interface
+            # of `LagrangianParticles`, which receives the same Δt that kernels do.
+            for timestepper in (:QuasiAdamsBashforth2, :RungeKutta3)
+                recorder = ΔtTypeRecorder(nothing)
+                particles = LagrangianParticles(; x, y, z, dynamics=recorder)
+                model = NonhydrostaticModel(grid; particles, timestepper)
+
+                time_step!(model, 1.0) # a Float64 Δt, as `aligned_time_step` may return
+                @test recorder.Δt_type === FT
+            end
+
+            for timestepper in (:QuasiAdamsBashforth2, :SplitRungeKutta3)
+                recorder = ΔtTypeRecorder(nothing)
+                particles = LagrangianParticles(; x, y, z, dynamics=recorder)
+                model = HydrostaticFreeSurfaceModel(grid; particles, timestepper)
+
+                time_step!(model, 1.0)
+                @test recorder.Δt_type === FT
+            end
+        end
     end
 
     for arch in archs, FT in float_types

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -21,12 +21,7 @@ end
 
 """
 Records the type of the `Δt` that `time_step!` hands to the model, via the `dynamics`
-interface of `LagrangianParticles` (which receives the same `Δt` that kernels do).
-
-`Clock.time` accumulates in Float64, so a Float64 `Δt` can reach `time_step!` even for a
-Float32 model. `time_step!` must demote it with `kernel_time_step`, or the Float64 leaks
-into kernels --- which promotes Float32 arithmetic everywhere and is invalid IR on
-architectures without double precision (e.g. Metal).
+interface of `LagrangianParticles`, which receives the same `Δt` that kernels do.
 """
 mutable struct ΔtTypeRecorder
     Δt_type :: Any
@@ -393,19 +388,16 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
             grid = RectilinearGrid(arch, FT; size=(1, 1, 1), extent=(1, 1, 1))
             clock = Clock(grid)
 
-            # `aligned_time_step` mixes `clock.time` (Float64) into Δt, so Δt reaching
-            # `time_step!` may be Float64 even for a Float32 model. It must not reach kernels.
             @test kernel_time_step(clock, 60.0) isa FT
             @test kernel_time_step(clock, 60.0f0) isa FT
             @test kernel_time_step(clock, 60) isa FT
         end
 
-        # `Δt` for DateTime clocks is interpreted as Float64 seconds, and stays Float64.
+        # `Δt` for DateTime clocks is Float64 seconds
         datetime_clock = Clock(time=DateTime(2020))
         @test kernel_time_step(datetime_clock, 60.0) isa Float64
         @test kernel_time_step(datetime_clock, 60.0f0) isa Float64
 
-        # Non-numeric time steps are passed through untouched.
         @test kernel_time_step(datetime_clock, Minute(1)) === Minute(1)
     end
 
@@ -418,14 +410,12 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
             y = on_architecture(arch, FT[0.5])
             z = on_architecture(arch, FT[-0.5])
 
-            # Probe Δt where it is handed to the model, via the `dynamics` interface
-            # of `LagrangianParticles`, which receives the same Δt that kernels do.
             for timestepper in (:QuasiAdamsBashforth2, :RungeKutta3)
                 recorder = ΔtTypeRecorder(nothing)
                 particles = LagrangianParticles(; x, y, z, dynamics=recorder)
                 model = NonhydrostaticModel(grid; particles, timestepper)
 
-                time_step!(model, 1.0) # a Float64 Δt, as `aligned_time_step` may return
+                time_step!(model, 1.0) # Float64, as `aligned_time_step` may return
                 @test recorder.Δt_type === FT
             end
 


### PR DESCRIPTION
Closes #5939. `CATKEVerticalDiffusivity` on a Float32 Metal grid fails to compile with `InvalidIRError: unsupported use of double value`, from two independent Float64 leaks. The reproducer from #5939 now runs to completion on Metal.

## 1. `Δt` reached kernels as Float64

`Clock.time` accumulates in Float64 deliberately, and #5570 added `kernel_time_type` + `Adapt.adapt_structure` so the *clock* arrives in kernels at grid precision. `Δt` is a separate scalar argument that machinery cannot reach: `aligned_time_step` computes `sim.stop_time - clock.time`, promoting an otherwise-Float32 `Δt` to Float64.

```julia
# Float32 grid, Float32 sim.Δt, Float32 sim.stop_time:
typeof(aligned_time_step(sim, sim.Δt)) == Float64
```

#5570 handled this with `convert(eltype(grid), Δt)` at individual launch sites, but `step_closure_prognostics!` and `step_lagrangian_particles!` were never covered, so `_ab2_substep_turbulent_kinetic_energy!` got `Δτ::Float64`. (The `convert(FT, Δτ)` already inside that kernel can't help — it's the argument *type* Metal rejects.)

Breeze.jl already had the right helper for this, so it moves into `Oceananigans.Utils` unchanged rather than becoming a second function with the same name and different semantics:

```julia
@inline kernel_time_step(arch, grid, Δt) = convert(eltype(grid), Δt)
```

applied once at the top of each `time_step!`, with the `ReactantState` pass-through Breeze needs since converting outside the kernel breaks tracing. Breeze can now drop its copy and import this.

Not Metal-specific — any Float32 grid was handing Float64 `Δt` to these kernels, promoting the arithmetic on every GPU.

With the conversion in one place, the per-site and in-kernel conversions are redundant and removed.

## 2. `Base.cbrt(::Float32)` emits double-precision instructions

[`Base._improve_cbrt(x::Float32, t::Float32)`](https://github.com/JuliaLang/julia/blob/v1.12.7/base/special/cbrt.jl#L79-L99) refines in Float64, and [says so](https://github.com/JuliaLang/julia/blob/v1.12.7/base/special/cbrt.jl#L85-L88):

```julia
# Use double precision so that its terms can be arranged for efficiency
# without causing overflow or underflow.
xx = Float64(x)
tt = Float64(t)
```

[`cbrt(x::Union{Float32,Float64})`](https://github.com/JuliaLang/julia/blob/v1.12.7/base/special/cbrt.jl#L142-L148) calls it unconditionally, so `cbrt` emits doubles even for a Float32 argument. All 18 reported reasons traced there:

```
Reason: unsupported use of double value
Stacktrace:
 [1] Float64            @ ./float.jl:345
 [2] _improve_cbrt      @ ./special/cbrt.jl:87
 [3] cbrt               @ ./special/cbrt.jl:147
 [4] macro expansion    @ .../catke_vertical_diffusivity.jl:292
```

Metal has no Float64, and no cube-root intrinsic to bind to — probed on device:

| candidate | result |
|---|---|
| `air.cbrt.f32`, `air.fast_cbrt.f32` | no such intrinsic |
| `air.pow.f32`, `air.powr.f32` | work |
| `x^(1f0/3f0)` (lowers to `air.pow.f32`) | works |
| `Base.cbrt` | `unsupported use of double value` |

So this adds `f32_safe_cbrt`, falling back to `Base.cbrt`, overridden for Metal via `^`. Our own function keeps it out of type-piracy territory; a `Base.cbrt` override belongs upstream, tracked at JuliaGPU/Metal.jl#952. It follows the `newton_div` pattern (overridden per-backend in an extension) and lives in its own file so it can be deleted wholesale when upstream lands. Used at the two call sites that run in kernels: `catke_vertical_diffusivity.jl:292` and `smagorinsky.jl:98` (a latent instance of the same bug).

**Accuracy**, measured on device against a correctly-rounded Float64 reference over 20612 samples spanning the Float32 exponent range plus a dense band across `1e-3` to `1e3`:

| | max | mean | exact | ≤ 1 ulp | ≤ 4 ulp |
|---|---|---|---|---|---|
| `f32_safe_cbrt` on Metal | 14 ulp | 0.65 ulp | 51.1% | 94.1% | 98.4% |
| `Base.cbrt` on CPU | 0 ulp | 0.000 ulp | 100% | 100% | 100% |

Zero, infinities, NaN and negatives match `Base.cbrt` exactly. The 14 ulp tail is `air.pow` being relaxed-precision plus `1f0/3f0` not being exactly ⅓ — immaterial for a turbulent length scale and a filter width.

**Subnormal arguments return zero**, because Metal flushes subnormal *operands* in arithmetic generally, not just in `pow`:

```
a * 2^24 on device   [0.0, 0.0, 0.0, 0.0, 1.97e-31]
a + a    on device   [0.0, 0.0, 0.0, 0.0, 2.35e-38]
a * 2^24 on CPU      [1.68e-31, 8.39e-32, 1.68e-33, 1.65e-37, 1.97e-31]
```

so no scaling trick recovers them. Consistent with every other operation on the device, and unreachable via arithmetic anyway since a subnormal intermediate flushes before it could be passed in. Worth knowing if this is upstreamed as a general `Base.cbrt` override.

## Tests

`test_time_stepping.jl` gains a unit test for `kernel_time_step` and a regression test that probes the `Δt` handed to the model through the documented `dynamics(particles, model, Δt)` interface of `LagrangianParticles`, which receives the same `Δt` kernels do — across all three timesteppers and both model types. With the conversion removed it catches every Float32 configuration:

```
CAUGHT: NonhydrostaticModel Float32 QuasiAdamsBashforth2         -> Δt::Float64
CAUGHT: NonhydrostaticModel Float32 RungeKutta3                  -> Δt::Float64
CAUGHT: HydrostaticFreeSurfaceModel Float32 QuasiAdamsBashforth2 -> Δt::Float64
CAUGHT: HydrostaticFreeSurfaceModel Float32 SplitRungeKutta3     -> Δt::Float64
```

`test_metal.jl` gains an `f32_safe_cbrt` check against `Base.cbrt` and the #5939 reproducer.

Run locally on an Apple Silicon GPU and on CPU:

| suite | result |
|---|---|
| `test_metal.jl` | all pass |
| `test_time_stepping.jl` | 144 pass, 2 broken (pre-existing) |
| `test_datetime_clock.jl` | 103 pass |
| `test_turbulence_closures.jl` | 263 pass |
| `test_shallow_water_models.jl` | 42 pass |
| `test_dynamics.jl` | 503 pass, 1 fail — "Tilted gravity" (`test_dynamics.jl:347`), identical on `main` at e33d4830a |

## Notes

- Callers of `ab2_step!` / `rk3_substep!` outside `time_step!` are now responsible for passing a Δt of the grid's precision.
- The Reactant override covers `ReactantState` but not `Distributed{<:ReactantState}`, matching Breeze.

Three unrelated Float64 leaks found while testing on Metal, not addressed here: `TKEDissipationVerticalDiffusivity` promotes inside a comparison in `compute_TKEDissipation_closure_fields!`; `LagrangianParticles` has `restitution = 1.0::Float64` and a promotion in `bounce_left`; `set!(field, x)` with a Float64 scalar compiles `gpu_fill_kernel!(..., ::Float64)`.

cc @enri66 — thanks for the precise report. Your `Clock` diagnosis was right as the mechanism: a Metal-specific `Clock(grid::MetalGrid) = Clock{Float32}(time=0)` used to exist in the Metal extension and was removed in #5570, which is why your explicit `Clock{Float32}` workaround restored the old behaviour. Would you mind confirming this branch on your M5 Max?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
