### PR TITLE
Make the model constructors type stable

### DIFF
--- a/docs/src/developer_docs/contributing.md
+++ b/docs/src/developer_docs/contributing.md
@@ -182,6 +182,12 @@ If the documentation built is successful, you can open `docs/build/index.html` i
 `JULIA_DEBUG=Documenter` will provide with more information in the documentation build process and
 thus help figuring out a potential bug.
 
+## Compiler annotations
+
+In the source code we sometimes use compiler annotations like `@inline`/`@noinline`, or `@nospecialize` and `Base.@nospecializeinfer`, or `Base.@constprop`.
+These should be used sparingly and with a clear understanding of what they do, and only when it is demonstrated that they give substantial compile-time, or run-time, speedup with no other significant drawbacks.
+For example, it may be possible that the compiler spends a very long time trying to specialise for certain arguments of a function, for no runtime benefit, in that case `Base.@nospecializeinfer` + `@nospecialize` may be beneficial if benchmarks show that there are no regressions.
+
 ## Pre-commit hook
 
 This project uses [pre-commit](https://pre-commit.com/) for ensuring some minimal formatting consistency in the codebase, in particular related to whitespace.

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -27,9 +27,9 @@ using Oceananigans: Oceananigans
 using Oceananigans.Architectures: Architectures, CPU, GPU, on_architecture
 using Oceananigans.Grids: Grids, AbstractGrid, Bounded, Center, DistributedFoldedTopology, Face,
                           Flat, FullyConnected, LatitudeLongitudeGrid, LeftConnected,
-                          RightCenterFolded, RightConnected, RightFaceFolded, node, φnode, topology
+                          RightCenterFolded, RightConnected, RightFaceFolded, halo_size, node, φnode, topology
 using Oceananigans.Operators: Ax, Ay, Az, volume, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
-using Oceananigans.Utils: AbstractTimeDiscretization, ExplicitTimeDiscretization, launch!
+using Oceananigans.Utils: AbstractTimeDiscretization, ExplicitTimeDiscretization, launch!, named_tuple
 
 # All possible fill_halo! kernels
 struct WestAndEast end

--- a/src/BoundaryConditions/boundary_condition_ordering.jl
+++ b/src/BoundaryConditions/boundary_condition_ordering.jl
@@ -14,36 +14,34 @@ extract_bc(bcs, ::SouthAndNorth) = (bcs.south, bcs.north)
 # fill_halo! events (see issue #3342)
 # `permute_boundary_conditions` returns a 2-tuple containing the ordered operations to execute in
 # position [1] and the associated boundary conditions in position [2]
-function permute_boundary_conditions(bcs)
+Base.@constprop :aggressive function permute_boundary_conditions(bcs)
 
     split_x_halo_filling = split_halo_filling(bcs.west, bcs.east)
     split_y_halo_filling = split_halo_filling(bcs.south, bcs.north)
 
-    if split_x_halo_filling
-        if split_y_halo_filling
-            sides      = [West(), East(), South(), North(), BottomAndTop()]
-            bcs_array  = [bcs.west, bcs.east, bcs.south, bcs.north, bcs.bottom]
-        else
-            sides     = [West(), East(), SouthAndNorth(), BottomAndTop()]
-            bcs_array = [bcs.west, bcs.east, bcs.south, bcs.bottom]
-        end
+    # A single assignment keeps `sides` unboxed in the closures below
+    sides, bcs_tuple = if split_x_halo_filling && split_y_halo_filling
+        (West(), East(), South(), North(), BottomAndTop()), (bcs.west, bcs.east, bcs.south, bcs.north, bcs.bottom)
+    elseif split_x_halo_filling
+        (West(), East(), SouthAndNorth(), BottomAndTop()), (bcs.west, bcs.east, bcs.south, bcs.bottom)
+    elseif split_y_halo_filling
+        (WestAndEast(), South(), North(), BottomAndTop()), (bcs.west, bcs.south, bcs.north, bcs.bottom)
     else
-        if split_y_halo_filling
-            sides     = [WestAndEast(), South(), North(), BottomAndTop()]
-            bcs_array = [bcs.west, bcs.south, bcs.north, bcs.bottom]
-        else
-            sides     = [WestAndEast(), SouthAndNorth(), BottomAndTop()]
-            bcs_array = [bcs.west, bcs.south, bcs.bottom]
-        end
+        (WestAndEast(), SouthAndNorth(), BottomAndTop()), (bcs.west, bcs.south, bcs.bottom)
     end
 
-    perm  = sortperm(bcs_array, lt=fill_first)
-    sides = tuple(sides[perm]...)
+    perm = filling_order(map(fill_priority, bcs_tuple))
 
-    boundary_conditions = Tuple(extract_bc(bcs, side) for side in sides)
+    ordered_sides = ntuple(Val(length(sides))) do n
+        Base.@_inline_meta
+        @inbounds sides[perm[n]]
+    end
 
-    return sides, boundary_conditions
+    boundary_conditions = map(side -> extract_bc(bcs, side), ordered_sides)
+
+    return ordered_sides, boundary_conditions
 end
+
 
 side_name(::West) = :west
 side_name(::East) = :east
@@ -92,51 +90,31 @@ const OBCTC = Union{NFBC, Tuple{Vararg{NFBC}}}
 # Periodic fills also corners while Flux, Value, Gradient do not
 # TODO: remove this ordering requirement (see issue https://github.com/CliMA/Oceananigans.jl/issues/3342)
 
-# Order of halo filling
+# Order of halo filling (see `fill_priority`)
 # 0) Nothing / no-op (Face on Bounded axis — no halo needed)
 # 1) Flux, Value, Gradient (TODO: remove these BC and apply them as fluxes)
 # 2) Periodic (PBCT)
 # 3) Shared Communication (MCBCT)
 # 4) Distributed Communication (DCBCT)
 
-# We define "greater than" `>` and "lower than", for boundary conditions
-# following the rules outlined in `fill_first`
-# i.e. if `bc1 > bc2` then `bc2` precedes `bc1` in filling order
-@inline Base.isless(bc1::BoundaryCondition, bc2::BoundaryCondition) = fill_first(bc1, bc2)
+# Sides are filled by increasing priority; among equal priorities, the side listed last goes first.
+# Everything here folds at compile time because the priorities depend only on the boundary condition types.
+@inline fill_priority(::Nothing) = 0
+@inline fill_priority(bc)        = 1
+@inline fill_priority(::PBCT)    = 2
+@inline fill_priority(::MCBCT)   = 3
+@inline fill_priority(::DCBCT)   = 4
 
-# fallback for `Nothing` BC.
-@inline Base.isless(::Nothing,           ::Nothing) = true
-@inline Base.isless(::BoundaryCondition, ::Nothing) = false
-@inline Base.isless(::Nothing, ::BoundaryCondition) = true
-@inline Base.isless(::BoundaryCondition, ::Missing) = false
-@inline Base.isless(::Missing, ::BoundaryCondition) = true
+@inline fills_before((p₁, i₁), (p₂, i₂)) = p₁ < p₂ || (p₁ == p₂ && i₁ > i₂)
 
-# Nothing BCs are no-ops; fill them first to get them out of the way.
-# These must be defined to maintain strict-weak-ordering for sortperm.
-fill_first(::Nothing, ::Nothing) = true
-fill_first(::Nothing, bc2)       = true
-fill_first(bc1, ::Nothing)       = false
-# Resolve method ambiguities with specific BC types
-fill_first(::Nothing, ::PBCT)    = true
-fill_first(::Nothing, ::DCBCT)   = true
-fill_first(::Nothing, ::MCBCT)   = true
-fill_first(::PBCT,    ::Nothing) = false
-fill_first(::DCBCT,   ::Nothing) = false
-fill_first(::MCBCT,   ::Nothing) = false
+@inline insert_in_order(x, ::Tuple{}) = (x,)
+Base.@constprop :aggressive @inline insert_in_order(x, sorted::Tuple) =
+    fills_before(x, first(sorted)) ? (x, sorted...) : (first(sorted), insert_in_order(x, Base.tail(sorted))...)
 
-fill_first(bc1::DCBCT, bc2)        = false
-fill_first(bc1::PBCT,  bc2::DCBCT) = true
-fill_first(bc1::DCBCT, bc2::PBCT)  = false
-fill_first(bc1::MCBCT, bc2::DCBCT) = true
-fill_first(bc1::DCBCT, bc2::MCBCT) = false
-fill_first(bc1, bc2::DCBCT)        = true
-fill_first(bc1::DCBCT, bc2::DCBCT) = true
-fill_first(bc1::PBCT,  bc2)        = false
-fill_first(bc1::MCBCT, bc2)        = false
-fill_first(bc1::PBCT,  bc2::MCBCT) = true
-fill_first(bc1::MCBCT, bc2::PBCT)  = false
-fill_first(bc1, bc2::PBCT)         = true
-fill_first(bc1, bc2::MCBCT)        = true
-fill_first(bc1::PBCT,  bc2::PBCT)  = true
-fill_first(bc1::MCBCT, bc2::MCBCT) = true
-fill_first(bc1, bc2)               = true
+@inline sort_in_order(::Tuple{}) = ()
+Base.@constprop :aggressive @inline sort_in_order(t::Tuple) = insert_in_order(first(t), sort_in_order(Base.tail(t)))
+
+Base.@constprop :aggressive @inline function filling_order(priorities::NTuple{N, Int}) where N
+    keyed = ntuple(i -> (priorities[i], i), Val(N))
+    return map(last, sort_in_order(keyed))
+end

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -235,29 +235,29 @@ function regularize_immersed_boundary_condition(ibc, grid, loc, field_name, args
     return nothing
 end
 
-  regularize_west_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
-  regularize_east_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
- regularize_south_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
- regularize_north_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
-regularize_bottom_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
-   regularize_top_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
+@inline   regularize_west_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
+@inline   regularize_east_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
+@inline  regularize_south_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
+@inline  regularize_north_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
+@inline regularize_bottom_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
+@inline    regularize_top_boundary_condition(bc, args...) = regularize_boundary_condition(bc, args...)
 
 # regularize default boundary conditions
-function regularize_boundary_condition(default::DefaultBoundaryCondition, grid, loc, dim, args...)
+@inline function regularize_boundary_condition(default::DefaultBoundaryCondition, grid, loc, dim, args...)
     default_bc = default_prognostic_bc(topology(grid, dim)(), loc[dim], default)
     return regularize_boundary_condition(default_bc, grid, loc, dim, args...)
 end
 
-function regularize_boundary_condition(bc::BoundaryCondition, grid, loc, dim, args...)
+@inline function regularize_boundary_condition(bc::BoundaryCondition, grid, loc, dim, args...)
     regularized = regularize_boundary_condition(bc.condition, grid, loc, dim, args...)
     return BoundaryCondition(bc.classification, regularized)
 end
 
 # Convert all `Number` boundary conditions to `eltype(grid)`
-regularize_boundary_condition(condition::Number, grid, args...) = convert(eltype(grid), condition)
-regularize_boundary_condition(condition, grid, args...) = condition # fallback
+@inline regularize_boundary_condition(condition::Number, grid, args...) = convert(eltype(grid), condition)
+@inline regularize_boundary_condition(condition, grid, args...) = condition # fallback
 
-function regularize_boundary_condition(mc::MixedCondition, grid, args...)
+@inline function regularize_boundary_condition(mc::MixedCondition, grid, args...)
     coefficient = regularize_boundary_condition(mc.coefficient, grid, args...)
     inhomogeneity = regularize_boundary_condition(mc.inhomogeneity, grid, args...)
     return MixedCondition(coefficient, inhomogeneity)
@@ -276,20 +276,20 @@ boundary conditions for prognostic model field boundary conditions.
     `ContinuousBoundaryFunction` is not supported on immersed boundaries.
     We therefore do not regularize the immersed boundary condition.
 """
-function regularize_field_boundary_conditions(bcs::FieldBoundaryConditions,
-                                              grid::AbstractGrid,
-                                              field_name::Symbol,
-                                              prognostic_names=nothing)
+@inline function regularize_field_boundary_conditions(bcs::FieldBoundaryConditions,
+                                                      grid::AbstractGrid,
+                                                      field_name::Symbol,
+                                                      prognostic_names=nothing)
 
     loc = assumed_field_location(field_name)
     return regularize_field_boundary_conditions(bcs, grid, loc, prognostic_names, field_name)
 end
 
-function regularize_field_boundary_conditions(bcs::FieldBoundaryConditions,
-                                              grid::AbstractGrid,
-                                              loc::Tuple,
-                                              prognostic_names=nothing,
-                                              field_name=nothing)
+@inline function regularize_field_boundary_conditions(bcs::FieldBoundaryConditions,
+                                                      grid::AbstractGrid,
+                                                      loc::Tuple,
+                                                      prognostic_names=nothing,
+                                                      field_name=nothing)
 
     west   = regularize_west_boundary_condition(bcs.west,     grid, loc, 1, LeftBoundary,  prognostic_names)
     east   = regularize_east_boundary_condition(bcs.east,     grid, loc, 1, RightBoundary, prognostic_names)
@@ -309,8 +309,10 @@ function regularize_field_boundary_conditions(boundary_conditions::NamedTuple,
                                               group_name::Symbol,
                                               prognostic_names=nothing)
 
-    return NamedTuple(field_name => regularize_field_boundary_conditions(field_bcs, grid, field_name, prognostic_names)
-                      for (field_name, field_bcs) in pairs(boundary_conditions))
+    return named_tuple(keys(boundary_conditions)) do field_name
+        Base.@constprop :aggressive
+        regularize_field_boundary_conditions(boundary_conditions[field_name], grid, field_name, prognostic_names)
+    end
 end
 
 regularize_field_boundary_conditions(::Missing,
@@ -325,8 +327,10 @@ needs_implicit_solver(bcs::FieldBoundaryConditions) = needs_implicit_solver(bcs.
 #####
 
 regularize_field_boundary_conditions(boundary_conditions::NamedTuple, grid::AbstractGrid, prognostic_names::Tuple) =
-    NamedTuple(field_name => regularize_field_boundary_conditions(field_bcs, grid, field_name, prognostic_names)
-               for (field_name, field_bcs) in pairs(boundary_conditions))
+    named_tuple(keys(boundary_conditions)) do field_name
+        Base.@constprop :aggressive
+        regularize_field_boundary_conditions(boundary_conditions[field_name], grid, field_name, prognostic_names)
+    end
 
 #####
 ##### Special behavior for LatitudeLongitudeGrid
@@ -334,10 +338,10 @@ regularize_field_boundary_conditions(boundary_conditions::NamedTuple, grid::Abst
 
 # TODO: these may be incorrect because we have not defined behavior for prognostic fields (which are
 # treated by `regularize`).
-regularize_north_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) =
+@inline regularize_north_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) =
     regularize_boundary_condition(default_prognostic_bc(grid, Val(:north), loc, bc), grid, loc, args...)
 
-regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) =
+@inline regularize_south_boundary_condition(bc::DefaultBoundaryCondition, grid::LatitudeLongitudeGrid, loc, args...) =
     regularize_boundary_condition(default_prognostic_bc(grid, Val(:south), loc, bc), grid, loc, args...)
 
 function default_prognostic_bc(grid::LatitudeLongitudeGrid, ::Val{:north}, (ℓx, ℓy, ℓz), default)

--- a/src/BoundaryConditions/fill_halo_kernels.jl
+++ b/src/BoundaryConditions/fill_halo_kernels.jl
@@ -8,7 +8,7 @@ and the provided `bcs` (a FieldBoundaryConditions` object).
 Return a new `FieldBoundaryConditions` object with the preconfigured kernels and
 ordered boundary conditions.
 """
-function construct_boundary_conditions_kernels(bcs::FieldBoundaryConditions,
+Base.@constprop :aggressive function construct_boundary_conditions_kernels(bcs::FieldBoundaryConditions,
                                                data::OffsetArray,
                                                grid::AbstractGrid,
                                                loc, indices)
@@ -32,26 +32,22 @@ construct_boundary_conditions_kernels(::Missing, data, grid, loc, indices) = mis
 
 @inline function fill_halo_kernels(bcs::FieldBoundaryConditions, data::OffsetArray, grid::AbstractGrid, loc, indices)
     sides, ordered_bcs = permute_boundary_conditions(bcs)
-    reduced_dimensions = findall(x -> x isa Nothing, loc)
-    reduced_dimensions = tuple(reduced_dimensions...)
-    names = Tuple(side_name(side) for side in sides)
-    kernels! = []
+    reduced_dims = reduced_dimensions(loc)
+    names = map(side_name, sides)
 
-    for task in 1:length(sides)
-        side = sides[task]
-        bc   = select_bc(ordered_bcs[task])
-
+    kernels! = map(sides, ordered_bcs) do side, side_bcs
+        bc      = select_bc(side_bcs)
         size    = fill_halo_size(data, side, indices, bc, loc, grid)
         offset  = fill_halo_offset(size, side, indices)
-        kernel! = fill_halo_kernel(side, bc, grid, size, offset, data, reduced_dimensions)
-
-        push!(kernels!, kernel!)
+        fill_halo_kernel(side, bc, grid, size, offset, data, reduced_dims)
     end
-
-    kernels! = tuple(kernels!...)
 
     return NamedTuple{names}(kernels!), NamedTuple{names}(ordered_bcs)
 end
+
+@inline reduced_dimension(::Nothing, dim) = (dim,)
+@inline reduced_dimension(loc, dim) = ()
+@inline reduced_dimensions(loc) = (reduced_dimension(loc[1], 1)..., reduced_dimension(loc[2], 2)..., reduced_dimension(loc[3], 3)...)
 
 @inline get_boundary_kernels(bcs::NoKernelFBC, data, grid, loc, indices) = fill_halo_kernels(bcs, data, grid, loc, indices)
 @inline get_boundary_kernels(bcs, args...) = bcs.kernels, bcs.ordered_bcs
@@ -63,15 +59,10 @@ end
     return (parent_size[dim1], parent_size[dim2])
 end
 
-@inline function periodic_offset(c, dim1, dim2, kernel_offset)
-    field_offsets = (c.offsets[dim1], c.offsets[dim2])
-
-    # Windowed fields (from `view(field, indices...)`) have positive OffsetArray offsets
-    # in windowed dimensions. Subtract these to avoid double-counting the kernel launch offset.
-    offset1 = kernel_offset[1] - max(0, field_offsets[1])
-    offset2 = kernel_offset[2] - max(0, field_offsets[2])
-    return (offset1, offset2)
-end
+# Windowed fields (from `view(field, indices...)`) have OffsetArray offsets equal to the kernel
+# launch offset in windowed dimensions, and negative ones elsewhere; subtracting the positive part
+# avoids double-counting the launch offset and leaves only windows starting at a non-positive index.
+@inline periodic_offset(c, dim1, dim2, kernel_offset) = (min(kernel_offset[1], 0), min(kernel_offset[2], 0))
 
 @inline periodic_offset(c, dim1, dim2, ::Symbol) = (0, 0)
 
@@ -81,7 +72,7 @@ end
 
 const NoBC = Union{Nothing, Missing}
 
-fill_halo_kernel(value, bc::NoBC, args...) = nothing
+@inline fill_halo_kernel(value, bc::NoBC, args...) = nothing
 
 @inline kernel_parameters(size, offset) = KernelParameters(size, offset)
 @inline kernel_parameters(size::Symbol, offset) = size
@@ -90,35 +81,35 @@ fill_halo_kernel(value, bc::NoBC, args...) = nothing
 ##### Two-sided fill halo kernels
 #####
 
-fill_halo_kernel(::WestAndEast, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
+@inline fill_halo_kernel(::WestAndEast, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
     configure_kernel(architecture(grid), grid, kernel_parameters(size, offset), _fill_west_and_east_halo!; reduced_dimensions)[1]
 
-fill_halo_kernel(::SouthAndNorth, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
+@inline fill_halo_kernel(::SouthAndNorth, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
     configure_kernel(architecture(grid), grid, kernel_parameters(size, offset), _fill_south_and_north_halo!; reduced_dimensions)[1]
 
-fill_halo_kernel(::BottomAndTop, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
+@inline fill_halo_kernel(::BottomAndTop, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
     configure_kernel(architecture(grid), grid, kernel_parameters(size, offset), _fill_bottom_and_top_halo!; reduced_dimensions)[1]
 
 #####
 ##### One-sided fill halo kernels
 #####
 
-fill_halo_kernel(::West, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
+@inline fill_halo_kernel(::West, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
     configure_kernel(architecture(grid), grid, kernel_parameters(size, offset), _fill_only_west_halo!; reduced_dimensions)[1]
 
-fill_halo_kernel(::East, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
+@inline fill_halo_kernel(::East, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
     configure_kernel(architecture(grid), grid, kernel_parameters(size, offset), _fill_only_east_halo!; reduced_dimensions)[1]
 
-fill_halo_kernel(::South, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
+@inline fill_halo_kernel(::South, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
     configure_kernel(architecture(grid), grid, kernel_parameters(size, offset), _fill_only_south_halo!; reduced_dimensions)[1]
 
-fill_halo_kernel(::North, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
+@inline fill_halo_kernel(::North, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
     configure_kernel(architecture(grid), grid, kernel_parameters(size, offset), _fill_only_north_halo!; reduced_dimensions)[1]
 
-fill_halo_kernel(::Bottom, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
+@inline fill_halo_kernel(::Bottom, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
     configure_kernel(architecture(grid), grid, kernel_parameters(size, offset), _fill_only_bottom_halo!; reduced_dimensions)[1]
 
-fill_halo_kernel(::Top, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
+@inline fill_halo_kernel(::Top, bc::BoundaryCondition, grid, size, offset, data, reduced_dimensions) =
     configure_kernel(architecture(grid), grid, kernel_parameters(size, offset), _fill_only_top_halo!; reduced_dimensions)[1]
 
 #####
@@ -130,25 +121,25 @@ struct PeriodicFillHalo{K, N, H}
     PeriodicFillHalo(kernel, ::Val{N}, ::Val{H}) where {N, H} = new{typeof(kernel), N, H}(kernel)
 end
 
-function fill_halo_kernel(::WestAndEast, bc::PBC, grid, size, offset, data, reduced_dimensions)
+@inline function fill_halo_kernel(::WestAndEast, bc::PBC, grid, size, offset, data, reduced_dimensions)
     yz_size  = periodic_size(data, 2, 3, size)
     yz_offset = periodic_offset(data, 2, 3, offset)
     kernel = configure_kernel(architecture(grid), grid, kernel_parameters(yz_size, yz_offset), _fill_periodic_west_and_east_halo!)[1]
-    return PeriodicFillHalo(kernel, Val(grid.Nx), Val(grid.Hx))
+    return PeriodicFillHalo(kernel, Val(Base.size(grid, 1)), Val(halo_size(grid, 1)))
 end
 
-function fill_halo_kernel(::SouthAndNorth, bc::PBC, grid, size, offset, data, reduced_dimensions)
+@inline function fill_halo_kernel(::SouthAndNorth, bc::PBC, grid, size, offset, data, reduced_dimensions)
     xz_size   = periodic_size(data, 1, 3, size)
     xz_offset = periodic_offset(data, 1, 3, offset)
     kernel = configure_kernel(architecture(grid), grid, kernel_parameters(xz_size, xz_offset), _fill_periodic_south_and_north_halo!)[1]
-    return PeriodicFillHalo(kernel, Val(grid.Ny), Val(grid.Hy))
+    return PeriodicFillHalo(kernel, Val(Base.size(grid, 2)), Val(halo_size(grid, 2)))
 end
 
-function fill_halo_kernel(::BottomAndTop, bc::PBC, grid, size, offset, data, reduced_dimensions)
+@inline function fill_halo_kernel(::BottomAndTop, bc::PBC, grid, size, offset, data, reduced_dimensions)
     xy_size   = periodic_size(data, 1, 2, size)
     xy_offset = periodic_offset(data, 1, 2, offset)
     kernel = configure_kernel(architecture(grid), grid, kernel_parameters(xy_size, xy_offset), _fill_periodic_bottom_and_top_halo!)[1]
-    return PeriodicFillHalo(kernel, Val(grid.Nz), Val(grid.Hz))
+    return PeriodicFillHalo(kernel, Val(Base.size(grid, 3)), Val(halo_size(grid, 3)))
 end
 
 #####

--- a/src/BoundaryConditions/fill_halo_kernels.jl
+++ b/src/BoundaryConditions/fill_halo_kernels.jl
@@ -9,9 +9,9 @@ Return a new `FieldBoundaryConditions` object with the preconfigured kernels and
 ordered boundary conditions.
 """
 Base.@constprop :aggressive function construct_boundary_conditions_kernels(bcs::FieldBoundaryConditions,
-                                               data::OffsetArray,
-                                               grid::AbstractGrid,
-                                               loc, indices)
+                                                                           data::OffsetArray,
+                                                                           grid::AbstractGrid,
+                                                                           loc, indices)
 
     kernels!, ordered_bcs = fill_halo_kernels(bcs, data, grid, loc, indices)
     regularized_bcs = FieldBoundaryConditions(bcs.west, bcs.east, bcs.south, bcs.north,

--- a/src/BoundaryConditions/fill_halo_regions.jl
+++ b/src/BoundaryConditions/fill_halo_regions.jl
@@ -1,5 +1,5 @@
 using OffsetArrays: OffsetArray
-using Oceananigans.Grids: architecture
+using Oceananigans.Grids: architecture, total_size
 
 #####
 ##### General halo filling functions
@@ -155,7 +155,8 @@ end
 
 # Calculate kernel size for windowed fields. This code is only called when
 # one or more of the elements of `idx` is not Colon in the two direction perpendicular
-# to the halo region and `bc` is not `PeriodicBoundaryCondition`.
+# to the halo region and `bc` is not `PeriodicBoundaryCondition`. The data size is
+# `total_size(grid, loc, idx)`, which is known at compile time when `idx` is.
 @inline function fill_halo_size(c::OffsetArray, ::WEB, idx, bc, loc, grid; include_right_boundaries=true)
     @inbounds begin
         whole_y_halo = whole_halo(idx[2], loc[2])
@@ -163,7 +164,7 @@ end
     end
 
     _, Ny, Nz = include_right_boundaries ? size(grid, loc) : size(grid)
-    _, Cy, Cz = size(c)
+    _, Cy, Cz = total_size(grid, loc, idx)
 
     Sy = ifelse(whole_y_halo, Ny, Cy)
     Sz = ifelse(whole_z_halo, Nz, Cz)
@@ -178,7 +179,7 @@ end
     end
 
     Nx, _, Nz = include_right_boundaries ? size(grid, loc) : size(grid)
-    Cx, _, Cz = size(c)
+    Cx, _, Cz = total_size(grid, loc, idx)
 
     Sx = ifelse(whole_x_halo, Nx, Cx)
     Sz = ifelse(whole_z_halo, Nz, Cz)
@@ -193,7 +194,7 @@ end
     end
 
     Nx, Ny, _ = include_right_boundaries ? size(grid, loc) : size(grid)
-    Cx, Cy, _ = size(c)
+    Cx, Cy, _ = total_size(grid, loc, idx)
 
     Sx = ifelse(whole_x_halo, Nx, Cx)
     Sy = ifelse(whole_y_halo, Ny, Cy)
@@ -201,23 +202,28 @@ end
     return (Sx, Sy)
 end
 
-# Remember that Periodic BCs also fill halo points!
-@inline fill_halo_size(c::OffsetArray, ::WEB, idx, ::PBC, args...) = tuple(size(c, 2), size(c, 3))
-@inline fill_halo_size(c::OffsetArray, ::SNB, idx, ::PBC, args...) = tuple(size(c, 1), size(c, 3))
-@inline fill_halo_size(c::OffsetArray, ::TBB, idx, ::PBC, args...) = tuple(size(c, 1), size(c, 2))
+# Remember that Periodic BCs also fill halo points! The array size is `total_size(grid, loc, idx)`,
+# which is known at compile time when the indices are `Colon`s.
+@inline fill_halo_size(c::OffsetArray, side::WEB, idx, ::PBC, loc, grid) = periodic_halo_size(side, idx, loc, grid)
+@inline fill_halo_size(c::OffsetArray, side::SNB, idx, ::PBC, loc, grid) = periodic_halo_size(side, idx, loc, grid)
+@inline fill_halo_size(c::OffsetArray, side::TBB, idx, ::PBC, loc, grid) = periodic_halo_size(side, idx, loc, grid)
 
-@inline function fill_halo_size(c::OffsetArray, ::WEB, ::Tuple{<:Any, <:Colon, <:Colon}, ::PBC, args...)
-    _, Cy, Cz = size(c)
+@inline fill_halo_size(c::OffsetArray, side::WEB, idx::Tuple{<:Any, <:Colon, <:Colon}, ::PBC, loc, grid) = periodic_halo_size(side, idx, loc, grid)
+@inline fill_halo_size(c::OffsetArray, side::SNB, idx::Tuple{<:Colon, <:Any, <:Colon}, ::PBC, loc, grid) = periodic_halo_size(side, idx, loc, grid)
+@inline fill_halo_size(c::OffsetArray, side::TBB, idx::Tuple{<:Colon, <:Colon, <:Any}, ::PBC, loc, grid) = periodic_halo_size(side, idx, loc, grid)
+
+@inline function periodic_halo_size(::WEB, idx, loc, grid)
+    _, Cy, Cz = total_size(grid, loc, idx)
     return (Cy, Cz)
 end
 
-@inline function fill_halo_size(c::OffsetArray, ::SNB, ::Tuple{<:Colon, <:Any, <:Colon}, ::PBC, args...)
-    Cx, _, Cz = size(c)
+@inline function periodic_halo_size(::SNB, idx, loc, grid)
+    Cx, _, Cz = total_size(grid, loc, idx)
     return (Cx, Cz)
 end
 
-@inline function fill_halo_size(c::OffsetArray, ::TBB, ::Tuple{<:Colon, <:Colon, <:Any}, ::PBC, args...)
-    Cx, Cy, _ = size(c)
+@inline function periodic_halo_size(::TBB, idx, loc, grid)
+    Cx, Cy, _ = total_size(grid, loc, idx)
     return (Cx, Cy)
 end
 

--- a/src/BuoyancyFormulations/buoyancy_force.jl
+++ b/src/BuoyancyFormulations/buoyancy_force.jl
@@ -51,7 +51,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 └── coriolis: Nothing
 ```
 """
-function BuoyancyForce(grid, formulation::AbstractBuoyancyFormulation; gravity_unit_vector=NegativeZDirection(), materialize_gradients=false)
+Base.@constprop :aggressive function BuoyancyForce(grid, formulation::AbstractBuoyancyFormulation; gravity_unit_vector=NegativeZDirection(), materialize_gradients=false)
     gravity_unit_vector = validate_unit_vector(gravity_unit_vector)
 
     if materialize_gradients

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -18,7 +18,7 @@ using Oceananigans.BoundaryConditions: BoundaryConditions, fill_halo_regions!
 using Oceananigans.Grids: Grids, AbstractGrid, Bounded, Center, Face, LatitudeLongitudeGrid, Periodic,
     RectilinearGrid, new_data, interior_indices, total_size, topology, nodes, xnodes,
     ynodes, znodes, node, xnode, ynode, znode
-using Oceananigans.Utils: KernelParameters, launch!, prettysummary, interpolator
+using Oceananigans.Utils: KernelParameters, launch!, prettysummary, interpolator, named_tuple
 
 "Return the location `(LX, LY, LZ)` of an `AbstractField{LX, LY, LZ}`."
 @inline Oceananigans.location(a) = (Nothing, Nothing, Nothing) # used in AbstractOperations for location inference

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -28,7 +28,7 @@ struct Field{LX, LY, LZ, O, G, I, D, T, B, S, F} <: AbstractField{LX, LY, LZ, G,
     communication_buffers :: F
 
     # Inner constructor that does not validate _anything_!
-    function Field{LX, LY, LZ}(grid::G, data::D, bcs::B, indices::I, op::O, status::S, buffers::F) where {LX, LY, LZ, G, D, B, O, S, I, F}
+    Base.@constprop :aggressive function Field{LX, LY, LZ}(grid::G, data::D, bcs::B, indices::I, op::O, status::S, buffers::F) where {LX, LY, LZ, G, D, B, O, S, I, F}
         T = eltype(data)
         @apply_regionally local_bcs = construct_boundary_conditions_kernels(bcs, data, grid, (LX(), LY(), LZ()), indices) # Adding the kernels to the bcs
         return new{LX, LY, LZ, O, G, I, D, T, typeof(local_bcs), S, F}(grid, data, local_bcs, indices, op, status, buffers)
@@ -98,7 +98,7 @@ validate_boundary_condition_location(bc::Zipper, loc::Face, side) =
 #####
 
 # Common outer constructor for all field flavors that performs input validation
-function Field(loc::Tuple{<:LX, <:LY, <:LZ}, grid::AbstractGrid, data, bcs, indices, op=nothing, status=nothing) where {LX, LY, LZ}
+Base.@constprop :aggressive function Field(loc::Tuple{<:LX, <:LY, <:LZ}, grid::AbstractGrid, data, bcs, indices, op=nothing, status=nothing) where {LX, LY, LZ}
     @apply_regionally indices = validate_indices(indices, loc, grid)
     @apply_regionally validate_field_data(loc, data, grid, indices)
     @apply_regionally validate_boundary_conditions(loc, grid, bcs)
@@ -112,7 +112,7 @@ communication_buffers(grid, data, bcs) = nothing
 
 """
     Field{LX, LY, LZ}(grid::AbstractGrid,
-                      T::DataType=eltype(grid); kw...) where {LX, LY, LZ}
+                      ::Type{T}=eltype(grid); kw...) where {LX, LY, LZ, T}
 
 Construct a `Field` on `grid` with data type `T` at the location `(LX, LY, LZ)`.
 Each of `(LX, LY, LZ)` is either `Center` or `Face` and determines the field's
@@ -168,21 +168,21 @@ julia> ωₛ = Field(∂x(v) - ∂y(u), indices=(:, :, grid.Nz))
     └── max=0.166667, min=-0.25, mean=-0.0208333
 ```
 """
-function Field{LX, LY, LZ}(grid::AbstractGrid,
-                           T::DataType=eltype(grid);
-                           kw...) where {LX, LY, LZ}
+Base.@constprop :aggressive function Field{LX, LY, LZ}(grid::AbstractGrid,
+                                                       ::Type{T}=eltype(grid);
+                                                       kw...) where {LX, LY, LZ, T}
 
     return Field((LX(), LY(), LZ()), grid, T; kw...)
 end
 
-function Field(loc::Tuple, # These are instantiated locations, e.g. (Center(), Face(), nothing)
-               grid::AbstractGrid,
-               T::DataType = eltype(grid);
-               indices = default_indices(3),
-               data = new_data(T, grid, loc, validate_indices(indices, loc, grid)),
-               boundary_conditions = FieldBoundaryConditions(grid, loc, validate_indices(indices, loc, grid)),
-               operand = nothing,
-               status = nothing)
+Base.@constprop :aggressive function Field(loc::Tuple, # These are instantiated locations, e.g. (Center(), Face(), nothing)
+                                           grid::AbstractGrid,
+                                           ::Type{T} = eltype(grid);
+                                           indices = default_indices(3),
+                                           data = new_data(T, grid, loc, validate_indices(indices, loc, grid)),
+                                           boundary_conditions = FieldBoundaryConditions(grid, loc, validate_indices(indices, loc, grid)),
+                                           operand = nothing,
+                                           status = nothing) where T
 
     return Field(loc, grid, data, boundary_conditions, indices, operand, status)
 end
@@ -196,7 +196,7 @@ Field(f::Field; indices=f.indices) = view(f, indices...) # hmm...
 Return a `Field{Center, Center, Center}` on `grid`.
 Additional keyword arguments are passed to the `Field` constructor.
 """
-CenterField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Center(), Center(), Center()), grid, T; kw...)
+CenterField(grid::AbstractGrid, ::Type{T}=eltype(grid); kw...) where T = Field((Center(), Center(), Center()), grid, T; kw...)
 
 """
     XFaceField(grid, T=eltype(grid); kw...)
@@ -204,7 +204,7 @@ CenterField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Center
 Return a `Field{Face, Center, Center}` on `grid`.
 Additional keyword arguments are passed to the `Field` constructor.
 """
-XFaceField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Face(), Center(), Center()), grid, T; kw...)
+XFaceField(grid::AbstractGrid, ::Type{T}=eltype(grid); kw...) where T = Field((Face(), Center(), Center()), grid, T; kw...)
 
 """
     YFaceField(grid, T=eltype(grid); kw...)
@@ -212,7 +212,7 @@ XFaceField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Face(),
 Return a `Field{Center, Face, Center}` on `grid`.
 Additional keyword arguments are passed to the `Field` constructor.
 """
-YFaceField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Center(), Face(), Center()), grid, T; kw...)
+YFaceField(grid::AbstractGrid, ::Type{T}=eltype(grid); kw...) where T = Field((Center(), Face(), Center()), grid, T; kw...)
 
 """
     ZFaceField(grid, T=eltype(grid); kw...)
@@ -220,7 +220,7 @@ YFaceField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Center(
 Return a `Field{Center, Center, Face}` on `grid`.
 Additional keyword arguments are passed to the `Field` constructor.
 """
-ZFaceField(grid::AbstractGrid, T::DataType=eltype(grid); kw...) = Field((Center(), Center(), Face()), grid, T; kw...)
+ZFaceField(grid::AbstractGrid, ::Type{T}=eltype(grid); kw...) where T = Field((Center(), Center(), Face()), grid, T; kw...)
 
 #####
 ##### Field utils

--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -91,7 +91,7 @@ end
 # TODO: This code belongs in the Models module
 
 "Returns true if the first three elements of `names` are `(:u, :v, :w)`."
-has_velocities(names) = :u == names[1] && :v == names[2] && :w == names[3]
+@inline has_velocities(names) = :u == names[1] && :v == names[2] && :w == names[3]
 
 # Tuples of length 0-2 cannot contain velocity fields
 has_velocities(::Tuple{}) = false
@@ -100,7 +100,7 @@ has_velocities(::Tuple{X, Y}) where {X, Y} = false
 
 tracernames(::Nothing) = ()
 tracernames(name::Symbol) = tuple(name)
-tracernames(names::NTuple{N, Symbol}) where N = has_velocities(names) ? names[4:end] : names
+@inline tracernames(names::NTuple{N, Symbol}) where N = has_velocities(names) ? names[4:end] : names
 tracernames(::NamedTuple{names}) where names = tracernames(names)
 
 #####
@@ -168,10 +168,14 @@ Return a `NamedTuple` with tracer fields specified by `tracer_names` initialized
 `CenterField`s on `grid`. Boundary conditions `user_bcs`
 may be specified via a named tuple of `FieldBoundaryCondition`s.
 """
-function TracerFields(tracer_names, grid, user_bcs)
-    default_bcs = NamedTuple(name => FieldBoundaryConditions(grid, (Center(), Center(), Center())) for name in tracer_names)
+Base.@constprop :aggressive function TracerFields(tracer_names, grid, user_bcs)
+    default_bcs = named_tuple(name -> FieldBoundaryConditions(grid, (Center(), Center(), Center())), tracer_names)
     bcs = merge(default_bcs, user_bcs) # provided bcs overwrite defaults
-    return NamedTuple(c => CenterField(grid, boundary_conditions=bcs[c]) for c in tracer_names)
+
+    return named_tuple(tracer_names) do c
+        Base.@constprop :aggressive
+        CenterField(grid, boundary_conditions=bcs[c])
+    end
 end
 
 """
@@ -181,8 +185,12 @@ Return a `NamedTuple` with tracer fields specified by `tracer_names` initialized
 `CenterField`s on `grid`. Fields may be passed via optional keyword arguments `kwargs`
 for each field.
 """
-TracerFields(tracer_names, grid; kwargs...) =
-    NamedTuple(c => c ∈ keys(kwargs) ? kwargs[c] : CenterField(grid) for c in tracer_names)
+Base.@constprop :aggressive function TracerFields(tracer_names, grid; kwargs...)
+    return named_tuple(tracer_names) do c
+        Base.@constprop :aggressive
+        c ∈ keys(kwargs) ? kwargs[c] : CenterField(grid)
+    end
+end
 
 # 'Nothing', or empty tracer fields
 TracerFields(::Union{Tuple{}, Nothing}, grid, bcs) = NamedTuple()
@@ -224,7 +232,9 @@ function TracerFields(proposed_tracers::NamedTuple, grid, bcs)
     validate_field_tuple_grid("tracers", proposed_tracers, grid)
 
     tracer_names = propertynames(proposed_tracers)
-    tracer_fields = Tuple(CenterField(grid, boundary_conditions=bcs[c], data=proposed_tracers[c].data) for c in tracer_names)
 
-    return NamedTuple{tracer_names}(tracer_fields)
+    return named_tuple(tracer_names) do c
+        Base.@constprop :aggressive
+        CenterField(grid, boundary_conditions=bcs[c], data=proposed_tracers[c].data)
+    end
 end

--- a/src/Forcings/Forcings.jl
+++ b/src/Forcings/Forcings.jl
@@ -8,6 +8,7 @@ using DocStringExtensions: TYPEDSIGNATURES
 using Oceananigans.Fields: field, location
 using Oceananigans.OutputReaders: FlavorOfFTS
 using Oceananigans.Units: Time
+using Oceananigans.Utils: named_tuple
 using Oceananigans.Architectures: Architectures, on_architecture
 
 include("multiple_forcings.jl")

--- a/src/Forcings/model_forcing.jl
+++ b/src/Forcings/model_forcing.jl
@@ -53,15 +53,11 @@ function model_forcing(user_forcings, model_fields, prognostic_fields=model_fiel
 
     model_field_names = keys(model_fields)
 
-    materialized = Tuple(
+    return named_tuple(keys(prognostic_fields)) do name
+        Base.@constprop :aggressive
+        field = prognostic_fields[name]
         name in keys(user_forcings) ?
             materialize_forcing(user_forcings[name], field, name, model_field_names) :
             Returns(zero(eltype(field)))
-            for (name, field) in pairs(prognostic_fields)
-    )
-
-    prognostic_names = keys(prognostic_fields)
-    forcings = NamedTuple{prognostic_names}(materialized)
-
-    return forcings
+    end
 end

--- a/src/Grids/grid_utils.jl
+++ b/src/Grids/grid_utils.jl
@@ -71,17 +71,17 @@ one dimension of `topo`logy with `N` centered cells and
 `H` halo cells. If `ind` is provided the total_length
 is restricted by `length(ind)`.
 """
-total_length(::Face,    ::AT,              N, H=0) = N + 2H
-total_length(::Center,  ::AT,              N, H=0) = N + 2H
-total_length(::Face,    ::FaceExtendedTopology, N, H=0) = N + 1 + 2H
-total_length(::Nothing, ::AT,              N, H=0) = 1
-total_length(::Nothing, ::Flat,            N, H=0) = N
-total_length(::Face,    ::Flat,            N, H=0) = N
-total_length(::Center,  ::Flat,            N, H=0) = N
+@inline total_length(::Face,    ::AT,              N, H=0) = N + 2H
+@inline total_length(::Center,  ::AT,              N, H=0) = N + 2H
+@inline total_length(::Face,    ::FaceExtendedTopology, N, H=0) = N + 1 + 2H
+@inline total_length(::Nothing, ::AT,              N, H=0) = 1
+@inline total_length(::Nothing, ::Flat,            N, H=0) = N
+@inline total_length(::Face,    ::Flat,            N, H=0) = N
+@inline total_length(::Center,  ::Flat,            N, H=0) = N
 
 # "Indices-aware" total length
-total_length(loc, topo, N, H, ::Colon) = total_length(loc, topo, N, H)
-total_length(loc, topo, N, H, ind::AbstractUnitRange)  = min(total_length(loc, topo, N, H), length(ind))
+@inline total_length(loc, topo, N, H, ::Colon) = total_length(loc, topo, N, H)
+@inline total_length(loc, topo, N, H, ind::AbstractUnitRange)  = min(total_length(loc, topo, N, H), length(ind))
 
 @inline Base.size(grid::AbstractGrid, loc::Tuple, indices=default_indices(Val(length(loc)))) =
     size(loc, topology(grid), size(grid), indices)
@@ -106,7 +106,7 @@ total_size(a) = size(a) # fallback
 Return the "total" size of a `grid` at `loc`. This is a 3-tuple of integers
 corresponding to the number of grid points along `x, y, z`.
 """
-function total_size(loc, topo, sz, halo_sz, indices=default_indices(Val(length(loc))))
+@inline function total_size(loc, topo, sz, halo_sz, indices=default_indices(Val(length(loc))))
     D = length(loc)
     N = ntuple(Val(D)) do d
         Base.@_inline_meta
@@ -115,7 +115,7 @@ function total_size(loc, topo, sz, halo_sz, indices=default_indices(Val(length(l
     return N
 end
 
-total_size(grid::AbstractGrid, loc, indices=default_indices(Val(length(loc)))) =
+@inline total_size(grid::AbstractGrid, loc, indices=default_indices(Val(length(loc)))) =
     total_size(loc, topology(grid), size(grid), halo_size(grid), indices)
 
 """

--- a/src/Grids/new_data.jl
+++ b/src/Grids/new_data.jl
@@ -61,14 +61,14 @@ $(TYPEDSIGNATURES)
 Return an `OffsetArray` of zeros of float type `FT` on `arch`itecture,
 with indices corresponding to a field on a `grid` of `size(grid)` and located at `loc`.
 """
-function new_data(FT::DataType, arch, loc, topo, sz, halo_sz, indices=default_indices(length(loc)))
+function new_data(::Type{FT}, arch, loc, topo, sz, halo_sz, indices=default_indices(length(loc))) where FT
     Tsz = total_size(loc, topo, sz, halo_sz, indices)
     underlying_data = zeros(arch, FT, Tsz...)
     indices = validate_indices(indices, loc, topo, sz, halo_sz)
     return offset_data(underlying_data, loc, topo, sz, halo_sz, indices)
 end
 
-new_data(FT::DataType, grid::AbstractGrid, loc, indices=default_indices(length(loc))) =
+new_data(::Type{FT}, grid::AbstractGrid, loc, indices=default_indices(length(loc))) where FT =
     new_data(FT, architecture(grid), loc, topology(grid), size(grid), halo_size(grid), indices)
 
 new_data(grid::AbstractGrid, loc, indices=default_indices) = new_data(eltype(grid), grid, loc, indices)

--- a/src/Models/HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/HydrostaticFreeSurfaceModels.jl
@@ -13,7 +13,7 @@ using Oceananigans.Architectures: architecture
 using Oceananigans.Fields: ZFaceField
 using Oceananigans.Grids: AbstractGrid, StaticVerticalDiscretization, OrthogonalSphericalShellGrid, Periodic, RectilinearGrid
 using Oceananigans.Operators: Δzᶜᶠᶜ, Δzᶠᶜᶜ
-using Oceananigans.TimeSteppers: TimeSteppers, SplitRungeKuttaTimeStepper, QuasiAdamsBashforth2TimeStepper
+using Oceananigans.TimeSteppers: TimeSteppers, SplitRungeKuttaTimeStepper, SplitRungeKuttaName, QuasiAdamsBashforth2TimeStepper
 using Oceananigans.Utils: Utils, launch!, @apply_regionally
 
 import Oceananigans: fields, prognostic_fields, initialize!
@@ -139,7 +139,7 @@ Return a flattened `NamedTuple` of the fields in `model.velocities`, `model.free
 
 velocity_names(user_velocities) = (:u, :v, :w)
 
-constructor_field_names(user_velocities, user_tracers, user_free_surface, auxiliary_fields, biogeochemistry, grid) =
+Base.@constprop :aggressive constructor_field_names(user_velocities, user_tracers, user_free_surface, auxiliary_fields, biogeochemistry, grid) =
     tuple(velocity_names(user_velocities)...,
           tracernames(user_tracers)...,
           free_surface_names(user_free_surface, user_velocities, grid)...,

--- a/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/SplitExplicitFreeSurfaces/split_explicit_free_surface.jl
@@ -230,7 +230,7 @@ split_explicit_substepping(::Nothing, ::Nothing, ::Nothing, grid, averaging_kern
 split_explicit_substepping(::Nothing, ::Nothing, fixed_Δt, grid, averaging_kernel, gravitational_acceleration) =
     split_explicit_substepping(nothing, MINIMUM_SUBSTEPS, fixed_Δt, grid, averaging_kernel, gravitational_acceleration)
 
-function hydrostatic_tendency_fields(velocities, free_surface::SplitExplicitFreeSurface, grid, tracer_names, bcs)
+Base.@constprop :aggressive function hydrostatic_tendency_fields(velocities, free_surface::SplitExplicitFreeSurface, grid, tracer_names, bcs)
     u = XFaceField(grid, boundary_conditions=bcs.u)
     v = YFaceField(grid, boundary_conditions=bcs.v)
 

--- a/src/Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/explicit_free_surface.jl
@@ -41,7 +41,7 @@ end
 ##### Tendency fields
 #####
 
-function hydrostatic_tendency_fields(velocities, free_surface::ExplicitFreeSurface, grid, tracer_names, bcs)
+Base.@constprop :aggressive function hydrostatic_tendency_fields(velocities, free_surface::ExplicitFreeSurface, grid, tracer_names, bcs)
     u = XFaceField(grid, boundary_conditions=bcs.u)
     v = YFaceField(grid, boundary_conditions=bcs.v)
     η = free_surface_displacement_field(velocities, free_surface, grid)

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_field_tuples.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_field_tuples.jl
@@ -5,7 +5,7 @@ function hydrostatic_velocity_fields(::Nothing, grid, clock, bcs)
     return (u=u, v=v, w=w)
 end
 
-function hydrostatic_tendency_fields(velocities, free_surface, grid, tracer_names, bcs)
+Base.@constprop :aggressive function hydrostatic_tendency_fields(velocities, free_surface, grid, tracer_names, bcs)
     u = XFaceField(grid, boundary_conditions=bcs.u)
     v = YFaceField(grid, boundary_conditions=bcs.v)
     tracers = TracerFields(tracer_names, grid, bcs)
@@ -16,5 +16,5 @@ previous_hydrostatic_tendency_fields(timestepper, args...)         = nothing
 previous_hydrostatic_tendency_fields(timestepper::Symbol, args...) = previous_hydrostatic_tendency_fields(Val(timestepper), args...)
 previous_hydrostatic_tendency_fields(::QuasiAdamsBashforth2TimeStepper, args...) = hydrostatic_tendency_fields(args...)
 
-previous_hydrostatic_tendency_fields(::Val{:QuasiAdamsBashforth2}, args...) = hydrostatic_tendency_fields(args...)
+Base.@constprop :aggressive previous_hydrostatic_tendency_fields(::Val{:QuasiAdamsBashforth2}, args...) = hydrostatic_tendency_fields(args...)
 previous_hydrostatic_tendency_fields(::Val{:SplitRungeKutta}, args...)      = nothing

--- a/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/hydrostatic_free_surface_model.jl
@@ -8,7 +8,7 @@ using Oceananigans.Fields: Field, CenterField, ZeroField, tracernames, TracerFie
 using Oceananigans.Forcings: model_forcing
 using Oceananigans.Grids: AbstractHorizontallyCurvilinearGrid, architecture, halo_size, MutableVerticalDiscretization, Face, Center
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBoundary
-using Oceananigans.Models: AbstractModel, validate_model_halo, validate_tracer_advection, extract_boundary_conditions
+using Oceananigans.Models: AbstractModel, validate_model_halo, validate_tracer_advection, extract_boundary_conditions, materialize_tracers, timestepper_name
 using Oceananigans.TimeSteppers: Clock, TimeStepper, AbstractLagrangianParticles, materialize_clock!, time_discretization
 using Oceananigans.TurbulenceClosures: validate_closure, with_tracers, build_closure_fields, add_closure_specific_boundary_conditions,
                                        implicit_diffusion_solver, VerticallyImplicitTimeDiscretization,
@@ -211,22 +211,43 @@ function HydrostaticFreeSurfaceModel(grid;
         tracers = tuple(user_tracer_names..., closure_tracer_names...)
     end
 
+    validate_buoyancy(buoyancy, tracernames(tracers))
+
+    !isnothing(particles) && arch isa Distributed && error("LagrangianParticles are not supported on Distributed architectures.")
+
+    # Tracer and timestepper names become type parameters from here on, so that the
+    # containers built from them can be inferred. `invokelatest` keeps the compiler from
+    # inferring `materialize_hydrostatic_free_surface_model` with the names unknown as well.
+    settings = (; clock, momentum_advection, tracer_advection, buoyancy, coriolis, free_surface, tracers, forcing, closure,
+                  boundary_conditions, particles, biogeochemistry, velocities, pressure, closure_fields,
+                  auxiliary_fields, vertical_coordinate)
+
+    return Base.invokelatest(materialize_hydrostatic_free_surface_model, grid, Val(tracernames(tracers)), timestepper_name(timestepper), settings)
+end
+
+function materialize_hydrostatic_free_surface_model(grid, ::Val{tracer_names}, timestepper, settings) where tracer_names
+
+    (; clock, momentum_advection, tracer_advection, buoyancy, coriolis, free_surface, tracers, forcing, closure,
+       boundary_conditions, particles, biogeochemistry, velocities, pressure, closure_fields,
+       auxiliary_fields, vertical_coordinate) = settings
+
+    arch = architecture(grid)
+
     # Reduce the advection order in directions that do not have enough grid points
     @apply_regionally momentum_advection = validate_momentum_advection(momentum_advection, grid)
     default_tracer_advection, tracer_advection = validate_tracer_advection(tracer_advection, grid)
     default_generator(name, tracer_advection) = default_tracer_advection
 
     # Generate tracer advection scheme for each tracer
-    tracer_advection_tuple = with_tracers(tracernames(tracers), tracer_advection, default_generator, with_velocities=false)
+    tracer_advection_tuple = with_tracers(tracer_names, tracer_advection, default_generator, with_velocities=false)
     momentum_advection_tuple = (; momentum = momentum_advection)
     advection = merge(momentum_advection_tuple, tracer_advection_tuple)
-    advection = NamedTuple(name => adapt_advection_order(scheme, grid) for (name, scheme) in pairs(advection))
+    advection = map(scheme -> adapt_advection_order(scheme, grid), advection)
 
     # Fill any settings in advection scheme that might have been deferred until
     # the grid and backend is known
-    advection = NamedTuple(name => materialize_advection(scheme, grid) for (name, scheme) in pairs(advection))
+    advection = map(scheme -> materialize_advection(scheme, grid), advection)
 
-    validate_buoyancy(buoyancy, tracernames(tracers))
     buoyancy = materialize_buoyancy(buoyancy, grid)
 
     # Collect boundary conditions for all model prognostic fields and, if specified, some model
@@ -242,8 +263,8 @@ function HydrostaticFreeSurfaceModel(grid;
                                          extract_boundary_conditions(closure_fields))
 
     # Next, we form a list of default boundary conditions:
-    field_names = constructor_field_names(velocities, tracers, free_surface, auxiliary_fields, biogeochemistry, grid)
-    default_boundary_conditions = NamedTuple{field_names}(FieldBoundaryConditions() for name in field_names)
+    field_names = constructor_field_names(velocities, tracer_names, free_surface, auxiliary_fields, biogeochemistry, grid)
+    default_boundary_conditions = NamedTuple{field_names}(ntuple(_ -> FieldBoundaryConditions(), Val(length(field_names))))
     default_boundary_conditions = merge(default_boundary_conditions, default_free_surface_boundary_conditions(free_surface, boundary_conditions))
 
     # Then we merge specified, embedded, and default boundary conditions. Specified boundary conditions
@@ -256,20 +277,34 @@ function HydrostaticFreeSurfaceModel(grid;
     boundary_conditions = add_closure_specific_boundary_conditions(closure,
                                                                    boundary_conditions,
                                                                    grid,
-                                                                   tracernames(tracers),
+                                                                   tracer_names,
                                                                    buoyancy)
 
     # Ensure `closure` describes all tracers
-    closure = with_tracers(tracernames(tracers), closure)
+    closure = with_tracers(tracer_names, closure)
 
     # Put CATKE first in the list of closures
     closure = validate_closure(closure)
 
+    # Boundary conditions can depend on runtime values (for example, whether a latitude-longitude
+    # grid reaches a pole), so the fields are built behind a second barrier
+    return Base.invokelatest(build_hydrostatic_free_surface_model, grid, Val(tracer_names), timestepper,
+                             advection, buoyancy, boundary_conditions, closure, settings)
+end
+
+function build_hydrostatic_free_surface_model(grid, ::Val{tracer_names}, timestepper,
+                                              advection, buoyancy, boundary_conditions, closure, settings) where tracer_names
+
+    (; clock, coriolis, free_surface, tracers, forcing, particles, biogeochemistry, velocities, pressure,
+       closure_fields, auxiliary_fields, vertical_coordinate) = settings
+
+    arch = architecture(grid)
+
     # Either check grid-correctness, or construct tuples of fields
     velocities     = hydrostatic_velocity_fields(velocities, grid, clock, boundary_conditions)
-    tracers        = TracerFields(tracers, grid, boundary_conditions)
+    tracers        = materialize_tracers(tracers, tracer_names, grid, boundary_conditions)
     pressure       = PressureField(grid)
-    closure_fields = build_closure_fields(closure_fields, grid, clock, tracernames(tracers), boundary_conditions, closure)
+    closure_fields = build_closure_fields(closure_fields, grid, clock, tracer_names, boundary_conditions, closure)
 
     @apply_regionally validate_velocity_boundary_conditions(grid, velocities)
 
@@ -280,20 +315,21 @@ function HydrostaticFreeSurfaceModel(grid;
     # Instantiate timestepper if not already instantiated
     prognostic_fields = hydrostatic_prognostic_fields(velocities, free_surface, tracers)
 
-    for field in prognostic_fields
+    map(prognostic_fields) do field
         @apply_regionally validate_implicit_explicit_flux_locations(field.boundary_conditions)
     end
 
     implicit_solver = implicit_diffusion_solver(time_discretization(closure), grid)
-    bc_needs_solver = any(field -> needs_implicit_solver(field.boundary_conditions), prognostic_fields)
+    bc_needs_solver = any(map(field -> needs_implicit_solver(field.boundary_conditions), prognostic_fields))
 
     if isnothing(implicit_solver) && (needs_implicit_solver(advection) || bc_needs_solver)
         implicit_solver = implicit_diffusion_solver(VerticallyImplicitTimeDiscretization(), grid)
     end
 
-    Gⁿ = hydrostatic_tendency_fields(velocities, free_surface, grid, tracernames(tracers), boundary_conditions)
-    G⁻ = previous_hydrostatic_tendency_fields(timestepper, velocities, free_surface, grid, tracernames(tracers), boundary_conditions)
-    timestepper = TimeStepper(timestepper, grid, prognostic_fields; implicit_solver, Gⁿ, G⁻)
+    Gⁿ = hydrostatic_tendency_fields(velocities, free_surface, grid, tracer_names, boundary_conditions)
+    G⁻ = previous_hydrostatic_tendency_fields(timestepper, velocities, free_surface, grid, tracer_names, boundary_conditions)
+    cached_state = previous_hydrostatic_state_fields(timestepper, velocities, free_surface, tracers)
+    timestepper = TimeStepper(timestepper, grid, prognostic_fields; implicit_solver, Gⁿ, G⁻, cached_state...)
     materialize_clock!(clock, timestepper)
 
     # Materialize forcing for model tracer and velocity fields.
@@ -303,8 +339,6 @@ function HydrostaticFreeSurfaceModel(grid;
     model_fields = merge(hydrostatic_fields(velocities, free_surface, tracers), auxiliary_fields)
     forcing = model_forcing(forcing, model_fields, prognostic_fields)
     transport_velocities = transport_velocity_fields(velocities)
-
-    !isnothing(particles) && arch isa Distributed && error("LagrangianParticles are not supported on Distributed architectures.")
 
     boundary_transport = initialize_targeted_boundary_transport(velocities)
 
@@ -318,6 +352,31 @@ function HydrostaticFreeSurfaceModel(grid;
 
     return model
 end
+
+# The state cached by `SplitRungeKuttaTimeStepper`, as a keyword argument for `TimeStepper`.
+# The free surface displacement is windowed at the top of the grid, so it is rebuilt from the
+# grid rather than with `similar`, whose halo-filling kernels depend on the runtime window.
+previous_hydrostatic_state_fields(timestepper, velocities, free_surface, tracers) = NamedTuple()
+
+const SplitRungeKutta = Union{SplitRungeKuttaName, SplitRungeKuttaTimeStepper}
+
+previous_hydrostatic_state_fields(::SplitRungeKutta, velocities, free_surface, tracers) =
+    (; Ψ⁻ = merge(map(similar, horizontal_velocities(velocities)),
+                  map(similar, tracers),
+                  previous_free_surface_fields(velocities, free_surface)))
+
+previous_free_surface_fields(velocities, ::Nothing) = NamedTuple()
+
+previous_free_surface_fields(velocities, free_surface) =
+    (; η = previous_displacement_field(velocities, free_surface))
+
+previous_free_surface_fields(velocities, free_surface::SplitExplicitFreeSurface) =
+    (η = previous_displacement_field(velocities, free_surface),
+     U = similar(free_surface.barotropic_velocities.U),
+     V = similar(free_surface.barotropic_velocities.V))
+
+previous_displacement_field(velocities, free_surface) =
+    free_surface_displacement_field(velocities, free_surface, free_surface.displacement.grid)
 
 transport_velocity_fields(velocities) = (u = copy_velocity(velocities.u),
                                          v = copy_velocity(velocities.v),

--- a/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/prescribed_hydrostatic_velocity_fields.jl
@@ -93,7 +93,7 @@ function Base.indexed_iterate(p::PrescribedVelocityFields, i::Int, state=1)
     end
 end
 
-hydrostatic_tendency_fields(::PrescribedVelocityFields, free_surface, grid, tracer_names, bcs) =
+Base.@constprop :aggressive hydrostatic_tendency_fields(::PrescribedVelocityFields, free_surface, grid, tracer_names, bcs) =
     merge((u=nothing, v=nothing), TracerFields(tracer_names, grid))
 
 free_surface_names(free_surface, ::PrescribedVelocityFields, grid) = tuple()
@@ -135,6 +135,7 @@ materialize_free_surface(::ImplicitFreeSurface{Nothing}, ::PrescribedVelocityFie
 materialize_free_surface(::SplitExplicitFreeSurface,     ::PrescribedVelocityFields, grid, bcs) = nothing
 
 hydrostatic_prognostic_fields(::PrescribedVelocityFields, ::Nothing, tracers) = tracers
+previous_hydrostatic_state_fields(::SplitRungeKutta, ::PrescribedVelocityFields, ::Nothing, tracers) = (; Ψ⁻ = map(similar, tracers))
 compute_hydrostatic_momentum_tendencies!(model, ::PrescribedVelocityFields, kernel_parameters; kwargs...) = nothing
 
 compute_flux_bcs!(::Nothing, c, arch, clock, model_fields) = nothing

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -19,7 +19,7 @@ using DocStringExtensions: TYPEDSIGNATURES
 using Oceananigans: AbstractModel, fields, prognostic_fields
 using Oceananigans.AbstractOperations: AbstractOperation
 using Oceananigans.Advection: AbstractAdvectionScheme, Centered
-using Oceananigans.Fields: Field
+using Oceananigans.Fields: Field, TracerFields
 using Oceananigans.Grids: halo_size, inflate_halo_size
 using Oceananigans.OutputReaders: update_field_time_series!, extract_field_time_series
 using Oceananigans.TimeSteppers: Clock
@@ -92,6 +92,13 @@ validate_tracer_advection(invalid_tracer_advection, grid) = error("$invalid_trac
 validate_tracer_advection(tracer_advection_tuple::NamedTuple, grid) = Centered(), tracer_advection_tuple
 validate_tracer_advection(tracer_advection::AbstractAdvectionScheme, grid) = tracer_advection, NamedTuple()
 validate_tracer_advection(tracer_advection::Nothing, grid) = nothing, NamedTuple()
+
+# Tracer names are passed separately so that they are compile-time constants
+materialize_tracers(tracers::NamedTuple, tracer_names, grid, boundary_conditions) = TracerFields(tracers, grid, boundary_conditions)
+materialize_tracers(tracers, tracer_names, grid, boundary_conditions) = TracerFields(tracer_names, grid, boundary_conditions)
+
+timestepper_name(timestepper::Symbol) = Val(timestepper)
+timestepper_name(timestepper) = timestepper
 
 # Used in both NonhydrostaticModels and HydrostaticFreeSurfaceModels
 function materialize_free_surface end

--- a/src/Models/NonhydrostaticModels/background_fields.jl
+++ b/src/Models/NonhydrostaticModels/background_fields.jl
@@ -15,14 +15,11 @@ function background_velocity_fields(fields, grid, clock)
     return (; u, v, w)
 end
 
-function background_tracer_fields(bg, tracer_names, grid, clock)
-    tracer_fields =
-        Tuple(c ∈ keys(bg) ?
-              regularize_background_field(Center, Center, Center, getindex(bg, c), grid, clock) :
-              ZeroField()
-              for c in tracer_names)
-
-    return NamedTuple{tracer_names}(tracer_fields)
+Base.@constprop :aggressive function background_tracer_fields(bg, tracer_names, grid, clock)
+    return named_tuple(tracer_names) do c
+        Base.@constprop :aggressive
+        c ∈ keys(bg) ? regularize_background_field(Center, Center, Center, getindex(bg, c), grid, clock) : ZeroField()
+    end
 end
 
 #####
@@ -51,13 +48,13 @@ function BackgroundFields(; background_closure_fluxes=false, fields...)
     return BackgroundFields{background_closure_fluxes}(velocities, tracers)
 end
 
-function BackgroundFields(background_fields::BackgroundFields{Q}, tracer_names, grid, clock) where Q
+Base.@constprop :aggressive function BackgroundFields(background_fields::BackgroundFields{Q}, tracer_names, grid, clock) where Q
     velocities = background_velocity_fields(background_fields.velocities, grid, clock)
     tracers = background_tracer_fields(background_fields.tracers, tracer_names, grid, clock)
     return BackgroundFields{Q}(velocities, tracers)
 end
 
-function BackgroundFields(background_fields::NamedTuple, tracer_names, grid, clock)
+Base.@constprop :aggressive function BackgroundFields(background_fields::NamedTuple, tracer_names, grid, clock)
     velocities = background_velocity_fields(background_fields, grid, clock)
     tracers = background_tracer_fields(background_fields, tracer_names, grid, clock)
     return BackgroundFields{false}(velocities, tracers)

--- a/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
+++ b/src/Models/NonhydrostaticModels/nonhydrostatic_model.jl
@@ -5,11 +5,11 @@ using Oceananigans.BoundaryConditions: MixedBoundaryCondition, needs_implicit_so
                                        regularize_field_boundary_conditions, validate_implicit_explicit_flux_locations
 using Oceananigans.BuoyancyFormulations: validate_buoyancy, materialize_buoyancy
 using Oceananigans.DistributedComputations: Distributed
-using Oceananigans.Fields: Field, tracernames, VelocityFields, TracerFields, CenterField, ZFaceField
+using Oceananigans.Fields: Field, tracernames, VelocityFields, CenterField, ZFaceField
 using Oceananigans.Forcings: model_forcing
 using Oceananigans.Grids: topology, inflate_halo_size, with_halo, architecture, halo_size
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
-using Oceananigans.Models: AbstractModel, extract_boundary_conditions, materialize_free_surface, validate_tracer_advection
+using Oceananigans.Models: AbstractModel, extract_boundary_conditions, materialize_free_surface, validate_tracer_advection, materialize_tracers, timestepper_name
 using Oceananigans.Solvers: FFTBasedPoissonSolver
 using Oceananigans.TimeSteppers: Clock, TimeStepper, update_state!, materialize_clock!, AbstractLagrangianParticles, time_discretization
 using Oceananigans.TurbulenceClosures: validate_closure, with_tracers, build_closure_fields, implicit_diffusion_solver, VerticallyImplicitTimeDiscretization, initialize_closure_fields!
@@ -226,10 +226,33 @@ function NonhydrostaticModel(grid;
     validate_buoyancy(buoyancy, tracernames(tracers))
     buoyancy = materialize_buoyancy(buoyancy, grid)
 
+    !isnothing(particles) && arch isa Distributed && error("LagrangianParticles are not supported on Distributed architectures.")
+
+    # Tracer and timestepper names become type parameters from here on, so that the
+    # containers built from them can be inferred. `invokelatest` keeps the compiler from
+    # inferring `materialize_nonhydrostatic_model` with the names unknown as well.
+    settings = (; clock, momentum_advection, tracer_advection, buoyancy, coriolis, stokes_drift, forcing, closure,
+                  free_surface, boundary_conditions, tracers, background_fields, particles, biogeochemistry,
+                  velocities, hydrostatic_pressure_anomaly, nonhydrostatic_pressure, closure_fields,
+                  pressure_solver, auxiliary_fields)
+
+    return Base.invokelatest(materialize_nonhydrostatic_model, grid, Val(tracernames(tracers)), timestepper_name(timestepper), settings)
+end
+
+
+function materialize_nonhydrostatic_model(grid, ::Val{tracer_names}, timestepper, settings) where tracer_names
+
+    (; clock, momentum_advection, tracer_advection, buoyancy, coriolis, stokes_drift, forcing, closure,
+       free_surface, boundary_conditions, tracers, background_fields, particles, biogeochemistry,
+       velocities, hydrostatic_pressure_anomaly, nonhydrostatic_pressure, closure_fields,
+       pressure_solver, auxiliary_fields) = settings
+
+    arch = architecture(grid)
+
     default_tracer_advection, tracer_advection = validate_tracer_advection(tracer_advection, grid)
     default_generator(name, tracer_advection) = default_tracer_advection
 
-    tracer_advection_tuple = with_tracers(tracernames(tracers), tracer_advection,
+    tracer_advection_tuple = with_tracers(tracer_names, tracer_advection,
                                           default_generator, with_velocities=false)
     momentum_advection_tuple = (; momentum = momentum_advection)
     advection = merge(momentum_advection_tuple, tracer_advection_tuple)
@@ -249,8 +272,8 @@ function NonhydrostaticModel(grid;
                                          extract_boundary_conditions(closure_fields))
 
     # Next, we form a list of default boundary conditions:
-    field_names = (:u, :v, :w, tracernames(tracers)..., keys(auxiliary_fields)...)
-    default_boundary_conditions = NamedTuple{field_names}(FieldBoundaryConditions() for name in field_names)
+    field_names = (:u, :v, :w, tracer_names..., keys(auxiliary_fields)...)
+    default_boundary_conditions = NamedTuple{field_names}(ntuple(_ -> FieldBoundaryConditions(), Val(length(field_names))))
 
     # Finally, we merge specified, embedded, and default boundary conditions. Specified boundary conditions
     # have precedence, followed by embedded, followed by default.
@@ -272,7 +295,22 @@ function NonhydrostaticModel(grid;
     boundary_conditions = regularize_field_boundary_conditions(boundary_conditions, grid, field_names)
 
     # Ensure `closure` describes all tracers
-    closure = with_tracers(tracernames(tracers), closure)
+    closure = with_tracers(tracer_names, closure)
+
+    # Boundary conditions can depend on runtime values (for example, whether a latitude-longitude
+    # grid reaches a pole), so the fields are built behind a second barrier
+    return Base.invokelatest(build_nonhydrostatic_model, grid, Val(tracer_names), timestepper,
+                             advection, buoyancy, boundary_conditions, closure, settings)
+end
+
+function build_nonhydrostatic_model(grid, ::Val{tracer_names}, timestepper,
+                                    advection, buoyancy, boundary_conditions, closure, settings) where tracer_names
+
+    (; clock, coriolis, stokes_drift, forcing, free_surface, tracers, background_fields, particles, biogeochemistry,
+       velocities, hydrostatic_pressure_anomaly, nonhydrostatic_pressure, closure_fields, pressure_solver,
+       auxiliary_fields) = settings
+
+    arch = architecture(grid)
 
     # TODO: limit free surface to `nothing` (rigid lid) or ImplicitFreeSurface
     if !isnothing(free_surface)
@@ -281,16 +319,16 @@ function NonhydrostaticModel(grid;
 
     # Either check grid-correctness, or construct tuples of fields
     velocities         = VelocityFields(velocities, grid, boundary_conditions)
-    tracers            = TracerFields(tracers,      grid, boundary_conditions)
+    tracers            = materialize_tracers(tracers, tracer_names, grid, boundary_conditions)
     pressures          = (pNHS=nonhydrostatic_pressure, pHY′=hydrostatic_pressure_anomaly)
-    closure_fields = build_closure_fields(closure_fields, grid, clock, tracernames(tracers), boundary_conditions, closure)
+    closure_fields = build_closure_fields(closure_fields, grid, clock, tracer_names, boundary_conditions, closure)
 
     if isnothing(pressure_solver)
         pressure_solver = nonhydrostatic_pressure_solver(grid, free_surface)
     end
 
     # Materialize background fields
-    background_fields = BackgroundFields(background_fields, tracernames(tracers), grid, clock)
+    background_fields = BackgroundFields(background_fields, tracer_names, grid, clock)
     model_fields = merge(velocities, tracers, auxiliary_fields)
     prognostic_fields = merge(velocities, tracers)
 
@@ -298,7 +336,7 @@ function NonhydrostaticModel(grid;
 
     # Instantiate timestepper if not already instantiated
     implicit_solver = implicit_diffusion_solver(time_discretization(closure), grid)
-    bc_needs_solver = any(field -> needs_implicit_solver(field.boundary_conditions), prognostic_fields)
+    bc_needs_solver = any(map(field -> needs_implicit_solver(field.boundary_conditions), prognostic_fields))
 
     if isnothing(implicit_solver) && (needs_implicit_solver(advection) || bc_needs_solver)
         implicit_solver = implicit_diffusion_solver(VerticallyImplicitTimeDiscretization(), grid)
@@ -314,8 +352,6 @@ function NonhydrostaticModel(grid;
 
     # Initialize boundary transport container
     boundary_transport = initialize_boundary_transport(velocities)
-
-    !isnothing(particles) && arch isa Distributed && error("LagrangianParticles are not supported on Distributed architectures.")
 
     model = NonhydrostaticModel(arch, grid, clock, advection, buoyancy, coriolis, stokes_drift,
                                 forcing, closure, free_surface, background_fields, particles, biogeochemistry, velocities, tracers,
@@ -335,8 +371,8 @@ timestepper(model::NonhydrostaticModel) = model.timestepper
 # Kept out of the constructor so the mapping does not capture `grid`, which is rebound by
 # `inflate_grid_halo_size` and would therefore be boxed.
 function materialize_model_advection(advection, grid)
-    advection = NamedTuple(name => adapt_advection_order(scheme, grid) for (name, scheme) in pairs(advection))
-    return NamedTuple(name => materialize_advection(scheme, grid) for (name, scheme) in pairs(advection))
+    advection = map(scheme -> adapt_advection_order(scheme, grid), advection)
+    return map(scheme -> materialize_advection(scheme, grid), advection)
 end
 
 Base.@constprop :aggressive @inline function inflate_grid_halo_size(grid, tendency_terms...)

--- a/src/Models/boundary_transport.jl
+++ b/src/Models/boundary_transport.jl
@@ -110,8 +110,8 @@ function initialize_boundary_transport(velocities::NamedTuple)
     w_bcs = w.boundary_conditions
 
     boundary_transports = NamedTuple()
-    right_scheme_boundaries = Symbol[]
-    left_scheme_boundaries = Symbol[]
+    right_scheme_boundaries = ()
+    left_scheme_boundaries = ()
     total_area_scheme_boundaries = zero(eltype(u))
     total_area_pool_boundaries = zero(eltype(u))
 
@@ -119,7 +119,7 @@ function initialize_boundary_transport(velocities::NamedTuple)
     west_transport_and_area = initialize_side_transport(u, u_bcs.west, Val(:west))
     boundary_transports = merge(boundary_transports, west_transport_and_area)
     if needs_transport_correction(u_bcs.west)
-        push!(left_scheme_boundaries, :west)
+        left_scheme_boundaries = (left_scheme_boundaries..., :west)
         total_area_scheme_boundaries += boundary_transports.west_area
         needs_pool_correction(u_bcs.west) && (total_area_pool_boundaries += boundary_transports.west_area)
     end
@@ -128,7 +128,7 @@ function initialize_boundary_transport(velocities::NamedTuple)
     east_transport_and_area = initialize_side_transport(u, u_bcs.east, Val(:east))
     boundary_transports = merge(boundary_transports, east_transport_and_area)
     if needs_transport_correction(u_bcs.east)
-        push!(right_scheme_boundaries, :east)
+        right_scheme_boundaries = (right_scheme_boundaries..., :east)
         total_area_scheme_boundaries += boundary_transports.east_area
         needs_pool_correction(u_bcs.east) && (total_area_pool_boundaries += boundary_transports.east_area)
     end
@@ -137,7 +137,7 @@ function initialize_boundary_transport(velocities::NamedTuple)
     south_transport_and_area = initialize_side_transport(v, v_bcs.south, Val(:south))
     boundary_transports = merge(boundary_transports, south_transport_and_area)
     if needs_transport_correction(v_bcs.south)
-        push!(left_scheme_boundaries, :south)
+        left_scheme_boundaries = (left_scheme_boundaries..., :south)
         total_area_scheme_boundaries += boundary_transports.south_area
         needs_pool_correction(v_bcs.south) && (total_area_pool_boundaries += boundary_transports.south_area)
     end
@@ -146,7 +146,7 @@ function initialize_boundary_transport(velocities::NamedTuple)
     north_transport_and_area = initialize_side_transport(v, v_bcs.north, Val(:north))
     boundary_transports = merge(boundary_transports, north_transport_and_area)
     if needs_transport_correction(v_bcs.north)
-        push!(right_scheme_boundaries, :north)
+        right_scheme_boundaries = (right_scheme_boundaries..., :north)
         total_area_scheme_boundaries += boundary_transports.north_area
         needs_pool_correction(v_bcs.north) && (total_area_pool_boundaries += boundary_transports.north_area)
     end
@@ -155,7 +155,7 @@ function initialize_boundary_transport(velocities::NamedTuple)
     bottom_transport_and_area = initialize_side_transport(w, w_bcs.bottom, Val(:bottom))
     boundary_transports = merge(boundary_transports, bottom_transport_and_area)
     if needs_transport_correction(w_bcs.bottom)
-        push!(left_scheme_boundaries, :bottom)
+        left_scheme_boundaries = (left_scheme_boundaries..., :bottom)
         total_area_scheme_boundaries += boundary_transports.bottom_area
         needs_pool_correction(w_bcs.bottom) && (total_area_pool_boundaries += boundary_transports.bottom_area)
     end
@@ -164,13 +164,13 @@ function initialize_boundary_transport(velocities::NamedTuple)
     top_transport_and_area = initialize_side_transport(w, w_bcs.top, Val(:top))
     boundary_transports = merge(boundary_transports, top_transport_and_area)
     if needs_transport_correction(w_bcs.top)
-        push!(right_scheme_boundaries, :top)
+        right_scheme_boundaries = (right_scheme_boundaries..., :top)
         total_area_scheme_boundaries += boundary_transports.top_area
         needs_pool_correction(w_bcs.top) && (total_area_pool_boundaries += boundary_transports.top_area)
     end
 
-    boundary_transports = merge(boundary_transports, (; left_scheme_boundaries = Tuple(left_scheme_boundaries),
-                                                        right_scheme_boundaries = Tuple(right_scheme_boundaries),
+    boundary_transports = merge(boundary_transports, (; left_scheme_boundaries,
+                                                        right_scheme_boundaries,
                                                         total_area_scheme_boundaries,
                                                         total_area_pool_boundaries))
 

--- a/src/MultiRegion/multi_region_grid.jl
+++ b/src/MultiRegion/multi_region_grid.jl
@@ -226,7 +226,7 @@ multi_region_object_from_array(a::AbstractArray, grid) = on_architecture(archite
 #### Utilities for MultiRegionGrid
 ####
 
-Grids.new_data(FT::DataType, mrg::MultiRegionGrids, args...) = construct_regionally(new_data, FT, mrg, args...)
+Grids.new_data(::Type{FT}, mrg::MultiRegionGrids, args...) where FT = construct_regionally(new_data, FT, mrg, args...)
 
 # This is kind of annoying but it is necessary to have compatible MultiRegion and Distributed
 function Grids.with_halo(new_halo, mrg::MultiRegionGrid)

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -93,9 +93,12 @@ TimeStepper(::Val{:RungeKutta3}, args...; kwargs...) =
 
 # Convenience constructors for SplitRungeKuttaTimeStepper with 2 to 5 stages
 # By calling TimeStepper(:SplitRungeKuttaN, ...)
+const SplitRungeKuttaName = Union{Val{:SplitRungeKutta2}, Val{:SplitRungeKutta3}, Val{:SplitRungeKutta4}, Val{:SplitRungeKutta5}}
+
 for stages in 2:5
+    coefficients = Tuple(stages:-1:1)
     @eval TimeStepper(::Val{Symbol(:SplitRungeKutta, $stages)}, args...; kwargs...) =
-              SplitRungeKuttaTimeStepper(args...; coefficients=tuple(collect($stages:-1:1)...), kwargs...)
+              SplitRungeKuttaTimeStepper(args...; coefficients=$coefficients, kwargs...)
 end
 
 TimeStepper(ts::SplitRungeKuttaTimeStepper, grid, prognostic_fields; kw...) =

--- a/src/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/TurbulenceClosures/TurbulenceClosures.jl
@@ -64,7 +64,7 @@ using Oceananigans.Operators: Operators,
     ∂y_zᶜᶠᶜ, ∂y_zᶜᶠᶠ, ∂y_zᶠᶜᶜ, ∂y_zᶜᶜᶠ,
     ∇²hᶜᶜᶜ, ∇²hᶜᶠᶜ, ∇²hᶠᶜᶜ, ∇²ᶜᶜᶜ, ∇²ᶜᶜᶠ, ∇²ᶜᶠᶜ, ∇²ᶠᶜᶜ
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, fill_halo_regions!
-using Oceananigans.Utils: Utils, launch!, prettysummary, with_tracers
+using Oceananigans.Utils: Utils, launch!, prettysummary, with_tracers, named_tuple
 using Oceananigans.Fields: Field, CenterField, FunctionField, ZFaceField
 using Oceananigans.ImmersedBoundaries: AbstractGridFittedBottom, ImmersedBoundaryGrid
 

--- a/src/TurbulenceClosures/closure_fields.jl
+++ b/src/TurbulenceClosures/closure_fields.jl
@@ -24,4 +24,4 @@ build_closure_fields(grid, clock, tracer_names, bcs, closure) = nothing
 #####
 
 build_closure_fields(grid, clock, tracer_names, bcs, closure_tuple::Tuple) =
-    Tuple(build_closure_fields(grid, clock, tracer_names, bcs, closure) for closure in closure_tuple)
+    map(closure -> build_closure_fields(grid, clock, tracer_names, bcs, closure), closure_tuple)

--- a/src/TurbulenceClosures/closure_tuples.jl
+++ b/src/TurbulenceClosures/closure_tuples.jl
@@ -71,7 +71,7 @@ end
 ##### Utilities
 #####
 
-Utils.with_tracers(tracers, closure_tuple::Tuple) = Tuple(with_tracers(tracers, closure) for closure in closure_tuple)
+Base.@constprop :aggressive Utils.with_tracers(tracers, closure_tuple::Tuple) = map(closure -> with_tracers(tracers, closure), closure_tuple)
 
 function compute_closure_fields!(closure_fields_tuple, closure_tuple::Tuple, args...; kwargs...)
     for (α, closure) in enumerate(closure_tuple)

--- a/src/TurbulenceClosures/turbulence_closure_implementations/Smagorinskys/smagorinsky.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/Smagorinskys/smagorinsky.jl
@@ -82,7 +82,7 @@ end
 
 Smagorinsky(FT::DataType; kwargs...) = Smagorinsky(ExplicitTimeDiscretization(), FT; kwargs...)
 
-function Utils.with_tracers(tracers, closure::Smagorinsky{TD}) where TD
+Base.@constprop :aggressive function Utils.with_tracers(tracers, closure::Smagorinsky{TD}) where TD
     Pr = tracer_diffusivities(tracers, closure.Pr)
     return Smagorinsky{TD}(closure.coefficient, Pr)
 end

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/TKEBasedVerticalDiffusivities.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/TKEBasedVerticalDiffusivities.jl
@@ -23,7 +23,7 @@ using Oceananigans.Operators: Δzᶜᶜᶜ, Δzᶜᶠᶠ, Δzᶠᶜᶠ, Δz⁻¹
 using Oceananigans.TimeSteppers: TimeSteppers, time_discretization
 using Oceananigans.TurbulenceClosures: getclosure, AbstractScalarDiffusivity, VerticalFormulation,
                                        VerticallyImplicitTimeDiscretization
-using Oceananigans.Utils: Utils, launch!, prettysummary, get_active_cells_map
+using Oceananigans.Utils: Utils, launch!, prettysummary, get_active_cells_map, named_tuple
 
 import Oceananigans: prognostic_state, restore_prognostic_state!
 import Oceananigans.TurbulenceClosures:

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/catke_vertical_diffusivity.jl
@@ -144,7 +144,7 @@ function CATKEVerticalDiffusivity(time_discretization::TD = VerticallyImplicitTi
                                         tke_time_step)
 end
 
-function Utils.with_tracers(tracer_names, closure::FlavorOfCATKE)
+Base.@constprop :aggressive function Utils.with_tracers(tracer_names, closure::FlavorOfCATKE)
     :e ∈ tracer_names ||
         throw(ArgumentError("Tracers must contain :e to represent turbulent kinetic energy " *
                             "for `CATKEVerticalDiffusivity`."))
@@ -200,7 +200,7 @@ function BoundaryConditions.fill_halo_regions!(catke_closure_fields::CATKEClosur
     return fill_halo_regions!(κ, args...; kw...)
 end
 
-function build_closure_fields(grid, clock, tracer_names, bcs, closure::FlavorOfCATKE)
+Base.@constprop :aggressive function build_closure_fields(grid, clock, tracer_names, bcs, closure::FlavorOfCATKE)
 
     default_diffusivity_bcs = (κu = FieldBoundaryConditions(grid, (Center(), Center(), Face())),
                                κc = FieldBoundaryConditions(grid, (Center(), Center(), Face())),
@@ -221,8 +221,15 @@ function build_closure_fields(grid, clock, tracer_names, bcs, closure::FlavorOfC
     previous_velocities = (; u=u⁻, v=v⁻)
 
     # Secret tuple for getting tracer diffusivities with tuple[tracer_index]
-    _tupled_tracer_diffusivities         = NamedTuple(name => name === :e ? κe : κc          for name in tracer_names)
-    _tupled_implicit_linear_coefficients = NamedTuple(name => name === :e ? Le : ZeroField() for name in tracer_names)
+    _tupled_tracer_diffusivities = named_tuple(tracer_names) do name
+        Base.@constprop :aggressive
+        name === :e ? κe : κc
+    end
+
+    _tupled_implicit_linear_coefficients = named_tuple(tracer_names) do name
+        Base.@constprop :aggressive
+        name === :e ? Le : ZeroField()
+    end
 
     return CATKEClosureFields(κu, κc, κe, Le, Jᵇ,
                                   previous_velocities,

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_vertical_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_dissipation_vertical_diffusivity.jl
@@ -148,7 +148,7 @@ function TKEDissipationVerticalDiffusivity(time_discretization::TD = VerticallyI
                                                  tke_dissipation_time_step)
 end
 
-function Utils.with_tracers(tracer_names, closure::FlavorOfTD)
+Base.@constprop :aggressive function Utils.with_tracers(tracer_names, closure::FlavorOfTD)
     :e ∈ tracer_names && :ϵ ∈ tracer_names ||
         throw(ArgumentError("Tracers must contain :e and :ϵ to represent turbulent kinetic energy " *
                             "for `TKEDissipationVerticalDiffusivity`."))

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_top_boundary_condition.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_top_boundary_condition.jl
@@ -45,10 +45,14 @@ See the implementation in catke_equation.jl.
 #####
 
 """ Infer tracer boundary conditions from user_bcs and tracer_names. """
-function top_tracer_boundary_conditions(grid, tracer_names, user_bcs)
-    default_tracer_bcs = NamedTuple(c => FieldBoundaryConditions(grid, (Center(), Center(), Center())) for c in tracer_names)
+Base.@constprop :aggressive function top_tracer_boundary_conditions(grid, tracer_names, user_bcs)
+    default_tracer_bcs = named_tuple(c -> FieldBoundaryConditions(grid, (Center(), Center(), Center())), tracer_names)
     bcs = merge(default_tracer_bcs, user_bcs)
-    return NamedTuple(c => bcs[c].top for c in tracer_names)
+
+    return named_tuple(tracer_names) do c
+        Base.@constprop :aggressive
+        bcs[c].top
+    end
 end
 
 """ Infer velocity boundary conditions from `user_bcs` and `tracer_names`. """

--- a/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/anisotropic_minimum_dissipation.jl
@@ -148,7 +148,7 @@ end
 
 AnisotropicMinimumDissipation(FT::DataType; kw...) = AnisotropicMinimumDissipation(ExplicitTimeDiscretization(), FT; kw...)
 
-function Utils.with_tracers(tracers, closure::AnisotropicMinimumDissipation{TD}) where TD
+Base.@constprop :aggressive function Utils.with_tracers(tracers, closure::AnisotropicMinimumDissipation{TD}) where TD
     Cκ = tracer_diffusivities(tracers, closure.Cκ)
     return AnisotropicMinimumDissipation{TD}(closure.Cν, Cκ, closure.Cb)
 end
@@ -361,16 +361,19 @@ end
 ##### build_closure_fields
 #####
 
-function build_closure_fields(grid, clock, tracer_names, user_bcs, ::AMD)
+Base.@constprop :aggressive function build_closure_fields(grid, clock, tracer_names, user_bcs, ::AMD)
 
     default_diffusivity_bcs = FieldBoundaryConditions(grid, (Center(), Center(), Center()))
-    default_κₑ_bcs = NamedTuple(c => default_diffusivity_bcs for c in tracer_names)
+    default_κₑ_bcs = named_tuple(c -> default_diffusivity_bcs, tracer_names)
     κₑ_bcs = :κₑ ∈ keys(user_bcs) ? merge(default_κₑ_bcs, user_bcs.κₑ) : default_κₑ_bcs
 
     bcs = merge((; νₑ = default_diffusivity_bcs, κₑ = κₑ_bcs), user_bcs)
 
     νₑ = CenterField(grid, boundary_conditions=bcs.νₑ)
-    κₑ = NamedTuple(c => CenterField(grid, boundary_conditions=bcs.κₑ[c]) for c in tracer_names)
+    κₑ = named_tuple(tracer_names) do c
+        Base.@constprop :aggressive
+        CenterField(grid, boundary_conditions=bcs.κₑ[c])
+    end
 
     return (; νₑ, κₑ)
 end

--- a/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/isopycnal_skew_symmetric_diffusivity.jl
@@ -71,20 +71,20 @@ end
 IsopycnalSkewSymmetricDiffusivity(FT::DataType; kw...) =
     IsopycnalSkewSymmetricDiffusivity(VerticallyImplicitTimeDiscretization(), FT; kw...)
 
-function Utils.with_tracers(tracers, closure::ISSD{TD, A, <:Any, <:Any, <:Any, <:Any, N}) where {TD, A<:DiffusiveFormulation, N}
+Base.@constprop :aggressive function Utils.with_tracers(tracers, closure::ISSD{TD, A, <:Any, <:Any, <:Any, <:Any, N}) where {TD, A<:DiffusiveFormulation, N}
     κ_skew = !isa(closure.κ_skew, NamedTuple) ? closure.κ_skew : tracer_diffusivities(tracers, closure.κ_skew)
     κ_symmetric = !isa(closure.κ_symmetric, NamedTuple) ? closure.κ_symmetric : tracer_diffusivities(tracers, closure.κ_symmetric)
     return IsopycnalSkewSymmetricDiffusivity{TD, A, N}(κ_skew, κ_symmetric, closure.isopycnal_tensor, closure.slope_limiter)
 end
 
-function Utils.with_tracers(tracers, closure::ISSD{TD, A, <:Any, <:Any, <:Any, <:Any, N}) where {TD, A<:AdvectiveFormulation, N}
+Base.@constprop :aggressive function Utils.with_tracers(tracers, closure::ISSD{TD, A, <:Any, <:Any, <:Any, <:Any, N}) where {TD, A<:AdvectiveFormulation, N}
     κ_skew = closure.κ_skew
     κ_symmetric = !isa(closure.κ_symmetric, NamedTuple) ? closure.κ_symmetric : tracer_diffusivities(tracers, closure.κ_symmetric)
     return IsopycnalSkewSymmetricDiffusivity{TD, A, N}(κ_skew, κ_symmetric, closure.isopycnal_tensor, closure.slope_limiter)
 end
 
 # For ensembles of closures
-function Utils.with_tracers(tracers, closure_vector::ISSDVector)
+Base.@constprop :aggressive function Utils.with_tracers(tracers, closure_vector::ISSDVector)
     arch = architecture(closure_vector)
 
     _closure_vector = arch isa Architectures.GPU ? Vector(closure_vector) : closure_vector

--- a/src/TurbulenceClosures/turbulence_closure_implementations/leith_enstrophy_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/leith_enstrophy_diffusivity.jl
@@ -61,7 +61,7 @@ Fox‐Kemper, B., & D. Menemenlis (2008). "Can large eddy simulation techniques 
 TwoDimensionalLeith(FT=Oceananigans.defaults.FloatType; C=0.3, C_Redi=1, C_GM=1, isopycnal_model=SmallSlopeIsopycnalTensor()) =
     TwoDimensionalLeith{FT}(C, C_Redi, C_GM, isopycnal_model)
 
-function Utils.with_tracers(tracers, closure::TwoDimensionalLeith{FT}) where FT
+Base.@constprop :aggressive function Utils.with_tracers(tracers, closure::TwoDimensionalLeith{FT}) where FT
     C_Redi = tracer_diffusivities(tracers, closure.C_Redi)
     C_GM = tracer_diffusivities(tracers, closure.C_GM)
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/scalar_biharmonic_diffusivity.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/scalar_biharmonic_diffusivity.jl
@@ -95,7 +95,7 @@ function ScalarBiharmonicDiffusivity(formulation = ThreeDimensionalFormulation()
     return ScalarBiharmonicDiffusivity{typeof(formulation), required_halo_size}(ν, κ)
 end
 
-function Utils.with_tracers(tracers, closure::ScalarBiharmonicDiffusivity{F, N}) where {F, N}
+Base.@constprop :aggressive function Utils.with_tracers(tracers, closure::ScalarBiharmonicDiffusivity{F, N}) where {F, N}
     κ = tracer_diffusivities(tracers, closure.κ)
     return ScalarBiharmonicDiffusivity{F, N}(closure.ν, κ)
 end

--- a/src/TurbulenceClosures/turbulence_closure_utils.jl
+++ b/src/TurbulenceClosures/turbulence_closure_utils.jl
@@ -5,13 +5,15 @@ const PossibleDiffusivity = Union{Number, Function, DiscreteDiffusionFunction, A
 @inline tracer_diffusivities(tracer_names, κ::PossibleDiffusivity) = with_tracers(tracer_names, NamedTuple(), (tracer_names, init) -> κ)
 @inline tracer_diffusivities(tracer_names, ::Nothing) = nothing
 
-@inline function tracer_diffusivities(tracer_names, user_κ::NamedTuple)
+Base.@constprop :aggressive @inline function tracer_diffusivities(tracer_names, user_κ::NamedTuple)
     all(name ∈ propertynames(user_κ) for name in tracer_names) ||
         throw(ArgumentError("Tracer diffusivities or diffusivity parameters must either be a constants
                             or a `NamedTuple` with a value for every tracer!"))
 
-    materialized_κ = NamedTuple(name => user_κ[name] for name in tracer_names)
-    return materialized_κ
+    return named_tuple(tracer_names) do name
+        Base.@constprop :aggressive
+        user_κ[name]
+    end
 end
 
 @inline convert_diffusivity(FT, κ::Nothing; kw...) = nothing

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -2,7 +2,7 @@ module Utils
 
 export configure_kernel, launch!, KernelParameters
 export prettytime, pretty_filesize
-export tupleit, parenttuple, datatuple, datatuples
+export tupleit, parenttuple, datatuple, datatuples, named_tuple
 export ordered_dict_show
 export instantiate
 export with_tracers

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -41,7 +41,7 @@ launch!(arch, grid, kp, kernel!, kernel_args...)
 
 See [`launch!`](@ref).
 """
-KernelParameters(size, offsets) = KernelParameters{size, offsets}()
+@inline KernelParameters(size, offsets) = KernelParameters{size, offsets}()
 
 # If `size` and `offsets` are numbers, we convert them to tuples
 KernelParameters(s::Number, o::Number) = KernelParameters(tuple(s), tuple(o))

--- a/src/Utils/tuple_utils.jl
+++ b/src/Utils/tuple_utils.jl
@@ -12,6 +12,20 @@ tupleit(nt::Vector) = tuple(nt...)
 
 parenttuple(obj) = Tuple(f.data.parent for f in obj)
 
+"""
+$(TYPEDSIGNATURES)
+
+Return a `NamedTuple` with keys `names` and values `f(name)`. The values are built by
+recursing over `names`, so that each `name` is a compile-time constant when `names` is;
+`f` should start with `Base.@constprop :aggressive` when its result type depends on `name`.
+The recursion does not go through `map` or `ntuple`, so that calls to those functions
+inside `f` are not mistaken for recursion by the compiler.
+"""
+@inline named_tuple(f, names::Tuple) = NamedTuple{names}(map_names(f, names))
+
+@inline map_names(f, ::Tuple{}) = ()
+@inline map_names(f, names::Tuple) = (f(first(names)), map_names(f, Base.tail(names))...)
+
 @inline datatuple(obj::Nothing) = nothing
 @inline datatuple(obj::AbstractArray) = obj
 @inline datatuple(obj::Tuple) = Tuple(datatuple(o) for o in obj)

--- a/test/test_quality_assurance.jl
+++ b/test/test_quality_assurance.jl
@@ -36,7 +36,7 @@ end
     # Do not increase this number. If ambiguities increase, resolve them before merging.
     number_of_ambiguities = length(detect_ambiguities(Oceananigans; recursive=true))
     # When ambiguities are resolved, update the cap accordingly.
-    @test number_of_ambiguities == 314
+    @test number_of_ambiguities == 269
     @info "Number of ambiguities: $number_of_ambiguities"
 
     modules = (
@@ -84,7 +84,6 @@ end
     @testset "No type piracy in $(mod)" for mod in get_submodules(Oceananigans)
         pirate_modules = (
             Oceananigans.AbstractOperations,
-            Oceananigans.BoundaryConditions,
             Oceananigans.BuoyancyFormulations,
             Oceananigans.Grids,
             Oceananigans.Models,


### PR DESCRIPTION
> `NonhydrostaticModel` and `HydrostaticFreeSurfaceModel` were inferred almost
> entirely on abstract types: tracer names arrive as a runtime `Tuple` of
> `Symbol`s, so every `NamedTuple` built from them (tracer fields, advection
> schemes, boundary conditions, closures, forcing, background fields, closure
> fields) was abstract, and each abstract value poisoned everything after it.
> `@snoop_inference` on the nonhydrostatic constructor showed 825 dynamic-dispatch
> inference roots and 14 s of 27 s inference on abstract signatures; the
> hydrostatic constructor on a plain latitude-longitude grid had 3510 roots and
> 162 s of 203 s on abstract signatures, including `ImmersedBoundaryGrid`
> constructors for `ConformalCubedSphereGrid` that the model never uses.
> 
> Both constructors now validate the user input, then hand the tracer names and
> the timestepper name over as `Val` type parameters through `Base.invokelatest`,
> which stops the compiler from also inferring the second stage with the names
> unknown. Boundary conditions can depend on runtime values (whether a
> latitude-longitude grid reaches a pole), so the fields, solvers and timestepper
> are built behind a second barrier once the boundary conditions are regularized.
> 
> The helpers on the constructor path build their containers without generators.
> A new `Utils.named_tuple(f, names)` unrolls over the names with its own
> recursion: going through `map` or `ntuple` made the compiler mistake the `map`
> and `ntuple` calls inside the `Field` constructor for recursion and widen the
> result. The closures whose result type depends on the name are marked
> `Base.@constprop :aggressive`, as are `with_tracers`, `TracerFields`,
> `regularize_field_boundary_conditions`, `permute_boundary_conditions`,
> `BackgroundFields`, `tracer_diffusivities`, `constructor_field_names`,
> `BuoyancyForce`, the `Field` constructors, the CATKE closure-field builders and
> the hydrostatic tendency-field builders.
> 
> Windowed fields (the free surface displacement, for example) had halo-filling
> kernels whose static size was read from the data array at runtime, so their type
> could not be inferred even with constant indices; the size now comes from
> `total_size(grid, loc, indices)`, which the `Field` constructor already
> enforces for the data. `similar` still depends on the runtime window of a
> field, so the state cached by `SplitRungeKuttaTimeStepper` in the hydrostatic
> model is built from the grid instead, and the `TimeStepper(:SplitRungeKuttaN)`
> shortcuts use literal coefficient tuples instead of `tuple(collect(...)...)`.
> 
> The `Field` constructors take the element type as `::Type{T}` so that the data
> eltype is known, `total_size`/`total_length`/`KernelParameters` are `@inline`,
> and the periodic halo-fill size is computed from `total_size` so that it folds.
> The halo-fill ordering in `permute_boundary_conditions` is now a compile-time
> sort by priority (`fill_priority`) that preserves the previous `sortperm`
> order (checked for 65 topology/location/boundary-condition combinations,
> including `Flat` directions). This also removes the `Base.isless` methods on
> `Nothing`, `Missing` and `BoundaryCondition` that `sortperm` needed, which were
> the type piracy in `BoundaryConditions` and 45 of the method ambiguities
> counted by the quality-assurance test. `initialize_boundary_transport`
> accumulates the scheme-boundary names in tuples instead of `Vector{Symbol}`.
> 
> Measured on CPU (Julia 1.12.7, one thread, shared machine):
> 
>     NonhydrostaticModel 32³, WENO(5), AMD, T/S, RK3:
>         construction 29.5 s -> 10.8 s (106 M -> 61 M allocations),
>         inference roots 825 -> 252, abstract inference 14 s -> 0.8 s
>     HydrostaticFreeSurfaceModel 90×45×20 lat-lon, split-explicit, CATKE,
>     WENOVectorInvariant, TEOS10, SplitRungeKutta3:
>         construction 142 s -> 44 s (inference roots 3510 -> 338, instances 72.5 k -> 15.7 k)
>     the same on an ImmersedBoundaryGrid with active cells map:
>         construction 185 s -> 71 s
> 
> Results are bit-identical to `main` for the nonhydrostatic (RK3/AB2, closure
> tuples, vertically implicit on an immersed grid, Fourier-tridiagonal solver)
> and hydrostatic (immersed and plain latitude-longitude) workloads after five
> time steps.
> 
> Remaining abstract pieces: on latitude-longitude grids the default north and
> south boundary conditions depend on the latitude values, so fields built with
> default boundary conditions are inferred as a small union there (rectilinear
> grids infer concretely throughout, and the hydrostatic constructor's return
> type is concrete); the nonhydrostatic FFT pressure solver's transforms depend
> on runtime values in `plan_transforms`.