### PR TITLE
Initialize reduced fields without Base's reduction internals

### DIFF
--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -718,12 +718,28 @@ const MinimumReduction = typeof(Base.minimum!)
 const AllReduction     = typeof(Base.all!)
 const AnyReduction     = typeof(Base.any!)
 
-initialize_reduced_field!(::SumReduction,     f, r::ReducedAbstractField, c) = Base.initarray!(interior(r), f, Base.add_sum, true, interior(c))
-initialize_reduced_field!(::ProdReduction,    f, r::ReducedAbstractField, c) = Base.initarray!(interior(r), f, Base.mul_prod, true, interior(c))
-initialize_reduced_field!(::AllReduction,     f, r::ReducedAbstractField, c) = Base.initarray!(interior(r), f, &, true, interior(c))
-initialize_reduced_field!(::AnyReduction,     f, r::ReducedAbstractField, c) = Base.initarray!(interior(r), f, |, true, interior(c))
-initialize_reduced_field!(::MaximumReduction, f, r::ReducedAbstractField, c) = Base.mapfirst!(f, interior(r), interior(c))
-initialize_reduced_field!(::MinimumReduction, f, r::ReducedAbstractField, c) = Base.mapfirst!(f, interior(r), interior(c))
+# Neutral element the in-place reduction starts from (it runs with `init=false`)
+reduction_init(::SumReduction,  T) = zero(T)
+reduction_init(::ProdReduction, T) = one(T)
+reduction_init(::AllReduction,  T) = true
+reduction_init(::AnyReduction,  T) = false
+
+initialize_reduced_field!(reduction, f, r::ReducedAbstractField, c) =
+    fill!(interior(r), reduction_init(reduction, eltype(r)))
+
+# `maximum` and `minimum` start from `f` of the operand's first slice along the reduced dimensions
+function initialize_reduced_field!(::Union{MaximumReduction, MinimumReduction}, f::F, r::ReducedAbstractField, c) where F
+    R, A = interior(r), interior(c)
+    return map!(f, R, view(A, first_slice(axes(R), axes(A))...))
+end
+
+# Axes of the first slice of `A` along the dimensions reduced in `R`, keeping the axis types
+first_slice(::Tuple{}, ::Tuple{}) = ()
+@inline first_slice(R::Tuple, A::Tuple) =
+    (length(R[1]) == 1 ? first_index(A[1]) : A[1], first_slice(Base.tail(R), Base.tail(A))...)
+
+first_index(::Base.OneTo) = Base.OneTo(1)
+first_index(ax::AbstractUnitRange) = first(ax):first(ax)
 
 filltype(f, c) = eltype(c)
 filltype(::Union{AllReduction, AnyReduction}, grid) = Bool
@@ -754,7 +770,8 @@ function reduced_dimension(loc)
     return dims
 end
 
-get_neutral_mask(::Union{AllReduction, AnyReduction})  = true
+get_neutral_mask(::AllReduction) = true
+get_neutral_mask(::AnyReduction) = false
 get_neutral_mask(::Union{SumReduction, MeanReduction}) = 0
 get_neutral_mask(::ProdReduction)    = 1
 

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -724,8 +724,7 @@ reduction_init(::ProdReduction, T) = one(T)
 reduction_init(::AllReduction,  T) = true
 reduction_init(::AnyReduction,  T) = false
 
-initialize_reduced_field!(reduction, f, r::ReducedAbstractField, c) =
-    fill!(interior(r), reduction_init(reduction, eltype(r)))
+initialize_reduced_field!(reduction, f, r::ReducedAbstractField, c) = fill!(interior(r), reduction_init(reduction, eltype(r)))
 
 # `maximum` and `minimum` start from `f` of the operand's first slice along the reduced dimensions
 function initialize_reduced_field!(::Union{MaximumReduction, MinimumReduction}, f::F, r::ReducedAbstractField, c) where F
