### PR TITLE
Bugfix distributed `RightFaceFolded` constructor

### DIFF
--- a/src/OrthogonalSphericalShellGrids/distributed_tripolar_grid.jl
+++ b/src/OrthogonalSphericalShellGrids/distributed_tripolar_grid.jl
@@ -99,34 +99,37 @@ function distribute_tripolar_grid(arch::Distributed, global_grid)
     jend = yrank == workers[2] - 1 ? Ny : sum(nylocal[1:yrank+1])
     jrange = jstart-Hy:jend+Hy
 
+    extra_fold_row = (yrank == workers[2] - 1) && (topology(global_grid, 2) === RightFaceFolded)
+    face_jrange = jstart-Hy:jend+Hy+extra_fold_row
+
     # The i-range
     istart = 1 + sum(nxlocal[1:xrank])
     iend = xrank == workers[1] - 1 ? Nx : sum(nxlocal[1:xrank+1])
     irange = istart-Hx:iend+Hx
 
     # Partitioning the Coordinates
-    λᶠᶠᵃ = partition_tripolar_metric(global_grid, :λᶠᶠᵃ, irange, jrange)
-    φᶠᶠᵃ = partition_tripolar_metric(global_grid, :φᶠᶠᵃ, irange, jrange)
+    λᶠᶠᵃ = partition_tripolar_metric(global_grid, :λᶠᶠᵃ, irange, face_jrange)
+    φᶠᶠᵃ = partition_tripolar_metric(global_grid, :φᶠᶠᵃ, irange, face_jrange)
     λᶠᶜᵃ = partition_tripolar_metric(global_grid, :λᶠᶜᵃ, irange, jrange)
     φᶠᶜᵃ = partition_tripolar_metric(global_grid, :φᶠᶜᵃ, irange, jrange)
-    λᶜᶠᵃ = partition_tripolar_metric(global_grid, :λᶜᶠᵃ, irange, jrange)
-    φᶜᶠᵃ = partition_tripolar_metric(global_grid, :φᶜᶠᵃ, irange, jrange)
+    λᶜᶠᵃ = partition_tripolar_metric(global_grid, :λᶜᶠᵃ, irange, face_jrange)
+    φᶜᶠᵃ = partition_tripolar_metric(global_grid, :φᶜᶠᵃ, irange, face_jrange)
     λᶜᶜᵃ = partition_tripolar_metric(global_grid, :λᶜᶜᵃ, irange, jrange)
     φᶜᶜᵃ = partition_tripolar_metric(global_grid, :φᶜᶜᵃ, irange, jrange)
 
     # Partitioning the Metrics
     Δxᶜᶜᵃ = partition_tripolar_metric(global_grid, :Δxᶜᶜᵃ, irange, jrange)
     Δxᶠᶜᵃ = partition_tripolar_metric(global_grid, :Δxᶠᶜᵃ, irange, jrange)
-    Δxᶜᶠᵃ = partition_tripolar_metric(global_grid, :Δxᶜᶠᵃ, irange, jrange)
-    Δxᶠᶠᵃ = partition_tripolar_metric(global_grid, :Δxᶠᶠᵃ, irange, jrange)
+    Δxᶜᶠᵃ = partition_tripolar_metric(global_grid, :Δxᶜᶠᵃ, irange, face_jrange)
+    Δxᶠᶠᵃ = partition_tripolar_metric(global_grid, :Δxᶠᶠᵃ, irange, face_jrange)
     Δyᶜᶜᵃ = partition_tripolar_metric(global_grid, :Δyᶜᶜᵃ, irange, jrange)
     Δyᶠᶜᵃ = partition_tripolar_metric(global_grid, :Δyᶠᶜᵃ, irange, jrange)
-    Δyᶜᶠᵃ = partition_tripolar_metric(global_grid, :Δyᶜᶠᵃ, irange, jrange)
-    Δyᶠᶠᵃ = partition_tripolar_metric(global_grid, :Δyᶠᶠᵃ, irange, jrange)
+    Δyᶜᶠᵃ = partition_tripolar_metric(global_grid, :Δyᶜᶠᵃ, irange, face_jrange)
+    Δyᶠᶠᵃ = partition_tripolar_metric(global_grid, :Δyᶠᶠᵃ, irange, face_jrange)
     Azᶜᶜᵃ = partition_tripolar_metric(global_grid, :Azᶜᶜᵃ, irange, jrange)
     Azᶠᶜᵃ = partition_tripolar_metric(global_grid, :Azᶠᶜᵃ, irange, jrange)
