### PR TITLE
Do not specialize output writers on the model type

### DIFF
--- a/ext/OceananigansNCDatasetsExt/dimensions.jl
+++ b/ext/OceananigansNCDatasetsExt/dimensions.jl
@@ -31,7 +31,7 @@ Arguments:
 - `dim_names`: Tuple of dimension names to create/validate
 - `dimension_name_generator`: Function to generate dimension names
 """
-function create_field_dimensions!(ds, fd::AbstractField, dimension_name_generator; time_dependent=false, with_halos=false, array_type=Array{eltype(fd)}, dimension_type=Float64, grid_index=nothing)
+Base.@nospecializeinfer function create_field_dimensions!(ds, @nospecialize(fd::AbstractField), dimension_name_generator; time_dependent=false, with_halos=false, array_type=Array{eltype(fd)}, dimension_type=Float64, grid_index=nothing)
     # `field_dimensions` returns a 3-tuple with `""` in slots where the field has a
     # Nothing location or the grid axis is Flat. The "effective" dim names are what
     # actually go into the variable's NetCDF signature.
@@ -53,7 +53,7 @@ end
 # field's NetCDF dim names with the field's `nodes(fd)` 1D arrays and pass them through
 # `create_spatial_dimensions!`, which creates missing coord vars or validates existing
 # ones against the field's nodes (catching mismatched dim sizes early as ArgumentError).
-function create_field_coord_variables!(ds, fd, grid, spatial_dim_names, dim_name_generator;
+Base.@nospecializeinfer function create_field_coord_variables!(ds, @nospecialize(fd), @nospecialize(grid), spatial_dim_names, dim_name_generator;
                                         with_halos, dimension_type, grid_index)
     dimension_attributes = default_dimension_attributes(grid, dim_name_generator; grid_index)
     spatial_dim_data = nodes(fd; with_halos)

--- a/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
+++ b/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
@@ -182,22 +182,23 @@ end
 ##### NetCDF file initialization
 #####
 
-function initialize_nc_file(model,
-                            grids,
-                            output_grid_map,
-                            filepath,
-                            outputs,
-                            array_type,
-                            indices,
-                            global_attributes,
-                            output_attributes,
-                            dimensions,
-                            with_halos,
-                            include_grid_metrics,
-                            overwrite_existing,
-                            deflatelevel,
-                            dimension_name_generator,
-                            dimension_type)
+# Runs once per file: not specializing on the model saves seconds of inference per model type
+Base.@nospecializeinfer function initialize_nc_file(@nospecialize(model),
+                                                    @nospecialize(grids),
+                                                    output_grid_map,
+                                                    filepath,
+                                                    @nospecialize(outputs),
+                                                    array_type,
+                                                    indices,
+                                                    global_attributes,
+                                                    output_attributes,
+                                                    dimensions,
+                                                    with_halos,
+                                                    include_grid_metrics,
+                                                    overwrite_existing,
+                                                    deflatelevel,
+                                                    dimension_name_generator,
+                                                    dimension_type)
 
     mode = (overwrite_existing || !isfile(filepath)) ? "c" : "a"
 

--- a/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
+++ b/ext/OceananigansNCDatasetsExt/netcdf_writer.jl
@@ -17,7 +17,7 @@ using Oceananigans.OutputWriters: add_schedule_metadata!, default_output_attribu
 defVar(ds::AbstractDataset, name, op::AbstractOperation; kwargs...) = defVar(ds, name, Field(op); kwargs...)
 defVar(ds::AbstractDataset, name, op::Reduction; kwargs...) = defVar(ds, name, Field(op); kwargs...)
 
-function defVar(ds::AbstractDataset, field_name, fd::AbstractField;
+Base.@nospecializeinfer function defVar(ds::AbstractDataset, field_name, @nospecialize(fd::AbstractField);
                 array_type=Array{eltype(fd)},
                 time_dependent=false,
                 with_halos=false,
@@ -368,7 +368,7 @@ function define_output_variable!(model, dataset, output, output_name; array_type
 end
 
 """ Defines empty field variable. """
-function define_output_variable!(model, dataset, output::AbstractField, output_name; array_type,
+Base.@nospecializeinfer function define_output_variable!(@nospecialize(model), dataset, @nospecialize(output::AbstractField), output_name; array_type,
                                  deflatelevel, attrib, dimension_name_generator,
                                  time_dependent, with_halos, grid_index=nothing,
                                  dimensions, filepath, dimension_type=Float64)

--- a/ext/OceananigansZarrExt/zarr_writer.jl
+++ b/ext/OceananigansZarrExt/zarr_writer.jl
@@ -255,7 +255,7 @@ function validate_existing_zarr_store(writer::ZarrWriter)
     return nothing
 end
 
-function initialize_zarr_store!(writer::ZarrWriter, model)
+Base.@nospecializeinfer function initialize_zarr_store!(@nospecialize(writer::ZarrWriter), @nospecialize(model))
     arch = architecture(model)
     distributed = arch isa Distributed
     is_root = !distributed || mpi_rank(global_communicator()) == 0
@@ -354,7 +354,7 @@ zarr_compressor(compressor, store) = compressor
 zarr_compressor(::Nothing, store) = Zarr.BloscCompressor()
 zarr_compressor(::Nothing, ::Zarr.DirectoryStore) = Zarr.NoCompressor()
 
-function define_zarr_output_variable!(g, writer::ZarrWriter, output::AbstractField, name, model)
+Base.@nospecializeinfer function define_zarr_output_variable!(g, @nospecialize(writer::ZarrWriter), @nospecialize(output::AbstractField), name, @nospecialize(model))
     arch = architecture(output.grid)
     distributed = arch isa Distributed
 

--- a/src/OutputWriters/jld2_writer.jl
+++ b/src/OutputWriters/jld2_writer.jl
@@ -212,6 +212,18 @@ function JLD2Writer(model, outputs; filename, schedule,
                       including, part, file_splitting, overwrite_existing, verbose, jld2_kw, false)
 end
 
+# Inferring this for a concrete model type means inferring `serializeproperty!` for the
+# union of all the model's property types, which takes seconds and is never needed
+Base.@nospecializeinfer function save_and_serialize_properties!(file, @nospecialize(model), including)
+    saveproperties!(file, model, including)
+
+    for property in including
+        serializeproperty!(file, "serialized/$property", getproperty(model, property))
+    end
+
+    return nothing
+end
+
 function initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, model)
     try
         jldopen(filepath, "a+"; jld2_kw...) do file
@@ -223,12 +235,7 @@ function initialize_jld2_file!(filepath, init, jld2_kw, including, outputs, mode
 
     try
         jldopen(filepath, "a+"; jld2_kw...) do file
-            saveproperties!(file, model, including)
-
-            # Serialize properties in `including`.
-            for property in including
-                serializeproperty!(file, "serialized/$property", getproperty(model, property))
-            end
+            save_and_serialize_properties!(file, model, including)
         end
     catch err
         @warn """Failed to save and serialize $including in $filepath because $(typeof(err)): $(sprint(showerror, err))"""


### PR DESCRIPTION
> `initialize_nc_file` runs once per output file, but its body was inferred and compiled from scratch for every distinct model type, including the grid-metrics branch when `include_grid_metrics = false`. On a new grid topology this cost about 5 s at `-O0 --check-bounds=yes`, more than constructing the model itself, and the NetCDF writer tests construct hundreds of distinct model types.
> 
> [`Base.@nospecializeinfer`](https://docs.julialang.org/en/v1/base/base/#Base.@nospecializeinfer) together with [`@nospecialize`](https://docs.julialang.org/en/v1/base/base/#Base.@nospecialize) on the model, grids and outputs makes Julia infer the body once with abstract argument types; the few calls inside dispatch dynamically, so only the code paths that actually execute get compiled for each new type. Initializing a NetCDF writer without grid metrics on a new grid topology now takes 0.3 s instead of 5.8 s.