### PR TITLE
Splat regional arguments with map instead of generators

### DIFF
--- a/src/Utils/multi_region_transformation.jl
+++ b/src/Utils/multi_region_transformation.jl
@@ -93,7 +93,7 @@ end
     R = isnothing(multi_region_args) ? regions(multi_region_kwargs) : regions(multi_region_args)
 
     for r in R
-        regional_func!((getregion(arg, r) for arg in args)...; (getregion(kwarg, r) for kwarg in kwargs)...)
+        regional_func!(map(Base.Fix2(getregion, r), args)...; map(Base.Fix2(getregion, r), values(kwargs))...)
     end
 
     return nothing
@@ -105,7 +105,7 @@ end
 @inline function apply_regionally!(regional_func!::MultiRegionObject, args...; kwargs...)
     R = regions(regional_func!)
     for r in R
-        getregion(regional_func!, r)((getregion(arg, r) for arg in args)...; (getregion(kwarg, r) for kwarg in kwargs)...)
+        getregion(regional_func!, r)(map(Base.Fix2(getregion, r), args)...; map(Base.Fix2(getregion, r), values(kwargs))...)
     end
     return nothing
 end
@@ -132,8 +132,7 @@ end
     # return values
     regional_return_values = Vector(undef, length(R))
     for r in R
-        regional_return_values[r] = regional_func((getregion(arg, r) for arg in args)...;
-                                                  (getregion(kwarg, r) for kwarg in kwargs)...)
+        regional_return_values[r] = regional_func(map(Base.Fix2(getregion, r), args)...; map(Base.Fix2(getregion, r), values(kwargs))...)
     end
 
     if Nreturns == 1


### PR DESCRIPTION
Getting rid of splatted generators seems to be a recurring theme 😛 

> The multi-region branches of `apply_regionally!`, `construct_regionally` and `multi_region_apply!` splatted `(getregion(arg, r) for arg in args)` generators into the regional call. Whenever inference reached one of these branches (every call whose `isregional` check does not fold), Julia had to infer iteration over a `Base.Generator` whose type embeds the full argument tuple type. On Julia 1.12 the compiler's `abstract_iteration` specialises its own `inferiterate` closures on the iterator type, so every distinct argument tuple made the compiler compile itself again, at roughly 15-30 ms per specialisation. Running `test_output_writers.jl` at `-O0 --check-bounds=yes` produced over 20000 such specialisations, about 380 s of codegen alone.
> 
> Mapping `getregion` over the argument tuple and the keyword NamedTuple sidesteps generator iteration entirely. (Splatting the tuple-recursive `getregion(::Tuple, r)` instead is much worse when the argument types are abstract, because inference has to unroll the recursion through `t[2:end]`.) With this change a `HydrostaticFreeSurfaceModel` on a `TripolarGrid` takes 4.7 s instead of 8.1 s to construct, and initialising a NetCDF writer on a new grid type is 30-40% faster.