-    Azᶜᶠᵃ = partition_tripolar_metric(global_grid, :Azᶜᶠᵃ, irange, jrange)
-    Azᶠᶠᵃ = partition_tripolar_metric(global_grid, :Azᶠᶠᵃ, irange, jrange)
+    Azᶜᶠᵃ = partition_tripolar_metric(global_grid, :Azᶜᶠᵃ, irange, face_jrange)
+    Azᶠᶠᵃ = partition_tripolar_metric(global_grid, :Azᶠᶠᵃ, irange, face_jrange)
 
     LX = workers[1] == 1 ? Periodic : FullyConnected
 

--- a/src/OrthogonalSphericalShellGrids/distributed_tripolar_grid.jl
+++ b/src/OrthogonalSphericalShellGrids/distributed_tripolar_grid.jl
@@ -394,25 +394,25 @@ function DistributedComputations.reconstruct_global_grid(grid::MPITripolarGrid)
                         fold_topology = fold_topology(grid.conformal_mapping))
 end
 
-function Grids.with_halo(new_halo, old_grid::MPITripolarGrid)
+function halo_filling_grid(new_halo, grid::MPITripolarGrid)
 
-    arch = old_grid.architecture
+    arch = grid.architecture
 
-    n  = size(old_grid)
+    n  = size(grid)
     N  = map(sum, concatenate_local_sizes(n, arch))
-    z  = cpu_face_constructor_z(old_grid)
+    z  = cpu_face_constructor_z(grid)
 
-    north_poles_latitude = old_grid.conformal_mapping.north_poles_latitude
-    first_pole_longitude = old_grid.conformal_mapping.first_pole_longitude
-    southernmost_latitude = old_grid.conformal_mapping.southernmost_latitude
-    return TripolarGrid(arch, eltype(old_grid);
+    north_poles_latitude = grid.conformal_mapping.north_poles_latitude
+    first_pole_longitude = grid.conformal_mapping.first_pole_longitude
+    southernmost_latitude = grid.conformal_mapping.southernmost_latitude
+    return TripolarGrid(arch, eltype(grid);
                         halo = new_halo,
                         size = N,
                         north_poles_latitude,
                         first_pole_longitude,
                         southernmost_latitude,
                         z,
-                        fold_topology = fold_topology(old_grid.conformal_mapping))
+                        fold_topology = fold_topology(grid.conformal_mapping))
 end
 
 #####

--- a/src/OrthogonalSphericalShellGrids/distributed_zipper.jl
+++ b/src/OrthogonalSphericalShellGrids/distributed_zipper.jl
@@ -41,13 +41,6 @@ has_fold_line(::Type{<:FPivotTopology}, ::Face)   = true
 # The serial ifelse(i > Nx÷2, ...) writes the east half only.
 # Corner conditions account for periodic wrap at rx=1 (NW) and rx=Rx (NE).
 
-# North buffer: east-of-pivot ranks write fold line
-function north_writes_fold_line(arch)
-    rx = arch.local_index[1]
-    Rx = ranks(arch)[1]
-    return rx > Rx ÷ 2
-end
-
 # NW corner: west edge past pivot, or rx=1 (periodic wrap to east half)
 function northwest_writes_fold_line(arch)
     rx = arch.local_index[1]
@@ -62,35 +55,62 @@ function northeast_writes_fold_line(arch)
     return rx >= Rx ÷ 2 && rx < Rx
 end
 
+function north_foldline_columns(arch, ℓx, Nx)
+    rx, Rx = arch.local_index[1], ranks(arch)[1]
+
+    shared_column = ℓx isa Face
+    writes_interior = rx > Rx ÷ 2
+    writes_shared = shared_column && rx >= Rx ÷ 2 && rx < Rx
+
+    first_column = writes_interior ? 1 : Nx
+    last_interior_column = shared_column ? Nx - 1 : Nx
+    last_column = writes_shared ? Nx : (writes_interior ? last_interior_column : 0)
+
+    return first_column:last_column
+end
+
+function northwest_foldline_columns(arch, ℓx, Hx)
+    rx, Rx = arch.local_index[1], ranks(arch)[1]
+
+    writes_halo = northwest_writes_fold_line(arch)
+    # The rank's own column 1 folds onto itself at the pivot, so it comes from a self-exchange there.
+    writes_own = ℓx isa Face && rx >= Rx ÷ 2 + 1
+
+    first_column = writes_halo ? 1 : Hx + 1
+    last_column = writes_own ? Hx + 1 : (writes_halo ? Hx : 0)
+
+    return first_column:last_column
+end
+
 #####
 ##### Zipper communication buffers with fold-aware packing
 #####
 
