### PR TITLE
Remove various `Core.Box`es being captured by closures in tests

### DIFF
--- a/test/test_lagrangian_particle_tracking.jl
+++ b/test/test_lagrangian_particle_tracking.jl
@@ -308,8 +308,7 @@ lagrangian_particle_test_grid_expanded(arch, ::Flat, z) =
 
 function lagrangian_particle_test_immersed_grid(arch, y_topo, z)
     underlying_grid = lagrangian_particle_test_grid_expanded(arch, y_topo, z)
-    z_immersed_boundary(x, z) = ifelse(z < -1, true, ifelse(z > 1, true, false))
-    z_immersed_boundary(x, y, z) = z_immersed_boundary(x, z)
+    z_immersed_boundary(x, y, z) = z < -1 || z > 1
     GFB = GridFittedBoundary(z_immersed_boundary)
     return ImmersedBoundaryGrid(underlying_grid, GFB)
 end

--- a/test/test_lagrangian_particle_tracking.jl
+++ b/test/test_lagrangian_particle_tracking.jl
@@ -308,6 +308,7 @@ lagrangian_particle_test_grid_expanded(arch, ::Flat, z) =
 
 function lagrangian_particle_test_immersed_grid(arch, y_topo, z)
     underlying_grid = lagrangian_particle_test_grid_expanded(arch, y_topo, z)
+    z_immersed_boundary(x, z) = z < -1 || z > 1
     z_immersed_boundary(x, y, z) = z < -1 || z > 1
     GFB = GridFittedBoundary(z_immersed_boundary)
     return ImmersedBoundaryGrid(underlying_grid, GFB)

--- a/test/test_multi_region_advection_diffusion.jl
+++ b/test/test_multi_region_advection_diffusion.jl
@@ -11,10 +11,10 @@ end
 
 function solid_body_tracer_advection_test(grid; P = XPartition, regions = 1)
 
-    if grid isa RectilinearGrid
-        L = 0.1
+    L = if grid isa RectilinearGrid
+        0.1
     else
-        L = 24 # degrees
+        24.0 # degrees
     end
 
     # Tracer patch parameters

--- a/test/test_zstar_conservation_explicit.jl
+++ b/test/test_zstar_conservation_explicit.jl
@@ -35,7 +35,9 @@ include("zstar_conservation_test_utils.jl")
                                                             buoyancy = BuoyancyTracer(),
                                                             vertical_coordinate = ZStarCoordinate())
 
-                        bᵢ(x, y, z) = x < grid.Lx / 2 ? 0.06 : 0.01
+                        Lx = grid.Lx
+
+                        bᵢ(x, y, z) = x < Lx / 2 ? 0.06 : 0.01
 
                         set!(model, c = (x, y, z) -> rand(), b = bᵢ, constant = 1)
 

--- a/test/test_zstar_conservation_implicit.jl
+++ b/test/test_zstar_conservation_implicit.jl
@@ -37,7 +37,9 @@ include("zstar_conservation_test_utils.jl")
                                                         buoyancy = BuoyancyTracer(),
                                                         vertical_coordinate = ZStarCoordinate())
 
-                    bᵢ(x, y, z) = x < grid.Lx / 2 ? 0.06 : 0.01
+                    Lx = grid.Lx
+
+                    bᵢ(x, y, z) = x < Lx / 2 ? 0.06 : 0.01
 
                     set!(model, c = (x, y, z) -> rand(), b = bᵢ, constant = 1)
 

--- a/validation/stratified_couette_flow/stratified_couette_flow.jl
+++ b/validation/stratified_couette_flow/stratified_couette_flow.jl
@@ -131,11 +131,15 @@ function simulate_stratified_couette_flow(; Nxy, Nz, arch=GPU(), h=1, U_wall=1,
     #####
 
     # Add a bit of surface-concentrated noise to the initial condition
-    ε(σ, z) = σ * randn() * z/model.grid.Lz * (1 + z/model.grid.Lz)
+    # Capture the extents as plain numbers so that the initial-condition functions stay isbits
+    # (kernel arguments cannot reference `model`).
+    Lx, Lz = grid.Lx, grid.Lz
+
+    ε(σ, z) = σ * randn() * z/Lz * (1 + z/Lz)
 
     # We add a sinusoidal initial condition to u to encourage instability.
-    T₀(x, y, z) = 2Θ_wall * (1/2 + z/model.grid.Lz) * (1 + ε(5e-1, z))
-    u₀(x, y, z) = 2U_wall * (1/2 + z/model.grid.Lz) * (1 + ε(5e-1, z)) * (1 + 0.5*sin(4π/model.grid.Lx * x))
+    T₀(x, y, z) = 2Θ_wall * (1/2 + z/Lz) * (1 + ε(5e-1, z))
+    u₀(x, y, z) = 2U_wall * (1/2 + z/Lz) * (1 + ε(5e-1, z)) * (1 + 0.5*sin(4π/Lx * x))
     v₀(x, y, z) = ε(5e-1, z)
     w₀(x, y, z) = ε(5e-1, z)
 
@@ -247,7 +251,6 @@ function simulate_stratified_couette_flow(; Nxy, Nz, arch=GPU(), h=1, U_wall=1,
     cfl(t) = min(0.01t, 0.1)
 
     function print_progress(simulation)
-        model = simulation.model
         clock = model.clock
 
         wizard.cfl = cfl(model.clock.time)


### PR DESCRIPTION
I mentioned multiple times that reusing same label is problematic, now it's biting us :slightly_smiling_face: 
Taken out of #5799.

> The stratified Couette flow validation script sets initial conditions via closures that reached into `model.grid` for the domain extents, and a nested `print_progress` function reassigned `model`, which turned the captured variable into a `Core.Box`. On KernelAbstractions 0.10 the CPU backend compiles kernels like GPU backends do, so these closures were rejected as non-bitstype kernel arguments:
> 
>     KernelError: passing non-bitstype argument
>       .ε is of type var"#ε#20" which is not isbits.
>         .model is of type Core.Box which is not isbits.
> 
> Capture `Lx` and `Lz` as plain numbers instead, and stop reassigning `model` inside `print_progress`, so the closures only hold numbers and compile on every backend.
