### PR TITLE
Update `clock.last_Δt` every time step with `SplitRungeKuttaTimeStepper`

### DIFF
--- a/src/TimeSteppers/split_runge_kutta.jl
+++ b/src/TimeSteppers/split_runge_kutta.jl
@@ -186,9 +186,10 @@ function time_step!(model::AbstractModel{<:SplitRungeKuttaTimeStepper}, Δt; cal
         # Step closure prognostics
         step_closure_prognostics!(model, Δτ)
 
-        # Tick the clock if we ended the stages
+        # Tick the clock and record the full time step if we ended the stages
         if stage == model.timestepper.Nstages
             tick_time!(model.clock, Δt)
+            model.clock.last_Δt = Δt
         end
 
         # Update the state

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -372,6 +372,30 @@ timesteppers = (:QuasiAdamsBashforth2, :RungeKutta3)
         @test Oceananigans.TimeSteppers.kernel_time_type(explicit_clock) == Float32
     end
 
+    @testset "Clock last_Δt tracks the most recent time step" begin
+        @info "  Testing that clock.last_Δt is updated by every time stepper..."
+
+        for arch in archs
+            grid = RectilinearGrid(arch, size=(2, 2, 2), extent=(1, 1, 1))
+
+            for timestepper in (:QuasiAdamsBashforth2, :RungeKutta3)
+                model = NonhydrostaticModel(grid; timestepper)
+                time_step!(model, 1)
+                @test model.clock.last_Δt == 1
+                time_step!(model, 2)
+                @test model.clock.last_Δt == 2
+            end
+
+            for timestepper in (:QuasiAdamsBashforth2, :SplitRungeKutta2, :SplitRungeKutta3, :SplitRungeKutta4, :SplitRungeKutta5)
+                model = HydrostaticFreeSurfaceModel(grid; timestepper)
+                time_step!(model, 1)
+                @test model.clock.last_Δt == 1
+                time_step!(model, 2)
+                @test model.clock.last_Δt == 2
+            end
+        end
+    end
+
     for arch in archs, FT in float_types
         A = typeof(arch)
         Oceananigans.defaults.FloatType = FT


### PR DESCRIPTION
With a `SplitRungeKuttaTimeStepper`, `model.clock.last_Δt` was written only once, in `maybe_prepare_first_time_step!` at iteration 0, and then kept the first step's value for the whole run.

This PR records `Δt` in `clock.last_Δt` at the final stage, next to `tick_time!`, and adds a test that steps `NonhydrostaticModel` (QAB2, RK3) and `HydrostaticFreeSurfaceModel` (QAB2, SplitRungeKutta2–5) twice with different `Δt` and checks that `clock.last_Δt` equals the most recent one.

Resolves #5953