-struct TwoDZipperBuffer{FL, WFL, TY, Loc, B, S}
+struct TwoDZipperBuffer{FL, TY, Loc, B, S, R}
     loc  :: Loc
     send :: B
     recv :: B
     sign :: S
+    foldline_columns :: R
 end
 
-struct ZipperCornerBuffer{FL, WFL, TY, Loc, B, S}
+struct ZipperCornerBuffer{FL, TY, Loc, B, S, R}
     loc  :: Loc
     send :: B
     recv :: B
     sign :: S
+    foldline_columns :: R
 end
 
-# Partial type-parameter constructors: FL, WFL, TY specified; Loc, B, S inferred
-TwoDZipperBuffer{FL, WFL, TY}(loc::Loc, send::B, recv::B, sign::S) where {FL, WFL, TY, Loc, B, S} =
-    TwoDZipperBuffer{FL, WFL, TY, Loc, B, S}(loc, send, recv, sign)
-ZipperCornerBuffer{FL, WFL, TY}(loc::Loc, send::B, recv::B, sign::S) where {FL, WFL, TY, Loc, B, S} =
-    ZipperCornerBuffer{FL, WFL, TY, Loc, B, S}(loc, send, recv, sign)
+# Partial type-parameter constructors: FL, TY specified; Loc, B, S, R inferred
+TwoDZipperBuffer{FL, TY}(loc::Loc, send::B, recv::B, sign::S, columns::R)   where {FL, TY, Loc, B, S, R} = TwoDZipperBuffer{FL, TY, Loc, B, S, R}(loc, send, recv, sign, columns)
+ZipperCornerBuffer{FL, TY}(loc::Loc, send::B, recv::B, sign::S, columns::R) where {FL, TY, Loc, B, S, R} = ZipperCornerBuffer{FL, TY, Loc, B, S, R}(loc, send, recv, sign, columns)
 
 Adapt.adapt_structure(to, buff::TwoDZipperBuffer) = nothing
 Adapt.adapt_structure(to, buff::ZipperCornerBuffer) = nothing
 
 # X-direction buffer for tripolar grids: like TwoDBuffer but with location-aware y-size
-# and fold-line awareness. FL/WFL mirror the corner buffer pattern:
+# and fold-line awareness. The whole row is decided at once here, so a pair of flags suffices:
 # - FL: buffer has fold-line row (same as corners, for MPI size matching)
 # - WFL: recv writes the fold-line row (complement of the adjacent corner)
 #   West WFL = !NW corner WFL, East WFL = !NE corner WFL.
@@ -134,8 +154,7 @@ _recv_from_east_buffer!(c, buff::TripolarXBuffer{true, false}, Hx, Hy, Nx, Ny) =
 
 # Fold-aware x-buffer constructors.
 # Separate west/east constructors since they complement different corners.
-function west_tripolar_buffer(arch, grid, data, Hx, bc, loc,
-                              north::TwoDZipperBuffer{<:Any, <:Any, TY}) where TY
+function west_tripolar_buffer(arch, grid, data, Hx, bc, loc, north::TwoDZipperBuffer{<:Any, TY}) where TY
     ℓy = north.loc[2]
     topo = fold_topo(north)
     fl = has_fold_line(TY, ℓy)
