### PR TITLE
Update z-star scaling in two kernel passes

### DIFF
--- a/src/Models/HydrostaticFreeSurfaceModels/z_star_coordinate.jl
+++ b/src/Models/HydrostaticFreeSurfaceModels/z_star_coordinate.jl
@@ -33,7 +33,7 @@ The previous scaling `σᶜᶜ⁻` is also updated for use in tracer evolution.
 """
 function ab2_step_grid!(grid::MutableGridOfSomeKind, model, ztype::ZStarCoordinate, Δt, χ)
     parent(grid.z.σᶜᶜ⁻) .= parent(grid.z.σᶜᶜⁿ)
-    launch!(architecture(grid), grid, surface_kernel_parameters(grid), _update_zstar_scaling!, model.free_surface.displacement, grid)
+    update_zstar_scaling!(grid, model.free_surface.displacement)
     return nothing
 end
 
@@ -47,14 +47,32 @@ Similar to `ab2_step_grid!`, but only updates `σᶜᶜ⁻` on the final substep
 """
 function rk_substep_grid!(grid::MutableGridOfSomeKind, model, ztype::ZStarCoordinate, Δt)
     parent(grid.z.σᶜᶜ⁻) .= parent(grid.z.σᶜᶜⁿ)
-    launch!(architecture(grid), grid, surface_kernel_parameters(grid), _update_zstar_scaling!, model.free_surface.displacement, grid)
+    update_zstar_scaling!(grid, model.free_surface.displacement)
     return nothing
 end
 
-# Update η in the grid
-@kernel function _update_zstar_scaling!(ηⁿ⁺¹, grid)
+"""
+$(TYPEDSIGNATURES)
+
+Store the free surface displacement `η` in `grid.z.ηⁿ` and recompute the grid
+stretching factors `σ` at all staggered locations from it.
+"""
+function update_zstar_scaling!(grid, η)
+    arch = architecture(grid)
+    parameters = surface_kernel_parameters(grid)
+    launch!(arch, grid, parameters, _update_grid_free_surface!, grid, η)
+    # the face scalings read `ηⁿ` in neighbouring columns, so they are computed in a second pass
+    launch!(arch, grid, parameters, _update_grid_scaling!, grid)
+    return nothing
+end
+
+@kernel function _update_grid_free_surface!(grid, η)
     i, j = @index(Global, NTuple)
-    @inbounds grid.z.ηⁿ[i, j, 1] = ηⁿ⁺¹[i, j, grid.Nz+1]
+    @inbounds grid.z.ηⁿ[i, j, 1] = η[i, j, grid.Nz+1]
+end
+
+@kernel function _update_grid_scaling!(grid)
+    i, j = @index(Global, NTuple)
     update_grid_scaling!(grid.z, i, j, grid)
 end
 
@@ -187,7 +205,7 @@ free surface height (we assume that `∂t_σ = 0`).
 reconcile_vertical_coordinate!(::ZCoordinate, model, grid) = nothing
 
 function reconcile_vertical_coordinate!(::ZStarCoordinate, model, grid::MutableGridOfSomeKind)
-    launch!(architecture(grid), grid, surface_kernel_parameters(grid), _update_zstar_scaling!, model.free_surface.displacement, grid)
+    update_zstar_scaling!(grid, model.free_surface.displacement)
     parent(grid.z.σᶜᶜ⁻) .= parent(grid.z.σᶜᶜⁿ)
     return nothing
 end

--- a/test/test_diffusion_stencils.jl
+++ b/test/test_diffusion_stencils.jl
@@ -2,7 +2,7 @@ include("dependencies_for_runtests.jl")
 
 using Oceananigans.Grids: MutableVerticalDiscretization, required_halo_size_x, required_halo_size_y, required_halo_size_z
 using Oceananigans.Models: ZStarCoordinate, ZCoordinate, surface_kernel_parameters
-using Oceananigans.Models.HydrostaticFreeSurfaceModels: _update_zstar_scaling!
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: update_zstar_scaling!
 using Oceananigans.TurbulenceClosures: with_tracers,
                                        IsopycnalSkewSymmetricDiffusivity,
                                        TriadIsopycnalSkewSymmetricDiffusivity,
@@ -179,7 +179,7 @@ function horizontal_diffusion_variance(arch)
     set!(η, η₀)
     fill_halo_regions!(η)
 
-    launch!(architecture(grid), grid, surface_kernel_parameters(grid), _update_zstar_scaling!, η, grid)
+    update_zstar_scaling!(grid, η)
 
     c₀ = [0.0168  -0.1936  -0.177   0.5344;
           0.0423  -0.1258  -0.4813  0.2036;


### PR DESCRIPTION
This addresses a race condition observed in #5968: some data is being read while it's being written to https://github.com/CliMA/Oceananigans.jl/blob/bba9b74327226ac000dea481f6bd83be8e3edd7e/src/Models/HydrostaticFreeSurfaceModels/z_star_coordinate.jl#L57 causing correctness test failures.  Splitting a kernel has probably some performance implications, but correctness is quite important, too.

> `_update_zstar_scaling!` wrote `grid.z.ηⁿ[i, j]` and, in the same kernel, computed the face scalings `σᶠᶜ`, `σᶜᶠ` and `σᶠᶠ` by interpolating `ηⁿ` from the neighbouring columns `i-1` and `j-1`. Those neighbours are written by other work items, so on the GPU each thread read a mix of old and new `ηⁿ` values depending on scheduling. The CPU backend processes the columns in order, so it always saw the updated neighbours and was not affected.
> 
> In the tripolar z-star conservation test the stale reads left `σᶜᶠ` inconsistent with `ηⁿ` by up to 1.4e-5, so the sum of the active cell thicknesses in a column no longer matched the column depth (1.4e-4 m), the corrected velocities drifted from the barotropic transport by 2e-10, and the vertical velocity at the surface, which must cancel to round-off, grew to 3e-14 on the GPU (3e-21 on the CPU), failing the `< eps` check in https://github.com/CliMA/Oceananigans.jl/blob/bba9b74327226ac000dea481f6bd83be8e3edd7e/test/zstar_conservation_test_utils.jl#L50 Launching the scaling kernel a second time changed `σᶜᶠ` by 1.4e-5 on the GPU and by nothing on the CPU.
> 
> `update_zstar_scaling!(grid, η)` now stores `ηⁿ` in one launch and computes the scalings in a second one. With the fix the GPU surface residual is 2e-21 and `test_zstar_conservation_tripolar.jl`, `_explicit.jl`, `_implicit.jl` and `test_diffusion_stencils.jl` pass on the GPU with Julia 1.13 and 1.12 and on the CPU.