### PR TITLE
Generalize implicit flux boundary conditions with a Patankar fallback and add IMEX BulkDrag

### DIFF
--- a/docs/src/models/boundary_conditions.md
+++ b/docs/src/models/boundary_conditions.md
@@ -235,7 +235,42 @@ that can be used, for example, to specify cooling, heating, evaporation, or wind
     Conversely, a positive flux at a _bottom_ boundary acts to increase the interior
     values of a quantity.
 
-### 3. Spatially- and temporally-varying flux
+### 3. Implicit `Flux` boundary condition
+
+A flux that depends on the boundary-cell value of its field, like a bottom drag or a surface relaxation, limits
+the time step when integrated explicitly: with ``J = \lambda \phi_b`` the explicit step is unstable for
+``\lambda \Delta t / \Delta z > 2`` in the boundary-adjacent cell. Passing [`IMEXFluxTimeDiscretization`](@ref)
+to [`FluxBoundaryCondition`](@ref) integrates the part of the flux that is linear in ``\phi_b`` with the vertical
+tridiagonal solver instead, which the model builds automatically:
+
+```jldoctest
+julia> @inline linear_drag(i, j, grid, clock, fields, r) = @inbounds r * fields.u[i, j, grid.Nz];
+
+julia> drag_bc = FluxBoundaryCondition(linear_drag; discrete_form=true, parameters=1e-3,
+                                       time_discretization=IMEXFluxTimeDiscretization())
+IMEXFluxBoundaryCondition: DiscreteBoundaryFunction linear_drag with parameters 0.001
+```
+
+Any flux condition, whether a number, an array, a `Field`, or a function, may be integrated this way. The flux is
+split at the boundary cell into ``J \approx F_e + \lambda \phi_b`` by the Patankar rule, ``\lambda = J / \phi_b``,
+keeping only the part of ``\lambda`` that damps ``\phi_b``. A flux proportional to ``\phi_b`` is thereby fully
+implicit, while a source, such as a wind stress, is integrated explicitly. Because the rule only sees the value
+of the flux, it cannot tell a relaxation toward a nonzero target from a source. For such a flux, or whenever the
+split is known, pass the explicit part as the flux and the linear coefficient to the discretization:
+
+```jldoctest
+julia> c★, k = 20.0, 1e-4;  # relaxation target and rate
+
+julia> relaxation_bc = FluxBoundaryCondition(-k * c★; time_discretization=IMEXFluxTimeDiscretization(k))
+IMEXFluxBoundaryCondition: -0.002 + 0.0001 φᵦ
+```
+
+which represents ``J = k (c_b - c^\star)``. [`IMEXFluxBoundaryCondition`](@ref)`(-k * c★, k)` is a shorthand.
+An implicit flux is supported only on the `bottom` and `top` boundaries and on the `bottom` and `top` facets of
+an [`ImmersedBoundaryCondition`](@ref). See also [`BulkDrag`](@ref), whose drag is split exactly rather than
+by the Patankar rule.
+
+### 4. Spatially- and temporally-varying flux
 
 Boundary conditions may be specified by functions,
 