@@ -148,8 +167,7 @@ function west_tripolar_buffer(arch, grid, data, Hx, bc, loc,
     return TripolarXBuffer{fl, wfl}(send, recv)
 end
 
-function east_tripolar_buffer(arch, grid, data, Hx, bc, loc,
-                              north::TwoDZipperBuffer{<:Any, <:Any, TY}) where TY
+function east_tripolar_buffer(arch, grid, data, Hx, bc, loc, north::TwoDZipperBuffer{<:Any, TY}) where TY
     ℓy = north.loc[2]
     topo = fold_topo(north)
     fl = has_fold_line(TY, ℓy)
@@ -202,10 +220,10 @@ function y_tripolar_buffer(arch, grid::AbstractGrid{<:Any, <:Any, TY},
     sgn = bc.condition.sign
     fl = has_fold_line(TY, loc[2])
     Hy′ = fl ? Hy + 1 : Hy
-    wfl = fl && north_writes_fold_line(arch)
+    columns = fl ? north_foldline_columns(arch, loc[1], Nx) : (1:0)
     send = on_architecture(arch, zeros(FT, Nx, Hy′, Tz))
     recv = on_architecture(arch, zeros(FT, Nx, Hy′, Tz))
-    return TwoDZipperBuffer{fl, wfl, TY}(loc, send, recv, sgn)
+    return TwoDZipperBuffer{fl, TY}(loc, send, recv, sgn, columns)
 end
 
 # Fallbacks: non-zipper corners
@@ -214,33 +232,31 @@ northeast_tripolar_buffer(arch, grid, data, Hx, Hy, xedge, yedge) = corner_commu
 
 # Corner buffers are only needed for 2D (MxN) partitions.
 # FL (fold line in buffer) is true for ALL corners when has_fold_line, to ensure
-# MPI size matching between mirror partners. WFL (writes fold line) is per-corner,
-# based on whether the corner's global x-position is past the pivot.
+# MPI size matching between mirror partners. Which of those columns the corner writes back is
+# `foldline_columns`, since the corner's global x-position decides it column by column.
 
-function northwest_tripolar_buffer(arch, grid, data, Hx, Hy, xedge,
-                                   yedge::TwoDZipperBuffer{<:Any, <:Any, TY}) where TY
+function northwest_tripolar_buffer(arch, grid, data, Hx, Hy, xedge, yedge::TwoDZipperBuffer{<:Any, TY}) where TY
     Tz = size(parent(data), 3); FT = eltype(data); sgn = yedge.sign
     ℓx, ℓy = yedge.loc[1], yedge.loc[2]
     fl = has_fold_line(TY, ℓy)
     Hy′ = fl ? Hy + 1 : Hy
-    wfl = fl && northwest_writes_fold_line(arch)
+    columns = fl ? northwest_foldline_columns(arch, ℓx, Hx) : (1:0)
     Hx′ = northwest_x_size(ℓx, Hx)
     send = on_architecture(arch, zeros(FT, Hx′, Hy′, Tz))
     recv = on_architecture(arch, zeros(FT, Hx′, Hy′, Tz))
-    return ZipperCornerBuffer{fl, wfl, TY}(yedge.loc, send, recv, sgn)
+    return ZipperCornerBuffer{fl, TY}(yedge.loc, send, recv, sgn, columns)
 end
 
-function northeast_tripolar_buffer(arch, grid, data, Hx, Hy, xedge,
-                                   yedge::TwoDZipperBuffer{<:Any, <:Any, TY}) where TY
+function northeast_tripolar_buffer(arch, grid, data, Hx, Hy, xedge, yedge::TwoDZipperBuffer{<:Any, TY}) where TY
     Tz = size(parent(data), 3); FT = eltype(data); sgn = yedge.sign
     ℓx, ℓy = yedge.loc[1], yedge.loc[2]
     fl = has_fold_line(TY, ℓy)
     Hy′ = fl ? Hy + 1 : Hy
-    wfl = fl && northeast_writes_fold_line(arch)
     Hx′ = northeast_x_size(ℓx, Hx)
+    columns = fl && northeast_writes_fold_line(arch) ? (1:Hx′) : (1:0)
     send = on_architecture(arch, zeros(FT, Hx′, Hy′, Tz))
     recv = on_architecture(arch, zeros(FT, Hx′, Hy′, Tz))
-    return ZipperCornerBuffer{fl, wfl, TY}(yedge.loc, send, recv, sgn)
+    return ZipperCornerBuffer{fl, TY}(yedge.loc, send, recv, sgn, columns)
 end
 
 #####
@@ -257,8 +273,8 @@ const FF = Tuple{<:Face,   <:Face,   <:Any}
 #####
 
 # Field accessors
-@inline fold_topo(::TwoDZipperBuffer{<:Any, <:Any, TY}) where TY = TY()
-@inline fold_topo(::ZipperCornerBuffer{<:Any, <:Any, TY}) where TY = TY()
+@inline fold_topo(::TwoDZipperBuffer{<:Any, TY})   where TY = TY()
+@inline fold_topo(::ZipperCornerBuffer{<:Any, TY}) where TY = TY()
 
 # North buffer: fold-line y-index (source/destination row at the fold)
 @inline north_foldline_send_y_index(::UPivotTopology, ::Center, Hy, Ny) = Ny + Hy
@@ -315,21 +331,16 @@ function _fill_north_send_buffer!(c, b::TwoDZipperBuffer{false}, Hx, Hy, Nx, Ny)
 end
 
 #####
-##### TwoDZipperBuffer: north recv (FL × WFL dispatch)
+##### TwoDZipperBuffer: north recv
 #####
 
-function _recv_from_north_buffer!(c, buff::TwoDZipperBuffer{true, true}, Hx, Hy, Nx, Ny)
+function _recv_from_north_buffer!(c, buff::TwoDZipperBuffer{true}, Hx, Hy, Nx, Ny)
     topo, ℓy = fold_topo(buff), buff.loc[2]
     j = north_foldline_recv_y_index(topo, ℓy, Hy, Ny)
     xr = north_recv_x_range(buff.loc[1], Hx, Nx)
     yr = north_halo_recv_y_range(topo, ℓy, Hy, Ny)
-    view(c, xr, j:j   , :) .= view(buff.recv, :, 1:1   , :)
-    view(c, xr, yr, :) .= view(buff.recv, :, 2:Hy+1, :)
-end
-
-function _recv_from_north_buffer!(c, buff::TwoDZipperBuffer{true, false}, Hx, Hy, Nx, Ny)
-    xr = north_recv_x_range(buff.loc[1], Hx, Nx)
-    yr = north_halo_recv_y_range(fold_topo(buff), buff.loc[2], Hy, Ny)
+    kr = buff.foldline_columns
+    view(c, first(xr) - 1 .+ kr, j:j, :) .= view(buff.recv, kr, 1:1, :)
     view(c, xr, yr, :) .= view(buff.recv, :, 2:Hy+1, :)
 end
 
@@ -374,21 +385,16 @@ function _fill_northeast_send_buffer!(c, b::ZipperCornerBuffer{false}, Hx, Hy, N
 end
 
 #####
-##### Corner recv: NW and NE (FL × WFL dispatch)
+##### Corner recv: NW and NE
 #####
 
-function _recv_from_northwest_buffer!(c, buff::ZipperCornerBuffer{true, true}, Hx, Hy, Nx, Ny)
+function _recv_from_northwest_buffer!(c, buff::ZipperCornerBuffer{true}, Hx, Hy, Nx, Ny)
     topo, ℓy = fold_topo(buff), buff.loc[2]
     j = north_foldline_recv_y_index(topo, ℓy, Hy, Ny)
     xr = northwest_recv_x_range(buff.loc[1], Hx, Nx)
     yr = north_halo_recv_y_range(topo, ℓy, Hy, Ny)
-    view(c, xr, j:j, :) .= view(buff.recv, :, 1:1, :)
-    view(c, xr,  yr, :) .= view(buff.recv, :, 2:size(buff.recv,2), :)
-end
-
-function _recv_from_northwest_buffer!(c, buff::ZipperCornerBuffer{true, false}, Hx, Hy, Nx, Ny)
-    xr = northwest_recv_x_range(buff.loc[1], Hx, Nx)
-    yr = north_halo_recv_y_range(fold_topo(buff), buff.loc[2], Hy, Ny)
+    kr = buff.foldline_columns
+    view(c, first(xr) - 1 .+ kr, j:j, :) .= view(buff.recv, kr, 1:1, :)
     view(c, xr, yr, :) .= view(buff.recv, :, 2:size(buff.recv,2), :)
 end
 
@@ -398,18 +404,13 @@ function _recv_from_northwest_buffer!(c, buff::ZipperCornerBuffer{false}, Hx, Hy
     view(c, xr, yr, :) .= buff.recv
 end
 
-function _recv_from_northeast_buffer!(c, buff::ZipperCornerBuffer{true, true}, Hx, Hy, Nx, Ny)
+function _recv_from_northeast_buffer!(c, buff::ZipperCornerBuffer{true}, Hx, Hy, Nx, Ny)
     topo, ℓy = fold_topo(buff), buff.loc[2]
-    xr = northeast_recv_x_range(buff.loc[1], Hx, Nx)
     j = north_foldline_recv_y_index(topo, ℓy, Hy, Ny)
-    yr = north_halo_recv_y_range(topo, ℓy, Hy, Ny)
-    view(c, xr, j:j, :) .= view(buff.recv, :, 1:1, :)
-    view(c, xr, yr , :) .= view(buff.recv, :, 2:size(buff.recv,2), :)
-end
-
-function _recv_from_northeast_buffer!(c, buff::ZipperCornerBuffer{true, false}, Hx, Hy, Nx, Ny)
     xr = northeast_recv_x_range(buff.loc[1], Hx, Nx)
-    yr = north_halo_recv_y_range(fold_topo(buff), buff.loc[2], Hy, Ny)
+    yr = north_halo_recv_y_range(topo, ℓy, Hy, Ny)
+    kr = buff.foldline_columns
+    view(c, first(xr) - 1 .+ kr, j:j, :) .= view(buff.recv, kr, 1:1, :)
     view(c, xr, yr, :) .= view(buff.recv, :, 2:size(buff.recv,2), :)
 end
 

--- a/src/OrthogonalSphericalShellGrids/tripolar_grid.jl
+++ b/src/OrthogonalSphericalShellGrids/tripolar_grid.jl
@@ -359,13 +359,21 @@ end
 function transfer_horizontal_field(old_data, helper_grid, bcs, LX, LY)
     TX, TY, _ = topology(helper_grid)
     Nx, Ny, _ = size(helper_grid)
-    new_field = Field{LX, LY, Center}(helper_grid; boundary_conditions = bcs)
+    new_field = Field{LX, LY, Nothing}(helper_grid; boundary_conditions = bcs)
     Ni = Base.length(LX(), TX(), Nx)
     Nj = Base.length(LY(), TY(), Ny)
-    cpu_old_data = on_architecture(CPU(), old_data)
-    new_field.data[1:Ni, 1:Nj, 1] .= cpu_old_data[1:Ni, 1:Nj]
+    new_field.data[1:Ni, 1:Nj, 1] .= on_architecture(architecture(helper_grid), old_data)[1:Ni, 1:Nj]
     fill_halo_regions!(new_field)
     return deepcopy(dropdims(new_field.data, dims=3))
+end
+
+# The grid the transferred metrics are filled on. Only its size, halo, topology and — when
+# distributed — its connectivity are read; its own metrics are never touched.
+function halo_filling_grid(new_halo, grid::TripolarGrid)
+    Nx, Ny, _ = size(grid)
+    TX, TY, _ = topology(grid)
+    Hx, Hy, _ = new_halo
+    return RectilinearGrid(; size = (Nx, Ny), halo = (Hx, Hy), x = (0, 1), y = (0, 1), topology = (TX, TY, Flat))
 end
 
 function Grids.with_halo(new_halo, old_grid::TripolarGrid)
@@ -375,21 +383,17 @@ function Grids.with_halo(new_halo, old_grid::TripolarGrid)
 
     Nx,  Ny,  Nz  = size(old_grid)
     TX,  TY,  TZ  = topology(old_grid)
-    Hxo, Hyo, Hzo = halo_size(old_grid)
     Hxn, Hyn, Hzn = new_halo
 
     # Reconstruct vertical coordinate with new halo
     z = cpu_face_constructor_z(old_grid)
     Lz, new_z = generate_coordinate(FT, topology(old_grid), (Nx, Ny, Nz), new_halo, z, :z, 3, CPU())
 
-    # Helper grid for halo filling (same approach as the TripolarGrid constructor)
-    helper_grid = RectilinearGrid(; size = (Nx, Ny),
-                                    halo = (Hxn, Hyn),
-                                    x = (0, 1), y = (0, 1),
-                                    topology = (TX, TY, Flat))
+    helper_grid = halo_filling_grid(new_halo, old_grid)
 
-    # Boundary conditions for halo filling (same as in the TripolarGrid constructor)
-    bcs = FieldBoundaryConditions(north  = north_fold_boundary_condition(TY)(),
+    # Boundary conditions for halo filling (same as in the TripolarGrid constructor). A distributed
+    # rank's own y-topology is `Connected`, so the conformal mapping names the fold.
+    bcs = FieldBoundaryConditions(north  = north_fold_boundary_condition(fold_topology(old_grid.conformal_mapping))(),
                                   south  = NoFluxBoundaryCondition(),
                                   west   = Oceananigans.PeriodicBoundaryCondition(),
                                   east   = Oceananigans.PeriodicBoundaryCondition(),

--- a/test/test_mpi_tripolar.jl
+++ b/test/test_mpi_tripolar.jl
@@ -101,6 +101,74 @@ tripolar_reconstructed_field_script(fold_topology) = """
     end
 """
 
+tripolar_metric_halo_script(fold_topology) = """
+    using MPI
+    MPI.Init()
+    using Test
+
+    include("distributed_tests_utils.jl")
+
+    using Oceananigans.Grids: with_halo, topology
+    using Oceananigans.BoundaryConditions: fill_halo_regions!, NoFluxBoundaryCondition, PeriodicBoundaryCondition
+    using Oceananigans.OrthogonalSphericalShellGrids: north_fold_boundary_condition
+
+    arch = Distributed(CPU(), partition = Partition(2, 2))
+
+    global_grid = TripolarGrid(size = (20, 20, 2), z = (-1000, 0), halo = (4, 4, 4), fold_topology = $fold_topology)
+    local_grid  = TripolarGrid(arch; size = (20, 20, 2), z = (-1000, 0), halo = (4, 4, 4), fold_topology = $fold_topology)
+
+    nx, ny, _ = size(local_grid)
+    rx, ry, _ = arch.local_index
+    i₀, j₀ = (rx - 1) * nx, (ry - 1) * ny
+
+    Hx, Hy, _ = halo_size(local_grid)
+    TX, TY, _ = topology(local_grid)
+
+    Njg = Base.length(Face(), topology(global_grid, 2)(), size(global_grid, 2))
+    Njl = Base.length(Face(), TY(), ny)
+
+    fold_bcs(sign) = FieldBoundaryConditions(north  = north_fold_boundary_condition($fold_topology)(sign),
+                                             south  = NoFluxBoundaryCondition(),
+                                             west   = PeriodicBoundaryCondition(),
+                                             east   = PeriodicBoundaryCondition(),
+                                             top = nothing, bottom = nothing)
+
+    # The fold is applied once to raw data on both grids, rather than seeded already folded: it flips
+    # the sign at its two fixed points, so folding twice is not the identity.
+    for sign in (1, -1)
+        reference = Field{Face, Face, Nothing}(global_grid; boundary_conditions = fold_bcs(sign))
+        for j in 1:Njg, i in 1:size(global_grid, 1)
+            reference[i, j] = i + 100j
+        end
+        fill_halo_regions!(reference)
+
+        local_field = Field{Face, Face, Nothing}(local_grid; boundary_conditions = fold_bcs(sign))
+        for j in 1:Njl, i in 1:nx
+            local_field[i, j] = i₀ + i + 100 * (j₀ + j)
+        end
+        fill_halo_regions!(local_field)
+
+        @test all(local_field[i, j] == reference[i₀ + i, j₀ + j] for j in 1-Hy:Njl+Hy, i in 1-Hx:nx+Hx)
+    end
+
+    # A mesh read from a file is not the analytic one, so scaling the metrics distinguishes a
+    # `with_halo` that transfers them from one that regenerates them.
+    for name in (:φᶜᶜᵃ, :φᶠᶜᵃ, :φᶜᶠᵃ, :φᶠᶠᵃ,
+                 :Δxᶜᶜᵃ, :Δxᶠᶜᵃ, :Δxᶜᶠᵃ, :Δxᶠᶠᵃ, :Δyᶜᶜᵃ, :Δyᶠᶜᵃ, :Δyᶜᶠᵃ, :Δyᶠᶠᵃ,
+                 :Azᶜᶜᵃ, :Azᶠᶜᵃ, :Azᶜᶠᵃ, :Azᶠᶠᵃ)
+        parent(getproperty(local_grid, name)) .*= 2
+    end
+
+    rehaloed = with_halo((4, 6, 4), local_grid)
+
+    for (name, ℓx, ℓy) in ((:φᶜᶜᵃ, Center(), Center()), (:Δyᶠᶜᵃ, Face(), Center()),
+                           (:Δxᶜᶠᵃ, Center(), Face()),  (:Azᶠᶠᵃ, Face(), Face()))
+        Ni = Base.length(ℓx, TX(), nx)
+        Nj = Base.length(ℓy, TY(), ny)
+        @test getproperty(rehaloed, name)[1:Ni, 1:Nj] == getproperty(local_grid, name)[1:Ni, 1:Nj]
+    end
+"""
+
 @testset "Test distributed TripolarGrid $fold_topology..." for fold_topology in fold_topologies
     write("distributed_tripolar_grid_$fold_topology.jl", tripolar_reconstructed_grid_script(fold_topology))
     run(`$(mpiexec()) -n 4 $(Base.julia_cmd()) -O0 $("distributed_tripolar_grid_$fold_topology.jl")`)
@@ -109,6 +177,10 @@ tripolar_reconstructed_field_script(fold_topology) = """
     write("distributed_tripolar_field_$fold_topology.jl", tripolar_reconstructed_field_script(fold_topology))
     run(`$(mpiexec()) -n 4 $(Base.julia_cmd()) -O0 $("distributed_tripolar_field_$fold_topology.jl")`)
     rm("distributed_tripolar_field_$fold_topology.jl")
+
+    write("distributed_tripolar_metric_halo_$fold_topology.jl", tripolar_metric_halo_script(fold_topology))
+    run(`$(mpiexec()) -n 4 $(Base.julia_cmd()) -O0 $("distributed_tripolar_metric_halo_$fold_topology.jl")`)
+    rm("distributed_tripolar_metric_halo_$fold_topology.jl")
 end
 
 tripolar_boundary_conditions_script(fold_topology) = """

--- a/test/test_mpi_tripolar.jl
+++ b/test/test_mpi_tripolar.jl
@@ -13,6 +13,7 @@ tripolar_reconstructed_grid_script(fold_topology) = """
     include("distributed_tests_utils.jl")
 
     using Oceananigans.OrthogonalSphericalShellGrids: distribute_tripolar_grid
+    using Oceananigans.Grids: total_length
 
     archs = [Distributed(CPU(), partition=Partition(1, 4)),
              Distributed(CPU(), partition=Partition(2, 2))]
@@ -41,6 +42,20 @@ tripolar_reconstructed_grid_script(fold_topology) = """
             @test getproperty(local_grid, var)[1:nx, 1:ny] == getproperty(global_grid, var)[irange, jrange]
             @test getproperty(local_grid, var)[1:nx, 1:ny] == getproperty(global_grid, var)[irange, jrange]
             @test getproperty(local_grid, var)[1:nx, 1:ny] == getproperty(global_grid, var)[irange, jrange]
+        end
+
+        # Each metric spans the extent of its own location: on the rank owning a `RightFaceFolded`
+        # fold a `Face`-in-y metric has one row more than a `Center`-in-y one.
+        Hy = halo_size(local_grid)[2]
+        TY = topology(local_grid, 2)()
+
+        for (var, ℓy) in [(:λᶜᶜᵃ, Center()), (:λᶠᶜᵃ, Center()), (:λᶜᶠᵃ, Face()), (:λᶠᶠᵃ, Face()),
+                          (:φᶜᶜᵃ, Center()), (:φᶠᶜᵃ, Center()), (:φᶜᶠᵃ, Face()), (:φᶠᶠᵃ, Face()),
+                          (:Δxᶜᶜᵃ, Center()), (:Δxᶠᶜᵃ, Center()), (:Δxᶜᶠᵃ, Face()), (:Δxᶠᶠᵃ, Face()),
+                          (:Δyᶜᶜᵃ, Center()), (:Δyᶠᶜᵃ, Center()), (:Δyᶜᶠᵃ, Face()), (:Δyᶠᶠᵃ, Face()),
+                          (:Azᶜᶜᵃ, Center()), (:Azᶠᶜᵃ, Center()), (:Azᶜᶠᵃ, Face()), (:Azᶠᶠᵃ, Face())]
+
+            @test size(parent(getproperty(local_grid, var)), 2) == total_length(ℓy, TY, ny, Hy)
         end
     end
 """


### PR DESCRIPTION
On a `RightFaceFolded` grid the fold line is a y-`Face`, at j = Ny+1, so on the rank that owns the fold a `Face`-in-y metric spans one row more than a `Center`-in-y one and needs its own range. 

This PR implements it
