### PR TITLE
Run the rectangular-grid CG solver sweep once

### DIFF
--- a/test/test_conjugate_gradient_poisson_solver.jl
+++ b/test/test_conjugate_gradient_poisson_solver.jl
@@ -290,8 +290,12 @@ end
             @testset "Divergence-free solution on [$(typeof(arch)), $float_type]" begin
                 @info "  Testing divergence-free solution [$(typeof(arch)), $float_type]..."
                 test_divergence_free_solution(arch, float_type, topos)
-                test_divergence_free_solution_on_rectangular_grids(arch, topos_3d)
             end
+        end
+
+        @testset "Divergence-free solution on rectangular grids [$(typeof(arch))]" begin
+            @info "  Testing divergence-free solution on rectangular grids [$(typeof(arch))]..."
+            test_divergence_free_solution_on_rectangular_grids(arch, topos_3d)
         end
 
         # Test more than one underlying_grid


### PR DESCRIPTION
`test_divergence_free_solution_on_rectangular_grids` does not take a floating-point type, so calling it inside the `float_types` loop ran the same 32 Float64 configurations twice. The second pass costs about 20 s of solver time on CI's single-threaded `-O0` runner for no extra coverage.