### PR TITLE
Interpolation for `TotallyInMemoryFTS` under Reactant

### DIFF
--- a/ext/OceananigansReactantExt/OutputReaders.jl
+++ b/ext/OceananigansReactantExt/OutputReaders.jl
@@ -1,7 +1,7 @@
 module OutputReaders
 
 using GPUArraysCore: @allowscalar
-using Oceananigans.Architectures: ReactantState, on_architecture, CPU, architecture
+using Oceananigans.Architectures: ReactantState, on_architecture, CPU
 using Oceananigans.Fields: Field, FixedTime, instantiated_location
 using Oceananigans.Grids: offset_data
 using Oceananigans.OutputReaders: TimeInterpolator, TotallyInMemoryFTS, memory_index
@@ -29,7 +29,7 @@ end
 
 function cpu_interpolating_time_indices(::ReactantState, times, time_indexing, t)
     cpu_times = on_architecture(CPU(), times)
-    return @allowscalar TimeInterpolator(time_indexing, cpu_times, t)
+    return TimeInterpolator(time_indexing, cpu_times, t)
 end
 
 # A dynamic slice along the time axis, so the index may be known only at run time
@@ -43,7 +43,7 @@ function Base.getindex(fts::TotallyInMemoryFTS, n::TracedRNumber)
 end
 
 function Base.getindex(fts::TotallyInMemoryFTS, time_index::Time{<:TracedRNumber})
-    indices = cpu_interpolating_time_indices(architecture(fts), fts.times, fts.time_indexing, time_index.time)
+    indices = @allowscalar TimeInterpolator(fts, time_index.time)
 
     # `ñ = 0` when `n₁ == n₂`, so no branch is needed
     ñ  = TracedRNumber{eltype(fts.grid)}(indices.fractional_index)

--- a/ext/OceananigansReactantExt/OutputReaders.jl
+++ b/ext/OceananigansReactantExt/OutputReaders.jl
@@ -1,8 +1,12 @@
 module OutputReaders
 
-using Oceananigans.Architectures: ReactantState, on_architecture, CPU
-using Reactant: TracedStepRangeLen
-using Oceananigans.OutputReaders: TimeInterpolator
+using GPUArraysCore: @allowscalar
+using Oceananigans.Architectures: ReactantState, on_architecture, CPU, architecture
+using Oceananigans.Fields: Field, FixedTime, instantiated_location
+using Oceananigans.Grids: offset_data
+using Oceananigans.OutputReaders: TimeInterpolator, TotallyInMemoryFTS, memory_index
+using Oceananigans.Units: Time
+using Reactant: TracedStepRangeLen, TracedRNumber
 import Oceananigans.OutputReaders: find_time_index, cpu_interpolating_time_indices
 
 @inline function find_time_index(times::TracedStepRangeLen, t)
@@ -25,7 +29,32 @@ end
 
 function cpu_interpolating_time_indices(::ReactantState, times, time_indexing, t)
     cpu_times = on_architecture(CPU(), times)
-    return TimeInterpolator(time_indexing, cpu_times, t)
+    return @allowscalar TimeInterpolator(time_indexing, cpu_times, t)
+end
+
+# A dynamic slice along the time axis, so the index may be known only at run time
+snapshot(fts, n) = parent(fts)[:, :, :, memory_index(fts, n)]
+
+function Base.getindex(fts::TotallyInMemoryFTS, n::TracedRNumber)
+    loc = instantiated_location(fts)
+    data = offset_data(snapshot(fts, n), fts.grid, loc, fts.indices)
+    status = @allowscalar FixedTime(fts.times[n])
+    return Field(loc, fts.grid; data, fts.boundary_conditions, fts.indices, status)
+end
+
+function Base.getindex(fts::TotallyInMemoryFTS, time_index::Time{<:TracedRNumber})
+    indices = cpu_interpolating_time_indices(architecture(fts), fts.times, fts.time_indexing, time_index.time)
+
+    # `ñ = 0` when `n₁ == n₂`, so no branch is needed
+    ñ  = TracedRNumber{eltype(fts.grid)}(indices.fractional_index)
+    ψ₁ = snapshot(fts, indices.first_index)
+    ψ₂ = snapshot(fts, indices.second_index)
+
+    loc = instantiated_location(fts)
+    data = offset_data(@.(ψ₂ * ñ + ψ₁ * (1 - ñ)), fts.grid, loc, fts.indices)
+    status = FixedTime(time_index.time)
+
+    return Field(loc, fts.grid; data, fts.boundary_conditions, fts.indices, status)
 end
 
 end

--- a/ext/OceananigansReactantExt/OutputReaders.jl
+++ b/ext/OceananigansReactantExt/OutputReaders.jl
@@ -38,7 +38,7 @@ snapshot(fts, n) = parent(fts)[:, :, :, memory_index(fts, n)]
 function Base.getindex(fts::TotallyInMemoryFTS, n::TracedRNumber)
     loc = instantiated_location(fts)
     data = offset_data(snapshot(fts, n), fts.grid, loc, fts.indices)
