### PR TITLE
Use unwrapped eltype in adapt_structure of operations

### DIFF
--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -14,7 +14,7 @@ using DocStringExtensions: TYPEDSIGNATURES
 using Oceananigans: location
 using Oceananigans.Architectures: Architectures, architecture, on_architecture
 using Oceananigans.Fields: AbstractField, instantiated_location
-using Oceananigans.Grids: Center, Face
+using Oceananigans.Grids: Center, Face, unwrapped_eltype
 using Oceananigans.Operators: interpolation_operator
 
 import Oceananigans.BoundaryConditions: fill_halo_regions!

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -228,7 +228,7 @@ Adapt.adapt_structure(to, binary::BinaryOperation{LX, LY, LZ}) where {LX, LY, LZ
                                 Adapt.adapt(to, binary.▶a),
                                 Adapt.adapt(to, binary.▶b),
                                 Adapt.adapt(to, binary.grid),
-                                eltype(binary))
+                                unwrapped_eltype(eltype(binary)))
 
 
 Architectures.on_architecture(to, binary::BinaryOperation{LX, LY, LZ}) where {LX, LY, LZ} =

--- a/src/AbstractOperations/kernel_function_operation.jl
+++ b/src/AbstractOperations/kernel_function_operation.jl
@@ -116,7 +116,7 @@ Adapt.adapt_structure(to, κ::KernelFunctionOperation{LX, LY, LZ}) where {LX, LY
     KernelFunctionOperation{LX, LY, LZ}(Adapt.adapt(to, κ.kernel_function),
                                         Adapt.adapt(to, κ.grid),
                                         Tuple(Adapt.adapt(to, a) for a in κ.arguments),
-                                        eltype(κ))
+                                        unwrapped_eltype(eltype(κ)))
 
 Architectures.on_architecture(to, κ::KernelFunctionOperation{LX, LY, LZ}) where {LX, LY, LZ} =
     KernelFunctionOperation{LX, LY, LZ}(on_architecture(to, κ.kernel_function),


### PR DESCRIPTION
Otherwise, in reactant tracing the eltype can be `TracedRNumber{Float32}` which results in method errors when compiling kernels.