### PR TITLE
Always bounds-check mapped kernels

### DIFF
--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -534,10 +534,11 @@ function partition(kernel::MappedKernel, inrange, ingroupsize)
     range = length(index_map)
     groupsize = get(static_workgroupsize)
 
-    blocks, groupsize, dynamic = NDIteration.partition(range, groupsize)
+    blocks, groupsize, _ = NDIteration.partition(range, groupsize)
     iterspace = NDRange{1, NDIteration.DynamicSize, static_workgroupsize}(CartesianIndices(blocks), IndexMap(index_map))
 
-    return iterspace, dynamic
+    # The map length is a runtime value, so the last block is always bounds-checked
+    return iterspace, NDIteration.DynamicCheck()
 end
 
 #####


### PR DESCRIPTION
This seems to help a bit on CPU, I'm not sure about the GPU impact (but the summary below suggests it should be effectively unchanged?)

> `partition(::MappedKernel, ...)` returned the `dynamic` flag computed by `NDIteration.partition` from the length of the index map, a runtime value, so the flag had type `Union{DynamicCheck, NoDynamicCheck}`. The KernelAbstractions CPU backend union-splits on it and compiles two specializations of every kernel launched over an active-cells map, plus two of `__run` / `__thread_run` each. In a `HydrostaticFreeSurfaceModel` on an immersed 90x45x20 grid with `active_cells_map = true` this doubled the inference and LLVM time of the momentum, tracer and CATKE kernels (for example `compute_hydrostatic_free_surface_Gv!` was inferred twice, 5.2 s + 5.0 s, and codegen'd twice, 0.78 s + 0.77 s).
> 
> Always return `DynamicCheck()`: the mapped `__validindex` then costs one integer comparison per work item, and only one specialization exists. The first `time_step!` of that model goes from 72 s to 45 s and its construction from 194 s to 180 s on a cold session (Julia 1.12.7); the steady-state step time is unchanged. GPU launches share this `partition`; they simply always carry the bounds check, which was already needed whenever the map length is not a multiple of the workgroup size.