-    status = @allowscalar FixedTime(fts.times[n])
+    status = FixedTime(@allowscalar fts.times[n])
     return Field(loc, fts.grid; data, fts.boundary_conditions, fts.indices, status)
 end
 

--- a/test/test_reactant_unit.jl
+++ b/test/test_reactant_unit.jl
@@ -1,7 +1,8 @@
 include("reactant_test_utils.jl")
 
 using CUDA
-using Oceananigans.OutputReaders: cpu_interpolating_time_indices
+using Oceananigans.OutputReaders: cpu_interpolating_time_indices, Clamp, Cyclical
+using Oceananigans.Units: Time
 
 arch = ReactantState()
 
@@ -309,6 +310,9 @@ ridge(λ, φ) = 0.1 * exp((λ - 2)^2 / 2)
     end
 end
 
+select_snapshot!(c, fts, n) = set!(c, fts[n])
+interpolate_in_time!(c, fts, t) = set!(c, fts[Time(t)])
+
 @testset "Reactant FieldTimeSeries tests" begin
     @info "Testing the use of a `FieldTimeSeries` on a `ReactantState` arch..."
 
@@ -319,6 +323,33 @@ end
 
     # Test I can index into a Reactant FieldTimeSeries
     @test fts[5] isa Field
+
+    # Index and interpolate in time with a traced index and time, as a compiled model does
+    # with `clock.time`, and compare with the CPU
+    cpu_grid = on_architecture(CPU(), grid)
+    for times in (0:3600.0:7200.0, [0.0, 1000.0, 7200.0]), time_indexing in (Clamp(), Cyclical())
+        fts     = FieldTimeSeries{Center, Center, Center}(grid, times; time_indexing)
+        cpu_fts = FieldTimeSeries{Center, Center, Center}(cpu_grid, times; time_indexing)
+        for (n, value) in enumerate((1, 4, 2))
+            set!(fts[n], value)
+            set!(cpu_fts[n], value)
+        end
+
+        c = CenterField(grid)
+        cpu_c = CenterField(cpu_grid)
+
+        r_select! = @compile select_snapshot!(c, fts, Reactant.ConcreteRNumber(1))
+        r_select!(c, fts, Reactant.ConcreteRNumber(2))
+        select_snapshot!(cpu_c, cpu_fts, 2)
+        @test Array(interior(c)) == Array(interior(cpu_c))
+
+        r_interpolate! = @compile interpolate_in_time!(c, fts, Reactant.ConcreteRNumber(0.0))
+        for t in (-1800.0, 900.0, 3600.0, 5400.0, 9000.0)
+            r_interpolate!(c, fts, Reactant.ConcreteRNumber(t))
+            interpolate_in_time!(cpu_c, cpu_fts, t)
+            @test Array(interior(c)) ≈ Array(interior(cpu_c))
+        end
+    end
 end
 
 @testset "Field materialize traced" begin


### PR DESCRIPTION
Resolves #5900

Claude-generated summary: 

## Time interpolation of an in-memory `FieldTimeSeries` at a traced time

`fts[Time(t)]` could not be traced under Reactant when `t` is a traced number, which is what
`clock.time` is inside a compiled time-stepping loop. This is needed, for example, to `set!` a
prescribed field from a forcing climatology during `update_state!`.

Two things blocked it, both in the consumers of the (already traceable) interpolation indices:

- `getindex(::FieldTimeSeries, ::Time)` branches on `if n₁ == n₂`, a traced `Bool`.
- `getindex(::InMemoryFTS, n::Int)` cannot select a snapshot at an index known only at run time.

### Changes

All in the Reactant extension, `src/` is untouched:

- `getindex(fts::TotallyInMemoryFTS, n::TracedRNumber)` returns the snapshot as a dynamic slice
  of the underlying data.
- `getindex(fts::TotallyInMemoryFTS, ::Time{<:TracedRNumber})` computes the indices with the
  existing `TimeInterpolator` and interpolates by broadcasting over the two snapshots. The
  `n₁ == n₂` branch is dropped rather than traced: the interpolator returns `ñ = 0` in that case,
  so the interpolated expression already equals the first snapshot.

Two details worth knowing:

- Reading `fts.times` at a traced index is a scalar read of a traced array when `times` is a
  `Vector`, which Reactant only permits under `@allowscalar`. It lowers to a `dynamic_slice`,
  with no host round trip; Reactant uses the same guard inside its own `searchsortedfirst`.
- The fractional index is converted to the grid's eltype with `TracedRNumber{FT}(ñ)`, since
  `times` are usually `Float64` while the data is typically `Float32`.

### Scope

Only totally in-memory series (`InMemory()`) are supported. `InMemory(n)` and `OnDisk()` load
snapshots from disk inside `getindex`, which cannot happen while tracing; they fail as before.

### Tests

The "Reactant FieldTimeSeries tests" testset now compiles a traced snapshot selection and a
traced-time interpolation once per configuration and compares against the CPU, over range and
`Vector` times with `Clamp` and `Cyclical` indexing, including out-of-range query times.
