### PR TITLE
Skip the multi-region branch statically in apply_regionally! and construct_regionally

### DIFF
--- a/src/Utils/multi_region_transformation.jl
+++ b/src/Utils/multi_region_transformation.jl
@@ -76,11 +76,19 @@ Base.parent(mo::MultiRegionObject) = construct_regionally(parent, mo)
 
 Architectures.on_architecture(arch, mo::MultiRegionObject) = MultiRegionObject(on_architecture(arch, mo.regional_objects))
 
-# For non-returning functions -> can we make it NON BLOCKING? This seems to be synchronous!
+# `isregional(args)` and `isregional(values(kwargs))` fold to compile-time constants for
+# non-regional arguments, so the multi-region branch is dead code (and is not inferred) for them.
 @inline function apply_regionally!(regional_func!, args...; kwargs...)
+    if isregional(args) || isregional(values(kwargs))
+        return multi_region_apply!(regional_func!, args...; kwargs...)
+    else
+        return regional_func!(args...; kwargs...)
+    end
+end
+
+@inline function multi_region_apply!(regional_func!, args...; kwargs...)
     multi_region_args   = isnothing(findfirst(isregional, args))   ? nothing : args[findfirst(isregional, args)]
     multi_region_kwargs = isnothing(findfirst(isregional, kwargs)) ? nothing : kwargs[findfirst(isregional, kwargs)]
-    isnothing(multi_region_args) && isnothing(multi_region_kwargs) && return regional_func!(args...; kwargs...)
 
     R = isnothing(multi_region_args) ? regions(multi_region_kwargs) : regions(multi_region_args)
 
@@ -107,11 +115,16 @@ end
 
 # For functions with return statements -> BLOCKING! (use as seldom as possible)
 @inline function construct_regionally(Nreturns::Int, regional_func::Base.Callable, args...; kwargs...)
-    # First, we deduce whether any of `args` or `kwargs` are multi-regional.
-    # If no regional objects are found, we call the function as usual
+    if isregional(args) || isregional(values(kwargs))
+        return multi_region_construct(Nreturns, regional_func, args...; kwargs...)
+    else
+        return regional_func(args...; kwargs...)
+    end
+end
+
+@inline function multi_region_construct(Nreturns::Int, regional_func::Base.Callable, args...; kwargs...)
     multi_region_args   = isnothing(findfirst(isregional, args))   ? nothing :   args[findfirst(isregional, args)]
     multi_region_kwargs = isnothing(findfirst(isregional, kwargs)) ? nothing : kwargs[findfirst(isregional, kwargs)]
-    isnothing(multi_region_args) && isnothing(multi_region_kwargs) && return regional_func(args...; kwargs...)
 
     R = isnothing(multi_region_args) ? regions(multi_region_kwargs) : regions(multi_region_args)
 


### PR DESCRIPTION
> `apply_regionally!` and `construct_regionally` decided at run time whether any argument is a `MultiRegionObject` with `findfirst(isregional, args)` and `findfirst(isregional, kwargs)`. The latter iterates a `Base.Pairs` and does not constant-fold, so type inference explored the multi-region loop, with its splatted generators, using widened argument types at every `@apply_regionally` call site. Under a single
> `@apply_regionally build_active_cells_map(grid, ib)` Julia inferred `build_active_cells_map(::Any, ::Any)` (2.6 s) and `build_active_cells_map(::Union{AbstractGrid{..., <:Distributed}}, ::Any)` (3.7 s) in addition to the concrete method (0.27 s); the same happens in `Field` constructors, `update_state!` and every other user of the macro.
> 
> Dispatch on `isregional(args) || isregional(values(kwargs))` instead, which folds to `false` for non-regional arguments, and move the loop into `multi_region_apply!` / `multi_region_construct`. These stay `@inline`: a `@noinline` variant made inference specialize them separately wherever the arguments are abstract and raised the number of method instances inferred while constructing a `HydrostaticFreeSurfaceModel` from 72.5k to 81k; with `@inline` it is 75.4k and total inference time is unchanged.
> 
> Constructing an `ImmersedBoundaryGrid` on a 90x45x20 `LatitudeLongitudeGrid` with `active_cells_map = true` goes from 13.8 s to 8.6 s on a cold session (Julia 1.12.7).