@@ -258,7 +293,7 @@ FluxBoundaryCondition: ContinuousBoundaryFunction surface_flux at (Nothing, Noth
     Alternative function signatures are specified by keyword arguments to
     `BoundaryCondition`, as illustrated in subsequent examples.
 
-### 4. Spatially- and temporally-varying flux with parameters
+### 5. Spatially- and temporally-varying flux with parameters
 
 Boundary condition functions may be 'parameterized',
 
@@ -275,7 +310,7 @@ FluxBoundaryCondition: ContinuousBoundaryFunction wind_stress at (Nothing, Nothi
     However, relatively simple objects such as floating point numbers or `NamedTuple`s must be used
     when running on the GPU.
 
-### 5. 'Field-dependent' boundary conditions
+### 6. 'Field-dependent' boundary conditions
 
 Boundary conditions may also depend on model fields. For example, a linear drag boundary condition
 is implemented with
@@ -290,7 +325,7 @@ FluxBoundaryCondition: ContinuousBoundaryFunction linear_drag at (Nothing, Nothi
 
 `field_dependencies` specifies the name of the dependent fields either with a `Symbol` or `Tuple` of `Symbol`s.
 
-### 6. 'Field-dependent' boundary conditions with parameters
+### 7. 'Field-dependent' boundary conditions with parameters
 
 When boundary conditions depends on fields _and_ parameters, their functions take the form
 
@@ -305,7 +340,7 @@ FluxBoundaryCondition: ContinuousBoundaryFunction quadratic_drag at (Nothing, No
 Put differently, `ξ, η, t` come first in the function signature, followed by field dependencies,
 followed by `parameters` is `!isnothing(parameters)`.
 
-### 7. Discrete-form boundary condition with parameters
+### 8. Discrete-form boundary condition with parameters
 
 Discrete field data may also be accessed directly from boundary condition functions
 using the `discrete_form`. For example:
@@ -333,7 +368,7 @@ FluxBoundaryCondition: DiscreteBoundaryFunction with filtered_drag
     The signature is similar for ``x`` and ``y`` boundary conditions expect that `i, j` is replaced
     with `j, k` and `i, k` respectively.
 
-### 8. Discrete-form boundary condition with parameters
+### 9. Discrete-form boundary condition with parameters
 
 ```jldoctest
 julia> Cd = 0.2; # drag coefficient
@@ -351,7 +386,7 @@ FluxBoundaryCondition: DiscreteBoundaryFunction linear_drag with parameters 0.2
     in a boundary condition function (such as `model_fields.u[i, j, 1]` in the above example).
     Using `@inbounds` will avoid a relatively expensive check that the index `i, j, 1` is 'in bounds'.
 
-### 9. A random, spatially-varying, constant-in-time temperature flux specified by an array
+### 10. A random, spatially-varying, constant-in-time temperature flux specified by an array
 
 ```jldoctest
 julia> Nx = Ny = 16;  # Number of grid points.
@@ -384,7 +419,7 @@ julia> p_top_bc = GradientBoundaryCondition(∂z_p)
 GradientBoundaryCondition: 4×4×1 Field{Center, Center, Center} on RectilinearGrid on CPU
 ```
 
-### 10. Open boundary condition with matching scheme
+### 11. Open boundary condition with matching scheme
 
 As discussed in [the numerical description of open boundary conditions](@ref numerical_bcs) it is often necessary to specify a matching scheme
 on open boundaries to approximate the behavior of the boundary nodes given the interior state
@@ -408,7 +443,7 @@ NormalFlowBoundaryCondition{PerturbationAdvection{Float64, Nothing, Nothing}}: 1
 The boundary value and timescales need to be carefully chosen to allow information to enter/
 exit the domain in each specific problem.
 
-### 11. Open boundary condition with a target transport
+### 12. Open boundary condition with a target transport
 
 A [`PerturbationAdvection`](@ref) scheme can additionally pin the *net volume transport*
 through the boundary — the integral of the normal velocity over the boundary area,
@@ -708,6 +743,51 @@ Oceananigans.FieldBoundaryConditions, with boundary conditions
 redirect_stderr(original_stderr)
 ```
 
+## Implicit flux boundary conditions
+
+An explicit dissipative flux, such as a drag or a relaxation, limits the time step to
+``\lambda \Delta t / \Delta z < 2`` in the boundary-adjacent cell, where ``\lambda`` is the flux per unit
+of the boundary value. Passing `time_discretization=IMEXFluxTimeDiscretization()` to
+[`FluxBoundaryCondition`](@ref) integrates the linear part of the flux with the vertical tridiagonal solver
+instead, which the model builds automatically. At the boundary cell the flux is split as
+``J(\phi_b) \approx F_e + \lambda \phi_b``: ``F_e`` goes through the tendency and ``\lambda \phi_b`` through the solver.
+
+How the split is found depends on the condition. A number, an array, a `Field`, or a function is split by the
+Patankar rule: ``\lambda`` is the dissipative part of ``J / \phi_b`` and the remainder ``J - \lambda \phi_b`` is
+integrated explicitly. Any dissipative flux proportional to ``\phi_b`` becomes implicit with no other change,
+here a linear drag on `u` given as a discrete function:
+
+```jldoctest
+using Oceananigans
+
+linear_drag(i, j, grid, clock, fields, r) = @inbounds - r * fields.u[i, j, 1]
+drag = FluxBoundaryCondition(linear_drag; discrete_form=true, parameters=2e-3,
+                             time_discretization=IMEXFluxTimeDiscretization())
+
+# output
+IMEXFluxBoundaryCondition: DiscreteBoundaryFunction with parameters 0.002
+```
+
+The Patankar rule estimates the slope of the flux from its value, so it only sees the part of the flux
+that vanishes with ``\phi_b``. A flux with a known linear part that does not, such as a relaxation
+``\lambda (\phi_b - \phi_\star)``, is written with its split instead, passing the explicit part ``F_e = -\lambda \phi_\star``
+as the flux and ``\lambda`` through `IMEXFluxTimeDiscretization(λ)`, or through the shorthand
+[`IMEXFluxBoundaryCondition`](@ref):
+
+```jldoctest
+using Oceananigans
+
+λ, c★ = 1e-4, 20.0
+relaxation = IMEXFluxBoundaryCondition(-λ * c★, λ)
+
+# output
+IMEXFluxBoundaryCondition: -0.002 + 0.0001 φᵦ
+```
+
+Conditions that know their own split, such as [`BulkDrag`](@ref), supply it directly. An implicit flux
+is supported only on the `bottom` and `top` boundaries and on the `bottom` and `top` facets of an
+[`ImmersedBoundaryCondition`](@ref).
+
 ## Bulk drag boundary conditions
 
 [`BulkDrag`](@ref) is a convenient constructor for velocity-flux boundary conditions
@@ -806,3 +886,35 @@ The tuple `(U∞, V∞, W∞)` is added to the prognostic velocities when comput
 speed `|U|` and the drag flux. Without this, the drag would only see the resolved
 perturbation velocity and underestimate the stress in the presence of a strong background
 current.
+
+### Implicit-explicit bottom drag
+
+An explicit drag flux limits the time step to ``C^D |\boldsymbol{U}| \Delta t / \Delta z < 2`` in the
+boundary-adjacent cell, which can be restrictive with thin bottom cells or strong near-bottom flow.
+Since the drag ``\tau = \lambda (u + U_\infty)`` with ``\lambda = -C^D |\boldsymbol{U}|`` is affine in the
+tangential velocity, its linear part can be integrated by the vertical tridiagonal solver instead.
+Pass `time_discretization=IMEXFluxTimeDiscretization()` to [`BulkDrag`](@ref):
+
+```jldoctest
+using Oceananigans
+
+drag = BulkDrag(coefficient=2e-3, time_discretization=IMEXFluxTimeDiscretization())
+u_bcs = FieldBoundaryConditions(bottom=drag)
+v_bcs = FieldBoundaryConditions(bottom=drag)
+
+grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
+model = HydrostaticFreeSurfaceModel(grid; boundary_conditions=(; u=u_bcs, v=v_bcs))
+
+model.velocities.u.boundary_conditions.bottom
+
+# output
+IMEXFluxBoundaryCondition: BulkDragFunction(QuadraticFormulation(), XDirection(), Cᴰ=0.002)
+```
+
+The explicit part ``\lambda U_\infty`` is integrated through the tendency, and the linear part
+``\lambda u`` is embedded in the boundary-cell diagonal of the implicit vertical solver, which the model
+builds automatically. For the quadratic formulation the speed ``|\boldsymbol{U}|`` is evaluated from the
+current velocities when the implicit solve is built, so the drag is linearized about the current speed.
+Like every [`IMEXFluxTimeDiscretization`](@ref), this is supported only on the `bottom` and `top` domain
+boundaries and on the `bottom` and `top` facets of an [`ImmersedBoundaryCondition`](@ref); lateral facets
+must keep the explicit drag.

--- a/docs/src/models/boundary_conditions.md
+++ b/docs/src/models/boundary_conditions.md
@@ -246,10 +246,12 @@ tridiagonal solver instead, which the model builds automatically:
 ```jldoctest
 julia> @inline linear_drag(i, j, grid, clock, fields, r) = @inbounds r * fields.u[i, j, grid.Nz];
 
-julia> drag_bc = FluxBoundaryCondition(linear_drag; discrete_form=true, parameters=1e-3,
-                                       time_discretization=IMEXFluxTimeDiscretization())
+julia> drag_bc = IMEXFluxBoundaryCondition(linear_drag; discrete_form=true, parameters=1e-3)
 IMEXFluxBoundaryCondition: DiscreteBoundaryFunction linear_drag with parameters 0.001
 ```
+
+[`IMEXFluxBoundaryCondition`](@ref)`(flux; kwargs...)` is shorthand for
+`FluxBoundaryCondition(flux; time_discretization=IMEXFluxTimeDiscretization(), kwargs...)`.
 
 Any flux condition, whether a number, an array, a `Field`, or a function, may be integrated this way. The flux is
 split at the boundary cell into ``J \approx F_e + \lambda \phi_b`` by the Patankar rule, ``\lambda = J / \phi_b``,
@@ -261,11 +263,11 @@ split is known, pass the explicit part as the flux and the linear coefficient to
 ```jldoctest
 julia> c★, k = 20.0, 1e-4;  # relaxation target and rate
 
-julia> relaxation_bc = FluxBoundaryCondition(-k * c★; time_discretization=IMEXFluxTimeDiscretization(k))
+julia> relaxation_bc = IMEXFluxBoundaryCondition(-k * c★, k)
 IMEXFluxBoundaryCondition: -0.002 + 0.0001 φᵦ
 ```
 
-which represents ``J = k (c_b - c^\star)``. [`IMEXFluxBoundaryCondition`](@ref)`(-k * c★, k)` is a shorthand.
+which represents ``J = k (c_b - c^\star)``.
 An implicit flux is supported only on the `bottom` and `top` boundaries and on the `bottom` and `top` facets of
 an [`ImmersedBoundaryCondition`](@ref). See also [`BulkDrag`](@ref), whose drag is split exactly rather than
 by the Patankar rule.
@@ -742,51 +744,6 @@ Oceananigans.FieldBoundaryConditions, with boundary conditions
 # Restore original stderr
 redirect_stderr(original_stderr)
 ```
-
-## Implicit flux boundary conditions
-
-An explicit dissipative flux, such as a drag or a relaxation, limits the time step to
-``\lambda \Delta t / \Delta z < 2`` in the boundary-adjacent cell, where ``\lambda`` is the flux per unit
-of the boundary value. Passing `time_discretization=IMEXFluxTimeDiscretization()` to
-[`FluxBoundaryCondition`](@ref) integrates the linear part of the flux with the vertical tridiagonal solver
-instead, which the model builds automatically. At the boundary cell the flux is split as
-``J(\phi_b) \approx F_e + \lambda \phi_b``: ``F_e`` goes through the tendency and ``\lambda \phi_b`` through the solver.
-
-How the split is found depends on the condition. A number, an array, a `Field`, or a function is split by the
-Patankar rule: ``\lambda`` is the dissipative part of ``J / \phi_b`` and the remainder ``J - \lambda \phi_b`` is
-integrated explicitly. Any dissipative flux proportional to ``\phi_b`` becomes implicit with no other change,
-here a linear drag on `u` given as a discrete function:
-
-```jldoctest
-using Oceananigans
-
-linear_drag(i, j, grid, clock, fields, r) = @inbounds - r * fields.u[i, j, 1]
-drag = FluxBoundaryCondition(linear_drag; discrete_form=true, parameters=2e-3,
-                             time_discretization=IMEXFluxTimeDiscretization())
-
-# output
-IMEXFluxBoundaryCondition: DiscreteBoundaryFunction with parameters 0.002
-```
-
-The Patankar rule estimates the slope of the flux from its value, so it only sees the part of the flux
-that vanishes with ``\phi_b``. A flux with a known linear part that does not, such as a relaxation
-``\lambda (\phi_b - \phi_\star)``, is written with its split instead, passing the explicit part ``F_e = -\lambda \phi_\star``
-as the flux and ``\lambda`` through `IMEXFluxTimeDiscretization(λ)`, or through the shorthand
-[`IMEXFluxBoundaryCondition`](@ref):
-
-```jldoctest
-using Oceananigans
-
-λ, c★ = 1e-4, 20.0
-relaxation = IMEXFluxBoundaryCondition(-λ * c★, λ)
-
-# output
-IMEXFluxBoundaryCondition: -0.002 + 0.0001 φᵦ
-```
-
-Conditions that know their own split, such as [`BulkDrag`](@ref), supply it directly. An implicit flux
-is supported only on the `bottom` and `top` boundaries and on the `bottom` and `top` facets of an
-[`ImmersedBoundaryCondition`](@ref).
 
 ## Bulk drag boundary conditions
 

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -6,7 +6,7 @@ export
     PeriodicBoundaryCondition, NormalFlowBoundaryCondition, NoFluxBoundaryCondition, MultiRegionCommunicationBoundaryCondition,
     FluxBoundaryCondition, ValueBoundaryCondition, GradientBoundaryCondition, DistributedCommunicationBoundaryCondition,
     IMEXFluxTimeDiscretization, IMEXFluxBoundaryCondition,
-    implicit_flux_coefficient,
+    implicit_flux_coefficient, explicit_flux,
     needs_implicit_solver, validate_implicit_explicit_flux_locations, total_boundary_flux,
     PerturbationAdvection, has_target_transport, get_target_transport,
     GravityWaveRadiation, NormalRadiation, SurfaceWaveRadiation, GravityWaveRadiationBoundaryCondition, SurfaceWaveRadiationBoundaryCondition,
@@ -41,6 +41,7 @@ struct South end
 struct North end
 struct Bottom end
 struct Top end
+struct ImmersedFacet end
 
 include("boundary_condition_classifications.jl")
 include("boundary_condition.jl")

--- a/src/BoundaryConditions/boundary_condition.jl
+++ b/src/BoundaryConditions/boundary_condition.jl
@@ -121,20 +121,21 @@ Return a `Flux` `BoundaryCondition` with `flux`.
 With the default `ExplicitTimeDiscretization`, `flux` is an ordinary flux boundary condition integrated
 through the tendency.
 
-With an [`IMEXFluxTimeDiscretization`](@ref) carrying a linear coefficient `λ`, the boundary condition
-represents the affine flux `J(φ_b) = flux + λ φ_b`, where `φ_b` is the boundary-cell field value. The
-explicit part `flux` is integrated through the tendency, while the linear part `λ φ_b` is integrated
-implicitly by the vertical tridiagonal solver. This removes the `Δz`-dependent CFL limit that an explicit
-flux imposes and is unconditionally stable for dissipative fluxes (drag, linear restoring), where `λ φ_b`
-is a sink:
+With an [`IMEXFluxTimeDiscretization`](@ref), the part of the flux that is linear in the boundary-cell
+field value `φ_b` is integrated implicitly by the vertical tridiagonal solver. This removes the `Δz`-dependent
+CFL limit that an explicit flux imposes and is unconditionally stable for dissipative fluxes such as a drag
+or a sink. The flux is split at the boundary cell as `J(φ_b) ≈ Fₑ + λ φ_b`, in one of two ways:
 
 ```julia
-FluxBoundaryCondition(flux; time_discretization = IMEXFluxTimeDiscretization(λ))
+FluxBoundaryCondition(J;  time_discretization = IMEXFluxTimeDiscretization())   # J split by the Patankar rule
+FluxBoundaryCondition(Fₑ; time_discretization = IMEXFluxTimeDiscretization(λ))  # J = Fₑ + λ φ_b
 ```
 
-`flux` and the `implicit_coefficient` follow the same conventions as any other function boundary condition;
-`kwargs` (`parameters`, `discrete_form`, `field_dependencies`) are applied to both. See also
-[`IMEXFluxBoundaryCondition`](@ref) for a shorthand.
+Without a coefficient, `J` is any flux condition (a number, an array, a `Field`, or a function) and is split by
+the Patankar rule, `λ = J / φ_b`, restricted to its dissipative part. With a coefficient `λ`, `flux` is the explicit
+part `Fₑ` and `λ` follows the same conventions as any other function boundary condition; `kwargs` (`parameters`,
+`discrete_form`, `field_dependencies`) are applied to both. See [`implicit_flux_coefficient`](@ref) for the split
+and [`IMEXFluxBoundaryCondition`](@ref) for a shorthand.
 
 !!! warning "Vertical boundaries only"
     The implicit part is embedded in the vertical tridiagonal solver, so a boundary condition with an

--- a/src/BoundaryConditions/compute_flux_bcs.jl
+++ b/src/BoundaryConditions/compute_flux_bcs.jl
@@ -46,7 +46,7 @@ Apply flux boundary conditions to a field `c` by adding the associated flux dive
 the source term `Gc` at the top and bottom.
 """
 compute_z_bcs!(Gc, grid::AbstractGrid, c, bottom_bc, top_bc, arch::AbstractArchitecture, args...) =
-    launch!(arch, grid, :xy, _compute_z_bcs!, Gc, instantiated_location(Gc), grid, bottom_bc, top_bc, Tuple(args))
+    launch!(arch, grid, :xy, _compute_z_bcs!, Gc, instantiated_location(Gc), grid, c, bottom_bc, top_bc, Tuple(args))
 
 """
 $(TYPEDSIGNATURES)
@@ -75,10 +75,10 @@ $(TYPEDSIGNATURES)
 
 Apply a top and/or bottom boundary condition to variable `c`.
 """
-@kernel function _compute_z_bcs!(Gc, loc, grid, bottom_bc, top_bc, args)
+@kernel function _compute_z_bcs!(Gc, loc, grid, c, bottom_bc, top_bc, args)
     i, j = @index(Global, NTuple)
-    compute_z_bottom_bc!(Gc, loc, bottom_bc, i, j, grid, args...)
-       compute_z_top_bc!(Gc, loc, top_bc,    i, j, grid, args...)
+    compute_z_bottom_bc!(Gc, loc, bottom_bc, i, j, grid, c, args...)
+       compute_z_top_bc!(Gc, loc, top_bc,    i, j, grid, c, args...)
 end
 
 # Shortcuts for zero flux or non-flux boundary conditions
@@ -122,9 +122,11 @@ end
     return nothing
 end
 
-@inline function compute_z_bottom_bc!(Gc, loc, bottom_flux::BC{<:Flux}, i, j, grid, args...)
+# The bottom and top fluxes may carry an implicit part; only their explicit part enters the tendency.
+@inline function compute_z_bottom_bc!(Gc, loc, bottom_flux::BC{<:Flux}, i, j, grid, c, args...)
     LX, LY, LZ = loc
-    @inbounds Gc[i, j, 1] += getbc(bottom_flux, i, j, grid, args...) * Az(i, j, 1, grid, LX, LY, flip(LZ)) / volume(i, j, 1, grid, LX, LY, LZ)
+    J = explicit_flux(bottom_flux, Bottom(), i, j, 1, grid, c, args...)
+    @inbounds Gc[i, j, 1] += J * Az(i, j, 1, grid, LX, LY, flip(LZ)) / volume(i, j, 1, grid, LX, LY, LZ)
     return nothing
 end
 
@@ -155,8 +157,9 @@ end
     return nothing
 end
 
-@inline function compute_z_top_bc!(Gc, loc, top_flux::BC{<:Flux}, i, j, grid, args...)
+@inline function compute_z_top_bc!(Gc, loc, top_flux::BC{<:Flux}, i, j, grid, c, args...)
     LX, LY, LZ = loc
-    @inbounds Gc[i, j, grid.Nz] -= getbc(top_flux, i, j, grid, args...) * Az(i, j, grid.Nz+1, grid, LX, LY, flip(LZ)) / volume(i, j, grid.Nz, grid, LX, LY, LZ)
+    J = explicit_flux(top_flux, Top(), i, j, grid.Nz, grid, c, args...)
+    @inbounds Gc[i, j, grid.Nz] -= J * Az(i, j, grid.Nz+1, grid, LX, LY, flip(LZ)) / volume(i, j, grid.Nz, grid, LX, LY, LZ)
     return nothing
 end

--- a/src/BoundaryConditions/field_boundary_conditions.jl
+++ b/src/BoundaryConditions/field_boundary_conditions.jl
@@ -263,6 +263,12 @@ end
     return MixedCondition(coefficient, inhomogeneity)
 end
 
+function regularize_boundary_condition(c::IMEXFlux, grid, args...)
+    explicit_flux = regularize_boundary_condition(c.explicit_flux, grid, args...)
+    implicit_coefficient = regularize_boundary_condition(c.implicit_coefficient, grid, args...)
+    return IMEXFlux(explicit_flux, implicit_coefficient)
+end
+
 """
     regularize_field_boundary_conditions(bcs::FieldBoundaryConditions,
                                          grid::AbstractGrid,

--- a/src/BoundaryConditions/implicit_explicit_flux_boundary_condition.jl
+++ b/src/BoundaryConditions/implicit_explicit_flux_boundary_condition.jl
@@ -1,16 +1,33 @@
 """
     struct IMEXFluxTimeDiscretization{C} <: AbstractTimeDiscretization
 
-Time-discretization of an affine `Flux` boundary condition `J(φᵦ) = Fₑ + λ φᵦ`, where `φᵦ` is the
-boundary-cell field value. `Fₑ` is integrated through the tendency and the linear part `λ φᵦ` — with
-`λ` the stored `implicit_coefficient` — by the vertical tridiagonal solver.
+Time-discretization of a `Flux` boundary condition whose linear part is integrated implicitly.
+At the boundary-adjacent cell the flux is split into
 
-    IMEXFluxTimeDiscretization(implicit_coefficient)
+```math
+J(φᵦ) ≈ Fₑ + λ φᵦ
+```
 
-Build the discretization carrying `λ`, then pass it to [`FluxBoundaryCondition`](@ref):
+where `φᵦ` is the boundary-cell field value. The explicit part `Fₑ` is integrated through the tendency
+and the linear part `λ φᵦ` by the vertical tridiagonal solver, which removes the `Δz`-dependent time step
+restriction of an explicit dissipative flux. How a boundary condition is split depends on its condition,
+see [`implicit_flux_coefficient`](@ref) and [`explicit_flux`](@ref):
+
+* A condition that carries its own split, such as an [`IMEXFlux`](@ref) or a `BulkDragFunction`, supplies
+  `Fₑ` and `λ` directly.
+* Any other condition, a number, an array, a `Field`, or a function, is split by the Patankar rule: with `J`
+  the flux at the current `φᵦ`, the dissipative part of `J / φᵦ` is the coefficient `λ` and the remainder
+  `J - λ φᵦ` is integrated explicitly.
+
+    IMEXFluxTimeDiscretization(implicit_coefficient=nothing)
+
+Build the discretization and pass it to [`FluxBoundaryCondition`](@ref). Without a coefficient, the flux
+passed to `FluxBoundaryCondition` is the whole flux `J`, split as described above. With a coefficient `λ`,
+the flux passed to `FluxBoundaryCondition` is the explicit part `Fₑ`:
 
 ```julia
-FluxBoundaryCondition(Fₑ; time_discretization = IMEXFluxTimeDiscretization(λ))
+FluxBoundaryCondition(J;  time_discretization = IMEXFluxTimeDiscretization())   # J split by the Patankar rule
+FluxBoundaryCondition(Fₑ; time_discretization = IMEXFluxTimeDiscretization(λ))  # J = Fₑ + λ φᵦ
 ```
 """
 struct IMEXFluxTimeDiscretization{C} <: AbstractTimeDiscretization
@@ -27,8 +44,8 @@ Adapt.adapt_structure(to, td::IMEXFluxTimeDiscretization) =
 """
     struct IMEXFlux{E, C}
 
-The condition of a `Flux` boundary condition with `IMEXFluxTimeDiscretization`, holding the
-`explicit_flux` `Fₑ` and the `implicit_coefficient` `λ` of the affine flux `J(φᵦ) = Fₑ + λ φᵦ`.
+A flux condition with a user-supplied affine split `J(φᵦ) = explicit_flux + implicit_coefficient φᵦ`.
+Built by [`FluxBoundaryCondition`](@ref) with an `IMEXFluxTimeDiscretization(λ)` that carries a coefficient.
 """
 struct IMEXFlux{E, C}
     explicit_flux        :: E
@@ -37,13 +54,14 @@ end
 
 const IEFBC = BoundaryCondition{<:Flux{<:IMEXFluxTimeDiscretization}}
 
-function materialize_flux_boundary_condition(explicit_flux, time_discretization::IMEXFluxTimeDiscretization;
+function materialize_flux_boundary_condition(flux, time_discretization::IMEXFluxTimeDiscretization;
                                              parameters, discrete_form, field_dependencies)
 
-    Fₑ = materialize_condition(explicit_flux,                            parameters, discrete_form, field_dependencies)
-    λ  = materialize_condition(time_discretization.implicit_coefficient, parameters, discrete_form, field_dependencies)
+    condition = materialize_condition(flux, parameters, discrete_form, field_dependencies)
+    λ = time_discretization.implicit_coefficient
+    isnothing(λ) || (condition = IMEXFlux(condition, materialize_condition(λ, parameters, discrete_form, field_dependencies)))
 
-    return BoundaryCondition(Flux(IMEXFluxTimeDiscretization()), IMEXFlux(Fₑ, λ))
+    return BoundaryCondition(Flux(IMEXFluxTimeDiscretization()), condition)
 end
 
 """
@@ -61,31 +79,99 @@ IMEXFluxBoundaryCondition(Fₑ, λ; kwargs...) =
 
 @inline getbc(condition::IMEXFlux, args...) = getbc(condition.explicit_flux, args...)
 
-"""
-    implicit_flux_coefficient(bc, i, j, grid, clock, fields)
+#####
+##### Evaluating a condition on a vertical boundary: domain boundaries take the two horizontal indices,
+##### immersed facets the three indices of the boundary-adjacent cell.
+#####
 
-The linear coefficient `λ` of an implicit-explicit `Flux` boundary condition, which the vertically-implicit
-solver embeds in the boundary-cell diagonal. Zero for any other boundary condition.
-"""
-@inline implicit_flux_coefficient(bc, i, j, grid, clock, fields) = zero(grid)
-@inline implicit_flux_coefficient(bc::IEFBC, i, j, grid, clock, fields) = getbc(bc.condition.implicit_coefficient, i, j, grid, clock, fields)
+@inline boundary_flux(condition, ::Union{Bottom, Top}, i, j, k, grid, args...) = getbc(condition, i, j, grid, args...)
+@inline boundary_flux(condition, ::ImmersedFacet,      i, j, k, grid, args...) = getbc(condition, i, j, k, grid, args...)
+@inline boundary_flux(::Nothing, boundary, i, j, k, grid, args...) = zero(grid)
 
-@inline immersed_implicit_flux_coefficient(bc, i, j, k, grid, clock, fields) = zero(grid)
-@inline immersed_implicit_flux_coefficient(bc::IEFBC, i, j, k, grid, clock, fields) = getbc(bc.condition.implicit_coefficient, i, j, k, grid, clock, fields)
+#####
+##### The affine split of a flux condition
+#####
+
+# A flux through the top enters the tendency as `-J/Δz`, through the bottom or any immersed facet as `+J/Δz`.
+# The implicit step damps `φᵦ` when `λ ≥ 0` on the top and `λ ≤ 0` elsewhere.
+@inline dissipative_part(::Top, λ) = max(λ, zero(λ))
+@inline dissipative_part(::Union{Bottom, ImmersedFacet}, λ) = min(λ, zero(λ))
+
+# The Patankar rule: `λ = J / φᵦ`, keeping only the part that damps `φᵦ`
+@inline function patankar_coefficient(boundary, J, φᵦ)
+    λ = ifelse(φᵦ == 0, zero(J), J / φᵦ)
+    return dissipative_part(boundary, λ)
+end
+
+"""
+    implicit_flux_coefficient(condition, boundary, i, j, k, grid, ϕ, args...)
+
+The linear coefficient `λ` of the affine split `J(φᵦ) ≈ Fₑ + λ φᵦ` of the flux `condition` at the
+boundary-adjacent cell `(i, j, k)` of the field `ϕ`, where `boundary` is `Bottom()`, `Top()`, or
+`ImmersedFacet()` and `args` are the arguments the condition is evaluated with (`clock, fields, ...`).
+The vertically implicit solver embeds `λ` in the boundary-cell diagonal.
+
+The fallback is the Patankar rule: with `J` the flux at the current `φᵦ`, `λ` is the dissipative part of
+`J / φᵦ`, the part with the sign that makes the implicit step damp `φᵦ`. For a flux proportional to `φᵦ`
+(a drag or a sink toward zero) this recovers `λ = J / φᵦ` and the whole flux is integrated implicitly. For a
+flux that does not vanish with `φᵦ`, such as a prescribed stress or a relaxation toward a nonzero target,
+the Patankar coefficient is zero or a poor estimate of the slope, and the remainder is integrated explicitly.
+Conditions that know their own split extend this function together with [`explicit_flux`](@ref), as
+[`IMEXFlux`](@ref) and `BulkDragFunction` do, and avoid the division.
+"""
+@inline function implicit_flux_coefficient(condition, boundary, i, j, k, grid, ϕ, args...)
+    J  = boundary_flux(condition, boundary, i, j, k, grid, args...)
+    φᵦ = @inbounds ϕ[i, j, k]
+    return patankar_coefficient(boundary, J, φᵦ)
+end
+
+"""
+    explicit_flux(condition, boundary, i, j, k, grid, ϕ, args...)
+
+The explicit part `Fₑ` of the affine split `J(φᵦ) ≈ Fₑ + λ φᵦ` of the flux `condition`, integrated through
+the tendency. See [`implicit_flux_coefficient`](@ref) for the arguments. The fallback is the Patankar
+remainder `J - λ φᵦ`.
+"""
+@inline function explicit_flux(condition, boundary, i, j, k, grid, ϕ, args...)
+    J  = boundary_flux(condition, boundary, i, j, k, grid, args...)
+    φᵦ = @inbounds ϕ[i, j, k]
+    λ  = patankar_coefficient(boundary, J, φᵦ)
+    return J - λ * φᵦ
+end
+
+# A user-supplied split
+@inline implicit_flux_coefficient(c::IMEXFlux, boundary, i, j, k, grid, ϕ, args...) = boundary_flux(c.implicit_coefficient, boundary, i, j, k, grid, args...)
+@inline explicit_flux(c::IMEXFlux, boundary, i, j, k, grid, ϕ, args...) = boundary_flux(c.explicit_flux, boundary, i, j, k, grid, args...)
+
+#####
+##### Boundary conditions: only an implicit-explicit flux has a linear part; any other boundary condition
+##### is integrated explicitly in full.
+#####
+
+@inline implicit_flux_coefficient(::Nothing,           boundary, i, j, k, grid, ϕ, args...) = zero(grid)
+@inline implicit_flux_coefficient(::BoundaryCondition, boundary, i, j, k, grid, ϕ, args...) = zero(grid)
+@inline implicit_flux_coefficient(bc::IEFBC,           boundary, i, j, k, grid, ϕ, args...) =
+    implicit_flux_coefficient(bc.condition, boundary, i, j, k, grid, ϕ, args...)
+
+@inline explicit_flux(::Nothing,             boundary, i, j, k, grid, ϕ, args...) = zero(grid)
+@inline explicit_flux(bc::BoundaryCondition, boundary, i, j, k, grid, ϕ, args...) = boundary_flux(bc, boundary, i, j, k, grid, args...)
+@inline explicit_flux(bc::IEFBC,             boundary, i, j, k, grid, ϕ, args...) =
+    explicit_flux(bc.condition, boundary, i, j, k, grid, ϕ, args...)
 
 needs_implicit_solver(bc) = false
 needs_implicit_solver(bc::IEFBC) = true
 
 """
-    total_boundary_flux(bc, i, j, k, grid, clock, fields, ϕ)
+    total_boundary_flux(bc, boundary, i, j, k, grid, ϕ, args...)
 
-The realized boundary flux of `bc` for the field `ϕ`, evaluated with the boundary-cell value `ϕ[i, j, k]`
-(`k = Nz` on a top boundary, `k = 1` on a bottom boundary). A derived boundary condition that needs the
-actual flux, such as the friction velocity `u★` of a TKE closure, reconstructs `Fₑ + λ φᵦ` with this
-function. For any other boundary condition it is `getbc`.
+The realized boundary flux `Fₑ + λ φᵦ` of `bc` for the field `ϕ`, evaluated with the boundary-cell value
+`ϕ[i, j, k]` (`k = Nz` on the `Top()`, `k = 1` on the `Bottom()`). A derived boundary condition that needs
+the actual flux, such as the friction velocity `u★` of a TKE closure, reconstructs it with this function.
+For a boundary condition without an implicit part it is the flux itself.
 """
-@inline total_boundary_flux(bc, i, j, k, grid, clock, fields, ϕ) = getbc(bc, i, j, grid, clock, fields)
-@inline total_boundary_flux(bc::IEFBC, i, j, k, grid, clock, fields, ϕ) = @inbounds getbc(bc, i, j, grid, clock, fields) + implicit_flux_coefficient(bc, i, j, grid, clock, fields) * ϕ[i, j, k]
+@inline total_boundary_flux(bc, boundary, i, j, k, grid, ϕ, args...) =
+    explicit_flux(bc, boundary, i, j, k, grid, ϕ, args...) +
+    implicit_flux_coefficient(bc, boundary, i, j, k, grid, ϕ, args...) * @inbounds ϕ[i, j, k]
 
 function validate_implicit_explicit_flux_locations(bcs)
     for side in (bcs.west, bcs.east, bcs.south, bcs.north)

--- a/src/BoundaryConditions/implicit_explicit_flux_boundary_condition.jl
+++ b/src/BoundaryConditions/implicit_explicit_flux_boundary_condition.jl
@@ -65,15 +65,24 @@ function materialize_flux_boundary_condition(flux, time_discretization::IMEXFlux
 end
 
 """
+    IMEXFluxBoundaryCondition(flux; kwargs...)
     IMEXFluxBoundaryCondition(explicit_flux, implicit_coefficient; kwargs...)
 
-Return a `Flux` boundary condition with the affine flux `J(φᵦ) = explicit_flux + implicit_coefficient φᵦ`.
-Shorthand for
+Return a `Flux` boundary condition whose linear part is integrated implicitly. With one argument, `flux` is
+the total flux `J` and is split at the boundary cell according to its condition (by the Patankar rule unless
+the condition supplies its own split). With two arguments, the boundary condition represents the affine flux
+`J(φᵦ) = explicit_flux + implicit_coefficient φᵦ`. Shorthands for
 
 ```julia
+FluxBoundaryCondition(flux;          time_discretization = IMEXFluxTimeDiscretization(), kwargs...)
 FluxBoundaryCondition(explicit_flux; time_discretization = IMEXFluxTimeDiscretization(implicit_coefficient), kwargs...)
 ```
+
+See [`IMEXFluxTimeDiscretization`](@ref).
 """
+IMEXFluxBoundaryCondition(J; kwargs...) =
+    FluxBoundaryCondition(J; time_discretization = IMEXFluxTimeDiscretization(), kwargs...)
+
 IMEXFluxBoundaryCondition(Fₑ, λ; kwargs...) =
     FluxBoundaryCondition(Fₑ; time_discretization = IMEXFluxTimeDiscretization(λ), kwargs...)
 

--- a/src/BoundaryConditions/show_boundary_conditions.jl
+++ b/src/BoundaryConditions/show_boundary_conditions.jl
@@ -26,6 +26,7 @@ Base.summary(bc::DFBC)                          = string("DefaultBoundaryConditi
 Base.summary(bc::NFBC{NormalFlow{MS}}) where MS = string("NormalFlowBoundaryCondition{$MS}: ", prettysummary(bc.condition))
 Base.summary(bc::IBC)                           = string("ImpenetrableBoundaryCondition")
 Base.summary(bc::FBC)                           = string("FluxBoundaryCondition: ", prettysummary(bc.condition))
+Base.summary(bc::IEFBC)                         = string("IMEXFluxBoundaryCondition: ", prettysummary(bc.condition))
 Base.summary(bc::VBC)                           = string("ValueBoundaryCondition: ", prettysummary(bc.condition))
 Base.summary(bc::GBC)                           = string("GradientBoundaryCondition: ", prettysummary(bc.condition))
 Base.summary(::PBC)                             = string("PeriodicBoundaryCondition")
@@ -40,6 +41,9 @@ function Base.summary(bc::MBC)
 end
 
 Base.show(io::IO, bc::BoundaryCondition) = print(io, summary(bc))
+
+Base.summary(c::IMEXFlux) = string(prettysummary(c.explicit_flux), " + ", prettysummary(c.implicit_coefficient), " φᵦ")
+Base.show(io::IO, c::IMEXFlux) = print(io, summary(c))
 
 #####
 ##### FieldBoundaryConditions

--- a/src/BuoyancyFormulations/BuoyancyFormulations.jl
+++ b/src/BuoyancyFormulations/BuoyancyFormulations.jl
@@ -10,7 +10,7 @@ using SeawaterPolynomials: SeawaterPolynomials, ρ′, thermal_expansion, haline
 
 using Oceananigans: Oceananigans
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ, ∂xᵣᶠᶜᶜ, ∂yᵣᶜᶠᶜ, ∂xᶠᶜᶜ, ∂yᶜᶠᶜ, ∂zᶜᶜᶠ
-using Oceananigans.BoundaryConditions: total_boundary_flux
+using Oceananigans.BoundaryConditions: total_boundary_flux, Bottom, Top
 
 """
     AbstractBuoyancyFormulation{EOS}

--- a/src/BuoyancyFormulations/buoyancy_tracer.jl
+++ b/src/BuoyancyFormulations/buoyancy_tracer.jl
@@ -17,5 +17,5 @@ required_tracers(::BuoyancyTracer) = (:b,)
 @inline  ∂y_b(i, j, k, grid, ::BuoyancyTracer, C) =  ∂yᶜᶠᶜ(i, j, k, grid, C.b)
 @inline  ∂z_b(i, j, k, grid, ::BuoyancyTracer, C) =  ∂zᶜᶜᶠ(i, j, k, grid, C.b)
 
-@inline    top_buoyancy_flux(i, j, grid, ::BuoyancyTracer, top_tracer_bcs, clock, fields) = total_boundary_flux(top_tracer_bcs.b, i, j, size(grid, 3), grid, clock, fields, fields.b)
-@inline bottom_buoyancy_flux(i, j, grid, ::BuoyancyTracer, bottom_tracer_bcs, clock, fields) = total_boundary_flux(bottom_tracer_bcs.b, i, j, 1, grid, clock, fields, fields.b)
+@inline    top_buoyancy_flux(i, j, grid, ::BuoyancyTracer, top_tracer_bcs, clock, fields) = total_boundary_flux(top_tracer_bcs.b, Top(), i, j, size(grid, 3), grid, fields.b, clock, fields)
+@inline bottom_buoyancy_flux(i, j, grid, ::BuoyancyTracer, bottom_tracer_bcs, clock, fields) = total_boundary_flux(bottom_tracer_bcs.b, Bottom(), i, j, 1, grid, fields.b, clock, fields)

--- a/src/BuoyancyFormulations/seawater_buoyancy.jl
+++ b/src/BuoyancyFormulations/seawater_buoyancy.jl
@@ -245,18 +245,18 @@ end
 @inline get_temperature_and_salinity_flux(::TemperatureSeawaterBuoyancy, bcs) = bcs.T, NoFluxBoundaryCondition()
 @inline get_temperature_and_salinity_flux(::SalinitySeawaterBuoyancy, bcs) = NoFluxBoundaryCondition(), bcs.S
 
-@inline function top_bottom_buoyancy_flux(i, j, k, grid, b::SeawaterBuoyancy, top_bottom_tracer_bcs, clock, fields)
+@inline function top_bottom_buoyancy_flux(i, j, k, grid, boundary, b::SeawaterBuoyancy, top_bottom_tracer_bcs, clock, fields)
     T, S = get_temperature_and_salinity(b, fields)
     T_flux_bc, S_flux_bc = get_temperature_and_salinity_flux(b, top_bottom_tracer_bcs)
 
     kc = clamp(k, 1, size(grid, 3))   # boundary cell adjacent to face k (top: Nz, bottom: 1)
-    T_flux = total_boundary_flux(T_flux_bc, i, j, kc, grid, clock, fields, T)
-    S_flux = total_boundary_flux(S_flux_bc, i, j, kc, grid, clock, fields, S)
+    T_flux = total_boundary_flux(T_flux_bc, boundary, i, j, kc, grid, T, clock, fields)
+    S_flux = total_boundary_flux(S_flux_bc, boundary, i, j, kc, grid, S, clock, fields)
 
     return b.gravitational_acceleration * (
               thermal_expansionᶜᶜᶠ(i, j, k, grid, b.equation_of_state, T, S) * T_flux
            - haline_contractionᶜᶜᶠ(i, j, k, grid, b.equation_of_state, T, S) * S_flux)
 end
 
-@inline    top_buoyancy_flux(i, j, grid, b::SeawaterBuoyancy, args...) = top_bottom_buoyancy_flux(i, j, grid.Nz+1, grid, b, args...)
-@inline bottom_buoyancy_flux(i, j, grid, b::SeawaterBuoyancy, args...) = top_bottom_buoyancy_flux(i, j, 1, grid, b, args...)
+@inline    top_buoyancy_flux(i, j, grid, b::SeawaterBuoyancy, args...) = top_bottom_buoyancy_flux(i, j, grid.Nz+1, grid, Top(),    b, args...)
+@inline bottom_buoyancy_flux(i, j, grid, b::SeawaterBuoyancy, args...) = top_bottom_buoyancy_flux(i, j, 1,         grid, Bottom(), b, args...)

--- a/src/ImmersedBoundaries/immersed_boundary_condition.jl
+++ b/src/ImmersedBoundaries/immersed_boundary_condition.jl
@@ -4,7 +4,7 @@ using Oceananigans.BoundaryConditions: BoundaryConditions,
                                        LeftBoundary,
                                        RightBoundary,
                                        regularize_boundary_condition,
-                                       VBC, GBC, FBC, Flux,
+                                       VBC, GBC, FBC, IEFBC, Flux,
                                        needs_implicit_solver
 
 import Oceananigans.BoundaryConditions: regularize_immersed_boundary_condition,
@@ -65,6 +65,13 @@ function ImmersedBoundaryCondition(; west = nothing,
 end
 
 BoundaryConditions.needs_implicit_solver(ibc::ImmersedBoundaryCondition) = needs_implicit_solver(ibc.bottom) | needs_implicit_solver(ibc.top)
+
+function BoundaryConditions.validate_immersed_implicit_explicit_flux(ibc::ImmersedBoundaryCondition)
+    for facet in (ibc.west, ibc.east, ibc.south, ibc.north)
+        facet isa IEFBC && error("IMEXFluxTimeDiscretization is supported only on the bottom and top facets of an ImmersedBoundaryCondition")
+    end
+    return nothing
+end
 
 #####
 ##### Boundary condition "regularization"

--- a/src/Models/BulkDragBoundaryConditions.jl
+++ b/src/Models/BulkDragBoundaryConditions.jl
@@ -30,7 +30,8 @@ using DocStringExtensions: TYPEDSIGNATURES
 
 using Oceananigans.Architectures: Architectures, on_architecture
 using Oceananigans.BoundaryConditions: BoundaryConditions, BoundaryCondition, Flux,
-                                       LeftBoundary, RightBoundary
+                                       LeftBoundary, RightBoundary, Bottom, Top, ImmersedFacet,
+                                       ExplicitTimeDiscretization, IMEXFluxTimeDiscretization
 using Oceananigans.Grids: AbstractGrid, XDirection, YDirection, ZDirection, Face
 using Oceananigans.Operators: ℑxyᶠᶜᵃ, ℑxyᶜᶠᵃ, ℑxzᶠᵃᶜ, ℑyzᵃᶠᶜ, ℑxzᶜᵃᶠ, ℑyzᵃᶜᶠ
 
@@ -141,141 +142,88 @@ function Base.show(io::IO, df::BulkDragFunction)
 end
 
 #####
-##### getbc for BulkDragFunction
+##### The drag coefficient λ, such that the drag flux on the tangential velocity is λ (u + U∞)
 #####
+
+# Quadratic drag: λ = -Cᴰ |U|
+@inline x_drag_coefficient(i, j, k, grid, ::QuadraticFormulation, fields, Cᴰ, U∞, V∞, W∞) = - Cᴰ * sqrt(speed²ᶠᶜᶜ(i, j, k, grid, fields, U∞, V∞, W∞))
+@inline y_drag_coefficient(i, j, k, grid, ::QuadraticFormulation, fields, Cᴰ, U∞, V∞, W∞) = - Cᴰ * sqrt(speed²ᶜᶠᶜ(i, j, k, grid, fields, U∞, V∞, W∞))
+@inline z_drag_coefficient(i, j, k, grid, ::QuadraticFormulation, fields, Cᴰ, U∞, V∞, W∞) = - Cᴰ * sqrt(speed²ᶜᶜᶠ(i, j, k, grid, fields, U∞, V∞, W∞))
+
+# Linear drag (Rayleigh friction): λ = -Cᴰ
+@inline x_drag_coefficient(i, j, k, grid, ::LinearFormulation, fields, Cᴰ, U∞, V∞, W∞) = - Cᴰ
+@inline y_drag_coefficient(i, j, k, grid, ::LinearFormulation, fields, Cᴰ, U∞, V∞, W∞) = - Cᴰ
+@inline z_drag_coefficient(i, j, k, grid, ::LinearFormulation, fields, Cᴰ, U∞, V∞, W∞) = - Cᴰ
 
 const XDBDF = XDirectionBulkDragFunction
 const YDBDF = YDirectionBulkDragFunction
 const ZDBDF = ZDirectionBulkDragFunction
 
-#####
-##### Core drag computations dispatched on formulation
-#####
+@inline drag_coefficient(i, j, k, grid, df::XDBDF, fields) = x_drag_coefficient(i, j, k, grid, df.formulation, fields, df.coefficient, df.background_velocities...)
+@inline drag_coefficient(i, j, k, grid, df::YDBDF, fields) = y_drag_coefficient(i, j, k, grid, df.formulation, fields, df.coefficient, df.background_velocities...)
+@inline drag_coefficient(i, j, k, grid, df::ZDBDF, fields) = z_drag_coefficient(i, j, k, grid, df.formulation, fields, df.coefficient, df.background_velocities...)
 
-# Quadratic drag: τ = -Cᴰ |U| u
-@inline function _x_bulk_drag(i, j, k, grid, ::QuadraticFormulation, fields, Cᴰ, U∞, V∞, W∞)
-    u = @inbounds fields.u[i, j, k]
-    U² = speed²ᶠᶜᶜ(i, j, k, grid, fields, U∞, V∞, W∞)
-    U = sqrt(U²)
-    return - Cᴰ * U * (u + U∞)
-end
+@inline tangential_velocity(i, j, k, grid, ::XDBDF, fields) = @inbounds fields.u[i, j, k]
+@inline tangential_velocity(i, j, k, grid, ::YDBDF, fields) = @inbounds fields.v[i, j, k]
+@inline tangential_velocity(i, j, k, grid, ::ZDBDF, fields) = @inbounds fields.w[i, j, k]
 
-@inline function _y_bulk_drag(i, j, k, grid, ::QuadraticFormulation, fields, Cᴰ, U∞, V∞, W∞)
-    v = @inbounds fields.v[i, j, k]
-    U² = speed²ᶜᶠᶜ(i, j, k, grid, fields, U∞, V∞, W∞)
-    U = sqrt(U²)
-    return - Cᴰ * U * (v + V∞)
-end
+@inline background_velocity(df::XDBDF) = df.background_velocities[1]
+@inline background_velocity(df::YDBDF) = df.background_velocities[2]
+@inline background_velocity(df::ZDBDF) = df.background_velocities[3]
 
-@inline function _z_bulk_drag(i, j, k, grid, ::QuadraticFormulation, fields, Cᴰ, U∞, V∞, W∞)
-    w = @inbounds fields.w[i, j, k]
-    U² = speed²ᶜᶜᶠ(i, j, k, grid, fields, U∞, V∞, W∞)
-    U = sqrt(U²)
-    return - Cᴰ * U * (w + W∞)
-end
-
-# Linear drag (Rayleigh friction): τ = -Cᴰ u
-@inline function _x_bulk_drag(i, j, k, grid, ::LinearFormulation, fields, Cᴰ, U∞, V∞, W∞)
-    u = @inbounds fields.u[i, j, k]
-    return - Cᴰ * (u + U∞)
-end
-
-@inline function _y_bulk_drag(i, j, k, grid, ::LinearFormulation, fields, Cᴰ, U∞, V∞, W∞)
-    v = @inbounds fields.v[i, j, k]
-    return - Cᴰ * (v + V∞)
-end
-
-@inline function _z_bulk_drag(i, j, k, grid, ::LinearFormulation, fields, Cᴰ, U∞, V∞, W∞)
-    w = @inbounds fields.w[i, j, k]
-    return - Cᴰ * (w + W∞)
+# The drag flux λ (u + U∞) along the inward-pointing boundary normal
+@inline function bulk_drag(i, j, k, grid, df::BulkDragFunction, fields)
+    λ  = drag_coefficient(i, j, k, grid, df, fields)
+    u  = tangential_velocity(i, j, k, grid, df, fields)
+    U∞ = background_velocity(df)
+    return λ * (u + U∞)
 end
 
 #####
-##### Helper for boundary index
+##### Domain boundaries: map the two boundary indices to (i, j, k) and orient the flux
 #####
 
 @inline boundary_index(::LeftBoundary,  N) = 1
 @inline boundary_index(::RightBoundary, N) = N
 
-#####
-##### Domain boundary getbc methods (2-index signatures)
-#####
+# `dim` is the boundary-normal direction: the boundary index replaces the missing one
+@inline boundary_ijk(::Val{1}, side, j, k, grid) = (boundary_index(side, grid.Nx), j, k)
+@inline boundary_ijk(::Val{2}, side, i, k, grid) = (i, boundary_index(side, grid.Ny), k)
+@inline boundary_ijk(::Val{3}, side, i, j, grid) = (i, j, boundary_index(side, grid.Nz))
 
-# Type aliases for dimension dispatch
-const XNormalBulkDragFunction{D} = BulkDragFunction{D, <:Any, Val{1}} where D  # dim=1: west/east
-const YNormalBulkDragFunction{D} = BulkDragFunction{D, <:Any, Val{2}} where D  # dim=2: south/north
-const ZNormalBulkDragFunction{D} = BulkDragFunction{D, <:Any, Val{3}} where D  # dim=3: bottom/top
+# A flux on a left boundary (west, south, bottom) enters the tendency as +J/Δ, and on a right
+# boundary (east, north, top) as -J/Δ. The drag `λ (u + U∞)` is a sink along the inward normal,
+# so on a right boundary it must be flipped to oppose the flow rather than accelerate it.
+@inline boundary_sign(::LeftBoundary)  = 1
+@inline boundary_sign(::RightBoundary) = -1
 
-# z-normal boundaries (bottom/top): getbc(df, i, j, grid, ...)
-# Applies to u-velocity (XDirection) and v-velocity (YDirection)
-@inline function BoundaryConditions.getbc(df::ZNormalBulkDragFunction{<:XDirection}, i::Integer, j::Integer,
+@inline function BoundaryConditions.getbc(df::BulkDragFunction, a::Integer, b::Integer,
                                           grid::AbstractGrid, clock, fields, args...)
-    U∞, V∞, W∞ = df.background_velocities
-    k = boundary_index(df.side, grid.Nz)
-    return _x_bulk_drag(i, j, k, grid, df.formulation, fields, df.coefficient, U∞, V∞, W∞)
-end
-
-@inline function BoundaryConditions.getbc(df::ZNormalBulkDragFunction{<:YDirection}, i::Integer, j::Integer,
-                                          grid::AbstractGrid, clock, fields, args...)
-    U∞, V∞, W∞ = df.background_velocities
-    k = boundary_index(df.side, grid.Nz)
-    return _y_bulk_drag(i, j, k, grid, df.formulation, fields, df.coefficient, U∞, V∞, W∞)
-end
-
-# x-normal boundaries (west/east): getbc(df, j, k, grid, ...)
-# Applies to v-velocity (YDirection) and w-velocity (ZDirection)
-@inline function BoundaryConditions.getbc(df::XNormalBulkDragFunction{<:YDirection}, j::Integer, k::Integer,
-                                          grid::AbstractGrid, clock, fields, args...)
-    U∞, V∞, W∞ = df.background_velocities
-    i = boundary_index(df.side, grid.Nx)
-    return _y_bulk_drag(i, j, k, grid, df.formulation, fields, df.coefficient, U∞, V∞, W∞)
-end
-
-@inline function BoundaryConditions.getbc(df::XNormalBulkDragFunction{<:ZDirection}, j::Integer, k::Integer,
-                                          grid::AbstractGrid, clock, fields, args...)
-    U∞, V∞, W∞ = df.background_velocities
-    i = boundary_index(df.side, grid.Nx)
-    return _z_bulk_drag(i, j, k, grid, df.formulation, fields, df.coefficient, U∞, V∞, W∞)
-end
-
-# y-normal boundaries (south/north): getbc(df, i, k, grid, ...)
-# Applies to u-velocity (XDirection) and w-velocity (ZDirection)
-@inline function BoundaryConditions.getbc(df::YNormalBulkDragFunction{<:XDirection}, i::Integer, k::Integer,
-                                          grid::AbstractGrid, clock, fields, args...)
-    U∞, V∞, W∞ = df.background_velocities
-    j = boundary_index(df.side, grid.Ny)
-    return _x_bulk_drag(i, j, k, grid, df.formulation, fields, df.coefficient, U∞, V∞, W∞)
-end
-
-@inline function BoundaryConditions.getbc(df::YNormalBulkDragFunction{<:ZDirection}, i::Integer, k::Integer,
-                                          grid::AbstractGrid, clock, fields, args...)
-    U∞, V∞, W∞ = df.background_velocities
-    j = boundary_index(df.side, grid.Ny)
-    return _z_bulk_drag(i, j, k, grid, df.formulation, fields, df.coefficient, U∞, V∞, W∞)
+    i, j, k = boundary_ijk(df.dim, df.side, a, b, grid)
+    return boundary_sign(df.side) * bulk_drag(i, j, k, grid, df, fields)
 end
 
 #####
-##### Immersed boundary getbc methods (3-index signatures)
+##### Immersed boundaries: (i, j, k) is the boundary-adjacent cell and every facet flux points inward
 #####
 
-# Immersed boundaries always use (i, j, k) explicitly
-@inline function BoundaryConditions.getbc(df::XDBDF, i::Integer, j::Integer, k::Integer,
-                                          grid::AbstractGrid, clock, fields, args...)
-    U∞, V∞, W∞ = df.background_velocities
-    return _x_bulk_drag(i, j, k, grid, df.formulation, fields, df.coefficient, U∞, V∞, W∞)
-end
+@inline BoundaryConditions.getbc(df::BulkDragFunction, i::Integer, j::Integer, k::Integer,
+                                 grid::AbstractGrid, clock, fields, args...) = bulk_drag(i, j, k, grid, df, fields)
 
-@inline function BoundaryConditions.getbc(df::YDBDF, i::Integer, j::Integer, k::Integer,
-                                          grid::AbstractGrid, clock, fields, args...)
-    U∞, V∞, W∞ = df.background_velocities
-    return _y_bulk_drag(i, j, k, grid, df.formulation, fields, df.coefficient, U∞, V∞, W∞)
-end
+#####
+##### Implicit-explicit time discretization: the drag λ (u + U∞) is affine in the tangential velocity, so
+##### the explicit part is `λ U∞` and the linear part `λ u` goes into the vertical tridiagonal solver.
+##### For the quadratic formulation the speed |U| in λ is lagged (evaluated when the diagonal is built).
+#####
 
-@inline function BoundaryConditions.getbc(df::ZDBDF, i::Integer, j::Integer, k::Integer,
-                                          grid::AbstractGrid, clock, fields, args...)
-    U∞, V∞, W∞ = df.background_velocities
-    return _z_bulk_drag(i, j, k, grid, df.formulation, fields, df.coefficient, U∞, V∞, W∞)
-end
+@inline boundary_sign(::Top) = -1
+@inline boundary_sign(::Union{Bottom, ImmersedFacet}) = 1
+
+@inline BoundaryConditions.implicit_flux_coefficient(df::BulkDragFunction, boundary, i, j, k, grid, ϕ, clock, fields, args...) =
+    boundary_sign(boundary) * drag_coefficient(i, j, k, grid, df, fields)
+
+@inline BoundaryConditions.explicit_flux(df::BulkDragFunction, boundary, i, j, k, grid, ϕ, clock, fields, args...) =
+    BoundaryConditions.implicit_flux_coefficient(df, boundary, i, j, k, grid, ϕ, clock, fields) * background_velocity(df)
 
 #####
 ##### Type alias for FluxBoundaryCondition with BulkDragFunction
@@ -293,6 +241,7 @@ $(TYPEDSIGNATURES)
 Regularize a `BulkDragFunction` by:
 1. Inferring the direction from the field location if not specified
 2. Setting the boundary side and dimension from the regularization context
+3. Converting numeric parameters to the grid's float type
 
 The direction is inferred as follows:
 - If `loc[1] == Face`, the field is a u-velocity → `XDirection()`
@@ -304,47 +253,44 @@ The dimension `dim` indicates which axis the boundary is normal to:
 - `dim=2`: y-normal boundary (south/north)
 - `dim=3`: z-normal boundary (bottom/top)
 """
-function BoundaryConditions.regularize_boundary_condition(df::BulkDragFunction{Nothing}, grid, loc, dim, Side, field_names)
-    # Infer direction from field location
+function BoundaryConditions.regularize_boundary_condition(df::BulkDragFunction, grid, loc, dim, Side, field_names)
+    direction = infer_direction(df.direction, loc)
+    FT = eltype(grid)
+    coefficient = regularize_parameter(FT, df.coefficient)
+    background_velocities = map(U -> regularize_parameter(FT, U), df.background_velocities)
+
+    # Side() instantiates the Side type (e.g., LeftBoundary → LeftBoundary())
+    # Val{dim} is used for type dispatch in getbc methods
+    return BulkDragFunction(direction, Side(), Val{dim}(), df.formulation, coefficient, background_velocities)
+end
+
+infer_direction(direction, loc) = direction
+
+function infer_direction(::Nothing, loc)
     if loc[1] isa Face
-        direction = XDirection()
+        return XDirection()
     elseif loc[2] isa Face
-        direction = YDirection()
+        return YDirection()
     elseif loc[3] isa Face
-        direction = ZDirection()
+        return ZDirection()
     else
         error("Cannot infer BulkDragFunction direction for field at location $loc. " *
               "Please specify direction explicitly.")
     end
-    # Side() instantiates the Side type (e.g., LeftBoundary → LeftBoundary())
-    # Val{dim} is used for type dispatch in getbc methods
-    return BulkDragFunction(direction, Side(), Val{dim}(), df.formulation, df.coefficient, df.background_velocities)
 end
 
-# Direction already specified, just set the Side and dim
-function BoundaryConditions.regularize_boundary_condition(df::BulkDragFunction, grid, loc, dim, Side, field_names)
-    return BulkDragFunction(df.direction, Side(), Val{dim}(), df.formulation, df.coefficient, df.background_velocities)
-end
+regularize_parameter(FT, p::Number) = convert(FT, p)
+regularize_parameter(FT, p) = p
 
 #####
 ##### Convenient constructor
 #####
 
 """
-    BulkDrag(formulation=QuadraticFormulation(); coefficient, background_velocities=(0, 0, 0))
+    BulkDrag(formulation=QuadraticFormulation(); coefficient, background_velocities=(0, 0, 0),
+             time_discretization=ExplicitTimeDiscretization())
 
 Create a `FluxBoundaryCondition` for velocity drag on any boundary.
-
-# Positional Arguments
-
-- `formulation`: The drag formulation, either `QuadraticFormulation()` (default) or `LinearFormulation()`.
-
-# Keyword Arguments
-
-- `coefficient`: The drag coefficient (required).
-- `background_velocities`: Background velocities as a tuple `(U∞, V∞, W∞)` (default: `(0, 0, 0)`).
-  These are added to the prognostic velocities when computing both the speed and the drag.
-
 
 With `QuadraticFormulation()` (default), the drag is:
 ```math
@@ -377,6 +323,36 @@ See [`BulkDragFunction`](@ref) for details.
                `ZDirection()`). If `nothing`, the direction is automatically inferred from
                the field location during boundary condition regularization.
 - `background_velocities`: Background velocities as a tuple `(U∞, V∞, W∞)` (default: `(0, 0, 0)`).
+  These are added to the prognostic velocities when computing both the speed and the drag.
+- `time_discretization`: Either `ExplicitTimeDiscretization()` (default), which integrates the drag
+                         through the tendency, or `IMEXFluxTimeDiscretization()`, which integrates
+                         the linear part of the drag implicitly (see below).
+
+# Implicit-explicit time discretization
+
+The drag is affine in the tangential velocity, ``τ = λ (u + U_∞)`` with ``λ = -C^D |U + U_∞|`` for the
+quadratic formulation and ``λ = -C^D`` for the linear one. With `time_discretization = IMEXFluxTimeDiscretization()`,
+the explicit part ``λ U_∞`` is integrated through the tendency while the linear part ``λ u`` is embedded in the
+vertical tridiagonal solver, which removes the time step restriction ``C^D |U| Δt / Δz < 2`` of the explicit
+treatment. For the quadratic formulation the speed ``|U + U_∞|`` in ``λ`` is evaluated from the current velocities
+when the implicit solve is built, so the drag is linearized about the current speed.
+
+Like every [`IMEXFluxTimeDiscretization`](@ref), this is supported only on the `bottom` and `top` boundaries and on
+the `bottom` and `top` facets of an [`ImmersedBoundaryCondition`](@ref).
+
+```jldoctest
+using Oceananigans
+
+drag = BulkDrag(coefficient=1e-3, time_discretization=IMEXFluxTimeDiscretization())
+u_bcs = FieldBoundaryConditions(bottom=drag)
+
+grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
+model = HydrostaticFreeSurfaceModel(grid; boundary_conditions=(; u=u_bcs))
+model.velocities.u.boundary_conditions.bottom
+
+# output
+IMEXFluxBoundaryCondition: BulkDragFunction(QuadraticFormulation(), XDirection(), Cᴰ=0.001)
+```
 
 # Examples
 
@@ -482,7 +458,15 @@ ImmersedBoundaryCondition:
 └── top: FluxBoundaryCondition: BulkDragFunction(QuadraticFormulation(), XDirection(), Cᴰ=0.001)
 ```
 """
-BulkDrag(formulation=QuadraticFormulation(); kwargs...) =
-    BoundaryCondition(Flux(), BulkDragFunction(formulation; kwargs...))
+function BulkDrag(formulation=QuadraticFormulation(); time_discretization=ExplicitTimeDiscretization(), kwargs...)
+    validate_drag_time_discretization(time_discretization)
+    return BoundaryCondition(Flux(time_discretization), BulkDragFunction(formulation; kwargs...))
+end
+
+validate_drag_time_discretization(td) = nothing
+
+validate_drag_time_discretization(td::IMEXFluxTimeDiscretization) =
+    isnothing(td.implicit_coefficient) ||
+        throw(ArgumentError("BulkDrag computes its own implicit coefficient; pass IMEXFluxTimeDiscretization() without one"))
 
 end # module

--- a/src/TurbulenceClosures/immersed_diffusive_fluxes.jl
+++ b/src/TurbulenceClosures/immersed_diffusive_fluxes.jl
@@ -1,5 +1,5 @@
 using Oceananigans.BoundaryConditions: Value, Gradient, BoundaryCondition
-using Oceananigans.BoundaryConditions: getbc
+using Oceananigans.BoundaryConditions: getbc, explicit_flux, ImmersedFacet
 using Oceananigans.BoundaryConditions: FBC, ZFBC
 using Oceananigans.Operators: index_left, index_right, Δx, Δy, Δz, div
 
@@ -55,7 +55,7 @@ for side in (:west, :south, :bottom)
     side_ib_flux = Symbol(side, :_ib_flux)
     @eval begin
         @inline $side_ib_flux(i, j, k, ibg, ::Nothing, args...) = zero(eltype(ibg))
-        @inline $side_ib_flux(i, j, k, ibg, bc::FBC, loc, c, closure, K, id, args...) = + getbc(bc, i, j, k, ibg, args...)
+        @inline $side_ib_flux(i, j, k, ibg, bc::FBC, loc, c, closure, K, id, args...) = + explicit_flux(bc, ImmersedFacet(), i, j, k, ibg, c, args...)
     end
 end
 
@@ -63,7 +63,7 @@ for side in (:east, :north, :top)
     side_ib_flux = Symbol(side, :_ib_flux)
     @eval begin
         @inline $side_ib_flux(i, j, k, ibg, ::Nothing, args...) = zero(eltype(ibg))
-        @inline $side_ib_flux(i, j, k, ibg, bc::FBC, loc, c, closure, K, id, args...) = - getbc(bc, i, j, k, ibg, args...)
+        @inline $side_ib_flux(i, j, k, ibg, bc::FBC, loc, c, closure, K, id, args...) = - explicit_flux(bc, ImmersedFacet(), i, j, k, ibg, c, args...)
     end
 end
 

--- a/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_top_boundary_condition.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/TKEBasedVerticalDiffusivities/tke_top_boundary_condition.jl
@@ -1,5 +1,5 @@
 using Oceananigans.Architectures: Architectures, on_architecture
-using Oceananigans.BoundaryConditions: BoundaryConditions, DiscreteBoundaryFunction, total_boundary_flux
+using Oceananigans.BoundaryConditions: BoundaryConditions, DiscreteBoundaryFunction, total_boundary_flux, Top
 using Oceananigans.Grids: AbstractGrid, topology
 
 struct TKETopBoundaryConditionParameters{C, U}
@@ -70,8 +70,8 @@ end
 @inline function friction_velocity(i, j, grid, clock, fields, velocity_bcs)
     FT = eltype(grid)
     Nz = size(grid, 3)
-    τx = total_boundary_flux(velocity_bcs.u, i, j, Nz, grid, clock, fields, fields.u)
-    τy = total_boundary_flux(velocity_bcs.v, i, j, Nz, grid, clock, fields, fields.v)
+    τx = total_boundary_flux(velocity_bcs.u, Top(), i, j, Nz, grid, fields.u, clock, fields)
+    τy = total_boundary_flux(velocity_bcs.v, Top(), i, j, Nz, grid, fields.v, clock, fields)
     return sqrt(sqrt(τx^2 + τy^2))
 end
 

--- a/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
+++ b/src/TurbulenceClosures/vertically_implicit_diffusion_solver.jl
@@ -1,7 +1,7 @@
 using Oceananigans.Advection: implicit_advection_upper_diagonal,
                               implicit_advection_lower_diagonal,
                               implicit_advection_diagonal
-using Oceananigans.BoundaryConditions: implicit_flux_coefficient, immersed_implicit_flux_coefficient, needs_implicit_solver
+using Oceananigans.BoundaryConditions: implicit_flux_coefficient, needs_implicit_solver, Bottom, Top, ImmersedFacet
 using Oceananigans.Fields: location
 using Oceananigans.Grids: Periodic, ZDirection, topology
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, ImmersedBoundaryCondition, immersed_inactive_node
@@ -138,22 +138,23 @@ end
 ##### boundary-cell diagonal (top: k = Nz, bottom: k = 1).
 #####
 
-@inline function boundary_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, top_bc, bottom_bc, immersed_bc)
+# `ϕ` is the field being solved for; the coefficients see its boundary-cell value after the explicit step.
+@inline function boundary_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, top_bc, bottom_bc, immersed_bc, ϕ)
     Nz  = size(grid, 3)
     Δzᵏ = Δz(i, j, k, grid, ℓx, ℓy, ℓz)
-    λᵗ  = implicit_flux_coefficient(top_bc,    i, j, grid, clk, fields)
-    λᵇ  = implicit_flux_coefficient(bottom_bc, i, j, grid, clk, fields)
+    λᵗ  = implicit_flux_coefficient(top_bc,    Top(),    i, j, Nz, grid, ϕ, clk, fields)
+    λᵇ  = implicit_flux_coefficient(bottom_bc, Bottom(), i, j, 1,  grid, ϕ, clk, fields)
     dᵗ  = ifelse(k == Nz,  Δt * λᵗ / Δzᵏ, zero(grid))  # top flux:     tendency −J/Δz
     dᵇ  = ifelse(k == 1,  -Δt * λᵇ / Δzᵏ, zero(grid))  # bottom flux:  tendency +J/Δz
-    dⁱ  = immersed_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, immersed_bc)
+    dⁱ  = immersed_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, immersed_bc, ϕ)
     return dᵗ + dᵇ + dⁱ
 end
 
-@inline immersed_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, immersed_bc) = zero(grid)
+@inline immersed_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, immersed_bc, ϕ) = zero(grid)
 
 # Immersed fluxes point along the inward-facing normal on every facet, so both immersed faces contribute
 # `+J/Δz` to the tendency, unlike the domain top which contributes `-J/Δz`.
-@inline function immersed_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, immersed_bc::ImmersedBoundaryCondition)
+@inline function immersed_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, immersed_bc::ImmersedBoundaryCondition, ϕ)
     Δzᵏ = Δz(i, j, k, grid, ℓx, ℓy, ℓz)
     active = !immersed_inactive_node(i, j, k, grid, ℓx, ℓy, ℓz)
 
@@ -162,8 +163,8 @@ end
     on_bottom = active & immersed_inactive_node(i, j, k-1, grid, ℓx, ℓy, ℓz)
     on_top    = active & immersed_inactive_node(i, j, k+1, grid, ℓx, ℓy, ℓz)
 
-    λᵇ = immersed_implicit_flux_coefficient(immersed_bc.bottom, i, j, k, grid, clk, fields)
-    λᵗ = immersed_implicit_flux_coefficient(immersed_bc.top,    i, j, k, grid, clk, fields)
+    λᵇ = implicit_flux_coefficient(immersed_bc.bottom, ImmersedFacet(), i, j, k, grid, ϕ, clk, fields)
+    λᵗ = implicit_flux_coefficient(immersed_bc.top,    ImmersedFacet(), i, j, k, grid, ϕ, clk, fields)
 
     return ifelse(on_bottom, -Δt * λᵇ / Δzᵏ, zero(grid)) +
            ifelse(on_top,    -Δt * λᵗ / Δzᵏ, zero(grid))
@@ -215,7 +216,7 @@ end
 # density-weighted (mass-flux) advection coefficients.
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionUpperDiagonal, p, ::ZDirection,
                                  clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection, w, density, top_bc, bottom_bc, immersed_bc)
+                                 advection, w, density, top_bc, bottom_bc, immersed_bc, ϕ)
     duκ = _ivd_upper_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
     duw = implicit_advection_upper_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, ℓz, density)
     return duκ + duw
@@ -223,7 +224,7 @@ end
 
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionLowerDiagonal, p, ::ZDirection,
                                  clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection, w, density, top_bc, bottom_bc, immersed_bc)
+                                 advection, w, density, top_bc, bottom_bc, immersed_bc, ϕ)
     dlκ = _ivd_lower_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
     dlw = implicit_advection_lower_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, ℓz, density)
     return dlκ + dlw
@@ -231,10 +232,10 @@ end
 
 @inline function get_coefficient(i, j, k, grid, ::VerticallyImplicitDiffusionDiagonal, p, ::ZDirection,
                                  clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields,
-                                 advection, w, density, top_bc, bottom_bc, immersed_bc)
+                                 advection, w, density, top_bc, bottom_bc, immersed_bc, ϕ)
     dκ  = ivd_diagonal(i, j, k, grid, clo, K, id, ℓx, ℓy, ℓz, Δt, clk, fields)
     dw  = implicit_advection_diagonal(i, j, k, grid, advection, w, Δt, ℓx, ℓy, ℓz, density)
-    dbc = boundary_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, top_bc, bottom_bc, immersed_bc)
+    dbc = boundary_flux_diagonal(i, j, k, grid, ℓx, ℓy, ℓz, Δt, clk, fields, top_bc, bottom_bc, immersed_bc, ϕ)
     return dκ + dw + dbc
 end
 
@@ -290,5 +291,5 @@ function implicit_step!(field::Field,
     return solve!(field, implicit_solver, field,
                   vi_closure, vi_closure_fields, tracer_index,
                   LX(), LY(), LZ(), Δt, clock, fields,
-                  advection, w, density, bcs.top, bcs.bottom, bcs.immersed)
+                  advection, w, density, bcs.top, bcs.bottom, bcs.immersed, field)
 end

--- a/test/test_bulk_drag.jl
+++ b/test/test_bulk_drag.jl
@@ -3,7 +3,7 @@ include("dependencies_for_runtests.jl")
 using Oceananigans.Grids: XDirection, YDirection, ZDirection
 using Oceananigans.Models: BulkDrag, BulkDragFunction, BulkDragBoundaryCondition,
                            QuadraticFormulation, LinearFormulation
-using Oceananigans.BoundaryConditions: FluxBoundaryCondition, FieldBoundaryConditions
+using Oceananigans.BoundaryConditions: FluxBoundaryCondition, FieldBoundaryConditions, IMEXFluxTimeDiscretization
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBottom, ImmersedBoundaryCondition
 
 @testset "BulkDrag" begin
@@ -95,6 +95,56 @@ using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBottom, I
             actual_Δu = Array(interior(model.velocities.u))[1, 1, 1] - U₀
 
             @test actual_Δu ≈ expected_Δu rtol=1e-4
+        end
+    end
+
+    #####
+    ##### Test that drag opposes the flow on right boundaries (top, east, north), where a flux enters the tendency as -J/Δ
+    #####
+
+    @testset "Quadratic drag tendency on top boundary" begin
+        for arch in archs
+            grid = RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 1, 1))
+
+            Cᴰ = 0.1
+            U₀ = 0.5
+            u_bcs = FieldBoundaryConditions(top=BulkDrag(coefficient=Cᴰ))
+            model = NonhydrostaticModel(grid; boundary_conditions=(u=u_bcs,))
+            set!(model, u=U₀)
+
+            Δt = 1e-6
+            time_step!(model, Δt)
+
+            expected_Δu = -Cᴰ * U₀^2 * Δt
+            actual_Δu = Array(interior(model.velocities.u))[1, 1, 1] - U₀
+
+            @test actual_Δu ≈ expected_Δu rtol=1e-4
+        end
+    end
+
+    @testset "BulkDrag decelerates the flow on every domain boundary" begin
+        for arch in archs
+            Cᴰ = 0.1
+            U₀ = 0.1
+            zgrid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1), topology=(Periodic, Periodic, Bounded))
+            xgrid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1), topology=(Bounded, Periodic, Periodic))
+            ygrid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1), topology=(Periodic, Bounded, Periodic))
+            drag = BulkDrag(coefficient=Cᴰ)
+
+            cases = ((zgrid, :u, :bottom), (zgrid, :u, :top),
+                     (xgrid, :v, :west),   (xgrid, :v, :east),
+                     (ygrid, :u, :south),  (ygrid, :u, :north))
+
+            for (grid, name, side) in cases
+                bcs = NamedTuple{(name,)}((FieldBoundaryConditions(; side => drag),))
+                model = NonhydrostaticModel(grid; boundary_conditions=bcs, advection=nothing, closure=nothing)
+                set!(model; name => U₀)
+                for _ in 1:10
+                    time_step!(model, 0.1)
+                end
+                Ū = sum(Array(interior(model.velocities[name]))) / length(interior(model.velocities[name]))
+                @test 0 < Ū < U₀
+            end
         end
     end
 
@@ -313,6 +363,122 @@ using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, GridFittedBottom, I
             time_step!(model, 1e-3)
 
             @test model.clock.iteration == 3
+        end
+    end
+
+    #####
+    ##### Implicit-explicit time discretization
+    #####
+
+    @testset "IMEX BulkDrag" begin
+        imex = IMEXFluxTimeDiscretization()
+
+        @test_throws ArgumentError BulkDrag(coefficient=1e-3, time_discretization=IMEXFluxTimeDiscretization(1.0))
+
+        drag = BulkDrag(coefficient=1e-3; time_discretization=imex)
+        @test drag isa BulkDragBoundaryCondition
+        @test occursin("IMEXFluxBoundaryCondition", sprint(show, drag))
+
+        for arch in archs
+            # A single cell with u = U₀ and no explicit part: a forward Euler step (the first AB2 step) followed
+            # by the implicit step gives u¹ = U₀ / (1 + Cᴰ |U| Δt) exactly.
+            grid = RectilinearGrid(arch, size=(1, 1, 1), extent=(1, 1, 1))
+            kw = (advection=nothing, closure=nothing, timestepper=:QuasiAdamsBashforth2)
+            Cᴰ = 0.1
+            U₀ = 0.5
+            Δt = 10.0 # Cᴰ |U| Δt / Δz = 0.5 for the quadratic and 1 for the linear drag
+
+            for (formulation, λ) in ((QuadraticFormulation(), Cᴰ * U₀), (LinearFormulation(), Cᴰ))
+                for side in (:bottom, :top)
+                    u_bcs = FieldBoundaryConditions(; side => BulkDrag(formulation; coefficient=Cᴰ, time_discretization=imex))
+                    model = NonhydrostaticModel(grid; boundary_conditions=(u=u_bcs,), kw...)
+                    bc = getproperty(model.velocities.u.boundary_conditions, side)
+                    @test bc isa BulkDragBoundaryCondition
+                    @test bc.classification.time_discretization isa IMEXFluxTimeDiscretization
+                    @test bc.condition.direction isa XDirection
+
+                    set!(model, u=U₀)
+                    time_step!(model, Δt)
+                    u¹ = Array(interior(model.velocities.u))[1, 1, 1]
+                    @test u¹ ≈ U₀ / (1 + λ * Δt)
+                end
+            end
+
+            # With a background velocity the explicit part λ U∞ contributes to the tendency, and the
+            # implicit step then divides by 1 + Cᴰ |U| Δt with |U| evaluated after the explicit step.
+            U∞ = 0.2
+            u_bcs = FieldBoundaryConditions(bottom=BulkDrag(coefficient=Cᴰ, background_velocities=(U∞, 0, 0), time_discretization=imex))
+            model = NonhydrostaticModel(grid; boundary_conditions=(u=u_bcs,), kw...)
+            set!(model, u=U₀)
+            time_step!(model, Δt)
+            u★ = U₀ - Δt * Cᴰ * (U₀ + U∞) * U∞
+            u¹ = u★ / (1 + Cᴰ * (u★ + U∞) * Δt)
+            @test Array(interior(model.velocities.u))[1, 1, 1] ≈ u¹
+
+            # IMEX and explicit drag agree for a small time step
+            Δt = 1e-4
+            drags = (explicit = BulkDrag(coefficient=Cᴰ, background_velocities=(U∞, 0, 0)),
+                     imex = BulkDrag(coefficient=Cᴰ, background_velocities=(U∞, 0, 0), time_discretization=imex))
+            u¹ = map(drags) do drag
+                model = NonhydrostaticModel(grid; boundary_conditions=(u=FieldBoundaryConditions(bottom=drag),), advection=nothing, closure=nothing)
+                set!(model, u=U₀)
+                time_step!(model, Δt)
+                Array(interior(model.velocities.u))[1, 1, 1]
+            end
+            @test u¹.imex ≈ u¹.explicit rtol=1e-6
+            @test u¹.imex != U₀
+
+            # The explicit treatment is unstable for Cᴰ Δt / Δz > 2; the implicit one is not. Without a closure
+            # only the bottom cell feels the drag.
+            column = RectilinearGrid(arch, size=4, z=(-4, 0), topology=(Flat, Flat, Bounded))
+            Cᴰ = 0.05
+            Δt = 100.0 # Cᴰ Δt / Δz = 5
+
+            u_bottom = map((explicit = BulkDrag(LinearFormulation(), coefficient=Cᴰ),
+                        imex = BulkDrag(LinearFormulation(), coefficient=Cᴰ, time_discretization=imex))) do drag
+                model = HydrostaticFreeSurfaceModel(column; boundary_conditions=(u=FieldBoundaryConditions(bottom=drag),),
+                                                    momentum_advection=nothing, tracer_advection=nothing, tracers=(),
+                                                    buoyancy=nothing, coriolis=nothing, closure=nothing)
+                set!(model, u=1)
+                for _ in 1:20
+                    time_step!(model, Δt)
+                end
+                Array(interior(model.velocities.u))[1, 1, 1]
+            end
+            @test !(abs(u_bottom.explicit) < 1)
+            @test 0 < u_bottom.imex < 1
+
+            # Immersed bottom facet: the drag acts on the cell above the immersed bottom
+            underlying = RectilinearGrid(arch, size=(1, 1, 4), x=(0, 1), y=(0, 1), z=(-4, 0))
+            grid = ImmersedBoundaryGrid(underlying, GridFittedBottom(-2))
+            Cᴰ = 0.1
+            Δt = 10.0
+            drag = BulkDrag(LinearFormulation(), coefficient=Cᴰ, time_discretization=imex)
+            u_bcs = FieldBoundaryConditions(immersed=ImmersedBoundaryCondition(bottom=drag))
+            model = NonhydrostaticModel(grid; boundary_conditions=(u=u_bcs,), kw...)
+            @test model.velocities.u.boundary_conditions.immersed.bottom isa BulkDragBoundaryCondition
+            set!(model, u=U₀)
+            time_step!(model, Δt)
+            u = Array(interior(model.velocities.u))[1, 1, :]
+            @test u[3] ≈ U₀ / (1 + Cᴰ * Δt)
+            @test u[4] ≈ U₀
+
+            # The same drag in a hydrostatic model with a split-explicit free surface decelerates the column
+            model = HydrostaticFreeSurfaceModel(grid; boundary_conditions=(u=u_bcs,),
+                                                momentum_advection=nothing, tracer_advection=nothing, tracers=(),
+                                                buoyancy=nothing, coriolis=nothing, closure=nothing)
+            set!(model, u=U₀)
+            for _ in 1:10
+                time_step!(model, Δt)
+            end
+            u = Array(interior(model.velocities.u))[1, 1, :]
+            @test 0 < u[3] < U₀
+            @test u[4] ≈ U₀
+
+            # Only vertical boundaries and facets are supported
+            xgrid = RectilinearGrid(arch, size=(4, 4, 4), extent=(1, 1, 1), topology=(Bounded, Periodic, Bounded))
+            @test_throws ErrorException NonhydrostaticModel(xgrid; boundary_conditions=(v=FieldBoundaryConditions(east=drag),), kw...)
+            @test_throws ErrorException NonhydrostaticModel(grid; boundary_conditions=(v=FieldBoundaryConditions(immersed=ImmersedBoundaryCondition(east=drag)),), kw...)
         end
     end
 

--- a/test/test_implicit_boundary_fluxes.jl
+++ b/test/test_implicit_boundary_fluxes.jl
@@ -2,6 +2,8 @@ include("dependencies_for_runtests.jl")
 
 using Oceananigans
 using Oceananigans: PrescribedVelocityFields
+using Oceananigans.Architectures: on_architecture
+using Oceananigans.BoundaryConditions: needs_implicit_solver
 using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization, CATKEVerticalDiffusivity
 
 #####
@@ -16,14 +18,24 @@ using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization, CAT
 @inline drag_explicit_part(i, j, grid, clock, fields, p) = -p.λ * p.c★
 @inline drag_coefficient(i, j, grid, clock, fields, p)   =  p.λ
 
-drag_bc(implicit, λ, c★) = implicit ?
-    FluxBoundaryCondition(drag_explicit_part; time_discretization=IMEXFluxTimeDiscretization(drag_coefficient), discrete_form=true, parameters=(; λ, c★)) :
-    FluxBoundaryCondition(drag_flux; discrete_form=true, parameters=(; λ, c★))
+# Continuous form of the same split, exercising the regularization of both parts.
+@inline continuous_drag_explicit_part(x, y, t, p) = -p.λ * p.c★
+@inline continuous_drag_coefficient(x, y, t, p)   =  p.λ
+
+function drag_bc(implicit, λ, c★; continuous=false)
+    if implicit && continuous
+        return FluxBoundaryCondition(continuous_drag_explicit_part; time_discretization=IMEXFluxTimeDiscretization(continuous_drag_coefficient), parameters=(; λ, c★))
+    elseif implicit
+        return FluxBoundaryCondition(drag_explicit_part; time_discretization=IMEXFluxTimeDiscretization(drag_coefficient), discrete_form=true, parameters=(; λ, c★))
+    else
+        return FluxBoundaryCondition(drag_flux; discrete_form=true, parameters=(; λ, c★))
+    end
+end
 
 # `closure = :auto` builds a zero-diffusivity vertically-implicit closure for the implicit BC, none otherwise.
-function relaxed_column(arch, Δt, nsteps; implicit, closure=:auto, λ=0.05, c★=1.0, c₀=0.0)
+function relaxed_column(arch, Δt, nsteps; implicit, closure=:auto, continuous=false, λ=0.05, c★=1.0, c₀=0.0)
     grid = RectilinearGrid(arch; size=(1, 1, 4), extent=(1, 1, 4), topology=(Periodic, Periodic, Bounded))
-    top = drag_bc(implicit, λ, c★)
+    top = drag_bc(implicit, λ, c★; continuous)
 
     actual_closure = closure !== :auto ? closure :
                      implicit ? VerticalScalarDiffusivity(VerticallyImplicitTimeDiscretization(), κ=0) : nothing
@@ -107,11 +119,53 @@ end
             @test isfinite(implicit_no_closure.cmax)
             @test isapprox(implicit_no_closure.csurf, c★; atol=1e-3)
 
+            # Both parts of a continuous-form implicit-explicit flux are regularized.
+            implicit_continuous = relaxed_column(arch, 100.0, 8; implicit=true, continuous=true)
+            @test implicit_continuous.csurf ≈ implicit_highΔt.csurf
+
             # An implicit-explicit flux BC is only valid on vertical boundaries.
             @test_throws ErrorException HydrostaticFreeSurfaceModel(
                 RectilinearGrid(arch; size=(1, 1, 4), extent=(1, 1, 4), topology=(Bounded, Periodic, Bounded));
                 tracers=:c, buoyancy=nothing, velocities=PrescribedVelocityFields(),
                 boundary_conditions=(; c=FieldBoundaryConditions(east=drag_bc(true, λ, c★))))
+        end
+
+        @testset "Patankar split of a generic flux [$(typeof(arch))]" begin
+            grid = RectilinearGrid(arch; size=4, z=(-4, 0), topology=(Flat, Flat, Bounded))
+            λ, Δt = 0.05, 100.0   # Δz = 1 ⇒ β = λ Δt / Δz = 5
+
+            function momentum_column(top; nsteps=1, u₀=1.0)
+                model = HydrostaticFreeSurfaceModel(grid; closure=nothing, momentum_advection=nothing, tracers=(),
+                                                    buoyancy=nothing, coriolis=nothing,
+                                                    boundary_conditions=(; u=FieldBoundaryConditions(; top)))
+                set!(model, u=u₀)
+                for _ in 1:nsteps
+                    time_step!(model, Δt)
+                end
+                return Array(interior(model.velocities.u))[1, 1, :]
+            end
+
+            # A drag toward zero given as a plain flux function: the Patankar rule recovers λ = J / u exactly,
+            # so the result matches the explicit split with the same coefficient.
+            patankar = FluxBoundaryCondition(mom_drag_u; discrete_form=true, parameters=(; λ), time_discretization=IMEXFluxTimeDiscretization())
+            split    = IMEXFluxBoundaryCondition(0.0, λ)
+            @test momentum_column(patankar; nsteps=8) ≈ momentum_column(split; nsteps=8)
+            @test momentum_column(patankar; nsteps=8)[end] < 1
+
+            # An array holding the flux J = λ u₀: one implicit step gives u¹ = u₀ / (1 + β)
+            u₀ = 1.0
+            J = on_architecture(arch, fill(λ * u₀, 1, 1, 1))
+            array_drag = FluxBoundaryCondition(J; time_discretization=IMEXFluxTimeDiscretization())
+            u = momentum_column(array_drag; u₀)
+            @test u[end] ≈ u₀ / (1 + λ * Δt)
+            @test u[1] ≈ u₀
+
+            # A source (a stress accelerating the flow) has no dissipative part and is integrated explicitly
+            τ = 1e-3
+            stress = FluxBoundaryCondition(on_architecture(arch, fill(-τ, 1, 1, 1)); time_discretization=IMEXFluxTimeDiscretization())
+            u = momentum_column(stress; u₀)
+            @test u[end] ≈ u₀ + Δt * τ
+            @test needs_implicit_solver(stress)
         end
 
         @testset "CATKE momentum drag [$(typeof(arch))]" begin

--- a/test/test_implicit_boundary_fluxes.jl
+++ b/test/test_implicit_boundary_fluxes.jl
@@ -147,7 +147,7 @@ end
 
             # A drag toward zero given as a plain flux function: the Patankar rule recovers λ = J / u exactly,
             # so the result matches the explicit split with the same coefficient.
-            patankar = FluxBoundaryCondition(mom_drag_u; discrete_form=true, parameters=(; λ), time_discretization=IMEXFluxTimeDiscretization())
+            patankar = IMEXFluxBoundaryCondition(mom_drag_u; discrete_form=true, parameters=(; λ))
             split    = IMEXFluxBoundaryCondition(0.0, λ)
             @test momentum_column(patankar; nsteps=8) ≈ momentum_column(split; nsteps=8)
             @test momentum_column(patankar; nsteps=8)[end] < 1
@@ -155,14 +155,14 @@ end
             # An array holding the flux J = λ u₀: one implicit step gives u¹ = u₀ / (1 + β)
             u₀ = 1.0
             J = on_architecture(arch, fill(λ * u₀, 1, 1, 1))
-            array_drag = FluxBoundaryCondition(J; time_discretization=IMEXFluxTimeDiscretization())
+            array_drag = IMEXFluxBoundaryCondition(J)
             u = momentum_column(array_drag; u₀)
             @test u[end] ≈ u₀ / (1 + λ * Δt)
             @test u[1] ≈ u₀
 
             # A source (a stress accelerating the flow) has no dissipative part and is integrated explicitly
             τ = 1e-3
-            stress = FluxBoundaryCondition(on_architecture(arch, fill(-τ, 1, 1, 1)); time_discretization=IMEXFluxTimeDiscretization())
+            stress = IMEXFluxBoundaryCondition(on_architecture(arch, fill(-τ, 1, 1, 1)))
             u = momentum_column(stress; u₀)
             @test u[end] ≈ u₀ + Δt * τ
             @test needs_implicit_solver(stress)


### PR DESCRIPTION
This PR makes `IMEXFluxTimeDiscretization` work with any flux boundary condition, adds an IMEX option to `BulkDrag`, and fixes the sign of `BulkDrag` on right boundaries.

cc @simone-silvestri

## Any flux can be integrated implicitly

```julia
IMEXFluxBoundaryCondition(J)          # J is a number, an array, a Field, or a function
IMEXFluxBoundaryCondition(Fₑ, λ)      # explicit split J = Fₑ + λ φᵦ, as before
```

The split `J ≈ Fₑ + λ φᵦ` at the boundary cell is decided by the condition through two extension points, `implicit_flux_coefficient(condition, boundary, i, j, k, grid, ϕ, args...)` and `explicit_flux(...)`, where `boundary` is `Bottom()`, `Top()`, or `ImmersedFacet()`.

The fallback for a condition without a specialization is the Patankar rule: `λ` is the dissipative part of `J / φᵦ` and the remainder `J - λ φᵦ` is integrated explicitly. A flux proportional to `φᵦ` (a drag, a sink) is therefore fully implicit and unconditionally stable, while a source (a wind stress) stays explicit. Because the rule only sees the value of the flux, it cannot recognize a relaxation toward a nonzero target; that case keeps the explicit split `IMEXFlux(Fₑ, λ)`. The docstring also notes that the implicit step cannot change the sign of `φᵦ` within a step.

To support the fallback, the tridiagonal solver and the bottom, top, and immersed flux kernels now receive the field being stepped. `total_boundary_flux` takes the boundary marker, and its three consumers (the CATKE friction velocity and the two buoyancy fluxes) are updated.

## `BulkDrag` with IMEX

```julia
BulkDrag(coefficient=2e-3, time_discretization=IMEXFluxTimeDiscretization())
```

The drag `λ (u + U∞)` with `λ = -Cᴰ|U|` is affine in the tangential velocity, so `BulkDragFunction` supplies the exact split, `λ` and `Fₑ = λ U∞`, and avoids the division. For the quadratic formulation `|U|` is evaluated from the current velocities when the diagonal is built.

## Sign fix

`BulkDrag` returned `-Cᴰ|U|u` on every boundary, but fluxes on top, east, and north enter the tendency as `-J/Δ`, so the drag on those boundaries accelerated the flow. Confirmed with a uniform initial velocity and no closure: bottom and west slowed it, top and east sped it up. The flux is now flipped on right boundaries. Immersed facets were already correct since they use the inward normal.

## Also

- `IMEXFlux` conditions are regularized, which continuous-form functions inside an implicit flux needed.
- An implicit flux on a lateral immersed facet now errors rather than silently dropping its implicit part. This means `immersed=drag` with an IMEX drag errors on grids with lateral facets; use `ImmersedBoundaryCondition(bottom=drag)`.
- Implicit flux boundary conditions print as `IMEXFluxBoundaryCondition`.
- Numeric `BulkDrag` parameters are converted to the grid's float type during regularization.

## Tests

Run locally on CPU: `test_implicit_boundary_fluxes.jl` (25, of which 6 new for the Patankar fallback), `test_bulk_drag.jl` (72, with sign tests on all six boundaries and exact single-step IMEX checks), `test_split_explicit_boundary_stress.jl`, `test_boundary_conditions.jl`, `test_buoyancy.jl`. Not run: GPU tests and Documenter doctests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