@@ -734,9 +733,8 @@ function initialize_reduced_field!(::Union{MaximumReduction, MinimumReduction}, 
 end
 
 # Axes of the first slice of `A` along the dimensions reduced in `R`, keeping the axis types
-first_slice(::Tuple{}, ::Tuple{}) = ()
-@inline first_slice(R::Tuple, A::Tuple) =
-    (length(R[1]) == 1 ? first_index(A[1]) : A[1], first_slice(Base.tail(R), Base.tail(A))...)
+@inline first_slice(::Tuple{}, ::Tuple{}) = ()
+@inline first_slice(R::Tuple, A::Tuple) = (length(R[1]) == 1 ? first_index(A[1]) : A[1], first_slice(Base.tail(R), Base.tail(A))...)
 
 first_index(::Base.OneTo) = Base.OneTo(1)
 first_index(ax::AbstractUnitRange) = first(ax):first(ax)

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -825,6 +825,44 @@ end
             end
         end
 
+        @testset "Boolean reductions [$(typeof(arch))]" for arch in archs
+            @info "  Testing Boolean field reductions [$(typeof(arch))]..."
+            grid = RectilinearGrid(arch; size=(4, 5, 3), extent=(1, 1, 1))
+            pattern = [(i + j + k) % 3 == 0 for i in 1:4, j in 1:5, k in 1:3]
+            b = CenterField(grid, Bool)
+            interior(b) .= on_architecture(arch, pattern)
+
+            @test any(b) == any(pattern)
+            @test all(b) == all(pattern)
+            for dims in (1, 2, 3, (1, 2), (1, 2, 3))
+                @test Array(interior(any(b; dims))) == any(pattern; dims)
+                @test Array(interior(all(b; dims))) == all(pattern; dims)
+            end
+
+            r = Field{Nothing, Center, Center}(grid, Bool)
+            any!(r, b)
+            @test Array(interior(r)) == any(pattern; dims=1)
+            all!(r, b)
+            @test Array(interior(r)) == all(pattern; dims=1)
+
+            # A `condition` and immersed cells wrap the operand in a `ConditionalOperation`
+            condition = (i, j, k, grid, b) -> i > 2
+            @test any(b; condition) == any(pattern[3:end, :, :])
+            @test all(b; condition) == all(pattern[3:end, :, :])
+            @test Array(interior(all(b; condition, dims=1))) == all(pattern[3:end, :, :]; dims=1)
+
+            # Immersed cells (k = 1 here) count as the neutral element of the reduction
+            immersed_grid = ImmersedBoundaryGrid(grid, GridFittedBottom(-0.6))
+            bᵢ = CenterField(immersed_grid, Bool)
+            interior(bᵢ) .= on_architecture(arch, pattern)
+            @test any(bᵢ) == any(pattern[:, :, 2:3])
+            @test all(bᵢ) == all(pattern[:, :, 2:3])
+            @test Array(interior(all(bᵢ; dims=3))) == all(pattern[:, :, 2:3]; dims=3)
+            wet_pattern = copy(pattern)
+            wet_pattern[:, :, 1] .= false
+            @test Array(interior(any(bᵢ; dims=(1, 2)))) == any(wet_pattern; dims=(1, 2))
+        end
+
         for arch in archs, FT in float_types
             @info "    Test reductions on WindowedFields [$(typeof(arch)), $FT]..."
 


### PR DESCRIPTION
Other issue popped up in #5968: some functions were using the internal Julia function `Base.initarray!`, which was changed in a breaking way for us.  The proposed solution is to avoid using internals entirely here, to make the code more future-proof.

> `initialize_reduced_field!` called `Base.initarray!` with `&` and `|` for `all` and `any`. Julia 1.13 reduces `all!`/`any!` with the new `Base.and_all`/`Base.or_any` and dropped the `&`/`|` methods of `initarray!`, so every `all`/`any` of a field failed:
> 
>     MethodError: no method matching initarray!(::CuArray{Bool, 3}, ::typeof(identity), ::typeof(&), ::Bool, ::ConditionalOperation{...})
> 
> The other initializers relied on `Base.initarray!` with `Base.add_sum` and `Base.mul_prod`, and on `Base.mapfirst!`, which can change the same way. Replace them with the equivalent operations spelled out: a `fill!` with the neutral element for `sum`, `prod`, `all` and `any`, and a `map!` of the operand's first slice along the reduced dimensions for `maximum` and `minimum`. These launch the same kernels as before and need no version conditionals; `and_all`/`or_any` do not exist before 1.13 and the compat floor stays at Julia 1.10.
> 
> Also correct the neutral mask of `any` from `true` to `false`: masked (conditional or immersed) cells made `any` return `true` regardless of the wet cells.
> 
> Add tests for `all`/`any` reductions of Boolean fields, which were only covered by an MPI test: plain, with `dims`, in place, with a `condition`, and on an immersed grid, on every architecture.
> 
> Build the first-slice view of a reduced field type-stably
> 
> The `ntuple` over the dimensions returned a `UnitRange` for reduced dimensions and the operand's `Base.OneTo` axis otherwise, so the type of the slice depended on a runtime check and the `view`/`map!` call dispatched dynamically, adding about ten allocations to every `maximum`/`minimum` and costing several times the kernel time on the GPU. The initializer also did not specialize on `f`, which it only passes on.
> 
> Build the slice by recursion over the axes, keeping each axis type, and specialize on `f`. The initializer now allocates the same as `Base.mapfirst!` for conditional operands and within 200 bytes of it otherwise.