### PR TITLE
Make halo inflation in NonhydrostaticModel type stable

### DIFF
--- a/src/Grids/automatic_halo_sizing.jl
+++ b/src/Grids/automatic_halo_sizing.jl
@@ -68,16 +68,14 @@ required_halo_size_z(::Nothing) = 0
 inflate_halo_size_one_dimension(req_H, old_H, _, grid)            = max(req_H, old_H)
 inflate_halo_size_one_dimension(req_H, old_H, ::Type{Flat}, grid) = 0
 
-function inflate_halo_size(Hx, Hy, Hz, grid, tendency_terms...)
-    topo = topology(grid)
-    for term in tendency_terms
-        Hx_required = required_halo_size_x(term)
-        Hy_required = required_halo_size_y(term)
-        Hz_required = required_halo_size_z(term)
-        Hx = inflate_halo_size_one_dimension(Hx_required, Hx, topo[1], grid)
-        Hy = inflate_halo_size_one_dimension(Hy_required, Hy, topo[2], grid)
-        Hz = inflate_halo_size_one_dimension(Hz_required, Hz, topo[3], grid)
-    end
+# Recursive over `tendency_terms` so that the result constant-folds when the required halo sizes
+# are compile-time constants
+@inline inflate_halo_size(Hx, Hy, Hz, grid) = (Hx, Hy, Hz)
 
-    return Hx, Hy, Hz
+Base.@constprop :aggressive @inline function inflate_halo_size(Hx, Hy, Hz, grid, term, tendency_terms...)
+    topo = topology(grid)
+    Hx = inflate_halo_size_one_dimension(required_halo_size_x(term), Hx, topo[1], grid)
+    Hy = inflate_halo_size_one_dimension(required_halo_size_y(term), Hy, topo[2], grid)
+    Hz = inflate_halo_size_one_dimension(required_halo_size_z(term), Hz, topo[3], grid)
+    return inflate_halo_size(Hx, Hy, Hz, grid, tendency_terms...)
 end

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -7,7 +7,7 @@ using Oceananigans.BuoyancyFormulations: validate_buoyancy, materialize_buoyancy
 using Oceananigans.DistributedComputations: Distributed
 using Oceananigans.Fields: Field, tracernames, VelocityFields, TracerFields, CenterField, ZFaceField
 using Oceananigans.Forcings: model_forcing
-using Oceananigans.Grids: topology, inflate_halo_size, with_halo, architecture
+using Oceananigans.Grids: topology, inflate_halo_size, with_halo, architecture, halo_size
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 using Oceananigans.Models: AbstractModel, extract_boundary_conditions, materialize_free_surface, validate_tracer_advection
 using Oceananigans.Solvers: FFTBasedPoissonSolver
@@ -339,20 +339,26 @@ function materialize_model_advection(advection, grid)
     return NamedTuple(name => materialize_advection(scheme, grid) for (name, scheme) in pairs(advection))
 end
 
-function inflate_grid_halo_size(grid, tendency_terms...)
-    user_halo = grid.Hx, grid.Hy, grid.Hz
-    required_halo = Hx, Hy, Hz = inflate_halo_size(user_halo..., grid, tendency_terms...)
+Base.@constprop :aggressive @inline function inflate_grid_halo_size(grid, tendency_terms...)
+    user_halo = halo_size(grid)
+    required_halo = inflate_halo_size(user_halo..., grid, tendency_terms...)
+    needs_inflation = any(map(<, user_halo, required_halo))
+    return inflate_grid_halo_size(needs_inflation, grid, required_halo)
+end
 
-    if any(user_halo .< required_halo) # Replace grid
-        @warn "Inflating model grid halo size to ($Hx, $Hy, $Hz) and recreating grid. " *
-              "Note that an ImmersedBoundaryGrid requires an extra halo point in all non-flat directions compared to a non-immersed boundary grid."
-              "The model grid will be different from the input grid. To avoid this warning, " *
-              "pass halo=($Hx, $Hy, $Hz) when constructing the grid."
+# `needs_inflation` folds to a compile-time constant when the halo sizes do, so the grid type is
+# known to the compiler whenever the user grid already has sufficient halos
+@inline inflate_grid_halo_size(needs_inflation::Bool, grid, required_halo) =
+    needs_inflation ? with_inflated_halo(grid, required_halo) : grid
 
-        grid = with_halo((Hx, Hy, Hz), grid)
-    end
+@noinline function with_inflated_halo(grid, required_halo)
+    Hx, Hy, Hz = required_halo
+    @warn "Inflating model grid halo size to ($Hx, $Hy, $Hz) and recreating grid. " *
+          "Note that an ImmersedBoundaryGrid requires an extra halo point in all non-flat directions compared to a non-immersed boundary grid. " *
+          "The model grid will be different from the input grid. To avoid this warning, " *
+          "pass halo=($Hx, $Hy, $Hz) when constructing the grid."
 
-    return grid
+    return with_halo((Hx, Hy, Hz), grid)
 end
 
 # return the total advective velocities


### PR DESCRIPTION
> `inflate_grid_halo_size` inferred as `Any` even when the grid already had sufficient halos: `inflate_halo_size` accumulated the required halo in a loop over the heterogeneous tuple of tendency terms, which does not constant-fold, and `with_halo` returns a grid whose type depends on the halo values. Since the constructor rebinds `grid` to the result, every later step of `NonhydrostaticModel` (field construction, boundary condition regularization, solver and timestepper setup, `update_state!`) was inferred with an abstract grid and dispatched dynamically.
> 
> Write `inflate_halo_size` as a recursion over the tendency terms, so it folds when `required_halo_size_*` are compile-time constants, and split `inflate_grid_halo_size` so the (inlined) comparison decides at compile time whether the `with_halo` branch is reachable. With the default `RectilinearGrid` halo and WENO(5) + AnisotropicMinimumDissipation, `Base.return_types(inflate_grid_halo_size, ...)` is now the concrete grid type; it is still `Any` when inflation actually happens, the case that already warns the user to pass `halo=...` explicitly.
> 
> The warning message was missing a `*` between its second and third strings, so its second half was evaluated as a separate expression and never printed; the strings are now concatenated.
> 
> On its own this does not reduce construction time yet, because other values in the constructor (`materialize_model_advection`, `TracerFields`, `regularize_field_boundary_conditions`, `with_tracers`) are also inferred as abstract `NamedTuple`s; those are addressed separately.